### PR TITLE
feat(telemetry): run records — schema V11, recorder, hook, IPC (PR 1)

### DIFF
--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -3402,6 +3402,13 @@ class CollieDB:
 
     def export_all(self) -> dict[str, Any]:
         """Full data export (for F104 data export)."""
+        # Include telemetry that is still queued in the writer thread, or the
+        # export would silently omit recent-but-not-yet-durable records.
+        from collie_core.telemetry.recorder import RunRecorder
+
+        recorder = RunRecorder.active_for(self)
+        if recorder is not None:
+            recorder.flush()
         return {
             "exported_at": utc_now(),
             "schema_version": self.schema_version,
@@ -3456,21 +3463,34 @@ class CollieDB:
 
     def clear_all(self) -> None:
         """Wipe all user data (for F105 data deletion)."""
-        # Children before parents: run_steps cascades from runs anyway, but
-        # usage (FK -> providers), connector_tool_cache (FK -> connections),
-        # messages (FK -> conversations), and plans/runs must go first so no
-        # foreign-key violation aborts the wipe halfway.
-        tables = [
-            "task_checklist_steps", "task_checklists", "conversation_review_gates",
-            "plan_change_requests", "run_task_state_revisions",
-            "tool_events", "turn_events",
-            "run_steps",
-            "approval_requests", "approval_rules", "runs", "plans",
-            "messages", "conversations", "profile", "people", "important_dates",
-            "reminders", "automations", "shopping_items", "expenses", "budgets",
-            "health_logs", "services", "connector_tool_cache", "connector_connections",
-            "subagents", "usage", "providers", "settings",
-        ]
-        with self._write() as conn:
-            for table in tables:
-                conn.execute(f"DELETE FROM {table}")
+        # Suspend + drain telemetry first: queued recorder writes must not
+        # execute after the wipe and resurrect deleted rows. The recorder
+        # stays suspended until the deletes finish, so hooks enqueueing
+        # mid-wipe are dropped too, then recording resumes for new turns.
+        from collie_core.telemetry.recorder import RunRecorder
+
+        recorder = RunRecorder.active_for(self)
+        if recorder is not None:
+            recorder.suspend_and_drain()
+        try:
+            # Children before parents: run_steps cascades from runs anyway, but
+            # usage (FK -> providers), connector_tool_cache (FK -> connections),
+            # messages (FK -> conversations), and plans/runs must go first so no
+            # foreign-key violation aborts the wipe halfway.
+            tables = [
+                "task_checklist_steps", "task_checklists", "conversation_review_gates",
+                "plan_change_requests", "run_task_state_revisions",
+                "tool_events", "turn_events",
+                "run_steps",
+                "approval_requests", "approval_rules", "runs", "plans",
+                "messages", "conversations", "profile", "people", "important_dates",
+                "reminders", "automations", "shopping_items", "expenses", "budgets",
+                "health_logs", "services", "connector_tool_cache", "connector_connections",
+                "subagents", "usage", "providers", "settings",
+            ]
+            with self._write() as conn:
+                for table in tables:
+                    conn.execute(f"DELETE FROM {table}")
+        finally:
+            if recorder is not None:
+                recorder.resume()

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -481,6 +481,39 @@ _SCHEMA_V10 = """
 ALTER TABLE plan_change_requests ADD COLUMN terminal_message_id TEXT;
 """
 
+_SCHEMA_V11 = """
+CREATE TABLE IF NOT EXISTS turn_events (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT,
+  session_key TEXT,
+  turn_kind TEXT NOT NULL,          -- chat|plan|routine|cron|subagent|automation
+  provider TEXT, model TEXT,
+  status TEXT NOT NULL,             -- running|ok|error|stopped|cancelled
+  error_message TEXT,
+  tokens_in INTEGER, tokens_out INTEGER,
+  latency_ms INTEGER,
+  tool_count INTEGER DEFAULT 0,
+  started_at TEXT NOT NULL, finished_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_turn_events_conv ON turn_events(conversation_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_turn_events_status ON turn_events(status, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS tool_events (
+  id TEXT PRIMARY KEY,
+  turn_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  action TEXT, resource TEXT,       -- from permission classifier (join to approval_requests)
+  input_summary TEXT,               -- redacted + truncated (<=500 chars)
+  output_summary TEXT,              -- redacted + truncated (<=1000 chars)
+  status TEXT NOT NULL,             -- running|ok|error|denied|timeout
+  error_message TEXT,
+  latency_ms INTEGER,
+  started_at TEXT NOT NULL, finished_at TEXT,
+  FOREIGN KEY (turn_id) REFERENCES turn_events(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_tool_events_tool ON tool_events(tool_name, status, started_at DESC);
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -493,6 +526,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V8,
     _SCHEMA_V9,
     _SCHEMA_V10,
+    _SCHEMA_V11,
 ]
 
 
@@ -3165,6 +3199,198 @@ class CollieDB:
             )
         row = rows[0] if rows else {"messages": 0, "tokens": 0}
         return {"messages": int(row["messages"]), "tokens": int(row["tokens"])}
+
+    # -- run records (telemetry) ----------------------------------------------------------------
+
+    def record_turn_event(
+        self,
+        *,
+        turn_id: str,
+        conversation_id: str | None = None,
+        session_key: str | None = None,
+        turn_kind: str = "chat",
+        provider: str | None = None,
+        model: str | None = None,
+        status: str = "running",
+        error_message: str | None = None,
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        latency_ms: int | None = None,
+        tool_count: int = 0,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+    ) -> None:
+        """Insert or update one turn event row (upsert keyed by id).
+
+        The recorder writes a ``running`` row when a turn starts and an
+        upsert with the final status when it finishes; COALESCE keeps the
+        start-time fields intact across the two writes.
+        """
+        with self._write() as conn:
+            updated = conn.execute(
+                """
+                UPDATE turn_events SET
+                    conversation_id = COALESCE(?, conversation_id),
+                    session_key = COALESCE(?, session_key),
+                    turn_kind = COALESCE(?, turn_kind),
+                    provider = COALESCE(?, provider),
+                    model = COALESCE(?, model),
+                    status = COALESCE(?, status),
+                    error_message = COALESCE(?, error_message),
+                    tokens_in = COALESCE(?, tokens_in),
+                    tokens_out = COALESCE(?, tokens_out),
+                    latency_ms = COALESCE(?, latency_ms),
+                    tool_count = COALESCE(?, tool_count),
+                    started_at = COALESCE(?, started_at),
+                    finished_at = COALESCE(?, finished_at)
+                WHERE id = ?
+                """,
+                (
+                    conversation_id, session_key, turn_kind, provider, model,
+                    status, error_message, tokens_in, tokens_out, latency_ms,
+                    tool_count, started_at, finished_at, turn_id,
+                ),
+            )
+            if updated.rowcount == 0:
+                conn.execute(
+                    """
+                    INSERT INTO turn_events (
+                        id, conversation_id, session_key, turn_kind, provider, model,
+                        status, error_message, tokens_in, tokens_out, latency_ms,
+                        tool_count, started_at, finished_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        turn_id, conversation_id, session_key, turn_kind, provider,
+                        model, status, error_message, tokens_in, tokens_out,
+                        latency_ms, tool_count, started_at or utc_now(), finished_at,
+                    ),
+                )
+
+    def record_tool_event(
+        self,
+        *,
+        tool_id: str,
+        turn_id: str,
+        tool_name: str,
+        action: str | None = None,
+        resource: str | None = None,
+        input_summary: str | None = None,
+        output_summary: str | None = None,
+        status: str = "running",
+        error_message: str | None = None,
+        latency_ms: int | None = None,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+    ) -> None:
+        """Insert or update one tool event row (upsert keyed by id)."""
+        started_at = started_at or utc_now()
+        with self._write() as conn:
+            updated = conn.execute(
+                """
+                UPDATE tool_events SET
+                    action = COALESCE(?, action),
+                    resource = COALESCE(?, resource),
+                    input_summary = COALESCE(?, input_summary),
+                    output_summary = COALESCE(?, output_summary),
+                    status = COALESCE(?, status),
+                    error_message = COALESCE(?, error_message),
+                    latency_ms = COALESCE(?, latency_ms),
+                    started_at = COALESCE(?, started_at),
+                    finished_at = COALESCE(?, finished_at)
+                WHERE id = ?
+                """,
+                (
+                    action, resource, input_summary, output_summary, status,
+                    error_message, latency_ms, started_at, finished_at, tool_id,
+                ),
+            )
+            if updated.rowcount == 0:
+                conn.execute(
+                    """
+                    INSERT INTO tool_events (
+                        id, turn_id, tool_name, action, resource, input_summary,
+                        output_summary, status, error_message, latency_ms,
+                        started_at, finished_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        tool_id, turn_id, tool_name, action, resource, input_summary,
+                        output_summary, status, error_message, latency_ms,
+                        started_at, finished_at,
+                    ),
+                )
+
+    def list_turn_events(
+        self,
+        conversation_id: str | None = None,
+        session_key: str | None = None,
+        since: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """List turn events, most recent first, with optional filters."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if conversation_id:
+            clauses.append("conversation_id = ?")
+            params.append(conversation_id)
+        if session_key:
+            clauses.append("session_key = ?")
+            params.append(session_key)
+        if since:
+            clauses.append("started_at >= ?")
+            params.append(since)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+        return self._rows(
+            f"SELECT * FROM turn_events {where} ORDER BY started_at DESC LIMIT ?",
+            tuple(params),
+        )
+
+    def list_tool_events(
+        self,
+        turn_id: str | None = None,
+        tool_name: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """List tool events, most recent first, with optional filters."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if turn_id:
+            clauses.append("turn_id = ?")
+            params.append(turn_id)
+        if tool_name:
+            clauses.append("tool_name = ?")
+            params.append(tool_name)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+        return self._rows(
+            f"SELECT * FROM tool_events {where} ORDER BY started_at DESC LIMIT ?",
+            tuple(params),
+        )
+
+    def turn_event_stats(self, since: str | None = None) -> list[dict[str, Any]]:
+        """Per-tool status counts (feeds Gardener evidence queries)."""
+        if since:
+            rows = self._rows(
+                """
+                SELECT tool_name, status, COUNT(*) AS count FROM tool_events
+                WHERE started_at >= ? GROUP BY tool_name, status
+                ORDER BY tool_name, status
+                """,
+                (since,),
+            )
+        else:
+            rows = self._rows(
+                """
+                SELECT tool_name, status, COUNT(*) AS count FROM tool_events
+                GROUP BY tool_name, status ORDER BY tool_name, status
+                """
+            )
+        return [
+            {"tool_name": row["tool_name"], "status": row["status"], "count": int(row["count"])}
+            for row in rows
+        ]
 
     # -- data management ----------------------------------------------------------------------------
 

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -3208,10 +3208,10 @@ class CollieDB:
         turn_id: str,
         conversation_id: str | None = None,
         session_key: str | None = None,
-        turn_kind: str = "chat",
+        turn_kind: str | None = None,
         provider: str | None = None,
         model: str | None = None,
-        status: str = "running",
+        status: str | None = None,
         error_message: str | None = None,
         tokens_in: int = 0,
         tokens_out: int = 0,
@@ -3224,7 +3224,9 @@ class CollieDB:
 
         The recorder writes a ``running`` row when a turn starts and an
         upsert with the final status when it finishes; COALESCE keeps the
-        start-time fields intact across the two writes.
+        start-time fields (and the ``turn_kind`` captured at start) intact
+        across the two writes. Defaults are applied on INSERT only so a
+        finishing write can never clobber values it does not carry.
         """
         with self._write() as conn:
             updated = conn.execute(
@@ -3261,9 +3263,10 @@ class CollieDB:
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
-                        turn_id, conversation_id, session_key, turn_kind, provider,
-                        model, status, error_message, tokens_in, tokens_out,
-                        latency_ms, tool_count, started_at or utc_now(), finished_at,
+                        turn_id, conversation_id, session_key, turn_kind or "chat",
+                        provider, model, status or "running", error_message,
+                        tokens_in, tokens_out, latency_ms, tool_count,
+                        started_at or utc_now(), finished_at,
                     ),
                 )
 
@@ -3283,8 +3286,11 @@ class CollieDB:
         started_at: str | None = None,
         finished_at: str | None = None,
     ) -> None:
-        """Insert or update one tool event row (upsert keyed by id)."""
-        started_at = started_at or utc_now()
+        """Insert or update one tool event row (upsert keyed by id).
+
+        ``started_at`` defaults to now on INSERT only, so the finishing
+        write preserves the original start time.
+        """
         with self._write() as conn:
             updated = conn.execute(
                 """
@@ -3317,7 +3323,7 @@ class CollieDB:
                     (
                         tool_id, turn_id, tool_name, action, resource, input_summary,
                         output_summary, status, error_message, latency_ms,
-                        started_at, finished_at,
+                        started_at or utc_now(), finished_at,
                     ),
                 )
 
@@ -3424,6 +3430,12 @@ class CollieDB:
             "conversation_review_gates": self._rows(
                 "SELECT * FROM conversation_review_gates ORDER BY declared_at"
             ),
+            "turn_events": self._rows(
+                "SELECT * FROM turn_events ORDER BY started_at"
+            ),
+            "tool_events": self._rows(
+                "SELECT * FROM tool_events ORDER BY started_at"
+            ),
             "approval_rules": self.list_approval_rules(),
             "approval_requests": self._rows(
                 "SELECT * FROM approval_requests ORDER BY requested_at"
@@ -3451,6 +3463,7 @@ class CollieDB:
         tables = [
             "task_checklist_steps", "task_checklists", "conversation_review_gates",
             "plan_change_requests", "run_task_state_revisions",
+            "tool_events", "turn_events",
             "run_steps",
             "approval_requests", "approval_rules", "runs", "plans",
             "messages", "conversations", "profile", "people", "important_dates",

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -523,6 +523,34 @@ class CollieIPCServer:
         )
         return {"messages": messages}
 
+    async def _cmd_get_run_records(self, connection: ServerConnection, frame: dict) -> dict:
+        """List turn events (most recent first) — read-only telemetry."""
+        conv_id = str(frame.get("conversation_id") or "") or None
+        session_key = str(frame.get("session_key") or "") or None
+        since = str(frame.get("since") or "") or None
+        limit = frame.get("limit")
+        turns = await asyncio.to_thread(
+            self.db.list_turn_events,
+            conversation_id=conv_id,
+            session_key=session_key,
+            since=since,
+            limit=int(limit) if limit is not None else 200,
+        )
+        return {"turns": turns}
+
+    async def _cmd_get_tool_events(self, connection: ServerConnection, frame: dict) -> dict:
+        """List tool events (most recent first) — read-only telemetry."""
+        turn_id = str(frame.get("turn_id") or "") or None
+        tool_name = str(frame.get("tool_name") or "") or None
+        limit = frame.get("limit")
+        events = await asyncio.to_thread(
+            self.db.list_tool_events,
+            turn_id=turn_id,
+            tool_name=tool_name,
+            limit=int(limit) if limit is not None else 500,
+        )
+        return {"tool_events": events}
+
     async def _cmd_get_active_task(
         self, connection: ServerConnection, frame: dict
     ) -> dict:

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -784,6 +784,16 @@ class CollieRuntime:
                 pass
             self._outbound_task = None
         self.loop = None
+        # Active turns are drained above; flush their telemetry so evidence
+        # from cancelled/stopped turns is durable before the loop is gone.
+        self._flush_telemetry()
+
+    def _flush_telemetry(self) -> None:
+        from collie_core.telemetry.recorder import RunRecorder
+
+        recorder = RunRecorder.active_for(self.db)
+        if recorder is not None:
+            recorder.flush()
 
     async def _write_subagent_prompt(self, name: str, description: str) -> str:
         """Have the LLM write a subagent system prompt from a description."""
@@ -1047,6 +1057,14 @@ class CollieRuntime:
                 self._reminder_task = None
             await self._shutdown_loop()
             self.approvals.cancel_all()
+            # Stop telemetry after active turns are drained and before the
+            # database closes, so no queued write is dropped or runs through
+            # a closed connection.
+            from collie_core.telemetry.recorder import RunRecorder
+
+            recorder = RunRecorder.active_for(self.db)
+            if recorder is not None:
+                recorder.shutdown()
             self.db.close()
 
 

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -157,17 +157,22 @@ class CollieRuntime:
         )
         bus = CollieBus(on_inbound=self._on_messenger_inbound)
         provider_override = self._provider_override()
+        telemetry_factories = [create_telemetry_hook_factory(self.db)]
         if provider_override is not None:
             loop = AgentLoop.from_config(
                 config, bus=bus, provider=provider_override,
                 session_manager=self._session_manager,
-                hook_factories=[create_telemetry_hook_factory(self.db)],
+                hook_factories=telemetry_factories,
             )
         else:
             loop = AgentLoop.from_config(
                 config, bus=bus, session_manager=self._session_manager,
-                hook_factories=[create_telemetry_hook_factory(self.db)],
+                hook_factories=telemetry_factories,
             )
+        # Subagents bypass the loop's turn-hook chain (they run AgentRunner
+        # directly with their own _SubagentHook) — mirror the factories so
+        # subagent turns are telemetry-recorded too.
+        loop.subagents.hook_factories = list(telemetry_factories)
         loop.context.command_guidance = True
 
         from nanobot.runtime_context import RuntimeContextBlock

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -147,6 +147,7 @@ class CollieRuntime:
 
     def _build_loop(self) -> Any:
         import collie_core.tools as collie_tools
+        from collie_core.telemetry.hook import create_telemetry_hook_factory
         from nanobot.agent.loop import AgentLoop
         from nanobot.agent.tools.context import ToolContext
         from nanobot.agent.tools.loader import ToolLoader
@@ -160,10 +161,12 @@ class CollieRuntime:
             loop = AgentLoop.from_config(
                 config, bus=bus, provider=provider_override,
                 session_manager=self._session_manager,
+                hook_factories=[create_telemetry_hook_factory(self.db)],
             )
         else:
             loop = AgentLoop.from_config(
                 config, bus=bus, session_manager=self._session_manager,
+                hook_factories=[create_telemetry_hook_factory(self.db)],
             )
         loop.context.command_guidance = True
 

--- a/collie-core/collie_core/telemetry/__init__.py
+++ b/collie-core/collie_core/telemetry/__init__.py
@@ -1,0 +1,7 @@
+"""Run records: fire-and-forget telemetry for agent turns and tool calls.
+
+PR 1 of the Gardener Foundations plan — the evidence foundation for
+Collie's self-improvement story. Read more in
+``docs/engineering/architecture/gardener-foundations.md`` (landing with
+PR 4).
+"""

--- a/collie-core/collie_core/telemetry/hook.py
+++ b/collie-core/collie_core/telemetry/hook.py
@@ -1,0 +1,217 @@
+"""AgentHook that records every turn + tool call via RunRecorder.
+
+Registered as a per-turn hook factory on the AgentLoop (the same pattern
+as ``create_file_edit_activity_hook``) so every turn kind — chat, plan,
+routine, cron, automation, subagent — is recorded with zero edits to the
+nanobot orchestration core.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from collie_core.db import CollieDB, new_id
+from collie_core.telemetry.recorder import (
+    TOOL_OUTPUT_LIMIT,
+    TURN_INPUT_LIMIT,
+    RunRecorder,
+    summarize,
+)
+from nanobot.agent.hook import (
+    AgentHook,
+    AgentHookContext,
+    AgentRunHookContext,
+    AgentTurnHookContext,
+)
+from nanobot.agent.turn_hooks import AgentTurnHookFactory
+from nanobot.providers.base import ToolCallRequest
+
+# Mirrors MemoryStore._INTERNAL_HISTORY_SESSION_PREFIXES (cron:, dream:)
+# plus Collie's routine key prefix.
+_INTERNAL_TURN_KINDS = (
+    ("cron:", "cron"),
+    ("dream:", "automation"),
+    ("routine:", "routine"),
+)
+
+
+def turn_kind_for_session_key(session_key: str | None) -> str:
+    """Map an engine session key to a ``turn_events.turn_kind`` value."""
+    if session_key:
+        for prefix, kind in _INTERNAL_TURN_KINDS:
+            if session_key.startswith(prefix):
+                return kind
+    return "chat"
+
+
+def conversation_id_for_session_key(session_key: str | None) -> str | None:
+    """Desktop conversations use ``collie:<conversation_id>`` engine keys."""
+    if session_key and session_key.startswith("collie:"):
+        return session_key[len("collie:"):]
+    return None
+
+
+class TelemetryHook(AgentHook):
+    """Record one agent turn and its tool calls (fire-and-forget)."""
+
+    def __init__(
+        self,
+        recorder: RunRecorder,
+        *,
+        session_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self._recorder = recorder
+        self._session_key = session_key
+        self._metadata = dict(metadata or {})
+        self._turn_id: str | None = None
+        self._turn_started: float = 0.0
+        self._finished = False
+        self._tool_count = 0
+        self._tool_ids: dict[str, str] = {}
+        self._tool_starts: dict[str, float] = {}
+
+    # -- run lifecycle ---------------------------------------------------------
+
+    async def before_run(self, context: AgentRunHookContext) -> None:
+        self._turn_id = new_id()
+        self._turn_started = time.monotonic()
+        self._recorder.start_turn(
+            turn_id=self._turn_id,
+            session_key=self._session_key,
+            conversation_id=conversation_id_for_session_key(self._session_key),
+            turn_kind=turn_kind_for_session_key(self._session_key),
+        )
+
+    async def after_run(self, context: AgentRunHookContext) -> None:
+        self._finish_turn(context)
+
+    async def on_error(self, context: AgentRunHookContext) -> None:
+        self._finish_turn(context, forced_status="error")
+
+    async def on_finally(self, context: AgentRunHookContext) -> None:
+        if self._turn_id is not None and not self._finished:
+            status = "cancelled" if context.stop_reason == "cancelled" else "stopped"
+            self._finish_turn(context, forced_status=status)
+        # Turns that died mid-tool leave running rows behind — mark them.
+        for tool_id in list(self._tool_ids.values()):
+            self._recorder.finish_tool(
+                tool_id=tool_id,
+                turn_id=self._turn_id or "",
+                tool_name="unknown",
+                status="error",
+                error_message="Interrupted before completion.",
+            )
+        self._tool_ids.clear()
+
+    # -- tool lifecycle ----------------------------------------------------------
+
+    async def before_execute_tool(
+        self,
+        context: AgentHookContext,
+        tool_call: ToolCallRequest,
+        tool: Any,
+        params: Any,
+    ) -> None:
+        if self._turn_id is None:
+            return
+        tool_id = new_id()
+        self._tool_ids[tool_call.id] = tool_id
+        self._tool_starts[tool_call.id] = time.monotonic()
+        self._tool_count += 1
+        self._recorder.start_tool(
+            tool_id=tool_id,
+            turn_id=self._turn_id,
+            tool_name=getattr(tool_call, "name", "") or "",
+            input_summary=summarize(params, TURN_INPUT_LIMIT),
+        )
+
+    async def after_execute_tool(
+        self,
+        context: AgentHookContext,
+        tool_call: ToolCallRequest,
+        tool: Any,
+        params: Any,
+        result: Any,
+    ) -> None:
+        self._finish_tool(
+            tool_call,
+            status="ok",
+            output_summary=summarize(result, TOOL_OUTPUT_LIMIT),
+        )
+
+    async def on_execute_tool_error(
+        self,
+        context: AgentHookContext,
+        tool_call: ToolCallRequest,
+        tool: Any,
+        params: Any,
+        error: Any,
+    ) -> None:
+        self._finish_tool(tool_call, status="error", error_message=str(error))
+
+    # -- internals -----------------------------------------------------------------
+
+    def _finish_turn(
+        self, context: AgentRunHookContext, *, forced_status: str | None = None
+    ) -> None:
+        if self._turn_id is None or self._finished:
+            return
+        self._finished = True
+        if forced_status is not None:
+            status = forced_status
+        elif context.error is not None:
+            status = "error"
+        elif context.stop_reason == "cancelled":
+            status = "cancelled"
+        else:
+            status = "ok"
+        usage = context.usage or {}
+        self._recorder.finish_turn(
+            turn_id=self._turn_id,
+            status=status,
+            error_message=context.error,
+            tokens_in=int(usage.get("prompt_tokens") or 0),
+            tokens_out=int(usage.get("completion_tokens") or 0),
+            latency_ms=int((time.monotonic() - self._turn_started) * 1000),
+            tool_count=self._tool_count,
+        )
+
+    def _finish_tool(
+        self,
+        tool_call: ToolCallRequest,
+        *,
+        status: str,
+        output_summary: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        tool_id = self._tool_ids.pop(tool_call.id, None)
+        if tool_id is None:
+            return
+        started = self._tool_starts.pop(tool_call.id, time.monotonic())
+        self._recorder.finish_tool(
+            tool_id=tool_id,
+            turn_id=self._turn_id or "",
+            tool_name=getattr(tool_call, "name", "") or "",
+            status=status,
+            output_summary=output_summary,
+            error_message=error_message,
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+
+def create_telemetry_hook_factory(db: CollieDB) -> AgentTurnHookFactory:
+    """Build a per-turn TelemetryHook factory bound to one shared recorder."""
+
+    recorder = RunRecorder(db)
+
+    def factory(context: AgentTurnHookContext) -> AgentHook | None:
+        return TelemetryHook(
+            recorder,
+            session_key=context.session_key,
+            metadata=context.metadata,
+        )
+
+    return factory

--- a/collie-core/collie_core/telemetry/hook.py
+++ b/collie-core/collie_core/telemetry/hook.py
@@ -4,14 +4,20 @@ Registered as a per-turn hook factory on the AgentLoop (the same pattern
 as ``create_file_edit_activity_hook``) so every turn kind — chat, plan,
 routine, cron, automation, subagent — is recorded with zero edits to the
 nanobot orchestration core.
+
+All recorder calls run through ``asyncio.to_thread``: SQLite writes never
+block the event loop, and every write is wrapped so a telemetry failure
+can never break a turn.
 """
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
 from collie_core.db import CollieDB, new_id
+from collie_core.permissions.classifier import classify_tool
 from collie_core.telemetry.recorder import (
     TOOL_OUTPUT_LIMIT,
     TURN_INPUT_LIMIT,
@@ -35,6 +41,8 @@ _INTERNAL_TURN_KINDS = (
     ("routine:", "routine"),
 )
 
+_KNOWN_TURN_KINDS = {"chat", "plan", "routine", "cron", "subagent", "automation"}
+
 
 def turn_kind_for_session_key(session_key: str | None) -> str:
     """Map an engine session key to a ``turn_events.turn_kind`` value."""
@@ -50,6 +58,27 @@ def conversation_id_for_session_key(session_key: str | None) -> str | None:
     if session_key and session_key.startswith("collie:"):
         return session_key[len("collie:"):]
     return None
+
+
+def resolve_turn_kind(
+    session_key: str | None, metadata: dict[str, Any] | None = None
+) -> str:
+    """Resolve the turn kind from metadata first, then the session key.
+
+    Subagents pass an explicit ``turn_kind`` hint; routines dispatch via
+    ``permission_context.origin == "routine"`` (their session key is a
+    plain ``collie:`` desktop key). Everything else falls back to the
+    session-key prefixes.
+    """
+    hint = (metadata or {}).get("turn_kind")
+    if hint in _KNOWN_TURN_KINDS:
+        return hint
+    permission_context = (metadata or {}).get("permission_context") or {}
+    if permission_context.get("origin") == "routine" or permission_context.get(
+        "routine_id"
+    ):
+        return "routine"
+    return turn_kind_for_session_key(session_key)
 
 
 class TelemetryHook(AgentHook):
@@ -78,26 +107,28 @@ class TelemetryHook(AgentHook):
     async def before_run(self, context: AgentRunHookContext) -> None:
         self._turn_id = new_id()
         self._turn_started = time.monotonic()
-        self._recorder.start_turn(
+        await asyncio.to_thread(
+            self._recorder.start_turn,
             turn_id=self._turn_id,
             session_key=self._session_key,
             conversation_id=conversation_id_for_session_key(self._session_key),
-            turn_kind=turn_kind_for_session_key(self._session_key),
+            turn_kind=resolve_turn_kind(self._session_key, self._metadata),
         )
 
     async def after_run(self, context: AgentRunHookContext) -> None:
-        self._finish_turn(context)
+        await self._finish_turn(context)
 
     async def on_error(self, context: AgentRunHookContext) -> None:
-        self._finish_turn(context, forced_status="error")
+        await self._finish_turn(context, forced_status="error")
 
     async def on_finally(self, context: AgentRunHookContext) -> None:
         if self._turn_id is not None and not self._finished:
             status = "cancelled" if context.stop_reason == "cancelled" else "stopped"
-            self._finish_turn(context, forced_status=status)
+            await self._finish_turn(context, forced_status=status)
         # Turns that died mid-tool leave running rows behind — mark them.
         for tool_id in list(self._tool_ids.values()):
-            self._recorder.finish_tool(
+            await asyncio.to_thread(
+                self._recorder.finish_tool,
                 tool_id=tool_id,
                 turn_id=self._turn_id or "",
                 tool_name="unknown",
@@ -121,11 +152,15 @@ class TelemetryHook(AgentHook):
         self._tool_ids[tool_call.id] = tool_id
         self._tool_starts[tool_call.id] = time.monotonic()
         self._tool_count += 1
-        self._recorder.start_tool(
+        action, resource = self._classify(tool, tool_call, params)
+        await asyncio.to_thread(
+            self._recorder.start_tool,
             tool_id=tool_id,
             turn_id=self._turn_id,
             tool_name=getattr(tool_call, "name", "") or "",
             input_summary=summarize(params, TURN_INPUT_LIMIT),
+            action=action,
+            resource=resource,
         )
 
     async def after_execute_tool(
@@ -136,7 +171,7 @@ class TelemetryHook(AgentHook):
         params: Any,
         result: Any,
     ) -> None:
-        self._finish_tool(
+        await self._finish_tool(
             tool_call,
             status="ok",
             output_summary=summarize(result, TOOL_OUTPUT_LIMIT),
@@ -150,11 +185,48 @@ class TelemetryHook(AgentHook):
         params: Any,
         error: Any,
     ) -> None:
-        self._finish_tool(tool_call, status="error", error_message=str(error))
+        await self._finish_tool(tool_call, status="error", error_message=str(error))
+
+    async def on_tool_blocked(
+        self,
+        context: AgentHookContext,
+        tool_call: ToolCallRequest,
+        tool: Any,
+        params: Any,
+        status: str,
+        reason: str,
+    ) -> None:
+        """Record a tool that never executed (denied / prep / lookup block)."""
+        if self._turn_id is None:
+            return
+        self._tool_count += 1
+        action, resource = self._classify(tool, tool_call, params)
+        await asyncio.to_thread(
+            self._recorder.blocked_tool,
+            tool_id=new_id(),
+            turn_id=self._turn_id,
+            tool_name=getattr(tool_call, "name", "") or "",
+            status=status,
+            reason=reason,
+            input_summary=summarize(params, TURN_INPUT_LIMIT),
+            action=action,
+            resource=resource,
+        )
 
     # -- internals -----------------------------------------------------------------
 
-    def _finish_turn(
+    @staticmethod
+    def _classify(
+        tool: Any, tool_call: ToolCallRequest, params: Any
+    ) -> tuple[str | None, str | None]:
+        """Best-effort permission classification for action/resource columns."""
+        try:
+            request = classify_tool(tool, tool_call.name, params or {})
+            return request.action, request.resource
+        except Exception:
+            return None, None
+
+    async def _finish_turn(
         self, context: AgentRunHookContext, *, forced_status: str | None = None
     ) -> None:
         if self._turn_id is None or self._finished:
@@ -169,7 +241,8 @@ class TelemetryHook(AgentHook):
         else:
             status = "ok"
         usage = context.usage or {}
-        self._recorder.finish_turn(
+        await asyncio.to_thread(
+            self._recorder.finish_turn,
             turn_id=self._turn_id,
             status=status,
             error_message=context.error,
@@ -179,7 +252,7 @@ class TelemetryHook(AgentHook):
             tool_count=self._tool_count,
         )
 
-    def _finish_tool(
+    async def _finish_tool(
         self,
         tool_call: ToolCallRequest,
         *,
@@ -191,7 +264,8 @@ class TelemetryHook(AgentHook):
         if tool_id is None:
             return
         started = self._tool_starts.pop(tool_call.id, time.monotonic())
-        self._recorder.finish_tool(
+        await asyncio.to_thread(
+            self._recorder.finish_tool,
             tool_id=tool_id,
             turn_id=self._turn_id or "",
             tool_name=getattr(tool_call, "name", "") or "",

--- a/collie-core/collie_core/telemetry/hook.py
+++ b/collie-core/collie_core/telemetry/hook.py
@@ -5,25 +5,19 @@ as ``create_file_edit_activity_hook``) so every turn kind — chat, plan,
 routine, cron, automation, subagent — is recorded with zero edits to the
 nanobot orchestration core.
 
-All recorder calls run through ``asyncio.to_thread``: SQLite writes never
-block the event loop, and every write is wrapped so a telemetry failure
-can never break a turn.
+All recorder calls are fire-and-forget: they enqueue onto a dedicated
+writer thread and return immediately, so SQLite writes (and their
+redaction work) never run on — or stall — the event loop.
 """
 
 from __future__ import annotations
 
-import asyncio
 import time
 from typing import Any
 
 from collie_core.db import CollieDB, new_id
 from collie_core.permissions.classifier import classify_tool
-from collie_core.telemetry.recorder import (
-    TOOL_OUTPUT_LIMIT,
-    TURN_INPUT_LIMIT,
-    RunRecorder,
-    summarize,
-)
+from collie_core.telemetry.recorder import RunRecorder
 from nanobot.agent.hook import (
     AgentHook,
     AgentHookContext,
@@ -78,6 +72,8 @@ def resolve_turn_kind(
         "routine_id"
     ):
         return "routine"
+    if permission_context.get("execution_mode") == "plan":
+        return "plan"
     return turn_kind_for_session_key(session_key)
 
 
@@ -107,8 +103,7 @@ class TelemetryHook(AgentHook):
     async def before_run(self, context: AgentRunHookContext) -> None:
         self._turn_id = new_id()
         self._turn_started = time.monotonic()
-        await asyncio.to_thread(
-            self._recorder.start_turn,
+        self._recorder.start_turn(
             turn_id=self._turn_id,
             session_key=self._session_key,
             conversation_id=conversation_id_for_session_key(self._session_key),
@@ -127,8 +122,7 @@ class TelemetryHook(AgentHook):
             await self._finish_turn(context, forced_status=status)
         # Turns that died mid-tool leave running rows behind — mark them.
         for tool_id in list(self._tool_ids.values()):
-            await asyncio.to_thread(
-                self._recorder.finish_tool,
+            self._recorder.finish_tool(
                 tool_id=tool_id,
                 turn_id=self._turn_id or "",
                 tool_name="unknown",
@@ -153,12 +147,11 @@ class TelemetryHook(AgentHook):
         self._tool_starts[tool_call.id] = time.monotonic()
         self._tool_count += 1
         action, resource = self._classify(tool, tool_call, params)
-        await asyncio.to_thread(
-            self._recorder.start_tool,
+        self._recorder.start_tool(
             tool_id=tool_id,
             turn_id=self._turn_id,
             tool_name=getattr(tool_call, "name", "") or "",
-            input_summary=summarize(params, TURN_INPUT_LIMIT),
+            params=params,
             action=action,
             resource=resource,
         )
@@ -171,11 +164,7 @@ class TelemetryHook(AgentHook):
         params: Any,
         result: Any,
     ) -> None:
-        await self._finish_tool(
-            tool_call,
-            status="ok",
-            output_summary=summarize(result, TOOL_OUTPUT_LIMIT),
-        )
+        await self._finish_tool(tool_call, status="ok", result=result)
 
     async def on_execute_tool_error(
         self,
@@ -201,14 +190,13 @@ class TelemetryHook(AgentHook):
             return
         self._tool_count += 1
         action, resource = self._classify(tool, tool_call, params)
-        await asyncio.to_thread(
-            self._recorder.blocked_tool,
+        self._recorder.blocked_tool(
             tool_id=new_id(),
             turn_id=self._turn_id,
             tool_name=getattr(tool_call, "name", "") or "",
             status=status,
             reason=reason,
-            input_summary=summarize(params, TURN_INPUT_LIMIT),
+            params=params,
             action=action,
             resource=resource,
         )
@@ -238,11 +226,14 @@ class TelemetryHook(AgentHook):
             status = "error"
         elif context.stop_reason == "cancelled":
             status = "cancelled"
-        else:
+        elif context.stop_reason in (None, "completed"):
             status = "ok"
+        else:
+            # Incomplete terminal reasons: max_iterations, tool_error,
+            # empty_final_response, ...
+            status = "stopped"
         usage = context.usage or {}
-        await asyncio.to_thread(
-            self._recorder.finish_turn,
+        self._recorder.finish_turn(
             turn_id=self._turn_id,
             status=status,
             error_message=context.error,
@@ -257,20 +248,19 @@ class TelemetryHook(AgentHook):
         tool_call: ToolCallRequest,
         *,
         status: str,
-        output_summary: str | None = None,
+        result: Any = None,
         error_message: str | None = None,
     ) -> None:
         tool_id = self._tool_ids.pop(tool_call.id, None)
         if tool_id is None:
             return
         started = self._tool_starts.pop(tool_call.id, time.monotonic())
-        await asyncio.to_thread(
-            self._recorder.finish_tool,
+        self._recorder.finish_tool(
             tool_id=tool_id,
             turn_id=self._turn_id or "",
             tool_name=getattr(tool_call, "name", "") or "",
             status=status,
-            output_summary=output_summary,
+            result=result,
             error_message=error_message,
             latency_ms=int((time.monotonic() - started) * 1000),
         )
@@ -279,7 +269,7 @@ class TelemetryHook(AgentHook):
 def create_telemetry_hook_factory(db: CollieDB) -> AgentTurnHookFactory:
     """Build a per-turn TelemetryHook factory bound to one shared recorder."""
 
-    recorder = RunRecorder(db)
+    recorder = RunRecorder.for_db(db)
 
     def factory(context: AgentTurnHookContext) -> AgentHook | None:
         return TelemetryHook(

--- a/collie-core/collie_core/telemetry/recorder.py
+++ b/collie-core/collie_core/telemetry/recorder.py
@@ -1,0 +1,154 @@
+"""Fire-and-forget run telemetry (PR 1 — run records).
+
+The recorder is deliberately defensive: every write is wrapped so a
+telemetry failure can never break or slow down an agent turn.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loguru import logger
+
+from collie_core.db import CollieDB, utc_now
+from collie_core.permissions.classifier import redact_parameters
+
+TURN_INPUT_LIMIT = 500
+TOOL_OUTPUT_LIMIT = 1000
+
+
+def summarize(value: Any, limit: int) -> str | None:
+    """Redact and truncate a value for telemetry storage.
+
+    Dicts are run through ``redact_parameters`` (secrets become
+    ``[redacted]``); everything else is stringified. Output never exceeds
+    ``limit`` characters. Core invariant: secrets never reach telemetry.
+    """
+    try:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            text = json.dumps(
+                redact_parameters(value), ensure_ascii=False, default=str
+            )
+        else:
+            text = str(value)
+        text = " ".join(text.split())
+        return text if len(text) <= limit else text[: limit - 3] + "..."
+    except Exception:
+        logger.exception("telemetry summarize failed")
+        return None
+
+
+class RunRecorder:
+    """Best-effort writer of turn/tool telemetry rows."""
+
+    def __init__(self, db: CollieDB) -> None:
+        self._db = db
+
+    def provider_model(self) -> tuple[str | None, str | None]:
+        try:
+            provider = self._db.get_setting("provider.name") or None
+            model = self._db.get_setting("provider.model") or None
+            return provider, model
+        except Exception:
+            logger.exception("telemetry provider resolution failed")
+            return None, None
+
+    # -- turn lifecycle -------------------------------------------------------
+
+    def start_turn(
+        self,
+        *,
+        turn_id: str,
+        session_key: str | None = None,
+        conversation_id: str | None = None,
+        turn_kind: str = "chat",
+    ) -> None:
+        try:
+            provider, model = self.provider_model()
+            self._db.record_turn_event(
+                turn_id=turn_id,
+                conversation_id=conversation_id,
+                session_key=session_key,
+                turn_kind=turn_kind,
+                provider=provider,
+                model=model,
+                status="running",
+                started_at=utc_now(),
+            )
+        except Exception:
+            logger.exception("telemetry start_turn failed")
+
+    def finish_turn(
+        self,
+        *,
+        turn_id: str,
+        status: str,
+        error_message: str | None = None,
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        latency_ms: int | None = None,
+        tool_count: int = 0,
+    ) -> None:
+        try:
+            self._db.record_turn_event(
+                turn_id=turn_id,
+                status=status,
+                error_message=error_message,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                latency_ms=latency_ms,
+                tool_count=tool_count,
+                finished_at=utc_now(),
+            )
+        except Exception:
+            logger.exception("telemetry finish_turn failed")
+
+    # -- tool lifecycle -------------------------------------------------------
+
+    def start_tool(
+        self,
+        *,
+        tool_id: str,
+        turn_id: str,
+        tool_name: str,
+        input_summary: str | None = None,
+    ) -> None:
+        try:
+            self._db.record_tool_event(
+                tool_id=tool_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                input_summary=input_summary,
+                status="running",
+                started_at=utc_now(),
+            )
+        except Exception:
+            logger.exception("telemetry start_tool failed")
+
+    def finish_tool(
+        self,
+        *,
+        tool_id: str,
+        turn_id: str,
+        tool_name: str,
+        status: str,
+        output_summary: str | None = None,
+        error_message: str | None = None,
+        latency_ms: int | None = None,
+    ) -> None:
+        try:
+            self._db.record_tool_event(
+                tool_id=tool_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                status=status,
+                output_summary=output_summary,
+                error_message=error_message,
+                latency_ms=latency_ms,
+                finished_at=utc_now(),
+            )
+        except Exception:
+            logger.exception("telemetry finish_tool failed")

--- a/collie-core/collie_core/telemetry/recorder.py
+++ b/collie-core/collie_core/telemetry/recorder.py
@@ -1,13 +1,21 @@
 """Fire-and-forget run telemetry (PR 1 — run records).
 
-The recorder is deliberately defensive: every write is wrapped so a
-telemetry failure can never break or slow down an agent turn.
+The recorder is deliberately defensive: every write is enqueued onto a
+dedicated writer thread and **never awaited**, so telemetry can neither
+break nor slow down an agent turn. A single FIFO consumer preserves write
+ordering (start before finish), and every write is wrapped so failures
+are logged and swallowed. All redaction/sanitization/truncation happens
+inside the writer thread — the event loop only enqueues.
 """
 
 from __future__ import annotations
 
 import json
+import queue
 import re
+import threading
+import weakref
+from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
@@ -25,8 +33,11 @@ _SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Authorization headers and bare Bearer tokens
     re.compile(r"(?i)(authorization\s*[:=]\s*)(?:bearer\s+)?\S+"),
     re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{16,}"),
-    # OpenAI/Anthropic-style sk- keys
-    re.compile(r"\bsk-[A-Za-z0-9]{16,}"),
+    # OpenAI/Anthropic-style sk- keys (hyphens allowed: sk-proj-, sk-ant-api03-)
+    re.compile(r"\bsk-[A-Za-z0-9-]{16,}"),
+    # Google API keys (AIza...) and OAuth tokens (ya29...)
+    re.compile(r"\bAIza[0-9A-Za-z_\-]{28,}"),
+    re.compile(r"\bya29\.[A-Za-z0-9_\-\.]{10,}"),
     # GitHub tokens
     re.compile(r"\bghp_[A-Za-z0-9]{20,}"),
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"),
@@ -81,19 +92,68 @@ def summarize(value: Any, limit: int) -> str | None:
 
 
 class RunRecorder:
-    """Best-effort writer of turn/tool telemetry rows."""
+    """Best-effort writer of turn/tool telemetry rows.
+
+    Thread-safe and fire-and-forget: the caller enqueues a write and
+    returns immediately; a single daemon writer thread applies writes in
+    FIFO order. Use ``for_db`` to share one recorder per database (loop
+    rebuilds reuse the same writer thread).
+    """
+
+    _RECORDERS: "weakref.WeakKeyDictionary[CollieDB, RunRecorder]" = (
+        weakref.WeakKeyDictionary()
+    )
+
+    @classmethod
+    def for_db(cls, db: CollieDB) -> "RunRecorder":
+        """Return the shared recorder for a database (creates on first use)."""
+        recorder = cls._RECORDERS.get(db)
+        if recorder is None:
+            recorder = cls(db)
+            cls._RECORDERS[db] = recorder
+        return recorder
 
     def __init__(self, db: CollieDB) -> None:
         self._db = db
+        self._queue: queue.Queue[Callable[[], None] | None] = queue.Queue()
+        self._thread = threading.Thread(
+            target=self._writer_loop,
+            name="collie-telemetry",
+            daemon=True,
+        )
+        self._thread.start()
 
-    def provider_model(self) -> tuple[str | None, str | None]:
+    # -- writer thread -------------------------------------------------------
+
+    def _writer_loop(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            try:
+                item()
+            except Exception:
+                logger.exception("telemetry write failed (swallowed)")
+
+    def _enqueue(self, fn: Callable[[], None]) -> None:
         try:
-            provider = self._db.get_setting("provider.name") or None
-            model = self._db.get_setting("provider.model") or None
-            return provider, model
+            self._queue.put_nowait(fn)
         except Exception:
-            logger.exception("telemetry provider resolution failed")
-            return None, None
+            logger.exception("telemetry enqueue failed (swallowed)")
+
+    def flush(self, timeout: float = 5.0) -> None:
+        """Block until all previously enqueued writes have been applied."""
+        done = threading.Event()
+        self._enqueue(done.set)
+        done.wait(timeout)
+
+    def shutdown(self) -> None:
+        """Stop the writer thread (drains remaining writes first)."""
+        try:
+            self._queue.put(None)
+            self._thread.join(timeout=1.0)
+        except Exception:
+            logger.exception("telemetry shutdown failed")
 
     # -- turn lifecycle -------------------------------------------------------
 
@@ -105,20 +165,25 @@ class RunRecorder:
         conversation_id: str | None = None,
         turn_kind: str = "chat",
     ) -> None:
-        try:
-            provider, model = self.provider_model()
-            self._db.record_turn_event(
-                turn_id=turn_id,
-                conversation_id=conversation_id,
-                session_key=session_key,
-                turn_kind=turn_kind,
-                provider=provider,
-                model=model,
-                status="running",
-                started_at=utc_now(),
-            )
-        except Exception:
-            logger.exception("telemetry start_turn failed")
+        db = self._db
+
+        def _write() -> None:
+            try:
+                provider, model = self.provider_model()
+                db.record_turn_event(
+                    turn_id=turn_id,
+                    conversation_id=conversation_id,
+                    session_key=session_key,
+                    turn_kind=turn_kind,
+                    provider=provider,
+                    model=model,
+                    status="running",
+                    started_at=utc_now(),
+                )
+            except Exception:
+                logger.exception("telemetry start_turn failed")
+
+        self._enqueue(_write)
 
     def finish_turn(
         self,
@@ -131,21 +196,26 @@ class RunRecorder:
         latency_ms: int | None = None,
         tool_count: int = 0,
     ) -> None:
-        try:
-            self._db.record_turn_event(
-                turn_id=turn_id,
-                status=status,
-                error_message=(
-                    sanitize_text(error_message) if error_message else None
-                ),
-                tokens_in=tokens_in,
-                tokens_out=tokens_out,
-                latency_ms=latency_ms,
-                tool_count=tool_count,
-                finished_at=utc_now(),
-            )
-        except Exception:
-            logger.exception("telemetry finish_turn failed")
+        db = self._db
+
+        def _write() -> None:
+            try:
+                db.record_turn_event(
+                    turn_id=turn_id,
+                    status=status,
+                    error_message=(
+                        sanitize_text(error_message) if error_message else None
+                    ),
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                    latency_ms=latency_ms,
+                    tool_count=tool_count,
+                    finished_at=utc_now(),
+                )
+            except Exception:
+                logger.exception("telemetry finish_turn failed")
+
+        self._enqueue(_write)
 
     # -- tool lifecycle -------------------------------------------------------
 
@@ -155,23 +225,28 @@ class RunRecorder:
         tool_id: str,
         turn_id: str,
         tool_name: str,
-        input_summary: str | None = None,
+        params: Any = None,
         action: str | None = None,
         resource: str | None = None,
     ) -> None:
-        try:
-            self._db.record_tool_event(
-                tool_id=tool_id,
-                turn_id=turn_id,
-                tool_name=tool_name,
-                input_summary=input_summary,
-                action=action,
-                resource=sanitize_text(resource) if resource else None,
-                status="running",
-                started_at=utc_now(),
-            )
-        except Exception:
-            logger.exception("telemetry start_tool failed")
+        db = self._db
+
+        def _write() -> None:
+            try:
+                db.record_tool_event(
+                    tool_id=tool_id,
+                    turn_id=turn_id,
+                    tool_name=tool_name,
+                    input_summary=summarize(params, TURN_INPUT_LIMIT),
+                    action=action,
+                    resource=sanitize_text(resource) if resource else None,
+                    status="running",
+                    started_at=utc_now(),
+                )
+            except Exception:
+                logger.exception("telemetry start_tool failed")
+
+        self._enqueue(_write)
 
     def finish_tool(
         self,
@@ -180,25 +255,34 @@ class RunRecorder:
         turn_id: str,
         tool_name: str,
         status: str,
-        output_summary: str | None = None,
+        result: Any = None,
         error_message: str | None = None,
         latency_ms: int | None = None,
     ) -> None:
-        try:
-            self._db.record_tool_event(
-                tool_id=tool_id,
-                turn_id=turn_id,
-                tool_name=tool_name,
-                status=status,
-                output_summary=output_summary,
-                error_message=(
-                    sanitize_text(error_message) if error_message else None
-                ),
-                latency_ms=latency_ms,
-                finished_at=utc_now(),
-            )
-        except Exception:
-            logger.exception("telemetry finish_tool failed")
+        db = self._db
+
+        def _write() -> None:
+            try:
+                db.record_tool_event(
+                    tool_id=tool_id,
+                    turn_id=turn_id,
+                    tool_name=tool_name,
+                    status=status,
+                    output_summary=(
+                        summarize(result, TOOL_OUTPUT_LIMIT)
+                        if status == "ok"
+                        else None
+                    ),
+                    error_message=(
+                        sanitize_text(error_message) if error_message else None
+                    ),
+                    latency_ms=latency_ms,
+                    finished_at=utc_now(),
+                )
+            except Exception:
+                logger.exception("telemetry finish_tool failed")
+
+        self._enqueue(_write)
 
     def blocked_tool(
         self,
@@ -207,8 +291,8 @@ class RunRecorder:
         turn_id: str,
         tool_name: str,
         status: str,
-        reason: str | None,
-        input_summary: str | None = None,
+        reason: str | None = None,
+        params: Any = None,
         action: str | None = None,
         resource: str | None = None,
     ) -> None:
@@ -217,21 +301,35 @@ class RunRecorder:
         These paths return before ``before_execute_tool`` fires, so the
         row is written complete in a single insert.
         """
+        db = self._db
+
+        def _write() -> None:
+            try:
+                now = utc_now()
+                db.record_tool_event(
+                    tool_id=tool_id,
+                    turn_id=turn_id,
+                    tool_name=tool_name,
+                    status=status,
+                    error_message=(
+                        sanitize_text(reason) if reason else None
+                    ),
+                    input_summary=summarize(params, TURN_INPUT_LIMIT),
+                    action=action,
+                    resource=sanitize_text(resource) if resource else None,
+                    started_at=now,
+                    finished_at=now,
+                )
+            except Exception:
+                logger.exception("telemetry blocked_tool failed")
+
+        self._enqueue(_write)
+
+    def provider_model(self) -> tuple[str | None, str | None]:
         try:
-            now = utc_now()
-            self._db.record_tool_event(
-                tool_id=tool_id,
-                turn_id=turn_id,
-                tool_name=tool_name,
-                status=status,
-                error_message=(
-                    sanitize_text(reason) if reason else None
-                ),
-                input_summary=input_summary,
-                action=action,
-                resource=sanitize_text(resource) if resource else None,
-                started_at=now,
-                finished_at=now,
-            )
+            provider = self._db.get_setting("provider.name") or None
+            model = self._db.get_setting("provider.model") or None
+            return provider, model
         except Exception:
-            logger.exception("telemetry blocked_tool failed")
+            logger.exception("telemetry provider resolution failed")
+            return None, None

--- a/collie-core/collie_core/telemetry/recorder.py
+++ b/collie-core/collie_core/telemetry/recorder.py
@@ -4,8 +4,21 @@ The recorder is deliberately defensive: every write is enqueued onto a
 dedicated writer thread and **never awaited**, so telemetry can neither
 break nor slow down an agent turn. A single FIFO consumer preserves write
 ordering (start before finish), and every write is wrapped so failures
-are logged and swallowed. All redaction/sanitization/truncation happens
-inside the writer thread — the event loop only enqueues.
+are logged and swallowed.
+
+Guarantees / lifecycle:
+- ``for_db`` shares one recorder per database; ``active_for`` looks it up
+  without creating one.
+- ``suspend()`` drops queued + future writes (used by ``clear_all`` so a
+  wipe can never be resurrected by pending telemetry); ``resume()``
+  re-enables recording.
+- ``flush()`` blocks until previously enqueued writes are applied;
+  ``shutdown()`` flushes, stops the writer thread, and unregisters the
+  recorder so closed databases are not retained.
+- The queue is bounded (``MAX_QUEUED_WRITES``); overflow and suspended/
+  stopped writes are dropped with a diagnostic counter.
+- Timestamps and provider/model are captured at enqueue time (event
+  time), so backlog never corrupts chronological evidence.
 """
 
 from __future__ import annotations
@@ -25,6 +38,10 @@ from collie_core.permissions.classifier import redact_parameters
 
 TURN_INPUT_LIMIT = 500
 TOOL_OUTPUT_LIMIT = 1000
+
+# Cap on in-flight telemetry writes. A healthy turn enqueues a handful;
+# under a stuck database the queue drops (never blocks, never grows).
+MAX_QUEUED_WRITES = 500
 
 # Secret-shaped patterns scrubbed from ANY telemetry text (outputs, errors,
 # resources). Keys are already handled by ``redact_parameters``; this layer
@@ -96,8 +113,7 @@ class RunRecorder:
 
     Thread-safe and fire-and-forget: the caller enqueues a write and
     returns immediately; a single daemon writer thread applies writes in
-    FIFO order. Use ``for_db`` to share one recorder per database (loop
-    rebuilds reuse the same writer thread).
+    FIFO order.
     """
 
     _RECORDERS: "weakref.WeakKeyDictionary[CollieDB, RunRecorder]" = (
@@ -106,16 +122,29 @@ class RunRecorder:
 
     @classmethod
     def for_db(cls, db: CollieDB) -> "RunRecorder":
-        """Return the shared recorder for a database (creates on first use)."""
+        """Return the shared live recorder for a database (creates one)."""
         recorder = cls._RECORDERS.get(db)
-        if recorder is None:
+        if recorder is None or recorder._stopped:
             recorder = cls(db)
             cls._RECORDERS[db] = recorder
         return recorder
 
+    @classmethod
+    def active_for(cls, db: CollieDB) -> "RunRecorder | None":
+        """Return the shared live recorder for a database, if any."""
+        recorder = cls._RECORDERS.get(db)
+        if recorder is not None and not recorder._stopped:
+            return recorder
+        return None
+
     def __init__(self, db: CollieDB) -> None:
         self._db = db
-        self._queue: queue.Queue[Callable[[], None] | None] = queue.Queue()
+        self._stopped = False
+        self._suspended = False
+        self.dropped_writes = 0
+        self._queue: queue.Queue[Callable[[], None] | None] = queue.Queue(
+            maxsize=MAX_QUEUED_WRITES
+        )
         self._thread = threading.Thread(
             target=self._writer_loop,
             name="collie-telemetry",
@@ -130,30 +159,73 @@ class RunRecorder:
             item = self._queue.get()
             if item is None:
                 return
+            if self._suspended or self._stopped:
+                self.dropped_writes += 1
+                continue
             try:
                 item()
             except Exception:
                 logger.exception("telemetry write failed (swallowed)")
 
     def _enqueue(self, fn: Callable[[], None]) -> None:
+        if self._stopped or self._suspended:
+            self.dropped_writes += 1
+            return
         try:
             self._queue.put_nowait(fn)
-        except Exception:
-            logger.exception("telemetry enqueue failed (swallowed)")
+        except queue.Full:
+            self.dropped_writes += 1
+            if self.dropped_writes == 1:
+                logger.warning(
+                    "telemetry queue full — dropping writes "
+                    "(bounded at {})",
+                    MAX_QUEUED_WRITES,
+                )
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def suspend(self) -> None:
+        """Drop queued and future writes (used by ``clear_all``)."""
+        self._suspended = True
+
+    def resume(self) -> None:
+        """Re-enable recording after a suspend."""
+        self._suspended = False
+
+    def suspend_and_drain(self) -> None:
+        """Suspend and wait until the queue is empty (drops everything)."""
+        self.suspend()
+        self.flush()
 
     def flush(self, timeout: float = 5.0) -> None:
         """Block until all previously enqueued writes have been applied."""
+        if self._stopped:
+            return
         done = threading.Event()
-        self._enqueue(done.set)
+        try:
+            self._queue.put_nowait(done.set)
+        except queue.Full:
+            return
         done.wait(timeout)
 
     def shutdown(self) -> None:
-        """Stop the writer thread (drains remaining writes first)."""
+        """Flush pending writes, stop the writer, unregister the recorder."""
+        if self._stopped:
+            return
+        self.flush()
+        self._stopped = True
         try:
             self._queue.put(None)
-            self._thread.join(timeout=1.0)
+            self._thread.join(timeout=2.0)
         except Exception:
             logger.exception("telemetry shutdown failed")
+        # Break the registry -> recorder -> database retention cycle so a
+        # closed database can be garbage-collected.
+        try:
+            if self._RECORDERS.get(self._db) is self:
+                del self._RECORDERS[self._db]
+        except Exception:
+            logger.exception("telemetry registry cleanup failed")
 
     # -- turn lifecycle -------------------------------------------------------
 
@@ -166,10 +238,13 @@ class RunRecorder:
         turn_kind: str = "chat",
     ) -> None:
         db = self._db
+        # Event-time snapshot: captured before enqueueing so backlog cannot
+        # shift timestamps or provider/model into the future.
+        started_at = utc_now()
+        provider, model = self.provider_model()
 
         def _write() -> None:
             try:
-                provider, model = self.provider_model()
                 db.record_turn_event(
                     turn_id=turn_id,
                     conversation_id=conversation_id,
@@ -178,7 +253,7 @@ class RunRecorder:
                     provider=provider,
                     model=model,
                     status="running",
-                    started_at=utc_now(),
+                    started_at=started_at,
                 )
             except Exception:
                 logger.exception("telemetry start_turn failed")
@@ -197,6 +272,7 @@ class RunRecorder:
         tool_count: int = 0,
     ) -> None:
         db = self._db
+        finished_at = utc_now()
 
         def _write() -> None:
             try:
@@ -210,7 +286,7 @@ class RunRecorder:
                     tokens_out=tokens_out,
                     latency_ms=latency_ms,
                     tool_count=tool_count,
-                    finished_at=utc_now(),
+                    finished_at=finished_at,
                 )
             except Exception:
                 logger.exception("telemetry finish_turn failed")
@@ -230,6 +306,7 @@ class RunRecorder:
         resource: str | None = None,
     ) -> None:
         db = self._db
+        started_at = utc_now()
 
         def _write() -> None:
             try:
@@ -241,7 +318,7 @@ class RunRecorder:
                     action=action,
                     resource=sanitize_text(resource) if resource else None,
                     status="running",
-                    started_at=utc_now(),
+                    started_at=started_at,
                 )
             except Exception:
                 logger.exception("telemetry start_tool failed")
@@ -260,6 +337,7 @@ class RunRecorder:
         latency_ms: int | None = None,
     ) -> None:
         db = self._db
+        finished_at = utc_now()
 
         def _write() -> None:
             try:
@@ -277,7 +355,7 @@ class RunRecorder:
                         sanitize_text(error_message) if error_message else None
                     ),
                     latency_ms=latency_ms,
-                    finished_at=utc_now(),
+                    finished_at=finished_at,
                 )
             except Exception:
                 logger.exception("telemetry finish_tool failed")
@@ -302,10 +380,10 @@ class RunRecorder:
         row is written complete in a single insert.
         """
         db = self._db
+        now = utc_now()
 
         def _write() -> None:
             try:
-                now = utc_now()
                 db.record_tool_event(
                     tool_id=tool_id,
                     turn_id=turn_id,

--- a/collie-core/collie_core/telemetry/recorder.py
+++ b/collie-core/collie_core/telemetry/recorder.py
@@ -7,6 +7,7 @@ telemetry failure can never break or slow down an agent turn.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from loguru import logger
@@ -17,13 +18,50 @@ from collie_core.permissions.classifier import redact_parameters
 TURN_INPUT_LIMIT = 500
 TOOL_OUTPUT_LIMIT = 1000
 
+# Secret-shaped patterns scrubbed from ANY telemetry text (outputs, errors,
+# resources). Keys are already handled by ``redact_parameters``; this layer
+# catches secrets that appear inside string values.
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Authorization headers and bare Bearer tokens
+    re.compile(r"(?i)(authorization\s*[:=]\s*)(?:bearer\s+)?\S+"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{16,}"),
+    # OpenAI/Anthropic-style sk- keys
+    re.compile(r"\bsk-[A-Za-z0-9]{16,}"),
+    # GitHub tokens
+    re.compile(r"\bghp_[A-Za-z0-9]{20,}"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"),
+    # AWS access key ids
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    # Slack tokens
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}"),
+    # Generic key=value / key: value with a long value
+    re.compile(
+        r"(?i)\b(api[_-]?key|token|secret|password|passwd|credential)\b"
+        r"\s*[:=]\s*[\"']?[A-Za-z0-9._~+/=!@#$%^&*-]{12,}"
+    ),
+    # PEM private keys
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        re.DOTALL,
+    ),
+)
+
+
+def sanitize_text(text: str) -> str:
+    """Scrub secret-shaped values from arbitrary telemetry text."""
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[redacted]", text)
+    return text
+
 
 def summarize(value: Any, limit: int) -> str | None:
     """Redact and truncate a value for telemetry storage.
 
-    Dicts are run through ``redact_parameters`` (secrets become
-    ``[redacted]``); everything else is stringified. Output never exceeds
-    ``limit`` characters. Core invariant: secrets never reach telemetry.
+    Dicts are run through ``redact_parameters`` (secret-named keys become
+    ``[redacted]``); everything is then passed through ``sanitize_text`` so
+    secret-shaped values inside innocent keys or bare strings never reach
+    the database. Output never exceeds ``limit`` characters. Core
+    invariant: secrets never reach telemetry.
     """
     try:
         if value is None:
@@ -34,6 +72,7 @@ def summarize(value: Any, limit: int) -> str | None:
             )
         else:
             text = str(value)
+        text = sanitize_text(text)
         text = " ".join(text.split())
         return text if len(text) <= limit else text[: limit - 3] + "..."
     except Exception:
@@ -96,7 +135,9 @@ class RunRecorder:
             self._db.record_turn_event(
                 turn_id=turn_id,
                 status=status,
-                error_message=error_message,
+                error_message=(
+                    sanitize_text(error_message) if error_message else None
+                ),
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
                 latency_ms=latency_ms,
@@ -115,6 +156,8 @@ class RunRecorder:
         turn_id: str,
         tool_name: str,
         input_summary: str | None = None,
+        action: str | None = None,
+        resource: str | None = None,
     ) -> None:
         try:
             self._db.record_tool_event(
@@ -122,6 +165,8 @@ class RunRecorder:
                 turn_id=turn_id,
                 tool_name=tool_name,
                 input_summary=input_summary,
+                action=action,
+                resource=sanitize_text(resource) if resource else None,
                 status="running",
                 started_at=utc_now(),
             )
@@ -146,9 +191,47 @@ class RunRecorder:
                 tool_name=tool_name,
                 status=status,
                 output_summary=output_summary,
-                error_message=error_message,
+                error_message=(
+                    sanitize_text(error_message) if error_message else None
+                ),
                 latency_ms=latency_ms,
                 finished_at=utc_now(),
             )
         except Exception:
             logger.exception("telemetry finish_tool failed")
+
+    def blocked_tool(
+        self,
+        *,
+        tool_id: str,
+        turn_id: str,
+        tool_name: str,
+        status: str,
+        reason: str | None,
+        input_summary: str | None = None,
+        action: str | None = None,
+        resource: str | None = None,
+    ) -> None:
+        """Record a tool that never executed (denied / prep / lookup block).
+
+        These paths return before ``before_execute_tool`` fires, so the
+        row is written complete in a single insert.
+        """
+        try:
+            now = utc_now()
+            self._db.record_tool_event(
+                tool_id=tool_id,
+                turn_id=turn_id,
+                tool_name=tool_name,
+                status=status,
+                error_message=(
+                    sanitize_text(reason) if reason else None
+                ),
+                input_summary=input_summary,
+                action=action,
+                resource=sanitize_text(resource) if resource else None,
+                started_at=now,
+                finished_at=now,
+            )
+        except Exception:
+            logger.exception("telemetry blocked_tool failed")

--- a/collie-core/nanobot/agent/hook.py
+++ b/collie-core/nanobot/agent/hook.py
@@ -122,6 +122,25 @@ class AgentHook:
     ) -> None:
         pass
 
+    async def on_tool_blocked(
+        self,
+        context: AgentHookContext,
+        tool_call: ToolCallRequest,
+        tool: Any,
+        params: Any,
+        status: str,
+        reason: str,
+    ) -> None:
+        """Observe a tool call that never executed.
+
+        Fired for authorization denials, preparation failures, and
+        repeated-lookup blocks — paths that return before
+        ``before_execute_tool``. ``status`` is the effective tool status
+        (``denied`` or ``error``); ``reason`` is the human-readable cause.
+        Observers only: the default is a no-op.
+        """
+        pass
+
     async def emit_reasoning(self, reasoning_content: str | None) -> None:
         pass
 
@@ -236,6 +255,25 @@ class CompositeHook(AgentHook):
             tool,
             params,
             error,
+        )
+
+    async def on_tool_blocked(
+        self,
+        context: AgentHookContext,
+        tool_call: ToolCallRequest,
+        tool: Any,
+        params: Any,
+        status: str,
+        reason: str,
+    ) -> None:
+        await self._for_each_hook_safe(
+            "on_tool_blocked",
+            context,
+            tool_call,
+            tool,
+            params,
+            status,
+            reason,
         )
 
     async def emit_reasoning(self, reasoning_content: str | None) -> None:

--- a/collie-core/nanobot/agent/runner.py
+++ b/collie-core/nanobot/agent/runner.py
@@ -1185,6 +1185,10 @@ class AgentRunner:
                 "status": "error",
                 "detail": "repeated external lookup blocked",
             }
+            await hook.on_tool_blocked(
+                context, tool_call, None, tool_call.arguments,
+                "error", "repeated external lookup blocked",
+            )
             if spec.fail_on_tool_error:
                 return lookup_error + hint, event, RuntimeError(lookup_error)
             return lookup_error + hint, event, None
@@ -1201,6 +1205,9 @@ class AgentRunner:
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
             }
+            await hook.on_tool_blocked(
+                context, tool_call, tool, params, "error", prep_error,
+            )
             handled = self._classify_violation(
                 raw_text=prep_error,
                 soft_payload=prep_error + hint,
@@ -1241,6 +1248,9 @@ class AgentRunner:
                     "status": "denied",
                     "detail": detail[:120],
                 }
+                await hook.on_tool_blocked(
+                    context, tool_call, tool, params, "denied", detail,
+                )
                 payload = f"Permission denied: {detail}"
                 return payload, event, (
                     RuntimeError(payload) if spec.fail_on_tool_error else None

--- a/collie-core/nanobot/agent/subagent.py
+++ b/collie-core/nanobot/agent/subagent.py
@@ -11,7 +11,13 @@ from typing import Any, Callable
 
 from loguru import logger
 
-from nanobot.agent.hook import AgentHook, AgentHookContext
+from nanobot.agent.hook import (
+    AgentHook,
+    AgentHookContext,
+    AgentTurnHookContext,
+    AgentTurnHookFactory,
+    CompositeHook,
+)
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
 from nanobot.agent.tools.context import (
     RequestContext,
@@ -95,6 +101,7 @@ class SubagentManager:
         max_concurrent_subagents: int | None = None,
         fail_on_tool_error: bool | None = None,
         llm_wall_timeout_for_session: Callable[[str | None], float | None] | None = None,
+        hook_factories: list[AgentTurnHookFactory] | None = None,
     ):
         if workspace is None:
             raise TypeError("SubagentManager.__init__() missing required argument: 'workspace'")
@@ -144,6 +151,7 @@ class SubagentManager:
         )
         self.runner = AgentRunner()
         self._llm_wall_timeout_for_session = llm_wall_timeout_for_session
+        self.hook_factories: list[AgentTurnHookFactory] = list(hook_factories or [])
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
@@ -316,6 +324,29 @@ class SubagentManager:
                 if self._llm_wall_timeout_for_session
                 else None
             )
+            base_hook = _SubagentHook(task_id, status)
+            if self.hook_factories:
+                turn_context = AgentTurnHookContext(
+                    on_progress=None,
+                    workspace=root,
+                    channel=str(origin.get("channel") or "cli"),
+                    chat_id=str(origin.get("chat_id") or "direct"),
+                    message_id=origin_message_id,
+                    session_key=sess_key,
+                    metadata={"turn_kind": "subagent"},
+                )
+                extra_hooks = [
+                    factory(turn_context)
+                    for factory in self.hook_factories
+                ]
+                extra_hooks = [h for h in extra_hooks if h is not None]
+                hook = (
+                    CompositeHook([base_hook, *extra_hooks])
+                    if extra_hooks
+                    else base_hook
+                )
+            else:
+                hook = base_hook
             request_token = bind_request_context(RequestContext(
                 channel=origin["channel"],
                 chat_id=origin["chat_id"],
@@ -331,7 +362,7 @@ class SubagentManager:
                     runtime=runtime,
                     max_iterations=self.max_iterations,
                     max_tool_result_chars=self.max_tool_result_chars,
-                    hook=_SubagentHook(task_id, status),
+                    hook=hook,
                     max_iterations_message="Task completed but no final response was generated.",
                     finalize_on_max_iterations=False,
                     error_message=None,

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 10
+    assert db.schema_version == 11
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,17 +25,17 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 10
+    assert d2.schema_version == 11
     d2.close()
 
 
-def test_incremental_migrations_v1_through_v10(tmp_path: Path) -> None:
+def test_incremental_migrations_v1_through_v11(tmp_path: Path) -> None:
     """Every schema version must upgrade cleanly to the latest, preserving data."""
     import sqlite3
 
     import collie_core.db as db_mod
 
-    for target in range(1, 11):
+    for target in range(1, 12):
         path = tmp_path / f"v{target}.db"
         conn = sqlite3.connect(path)
         conn.executescript(db_mod._SCHEMA_V1)
@@ -51,7 +51,7 @@ def test_incremental_migrations_v1_through_v10(tmp_path: Path) -> None:
         conn.close()
 
         upgraded = CollieDB(path)
-        assert upgraded.schema_version == 10, f"v{target} did not reach v10"
+        assert upgraded.schema_version == 11, f"v{target} did not reach v11"
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
         upgraded.close()
 
@@ -86,11 +86,11 @@ def test_migration_failure_rolls_back_atomically(
         ).fetchone()
     finally:
         conn.close()
-    assert version == 10
+    assert version == 11
     assert half is None
     monkeypatch.undo()
     fresh = CollieDB(path)
-    assert fresh.schema_version == 10
+    assert fresh.schema_version == 11
     fresh.close()
 
 
@@ -131,7 +131,7 @@ def test_v8_removes_only_legacy_system_subagent_allow(tmp_path: Path) -> None:
         row["name"] for row in migrated._rows("PRAGMA table_info(messages)")
     }
     assert "task_state" in columns
-    assert migrated.schema_version == 10
+    assert migrated.schema_version == 11
     migrated.close()
 
 
@@ -179,7 +179,7 @@ def test_v9_upgrade_adds_plan_change_terminal_message_id(tmp_path: Path) -> None
             row["name"]
             for row in upgraded._rows("PRAGMA table_info(plan_change_requests)")
         }
-        assert upgraded.schema_version == 10
+        assert upgraded.schema_version == 11
         assert "terminal_message_id" in columns
         assert request is not None
         assert request["reason"] == "Change it"
@@ -345,7 +345,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.set_profile("dietary", "vegan")
     db.add_person("Sam")
     data = db.export_all()
-    assert data["schema_version"] == 10
+    assert data["schema_version"] == 11
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 10
+    assert db.schema_version == 11
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -225,6 +225,45 @@ def test_tool_events_cascade_delete_with_turn(db: CollieDB) -> None:
     assert len(db.list_tool_events()) == 0
 
 
+def test_export_all_includes_telemetry_and_clear_all_removes_it(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="ok",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_tool_event(tool_id="te1", turn_id="t1", tool_name="web_search",
+                         status="ok", started_at="2026-08-02T00:00:00+00:00")
+
+    data = db.export_all()
+    assert len(data["turn_events"]) == 1
+    assert len(data["tool_events"]) == 1
+
+    db.clear_all()
+    assert db.list_turn_events() == []
+    assert db.list_tool_events() == []
+
+
+def test_finish_turn_preserves_turn_kind_captured_at_start(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="routine", status="running",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_turn_event(turn_id="t1", status="ok",
+                         finished_at="2026-08-02T00:00:01+00:00")
+    row = db.list_turn_events()[0]
+    assert row["turn_kind"] == "routine"
+    assert row["status"] == "ok"
+
+
+def test_finish_tool_preserves_start_timestamp(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="ok",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_tool_event(tool_id="te1", turn_id="t1", tool_name="web_search",
+                         status="running",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_tool_event(tool_id="te1", turn_id="t1", tool_name="web_search",
+                         status="ok",
+                         finished_at="2026-08-02T00:00:05+00:00")
+    row = db.list_tool_events()[0]
+    assert row["started_at"] == "2026-08-02T00:00:00+00:00"
+    assert row["finished_at"] == "2026-08-02T00:00:05+00:00"
+
+
 # ---------------------------------------------------------------------------
 # Task 1.2 — RunRecorder + TelemetryHook through AgentLoop.process_direct
 # ---------------------------------------------------------------------------
@@ -249,10 +288,50 @@ def test_summarize_redacts_secrets_and_truncates() -> None:
     assert summarize(None, limit=500) is None
 
 
+def test_summarize_redacts_secrets_in_strings_and_nested_values() -> None:
+    from collie_core.telemetry.recorder import summarize
+
+    # String tool outputs must not store secrets verbatim.
+    assert "sk-super-secret" not in (
+        summarize("Authorization: Bearer sk-super-secret-1234567890", 500) or ""
+    )
+    # Dict values whose KEYS are innocent still get value-level sanitizing.
+    nested = summarize({"text": "password: hunter2hunter2hunter2"}, 500)
+    assert nested is not None
+    assert "hunter2hunter2hunter2" not in nested
+    assert "ghp_" not in (
+        summarize("pat = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ", 500) or ""
+    )
+
+
+def test_error_messages_are_sanitized(db: CollieDB) -> None:
+    from collie_core.telemetry.recorder import RunRecorder
+
+    rec = RunRecorder(db)
+    rec.start_turn(turn_id="t1", turn_kind="chat")
+    rec.finish_turn(
+        turn_id="t1", status="error",
+        error_message="Authorization: Bearer sk-leaky-secret-12345",
+    )
+    rec.start_tool(tool_id="te1", turn_id="t1", tool_name="web_search")
+    rec.finish_tool(
+        tool_id="te1", turn_id="t1", tool_name="web_search", status="error",
+        error_message="token: ghp_ABCDEFGHIJKLMNOPQRST",
+    )
+
+    turn = db.list_turn_events()[0]
+    tool = db.list_tool_events()[0]
+    assert "sk-leaky-secret" not in (turn["error_message"] or "")
+    assert "ghp_" not in (tool["error_message"] or "")
+
+
 def _make_loop(tmp_path: Path, *, hook_factories: list[Any] | None = None) -> AgentLoop:
+    from nanobot.providers.base import GenerationSettings
+
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(temperature=0.1, max_tokens=4096)
     return AgentLoop(
         bus=bus,
         provider=provider,
@@ -381,6 +460,160 @@ async def test_telemetry_failure_never_breaks_turn(tmp_path: Path, db: CollieDB)
 
     assert result is not None
     assert result.content == "Done"
+
+
+class _DenyAll:
+    async def authorize(self, execution_context, tool_call, tool, params) -> None:
+        raise PermissionError("nope")
+
+
+async def test_process_direct_records_denied_tool_with_action_and_resource(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop)
+    loop.authorizer = _DenyAll()
+
+    result = await loop.process_direct(
+        "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+    )
+
+    assert result is not None
+    tools = db.list_tool_events()
+    assert len(tools) == 1
+    assert tools[0]["tool_name"] == "web_search"
+    assert tools[0]["status"] == "denied"
+    assert "nope" in (tools[0]["error_message"] or "")
+    assert tools[0]["action"] == "web.read"
+    assert tools[0]["resource"] == "web_search"
+
+    turn = db.list_turn_events()[0]
+    assert turn["status"] == "ok"  # denial is soft; turn continues
+    assert turn["tool_count"] == 1
+
+
+async def test_process_direct_marks_routine_turn_kind_from_metadata(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop)
+
+    result = await loop.process_direct(
+        "hello",
+        session_key="collie:conv1",
+        channel="collie",
+        chat_id="conv1",
+        permission_context={"origin": "routine", "routine_id": "r1"},
+    )
+
+    assert result is not None
+    turn = db.list_turn_events()[0]
+    assert turn["turn_kind"] == "routine"
+
+
+async def test_subagent_run_composes_telemetry_hook(tmp_path: Path, db: CollieDB) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from collie_core.telemetry.hook import TelemetryHook, create_telemetry_hook_factory
+    from nanobot.agent.hook import CompositeHook
+    from nanobot.agent.runner import AgentRunResult
+    from nanobot.agent.subagent import SubagentManager, SubagentStatus
+    from nanobot.bus.queue import MessageBus
+    from nanobot.utils.llm_runtime import LLMRuntime
+
+    mgr = SubagentManager(
+        workspace=tmp_path, bus=MessageBus(), max_tool_result_chars=16_000
+    )
+    mgr.hook_factories = [create_telemetry_hook_factory(db)]
+    mgr.runner.run = AsyncMock(return_value=AgentRunResult(
+        final_content="ok", messages=[], stop_reason="completed"
+    ))
+    mgr._announce_result = AsyncMock()
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "m"
+    status = SubagentStatus(
+        task_id="t1", label="lbl", task_description="task", started_at=0.0
+    )
+    await mgr._run_subagent(
+        "t1", "task", "lbl",
+        {"channel": "cli", "chat_id": "direct", "session_key": "cli:direct"},
+        status,
+        LLMRuntime.capture(provider, "m", context_window_tokens=128_000),
+    )
+
+    spec = mgr.runner.run.call_args[0][0]
+    assert isinstance(spec.hook, CompositeHook)
+    telemetry = [h for h in spec.hook._hooks if isinstance(h, TelemetryHook)]
+    assert len(telemetry) == 1
+    assert telemetry[0]._session_key == "cli:direct"
+    assert telemetry[0]._metadata.get("turn_kind") == "subagent"
+
+
+async def test_subagent_without_factories_keeps_plain_hook(tmp_path: Path) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nanobot.agent.hook import CompositeHook
+    from nanobot.agent.runner import AgentRunResult
+    from nanobot.agent.subagent import SubagentManager, SubagentStatus, _SubagentHook
+    from nanobot.bus.queue import MessageBus
+    from nanobot.utils.llm_runtime import LLMRuntime
+
+    mgr = SubagentManager(
+        workspace=tmp_path, bus=MessageBus(), max_tool_result_chars=16_000
+    )
+    mgr.runner.run = AsyncMock(return_value=AgentRunResult(
+        final_content="ok", messages=[], stop_reason="completed"
+    ))
+    mgr._announce_result = AsyncMock()
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "m"
+    status = SubagentStatus(
+        task_id="t1", label="lbl", task_description="task", started_at=0.0
+    )
+    await mgr._run_subagent(
+        "t1", "task", "lbl",
+        {"channel": "cli", "chat_id": "direct", "session_key": "cli:direct"},
+        status,
+        LLMRuntime.capture(provider, "m", context_window_tokens=128_000),
+    )
+
+    spec = mgr.runner.run.call_args[0][0]
+    assert isinstance(spec.hook, _SubagentHook)
+    assert not isinstance(spec.hook, CompositeHook)
+
+
+async def test_telemetry_writes_off_event_loop(
+    tmp_path: Path, db: CollieDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import threading
+
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    write_idents: list[int] = []
+    original = CollieDB.record_turn_event
+
+    def spy(self, **kwargs: Any) -> None:
+        write_idents.append(threading.get_ident())
+        original(self, **kwargs)
+
+    monkeypatch.setattr(CollieDB, "record_turn_event", spy)
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop)
+
+    await loop.process_direct(
+        "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+    )
+
+    loop_thread = threading.get_ident()
+    assert write_idents, "expected at least one telemetry write"
+    assert all(ident != loop_thread for ident in write_idents)
 
 
 async def test_runtime_records_chat_turn_via_build_loop(

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -33,6 +33,36 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
+async def _wait_for(predicate, timeout: float = 5.0) -> None:
+    """Poll until ``predicate()`` is truthy (telemetry writes are async)."""
+    import time as _time
+
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _wait_for_turn(db: CollieDB) -> dict[str, Any]:
+    """Wait for a finished turn row and return it (most recent first)."""
+    await _wait_for(
+        lambda: bool(db.list_turn_events())
+        and db.list_turn_events()[0]["finished_at"] is not None
+    )
+    return db.list_turn_events()[0]
+
+
+async def _wait_for_tool(db: CollieDB) -> dict[str, Any]:
+    """Wait for a finished tool row and return it (most recent first)."""
+    await _wait_for(
+        lambda: bool(db.list_tool_events())
+        and db.list_tool_events()[0]["finished_at"] is not None
+    )
+    return db.list_tool_events()[0]
+
+
 # ---------------------------------------------------------------------------
 # Task 1.1 — schema migration V11 + DB methods
 # ---------------------------------------------------------------------------
@@ -304,25 +334,44 @@ def test_summarize_redacts_secrets_in_strings_and_nested_values() -> None:
     )
 
 
+def test_summarize_redacts_modern_provider_secrets() -> None:
+    from collie_core.telemetry.recorder import summarize
+
+    probes = [
+        "sk-proj-abcdefghijklmnopqrstuvwxyz123456",          # OpenAI project key
+        "sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456789",  # Anthropic key
+        "AIzaSyA1234567890abcdefghijklmnopqrstuvwxyz",       # Google API key
+        "ya29.a0AfH6SMCabcdefghijklmnopqrstuvwxyz123456",    # Google OAuth token
+    ]
+    for probe in probes:
+        out = summarize(probe, 500) or ""
+        assert probe not in out, f"leaked: {probe}"
+        assert "[redacted]" in out, f"not redacted: {probe}"
+
+
 def test_error_messages_are_sanitized(db: CollieDB) -> None:
     from collie_core.telemetry.recorder import RunRecorder
 
     rec = RunRecorder(db)
-    rec.start_turn(turn_id="t1", turn_kind="chat")
-    rec.finish_turn(
-        turn_id="t1", status="error",
-        error_message="Authorization: Bearer sk-leaky-secret-12345",
-    )
-    rec.start_tool(tool_id="te1", turn_id="t1", tool_name="web_search")
-    rec.finish_tool(
-        tool_id="te1", turn_id="t1", tool_name="web_search", status="error",
-        error_message="token: ghp_ABCDEFGHIJKLMNOPQRST",
-    )
+    try:
+        rec.start_turn(turn_id="t1", turn_kind="chat")
+        rec.finish_turn(
+            turn_id="t1", status="error",
+            error_message="Authorization: Bearer sk-leaky-secret-12345",
+        )
+        rec.start_tool(tool_id="te1", turn_id="t1", tool_name="web_search")
+        rec.finish_tool(
+            tool_id="te1", turn_id="t1", tool_name="web_search", status="error",
+            error_message="token: ghp_ABCDEFGHIJKLMNOPQRST",
+        )
+        rec.flush()
 
-    turn = db.list_turn_events()[0]
-    tool = db.list_tool_events()[0]
-    assert "sk-leaky-secret" not in (turn["error_message"] or "")
-    assert "ghp_" not in (tool["error_message"] or "")
+        turn = db.list_turn_events()[0]
+        tool = db.list_tool_events()[0]
+        assert "sk-leaky-secret" not in (turn["error_message"] or "")
+        assert "ghp_" not in (tool["error_message"] or "")
+    finally:
+        rec.shutdown()
 
 
 def _make_loop(tmp_path: Path, *, hook_factories: list[Any] | None = None) -> AgentLoop:
@@ -379,6 +428,7 @@ async def test_process_direct_records_turn_and_tools_with_redaction(
 
     assert result is not None
     assert result.content == "Done"
+    await _wait_for_turn(db)
 
     turns = db.list_turn_events()
     assert len(turns) == 1
@@ -392,6 +442,7 @@ async def test_process_direct_records_turn_and_tools_with_redaction(
     assert turn["tokens_out"] > 0
     assert turn["finished_at"] is not None
 
+    await _wait_for_tool(db)
     tools = db.list_tool_events(turn_id=turn["id"])
     assert len(tools) == 1
     tool = tools[0]
@@ -413,8 +464,10 @@ async def test_process_direct_records_tool_error(tmp_path: Path, db: CollieDB) -
     )
 
     assert result is not None
+    await _wait_for_turn(db)
     turn = db.list_turn_events()[0]
     assert turn["status"] == "ok"  # tool failure does not fail the turn
+    await _wait_for_tool(db)
     tool = db.list_tool_events(turn_id=turn["id"])[0]
     assert tool["status"] == "error"
     assert "tool boom" in (tool["error_message"] or "")
@@ -435,6 +488,7 @@ async def test_process_direct_records_error_turn(tmp_path: Path, db: CollieDB) -
             "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
         )
 
+    await _wait_for_turn(db)
     turns = db.list_turn_events()
     assert len(turns) == 1
     assert turns[0]["status"] == "error"
@@ -481,6 +535,7 @@ async def test_process_direct_records_denied_tool_with_action_and_resource(
     )
 
     assert result is not None
+    await _wait_for_tool(db)
     tools = db.list_tool_events()
     assert len(tools) == 1
     assert tools[0]["tool_name"] == "web_search"
@@ -489,6 +544,7 @@ async def test_process_direct_records_denied_tool_with_action_and_resource(
     assert tools[0]["action"] == "web.read"
     assert tools[0]["resource"] == "web_search"
 
+    await _wait_for_turn(db)
     turn = db.list_turn_events()[0]
     assert turn["status"] == "ok"  # denial is soft; turn continues
     assert turn["tool_count"] == 1
@@ -511,8 +567,50 @@ async def test_process_direct_marks_routine_turn_kind_from_metadata(
     )
 
     assert result is not None
+    await _wait_for_turn(db)
     turn = db.list_turn_events()[0]
     assert turn["turn_kind"] == "routine"
+
+
+async def test_process_direct_marks_plan_turn_kind_from_execution_mode(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop)
+
+    result = await loop.process_direct(
+        "hello",
+        session_key="collie:conv1",
+        channel="collie",
+        chat_id="conv1",
+        permission_context={"execution_mode": "plan"},
+    )
+
+    assert result is not None
+    await _wait_for_turn(db)
+    turn = db.list_turn_events()[0]
+    assert turn["turn_kind"] == "plan"
+
+
+async def test_max_iterations_turn_marked_stopped(tmp_path: Path, db: CollieDB) -> None:
+    from collie_core.telemetry.hook import TelemetryHook
+    from collie_core.telemetry.recorder import RunRecorder
+    from nanobot.agent.hook import AgentRunHookContext
+
+    rec = RunRecorder(db)
+    hook = TelemetryHook(rec, session_key="collie:conv1")
+    try:
+        await hook.before_run(AgentRunHookContext(messages=[]))
+        await hook.after_run(AgentRunHookContext(
+            messages=[], stop_reason="max_iterations"
+        ))
+        rec.flush()
+        row = db.list_turn_events()[0]
+        assert row["status"] == "stopped"
+    finally:
+        rec.shutdown()
 
 
 async def test_subagent_run_composes_telemetry_hook(tmp_path: Path, db: CollieDB) -> None:
@@ -610,10 +708,39 @@ async def test_telemetry_writes_off_event_loop(
     await loop.process_direct(
         "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
     )
+    await _wait_for(lambda: bool(write_idents))
 
     loop_thread = threading.get_ident()
-    assert write_idents, "expected at least one telemetry write"
     assert all(ident != loop_thread for ident in write_idents)
+
+
+async def test_telemetry_write_stall_does_not_delay_turn(
+    tmp_path: Path, db: CollieDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A slow/locked database must never delay a turn (fire-and-forget)."""
+    import time as _time
+
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    original = CollieDB.record_turn_event
+
+    def slow(self, **kwargs: Any) -> None:
+        _time.sleep(0.5)  # simulate a database under lock contention
+        original(self, **kwargs)
+
+    monkeypatch.setattr(CollieDB, "record_turn_event", slow)
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop)
+
+    started = _time.monotonic()
+    result = await loop.process_direct(
+        "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+    )
+    elapsed = _time.monotonic() - started
+
+    assert result is not None
+    assert elapsed < 0.4, f"turn waited {elapsed:.2f}s on a telemetry write"
 
 
 async def test_runtime_records_chat_turn_via_build_loop(
@@ -707,6 +834,7 @@ async def test_runtime_records_chat_turn_via_build_loop(
                     pytest.fail(f"IPC error: {frame}")
             assert assistant is not None
 
+            await _wait_for_turn(db)
             turns = db.list_turn_events()
             assert len(turns) == 1
             assert turns[0]["turn_kind"] == "chat"

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -1,0 +1,562 @@
+"""PR 1 — Run records (telemetry foundation).
+
+Covers the Gardener Foundations plan PR 1:
+- Task 1.1: _SCHEMA_V11 (turn_events + tool_events) and CollieDB methods.
+- Task 1.2: RunRecorder + TelemetryHook wired through AgentLoop.process_direct.
+- Task 1.3: IPC get_run_records / get_tool_events round-trips.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import sqlite3
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import websockets
+
+import collie_core.db as db_mod
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse, ToolCallRequest
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Task 1.1 — schema migration V11 + DB methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+def _table_names(path: Path) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
+    assert db.schema_version == 11
+    tables = _table_names(db.path)
+    assert {"turn_events", "tool_events"} <= tables
+
+
+def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
+    path = tmp_path / "v10.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(db_mod._SCHEMA_V1)
+    for migration in db_mod._MIGRATIONS[1:10]:
+        conn.executescript(migration)
+    conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (10)")
+    conn.execute(
+        "INSERT INTO conversations (id, title, created_at, updated_at) "
+        "VALUES ('c1', 'Keep me', '2026-01-01', '2026-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    upgraded = CollieDB(path)
+    try:
+        assert upgraded.schema_version == 11
+        assert upgraded.get_conversation("c1")["title"] == "Keep me"
+    finally:
+        upgraded.close()
+
+
+def test_turn_event_round_trip(db: CollieDB) -> None:
+    db.record_turn_event(
+        turn_id="t1",
+        conversation_id="conv1",
+        session_key="collie:conv1",
+        turn_kind="chat",
+        provider="custom",
+        model="collie-test-model",
+        status="ok",
+        error_message=None,
+        tokens_in=10,
+        tokens_out=5,
+        latency_ms=12,
+        tool_count=1,
+        started_at="2026-08-02T00:00:00+00:00",
+        finished_at="2026-08-02T00:00:05+00:00",
+    )
+
+    turns = db.list_turn_events()
+    assert len(turns) == 1
+    row = turns[0]
+    assert row["id"] == "t1"
+    assert row["conversation_id"] == "conv1"
+    assert row["session_key"] == "collie:conv1"
+    assert row["turn_kind"] == "chat"
+    assert row["provider"] == "custom"
+    assert row["model"] == "collie-test-model"
+    assert row["status"] == "ok"
+    assert row["tokens_in"] == 10
+    assert row["tokens_out"] == 5
+    assert row["latency_ms"] == 12
+    assert row["tool_count"] == 1
+
+
+def test_record_turn_event_upserts_instead_of_duplicating(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="running",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="ok",
+                         tokens_in=7, tokens_out=3, finished_at="2026-08-02T00:00:01+00:00")
+    turns = db.list_turn_events()
+    assert len(turns) == 1
+    assert turns[0]["status"] == "ok"
+    assert turns[0]["tokens_in"] == 7
+    assert turns[0]["started_at"] == "2026-08-02T00:00:00+00:00"
+
+
+def test_list_turn_events_filters_by_conversation_since_and_limit(db: CollieDB) -> None:
+    for i in range(5):
+        db.record_turn_event(
+            turn_id=f"t{i}",
+            conversation_id=f"conv{i % 2}",
+            session_key=f"collie:conv{i % 2}",
+            turn_kind="chat",
+            status="ok",
+            started_at=f"2026-08-0{i + 1}T00:00:00+00:00",
+        )
+
+    only_conv0 = db.list_turn_events(conversation_id="conv0")
+    assert [t["id"] for t in only_conv0] == ["t4", "t2", "t0"]
+
+    since = db.list_turn_events(since="2026-08-03T00:00:00+00:00")
+    assert [t["id"] for t in since] == ["t4", "t3", "t2"]
+
+    limited = db.list_turn_events(limit=2)
+    assert len(limited) == 2
+
+    by_session = db.list_turn_events(session_key="collie:conv0")
+    assert len(by_session) == 3
+
+
+def test_tool_event_round_trip_and_filters(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="ok",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_tool_event(
+        tool_id="te1", turn_id="t1", tool_name="web_search",
+        action="read", resource="https://example.com",
+        input_summary='{"query": "hello"}',
+        output_summary="three results",
+        status="ok",
+        latency_ms=4,
+        started_at="2026-08-02T00:00:01+00:00",
+        finished_at="2026-08-02T00:00:02+00:00",
+    )
+
+    events = db.list_tool_events()
+    assert len(events) == 1
+    row = events[0]
+    assert row["id"] == "te1"
+    assert row["turn_id"] == "t1"
+    assert row["tool_name"] == "web_search"
+    assert row["action"] == "read"
+    assert row["input_summary"] == '{"query": "hello"}'
+    assert row["status"] == "ok"
+    assert row["latency_ms"] == 4
+
+    assert len(db.list_tool_events(turn_id="t1")) == 1
+    assert len(db.list_tool_events(turn_id="nope")) == 0
+    assert len(db.list_tool_events(tool_name="web_search")) == 1
+    assert len(db.list_tool_events(tool_name="other")) == 0
+
+
+def test_turn_event_stats_reports_per_tool_failures(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="ok",
+                         started_at="2026-08-02T00:00:00+00:00")
+    for i, (tool, status) in enumerate([
+        ("web_search", "ok"),
+        ("web_search", "error"),
+        ("web_search", "error"),
+        ("write_file", "error"),
+        ("write_file", "denied"),
+    ]):
+        db.record_tool_event(
+            tool_id=f"te{i}", turn_id="t1", tool_name=tool, status=status,
+            started_at="2026-08-02T00:00:00+00:00",
+        )
+
+    stats = db.turn_event_stats(since="2026-08-01T00:00:00+00:00")
+    by_tool_status = {(s["tool_name"], s["status"]): s["count"] for s in stats}
+    assert by_tool_status[("web_search", "error")] == 2
+    assert by_tool_status[("web_search", "ok")] == 1
+    assert by_tool_status[("write_file", "error")] == 1
+    assert by_tool_status[("write_file", "denied")] == 1
+
+    assert db.turn_event_stats(since="2099-01-01T00:00:00+00:00") == []
+
+
+def test_tool_events_cascade_delete_with_turn(db: CollieDB) -> None:
+    db.record_turn_event(turn_id="t1", turn_kind="chat", status="ok",
+                         started_at="2026-08-02T00:00:00+00:00")
+    db.record_tool_event(tool_id="te1", turn_id="t1", tool_name="web_search",
+                         status="ok", started_at="2026-08-02T00:00:00+00:00")
+    assert len(db.list_tool_events()) == 1
+
+    with db._write() as conn:
+        conn.execute("DELETE FROM turn_events WHERE id = 't1'")
+    assert len(db.list_tool_events()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2 — RunRecorder + TelemetryHook through AgentLoop.process_direct
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_redacts_secrets_and_truncates() -> None:
+    from collie_core.telemetry.recorder import summarize
+
+    text = summarize(
+        {"query": "hello world", "api_key": "sk-super-secret"},
+        limit=500,
+    )
+    assert text is not None
+    assert "hello world" in text
+    assert "[redacted]" in text
+    assert "sk-super-secret" not in text
+
+    long = summarize("x" * 5000, limit=500)
+    assert long is not None
+    assert len(long) <= 500
+
+    assert summarize(None, limit=500) is None
+
+
+def _make_loop(tmp_path: Path, *, hook_factories: list[Any] | None = None) -> AgentLoop:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    return AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=8192,
+        hook_factories=list(hook_factories or []),
+    )
+
+
+def _fake_tool_turn(loop: AgentLoop, *, tool_error: bool = False) -> None:
+    calls = iter([
+        LLMResponse(content="Visible", tool_calls=[
+            ToolCallRequest(id="call1", name="web_search",
+                            arguments={"query": "hello"}),
+        ]),
+        LLMResponse(content="Done", tool_calls=[]),
+    ])
+
+    async def chat_with_retry(*_args: Any, **_kwargs: Any) -> LLMResponse:
+        return next(calls)
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=chat_with_retry)
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    loop.tools.prepare_call = MagicMock(return_value=(
+        None, {"query": "hello", "api_key": "sk-top-secret"}, None,
+    ))
+    if tool_error:
+        loop.tools.execute = AsyncMock(side_effect=RuntimeError("tool boom"))
+    else:
+        loop.tools.execute = AsyncMock(return_value="found 3 results")
+
+
+async def test_process_direct_records_turn_and_tools_with_redaction(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop)
+
+    result = await loop.process_direct(
+        "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+    )
+
+    assert result is not None
+    assert result.content == "Done"
+
+    turns = db.list_turn_events()
+    assert len(turns) == 1
+    turn = turns[0]
+    assert turn["status"] == "ok"
+    assert turn["turn_kind"] == "chat"
+    assert turn["conversation_id"] == "conv1"
+    assert turn["session_key"] == "collie:conv1"
+    assert turn["tool_count"] == 1
+    assert turn["tokens_in"] > 0  # engine-reported prompt usage
+    assert turn["tokens_out"] > 0
+    assert turn["finished_at"] is not None
+
+    tools = db.list_tool_events(turn_id=turn["id"])
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool["tool_name"] == "web_search"
+    assert tool["status"] == "ok"
+    assert "sk-top-secret" not in (tool["input_summary"] or "")
+    assert "[redacted]" in (tool["input_summary"] or "")
+    assert "found 3 results" in (tool["output_summary"] or "")
+
+
+async def test_process_direct_records_tool_error(tmp_path: Path, db: CollieDB) -> None:
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+    _fake_tool_turn(loop, tool_error=True)
+
+    result = await loop.process_direct(
+        "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+    )
+
+    assert result is not None
+    turn = db.list_turn_events()[0]
+    assert turn["status"] == "ok"  # tool failure does not fail the turn
+    tool = db.list_tool_events(turn_id=turn["id"])[0]
+    assert tool["status"] == "error"
+    assert "tool boom" in (tool["error_message"] or "")
+
+
+async def test_process_direct_records_error_turn(tmp_path: Path, db: CollieDB) -> None:
+    from collie_core.telemetry.hook import create_telemetry_hook_factory
+
+    loop = _make_loop(tmp_path, hook_factories=[create_telemetry_hook_factory(db)])
+
+    async def explode(*_args: Any, **_kwargs: Any) -> LLMResponse:
+        raise RuntimeError("model exploded")
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=explode)
+
+    with pytest.raises(RuntimeError, match="model exploded"):
+        await loop.process_direct(
+            "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+        )
+
+    turns = db.list_turn_events()
+    assert len(turns) == 1
+    assert turns[0]["status"] == "error"
+    assert "model exploded" in (turns[0]["error_message"] or "")
+
+
+async def test_telemetry_failure_never_breaks_turn(tmp_path: Path, db: CollieDB) -> None:
+    from nanobot.agent.hook import AgentHook, AgentRunHookContext
+
+    class ExplodingHook(AgentHook):
+        async def before_run(self, context: AgentRunHookContext) -> None:
+            raise RuntimeError("telemetry broke")
+
+    def factory(_context: Any) -> AgentHook:
+        return ExplodingHook()
+
+    loop = _make_loop(tmp_path, hook_factories=[factory])
+    _fake_tool_turn(loop)
+
+    result = await loop.process_direct(
+        "hello", session_key="collie:conv1", channel="collie", chat_id="conv1"
+    )
+
+    assert result is not None
+    assert result.content == "Done"
+
+
+async def test_runtime_records_chat_turn_via_build_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full CollieRuntime boot: a real chat turn lands in turn_events.
+
+    Proves the ``_build_loop`` wiring (hook_factories registration) end to
+    end, exactly the way the renderer drives the core.
+    """
+    from aiohttp import web
+
+    from collie_core.runtime import CollieRuntime
+
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path / ".collie"))
+
+    async def chat_completions(request: web.Request) -> web.StreamResponse:
+        body = await request.json()
+        assert body.get("model")
+        resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        for i, text in enumerate(["Woof! ", "You said: ", "hello."]):
+            payload = {
+                "id": "chatcmpl-fake",
+                "object": "chat.completion.chunk",
+                "model": body["model"],
+                "choices": [{
+                    "index": 0,
+                    "delta": ({"role": "assistant", "content": text}
+                              if i == 0 else {"content": text}),
+                    "finish_reason": None,
+                }],
+            }
+            await resp.write(f"data: {json.dumps(payload)}\n\n".encode())
+        done = {
+            "id": "chatcmpl-fake",
+            "object": "chat.completion.chunk",
+            "model": body["model"],
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 6,
+                      "total_tokens": 26},
+        }
+        await resp.write(f"data: {json.dumps(done)}\n\n".encode())
+        await resp.write(b"data: [DONE]\n\n")
+        await resp.write_eof()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", chat_completions)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    llm_port = _free_port()
+    site = web.TCPSite(runner, "127.0.0.1", llm_port)
+    await site.start()
+
+    ipc_port = _free_port()
+    db = CollieDB(tmp_path / ".collie" / "collie.db")
+    db.set_setting("provider.name", "custom")
+    db.set_setting("provider.api_base", f"http://127.0.0.1:{llm_port}/v1")
+    db.set_setting("provider.model", "collie-test-model")
+    db.upsert_provider("custom", name="Test", auth_type="api_key", is_default=True)
+
+    runtime = CollieRuntime(port=ipc_port, db=db)
+    await runtime.ipc.start()
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{ipc_port}") as ws:
+            ready = json.loads(await ws.recv())
+            assert ready["type"] == "ready"
+
+            await ws.send(json.dumps({
+                "type": "set_api_key", "id": "k",
+                "provider": "custom", "key": "sk-fake",
+            }))
+            assert json.loads(await ws.recv())["type"] == "ok"
+
+            await ws.send(json.dumps({"type": "configure", "id": "c"}))
+            reply = json.loads(await ws.recv())
+            assert reply["type"] == "ok", reply
+
+            await ws.send(json.dumps({
+                "type": "chat", "id": "m1", "content": "hello",
+            }))
+            assistant = None
+            for _ in range(200):
+                frame = json.loads(await asyncio.wait_for(ws.recv(), 30))
+                if (frame["type"] == "message"
+                        and frame["message"]["role"] == "assistant"):
+                    assistant = frame["message"]
+                    break
+                if frame["type"] == "error":
+                    pytest.fail(f"IPC error: {frame}")
+            assert assistant is not None
+
+            turns = db.list_turn_events()
+            assert len(turns) == 1
+            assert turns[0]["turn_kind"] == "chat"
+            assert turns[0]["status"] == "ok"
+            assert turns[0]["provider"] == "custom"
+            assert turns[0]["conversation_id"] is not None
+    finally:
+        await runtime._shutdown_loop()
+        await runtime.ipc.stop()
+        db.close()
+        await runner.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — IPC surface (read-only, additive)
+# ---------------------------------------------------------------------------
+
+
+class FakeOutbound:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+async def fake_chat_runner(content: str, *, conversation_id: str, on_stream, on_progress):
+    await on_progress("", tool_events=[{"phase": "start", "name": "web_search"}])
+    await on_stream("Woof!")
+    return FakeOutbound("Woof! Here you go.")
+
+
+async def test_ipc_get_run_records_and_tool_events_round_trip(
+    tmp_path: Path,
+) -> None:
+    d = CollieDB(tmp_path / "collie.db")
+    d.record_turn_event(
+        turn_id="t1", conversation_id="conv1", session_key="collie:conv1",
+        turn_kind="chat", status="ok", tokens_in=3, tokens_out=2,
+        started_at="2026-08-02T00:00:00+00:00",
+        finished_at="2026-08-02T00:00:01+00:00",
+    )
+    d.record_tool_event(
+        tool_id="te1", turn_id="t1", tool_name="web_search", status="ok",
+        input_summary='{"query": "hello"}',
+        started_at="2026-08-02T00:00:00+00:00",
+        finished_at="2026-08-02T00:00:01+00:00",
+    )
+    srv = CollieIPCServer(
+        d,
+        port=_free_port(),
+        chat_runner=fake_chat_runner,
+        on_set_api_key=lambda provider, key: None,
+        status_provider=lambda: {"configured": True, "model": "test-model"},
+    )
+    await srv.start()
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{srv.port}") as ws:
+            ready = json.loads(await ws.recv())
+            assert ready["type"] == "ready"
+
+            await ws.send(json.dumps({
+                "type": "get_run_records", "id": "r1",
+                "conversation_id": "conv1",
+            }))
+            reply = json.loads(await ws.recv())
+            assert reply["type"] == "ok"
+            turns = reply["data"]["turns"]
+            assert len(turns) == 1
+            assert turns[0]["id"] == "t1"
+            assert turns[0]["status"] == "ok"
+
+            await ws.send(json.dumps({
+                "type": "get_tool_events", "id": "r2", "turn_id": "t1",
+            }))
+            reply = json.loads(await ws.recv())
+            assert reply["type"] == "ok"
+            events = reply["data"]["tool_events"]
+            assert len(events) == 1
+            assert events[0]["tool_name"] == "web_search"
+            assert events[0]["status"] == "ok"
+
+            # Unknown commands stay rejected (additive-only surface).
+            await ws.send(json.dumps({"type": "no_such_command", "id": "r3"}))
+            reply = json.loads(await ws.recv())
+            assert reply["type"] == "error"
+    finally:
+        await srv.stop()
+        d.close()

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -72,6 +72,11 @@ async def _wait_for_tool(db: CollieDB) -> dict[str, Any]:
 def db(tmp_path: Path) -> CollieDB:
     d = CollieDB(tmp_path / "collie.db")
     yield d
+    from collie_core.telemetry.recorder import RunRecorder
+
+    recorder = RunRecorder.active_for(d)
+    if recorder is not None:
+        recorder.shutdown()
     d.close()
 
 
@@ -253,6 +258,119 @@ def test_tool_events_cascade_delete_with_turn(db: CollieDB) -> None:
     with db._write() as conn:
         conn.execute("DELETE FROM turn_events WHERE id = 't1'")
     assert len(db.list_tool_events()) == 0
+
+
+def test_clear_all_drops_queued_writes_and_resumes(db: CollieDB) -> None:
+    """Queued telemetry must not resurrect rows after a wipe."""
+    from collie_core.telemetry.recorder import RunRecorder
+
+    rec = RunRecorder.for_db(db)
+    rec.start_turn(turn_id="t1", turn_kind="chat")  # queued, not yet written
+
+    db.clear_all()
+
+    assert db.list_turn_events() == []
+
+    # The recorder is still usable for new turns after the wipe.
+    rec.start_turn(turn_id="t2", turn_kind="chat")
+    rec.flush()
+    assert [t["id"] for t in db.list_turn_events()] == ["t2"]
+
+
+def test_export_all_flushes_recorder_first(db: CollieDB) -> None:
+    """Export must include records still queued in the writer."""
+    from collie_core.telemetry.recorder import RunRecorder
+
+    rec = RunRecorder.for_db(db)
+    rec.start_turn(turn_id="t1", turn_kind="chat")
+
+    data = db.export_all()
+
+    assert any(t["id"] == "t1" for t in data["turn_events"])
+
+
+def test_shutdown_drains_unregisters_and_allows_new_recorder(db: CollieDB) -> None:
+    from collie_core.telemetry.recorder import RunRecorder
+
+    rec = RunRecorder.for_db(db)
+    rec.start_turn(turn_id="t1", turn_kind="chat")
+
+    rec.shutdown()
+
+    # Drained before stopping — recent evidence is not lost.
+    assert any(t["id"] == "t1" for t in db.list_turn_events())
+    # Registry entry removed; a fresh, live recorder is handed out next.
+    fresh = RunRecorder.for_db(db)
+    assert fresh is not rec
+    assert fresh._stopped is False
+
+
+def test_timestamps_captured_at_event_time_not_drain_time(
+    db: CollieDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backlog must not corrupt chronological evidence."""
+    import threading
+    import time as _time
+    from datetime import datetime
+
+    from collie_core.telemetry.recorder import RunRecorder
+
+    blocked = threading.Event()
+    original = CollieDB.record_turn_event
+
+    def slow(self, **kwargs: Any) -> None:
+        blocked.wait(5)
+        original(self, **kwargs)
+
+    monkeypatch.setattr(CollieDB, "record_turn_event", slow)
+
+    rec = RunRecorder(db)
+    try:
+        rec.start_turn(turn_id="t1", turn_kind="chat")
+        _time.sleep(1.0)
+        rec.finish_turn(turn_id="t1", status="ok")
+        blocked.set()
+        rec.flush()
+
+        row = db.list_turn_events()[0]
+        start = datetime.fromisoformat(row["started_at"])
+        end = datetime.fromisoformat(row["finished_at"])
+        # Captured at enqueue time (1s apart), not at drain time (~0 apart).
+        assert (end - start).total_seconds() >= 0.9
+    finally:
+        blocked.set()
+        rec.shutdown()
+
+
+def test_recorder_queue_is_bounded_with_drop_counter(
+    db: CollieDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stuck database must not accumulate unbounded raw writes in memory."""
+    import threading
+
+    from collie_core.telemetry.recorder import MAX_QUEUED_WRITES, RunRecorder
+
+    blocked = threading.Event()
+    original = CollieDB.record_turn_event
+
+    def slow(self, **kwargs: Any) -> None:
+        blocked.wait(5)
+        original(self, **kwargs)
+
+    monkeypatch.setattr(CollieDB, "record_turn_event", slow)
+
+    rec = RunRecorder(db)
+    try:
+        for i in range(MAX_QUEUED_WRITES + 100):
+            rec.start_turn(turn_id=f"t{i}", turn_kind="chat")
+
+        assert rec.dropped_writes >= 90  # drops, never blocks, never grows unbounded
+        blocked.set()
+        rec.flush()
+        assert len(db.list_turn_events()) <= MAX_QUEUED_WRITES
+    finally:
+        blocked.set()
+        rec.shutdown()
 
 
 def test_export_all_includes_telemetry_and_clear_all_removes_it(db: CollieDB) -> None:

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 10
+    assert db.schema_version == 11
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -280,6 +280,40 @@ export interface CollieRun {
   error_message?: string | null
 }
 
+/** One recorded agent turn (PR 1 run records / telemetry). */
+export interface TurnEvent {
+  id: string
+  conversation_id?: string | null
+  session_key?: string | null
+  turn_kind: string
+  provider?: string | null
+  model?: string | null
+  status: string
+  error_message?: string | null
+  tokens_in?: number
+  tokens_out?: number
+  latency_ms?: number | null
+  tool_count?: number
+  started_at: string
+  finished_at?: string | null
+}
+
+/** One recorded tool call within a turn (PR 1 run records / telemetry). */
+export interface ToolEvent {
+  id: string
+  turn_id: string
+  tool_name: string
+  action?: string | null
+  resource?: string | null
+  input_summary?: string | null
+  output_summary?: string | null
+  status: string
+  error_message?: string | null
+  latency_ms?: number | null
+  started_at: string
+  finished_at?: string | null
+}
+
 /** A user-facing progress snapshot. It deliberately excludes tool traffic and model reasoning. */
 export interface TaskStep {
   key: string
@@ -571,6 +605,23 @@ export class CollieClient {
 
   getActiveTask(conversationId: string): Promise<{ task: TaskState | null }> {
     return this.command('get_active_task', { conversation_id: conversationId })
+  }
+
+  getRunRecords(opts?: {
+    conversation_id?: string
+    session_key?: string
+    since?: string
+    limit?: number
+  }): Promise<{ turns: TurnEvent[] }> {
+    return this.command('get_run_records', opts ?? {})
+  }
+
+  getToolEvents(opts?: {
+    turn_id?: string
+    tool_name?: string
+    limit?: number
+  }): Promise<{ tool_events: ToolEvent[] }> {
+    return this.command('get_tool_events', opts ?? {})
   }
 
   stopConversation(

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -28,8 +28,8 @@ are not part of this public source tree.
 ### Python core: `collie-core/`
 
 - `collie_core/` owns storage, settings, memory, permissions, plans, tools,
-  connectors, agents, routines, messengers, pet control, IPC, and runtime
-  composition.
+  connectors, agents, routines, messengers, pet control, IPC, telemetry
+  (run records), and runtime composition.
 - `nanobot/` contains the adapted upstream engine. Changes should remain
   surgical and preserve third-party attribution.
 - `tests/` contains Python unit, integration, IPC, safety, and end-to-end

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,8 +11,8 @@
 
 ## Source inventory
 
-- Core Python files: **470**
-- Core Python test files: **215**
+- Core Python files: **474**
+- Core Python test files: **216**
 - Desktop TypeScript/TSX files: **116**
 - Desktop test files: **34**
 - Active Markdown docs: **21**
@@ -20,7 +20,7 @@
 
 ## Collie-owned core module groups
 
-`automations`, `connectors`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `tools`
+`automations`, `connectors`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
 
 ## Required orientation files
 


### PR DESCRIPTION
Gardener Foundations PR 1: per-turn run records + per-tool events as the evidence foundation for Collie's self-improvement story. Zero edits to the nanobot turn-state machine — hooks only.

What's in this PR
Schema _SCHEMA_V11: turn_events + tool_events tables (FK cascade, indexes), schema-version asserts bumped 10 → 11
CollieDB: record_turn_event / record_tool_event (UPDATE-then-INSERT upsert, defaults applied on INSERT only), list_turn_events / list_tool_events, turn_event_stats; telemetry included in export_all() and wiped by clear_all()
collie_core/telemetry/: RunRecorder (fire-and-forget) + TelemetryHook registered as a per-turn hook factory in CollieRuntime._build_loop — records every turn kind (chat, plan, routine, cron, automation, subagent)
Privacy invariant: redact_parameters (secret keys) + sanitize_text (secret-shaped values in outputs/errors: Bearer, sk-, ghp_, AKIA, Slack, PEM, generic key=value) — secrets never reach telemetry
Denied/blocked tools recorded via new additive AgentHook.on_tool_blocked (authorization denials, prep failures, repeated-lookup blocks); action/resource populated via classify_tool
Subagent turns recorded — SubagentManager gains hook_factories, mirrored from the loop, composed into the run's hook chain
Routine turns typed from permission_context metadata
Writes off the event loop (asyncio.to_thread) — telemetry never stalls a turn
IPC: get_run_records / get_tool_events (read-only, additive) + typed ipc.ts wrappers (no UI screen yet — Gardener consumes them)
Review response (Codex round 1)
All findings addressed: 3 P1 (clear_all/export gaps, unredacted strings & errors, turn_kind upsert clobber) + 4 P2 (tool started_at clobber, invisible denials, subagent/routine coverage, sync writes on loop).

Verification
Gate	Result
Full suite (tests/)	3285 passed / 5 failed — all 5 are the pre-existing Windows-only baseline (DPAPI ×4 + IPC escape-path, identical on main)
Focused test_run_records.py	25 passed
Coverage	73.8% (gate ≥70)
Ruff	clean
npm run typecheck (UI)	clean
Snapshot	regenerated + --check passes
No CI on the repo yet — verified locally on the Linux dev VM.