### PR TITLE
feat(chat): switch models in chat via /model and set_model tool

### DIFF
--- a/collie-core/collie_core/commands.py
+++ b/collie-core/collie_core/commands.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 from nanobot.agent.skills import SkillsLoader
 
@@ -36,6 +36,12 @@ CORE_COMMANDS: tuple[CommandSpec, ...] = (
     CommandSpec("new", "Start a fresh conversation", "/new", "Session"),
     CommandSpec("compact", "Summarize older context and keep recent turns", "/compact", "Session"),
     CommandSpec("status", "Show model, context, and active helpers", "/status", "Session"),
+    CommandSpec(
+        "model",
+        "Show or switch the active AI model",
+        "/model [model-id]",
+        "Settings",
+    ),
     CommandSpec("stop", "Stop the current response and its helpers", "/stop", "Session"),
     CommandSpec(
         "goal",
@@ -80,11 +86,15 @@ class CommandController:
         subagent_loader: Any,
         loop_provider: Callable[[], Any],
         status_provider: Callable[[], dict[str, Any]],
+        model_switcher: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
+        providers_provider: Callable[[], list[dict[str, Any]]] | None = None,
     ) -> None:
         self.workspace = workspace
         self.subagents = subagent_loader
         self._loop_provider = loop_provider
         self._status_provider = status_provider
+        self._model_switcher = model_switcher
+        self._providers_provider = providers_provider
 
     def catalog(self) -> dict[str, Any]:
         agents = self.subagents.sync() if self.subagents is not None else []
@@ -240,6 +250,9 @@ class CommandController:
                 },
             }
 
+        if command == "model":
+            return await self._handle_model(arguments)
+
         if command == "stop":
             stopped = await loop.cancel_session(session_key) if loop is not None else 0
             return {
@@ -359,3 +372,72 @@ class CommandController:
             }
 
         return None
+
+    async def _handle_model(self, arguments: str) -> dict[str, Any]:
+        """Implement ``/model [model-id]`` — show or switch the active model."""
+        if arguments:
+            if self._model_switcher is None:
+                return {
+                    "handled": True,
+                    "content": "Model switching isn't available in this session.",
+                }
+            result = await self._model_switcher(arguments)
+            if not result.get("switched"):
+                return {
+                    "handled": True,
+                    "content": (
+                        "I couldn't switch models: "
+                        f"{result.get('error') or 'unknown error'}"
+                    ),
+                }
+            model = str(result.get("model") or arguments)
+            if result.get("unchanged"):
+                content = f"Collie is already on **{model}**."
+            elif result.get("applied") is False:
+                content = f"Saved — I'll use **{model}** once a provider is connected."
+            else:
+                previous = str(result.get("previous") or "").strip()
+                if previous and previous != model:
+                    content = (
+                        f"Done — switched from **{previous}** to **{model}**. "
+                        "The next messages will use it."
+                    )
+                else:
+                    content = f"Done — the active model is now **{model}**."
+            return {
+                "handled": True,
+                "content": content,
+                "card_type": "status",
+                "card_data": {"model": model},
+            }
+
+        status = self._status_provider()
+        model = str(status.get("model") or "").strip()
+        providers = (
+            self._providers_provider()
+            if self._providers_provider is not None
+            else []
+        )
+        lines = [f"**Current model:** {model or 'not connected'}"]
+        if providers:
+            lines.append("")
+            lines.append("Configured providers:")
+            for provider in providers:
+                marker = " (active)" if provider.get("is_default") else ""
+                provider_model = provider.get("model") or "default"
+                provider_name = (
+                    provider.get("runtime_name") or provider.get("name") or "?"
+                )
+                lines.append(f"- **{provider_name}**: {provider_model}{marker}")
+            lines.append("")
+            lines.append(
+                "Switch with `/model <model-id>` — e.g. `/model deepseek-v4-flash`."
+            )
+        else:
+            lines.append("No providers configured yet. Add one in Settings first.")
+        return {
+            "handled": True,
+            "content": "\n".join(lines),
+            "card_type": "status",
+            "card_data": {"model": model},
+        }

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -37,6 +37,7 @@ from collie_core.session_identity import desktop_session_key
 from collie_core.subagents.loader import SubagentLoader, bind_subagent_loader
 from collie_core.tools.life_db import bind_life_db
 from collie_core.tools.memory import bind_profile_store
+from collie_core.tools.model_switch import bind_model_switcher
 from collie_core.tools.plans import bind_plans_db
 from collie_core.tools.reminders import bind_reminders_db
 from collie_core.tools.suggest_profile import bind_suggest_workspace
@@ -66,6 +67,7 @@ class CollieRuntime:
         bind_reminders_db(self.db)
         bind_life_db(self.db)
         bind_plans_db(self.db)
+        bind_model_switcher(self._switch_model)
         bind_task_checklists_db(self.db)
         # The connector manager keeps the old ServiceManager-shaped facade for
         # one transition release, so existing life-tool bridges stay bootable.
@@ -104,6 +106,8 @@ class CollieRuntime:
             subagent_loader=self.subagents,
             loop_provider=lambda: self.loop,
             status_provider=self._status,
+            model_switcher=self._switch_model,
+            providers_provider=lambda: self.db.list_providers(),
         )
         self.ipc = CollieIPCServer(
             self.db,
@@ -868,6 +872,48 @@ class CollieRuntime:
             except Exception:
                 pass
         return status
+
+    async def _switch_model(self, model: str) -> dict[str, Any]:
+        """Persist and live-apply a new active model for future turns.
+
+        The setting is saved first so a later loop rebuild (provider change,
+        app restart) keeps the choice. When a loop is running, the change is
+        also applied live via the runtime resolver so the very next turn uses
+        the new model — no loop rebuild, no interrupted turn.
+        """
+        name = str(model).strip()
+        if not name:
+            return {"switched": False, "error": "A model name is required."}
+        previous = self.db.get_setting("provider.model")
+        if name == previous:
+            return {
+                "switched": True,
+                "model": name,
+                "previous": previous,
+                "unchanged": True,
+                "applied": True,
+            }
+        self.db.set_setting("provider.model", name)
+        applied = False
+        loop = self.loop
+        if loop is not None:
+            resolver = getattr(loop, "runtime_resolver", None)
+            select = getattr(resolver, "select_model", None)
+            if callable(select):
+                try:
+                    select(name)
+                    applied = True
+                except Exception:
+                    logger.exception(
+                        "Live model switch failed; the new model will apply "
+                        "on the next loop rebuild"
+                    )
+        return {
+            "switched": True,
+            "model": name,
+            "previous": previous,
+            "applied": applied,
+        }
 
     async def _chat(
         self,

--- a/collie-core/collie_core/tools/model_switch.py
+++ b/collie-core/collie_core/tools/model_switch.py
@@ -1,0 +1,112 @@
+"""Switch the active AI model from chat (``set_model`` tool).
+
+The runtime binds one live switcher at boot (``CollieRuntime._switch_model``);
+both the deterministic ``/model`` command and the agent's ``set_model`` tool
+call through it. The change is persisted to settings and applied live to the
+running loop, so the next turn uses the new model without a loop rebuild.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from collie_core.permissions.models import PermissionRequest, Risk
+from nanobot.agent.tools.base import Tool, tool_parameters
+
+__all__ = ["SetModelTool", "bind_model_switcher", "model_switcher"]
+
+ModelSwitcher = Callable[[str], Awaitable[dict[str, Any]]]
+
+_switcher: ModelSwitcher | None = None
+
+
+def bind_model_switcher(switcher: ModelSwitcher | None) -> None:
+    """Bind the live runtime switcher (called once at boot)."""
+    global _switcher
+    _switcher = switcher
+
+
+def model_switcher() -> ModelSwitcher | None:
+    """Return the bound switcher, or ``None`` when no runtime is attached."""
+    return _switcher
+
+
+@tool_parameters({
+    "type": "object",
+    "properties": {
+        "model": {
+            "type": "string",
+            "description": (
+                "Exact model ID to switch to, e.g. 'deepseek-v4-flash' or 'gpt-5.5'."
+            ),
+        },
+    },
+    "required": ["model"],
+})
+class SetModelTool(Tool):
+    """Switch the active AI model for the next messages."""
+
+    @property
+    def name(self) -> str:
+        return "set_model"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Switch the active AI model to a specific model ID (e.g. "
+            "'deepseek-v4-flash' or 'gpt-5.5'). The change is saved and applies "
+            "to the next messages. Use this when the user asks to change or "
+            "switch the model."
+        )
+
+    @property
+    def read_only(self) -> bool:
+        return False
+
+    def permission_request(self, params: dict[str, Any]) -> PermissionRequest:
+        # Changing the active model mutates provider settings, so it stays
+        # approval-gated (see mvp-agent-skill-runtime.md: provider/settings
+        # operations never gain automatic or task-wide authority). The risk is
+        # still LOCAL_WRITE and fully reversible, so no hard approval.
+        return PermissionRequest(
+            action="runtime.set_model",
+            resource=str(params.get("model") or "model"),
+            risk=Risk.LOCAL_WRITE,
+            summary="Switch the active AI model",
+            reversible=True,
+        )
+
+    @classmethod
+    def enabled(cls, ctx: Any) -> bool:
+        return True
+
+    @classmethod
+    def create(cls, ctx: Any) -> "SetModelTool":
+        return cls()
+
+    async def execute(self, **kwargs: Any) -> Any:
+        name = str(kwargs.get("model") or "").strip()
+        if not name:
+            return self.error(
+                "Which model should I switch to? Give me the exact model ID, "
+                "e.g. 'deepseek-v4-flash'."
+            )
+        switcher = model_switcher()
+        if switcher is None:
+            return self.error("Model switching is not available in this session.")
+        try:
+            result = await switcher(name)
+        except Exception as error:
+            return self.error(f"I couldn't switch models: {error}")
+        if not result.get("switched"):
+            return self.error(
+                str(result.get("error") or "I couldn't switch models.")
+            )
+        model = str(result.get("model") or name)
+        if result.get("applied"):
+            return (
+                f"Done — the active model is now **{model}**. "
+                "The next messages will use it."
+            )
+        return f"Saved — I'll use **{model}** once a provider is connected."

--- a/collie-core/nanobot/agent/context.py
+++ b/collie-core/nanobot/agent/context.py
@@ -100,11 +100,14 @@ class ContextBuilder:
         if self.command_guidance:
             parts.append(
                 "# User Commands\n\n"
-                "The user can type /new, /compact, /status, /stop, /agents, /skills, "
+                "The user can type /new, /compact, /status, /model, /stop, /agents, /skills, "
                 "/agent, /skill, /create-agent, and /create-skill. You may suggest the "
                 "most relevant command when it would help, but you cannot invoke commands "
                 "yourself and must never claim that printing command text executed it. "
-                "Only an exact command entered by the user is treated as authorization."
+                "Only an exact command entered by the user is treated as authorization.\n"
+                "To change the AI model, call the set_model tool with the exact model ID "
+                "(it applies to the next messages), or tell the user to type "
+                "/model <model-id> — do not invent other model commands."
             )
 
         if include_memory_recent_history:

--- a/collie-core/tests/collie/test_commands_and_capabilities.py
+++ b/collie-core/tests/collie/test_commands_and_capabilities.py
@@ -14,7 +14,7 @@ from collie_core.commands import CommandController, parse_command
 from collie_core.db import CollieDB
 from collie_core.ipc.server import CollieIPCServer
 from collie_core.permissions.evaluator import PermissionEvaluator
-from collie_core.permissions.models import Effect, ExecutionContext
+from collie_core.permissions.models import Effect, ExecutionContext, Risk
 from collie_core.runtime import CollieRuntime
 from collie_core.subagents.loader import SubagentLoader
 from collie_core.tools.capabilities import (
@@ -23,6 +23,12 @@ from collie_core.tools.capabilities import (
     LoadSkillTool,
     create_workspace_skill,
 )
+from collie_core.tools.model_switch import (
+    SetModelTool,
+    bind_model_switcher,
+    model_switcher,
+)
+from nanobot.agent.context import ContextBuilder
 from nanobot.agent.tools.loader import ToolLoader
 
 
@@ -423,3 +429,286 @@ async def test_messenger_new_cancels_and_deletes_only_short_term_session(
         assert calls == [("cancel", "telegram:42"), ("delete", "telegram:42")]
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# /model command
+# ---------------------------------------------------------------------------
+
+
+def _model_controller(
+    tmp_path: Path,
+    *,
+    switcher=None,
+    providers=None,
+) -> CommandController:
+    return CommandController(
+        workspace=tmp_path / "workspace",
+        subagent_loader=None,
+        loop_provider=lambda: None,
+        status_provider=lambda: {
+            "model": "deepseek-v4-pro",
+            "active_agents": [],
+        },
+        model_switcher=switcher,
+        providers_provider=lambda: providers or [],
+    )
+
+
+def test_model_command_is_in_catalog(tmp_path: Path) -> None:
+    db, _workspace, _loader, controller = _controller(tmp_path)
+    try:
+        model_command = next(
+            item
+            for item in controller.catalog()["commands"]
+            if item["name"] == "model"
+        )
+        assert model_command["usage"] == "/model [model-id]"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_model_command_without_arguments_lists_current_and_providers(
+    tmp_path: Path,
+) -> None:
+    providers = [
+        {
+            "name": "deepseek",
+            "runtime_name": "DeepSeek",
+            "model": "deepseek-v4-pro",
+            "is_default": 1,
+        },
+        {
+            "name": "openai",
+            "runtime_name": "OpenAI",
+            "model": "gpt-5.5",
+            "is_default": 0,
+        },
+    ]
+    controller = _model_controller(tmp_path, providers=providers)
+    result = await controller.execute(
+        "/model",
+        session_key="collie:one",
+        origin="desktop",
+    )
+    assert result is not None
+    assert result["handled"] is True
+    assert "**Current model:** deepseek-v4-pro" in result["content"]
+    assert "**DeepSeek**: deepseek-v4-pro (active)" in result["content"]
+    assert "**OpenAI**: gpt-5.5" in result["content"]
+    assert result["card_type"] == "status"
+    assert result["card_data"]["model"] == "deepseek-v4-pro"
+
+
+@pytest.mark.asyncio
+async def test_model_command_switches_via_runtime_bridge(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    async def switcher(name: str) -> dict:
+        calls.append(name)
+        return {
+            "switched": True,
+            "model": name,
+            "previous": "deepseek-v4-pro",
+            "applied": True,
+        }
+
+    controller = _model_controller(tmp_path, switcher=switcher)
+    result = await controller.execute(
+        "/model deepseek-v4-flash",
+        session_key="collie:one",
+        origin="desktop",
+    )
+    assert calls == ["deepseek-v4-flash"]
+    assert result is not None
+    assert result["handled"] is True
+    assert (
+        "switched from **deepseek-v4-pro** to **deepseek-v4-flash**"
+        in result["content"]
+    )
+    assert result["card_type"] == "status"
+    assert result["card_data"]["model"] == "deepseek-v4-flash"
+
+
+@pytest.mark.asyncio
+async def test_model_command_reports_unchanged_and_failures(
+    tmp_path: Path,
+) -> None:
+    async def unchanged(name: str) -> dict:
+        return {
+            "switched": True,
+            "model": name,
+            "previous": name,
+            "unchanged": True,
+            "applied": True,
+        }
+
+    async def failing(name: str) -> dict:
+        return {"switched": False, "error": "that model is not on the menu"}
+
+    controller = _model_controller(tmp_path, switcher=unchanged)
+    same = await controller.execute(
+        "/model deepseek-v4-pro",
+        session_key="collie:one",
+        origin="desktop",
+    )
+    assert same and "already on **deepseek-v4-pro**" in same["content"]
+
+    controller = _model_controller(tmp_path, switcher=failing)
+    failed = await controller.execute(
+        "/model nope-9",
+        session_key="collie:one",
+        origin="desktop",
+    )
+    assert failed and "I couldn't switch models" in failed["content"]
+    assert "that model is not on the menu" in failed["content"]
+
+    controller = _model_controller(tmp_path, switcher=None)
+    unavailable = await controller.execute(
+        "/model deepseek-v4-flash",
+        session_key="collie:one",
+        origin="desktop",
+    )
+    assert unavailable and "isn't available" in unavailable["content"]
+
+
+# ---------------------------------------------------------------------------
+# set_model tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_model_tool_switches_via_bound_runtime() -> None:
+    calls: list[str] = []
+
+    async def switcher(name: str) -> dict:
+        calls.append(name)
+        return {
+            "switched": True,
+            "model": name,
+            "previous": "deepseek-v4-pro",
+            "applied": True,
+        }
+
+    try:
+        bind_model_switcher(switcher)
+        assert model_switcher() is switcher
+        tool = SetModelTool()
+        out = await tool.execute(model="deepseek-v4-flash")
+        assert calls == ["deepseek-v4-flash"]
+        assert "deepseek-v4-flash" in out
+        assert "next messages" in out
+    finally:
+        bind_model_switcher(None)
+
+
+@pytest.mark.asyncio
+async def test_set_model_tool_errors_are_explicit() -> None:
+    try:
+        bind_model_switcher(None)
+        tool = SetModelTool()
+        missing = await tool.execute()
+        assert "Which model" in missing
+        unbound = await tool.execute(model="deepseek-v4-flash")
+        assert "not available" in unbound
+
+        async def failing(name: str) -> dict:
+            return {"switched": False, "error": "bad model"}
+
+        bind_model_switcher(failing)
+        failed = await tool.execute(model="deepseek-v4-flash")
+        assert "bad model" in failed
+    finally:
+        bind_model_switcher(None)
+
+
+def test_set_model_tool_permission_is_reversible_local_write() -> None:
+    request = SetModelTool().permission_request({"model": "deepseek-v4-flash"})
+    assert request.action == "runtime.set_model"
+    assert request.resource == "deepseek-v4-flash"
+    assert request.risk == Risk.LOCAL_WRITE
+    assert request.reversible is True
+    assert request.hard_approval is False
+    # Provider/settings operations stay approval-gated (never automatic).
+    assert request.approval_free is False
+    assert request.approve_for_me is False
+
+
+def test_set_model_tool_is_discoverable() -> None:
+    import collie_core.tools as collie_tools
+
+    names = {tool.__name__ for tool in ToolLoader(collie_tools).discover()}
+    assert "SetModelTool" in names
+
+
+# ---------------------------------------------------------------------------
+# runtime model switching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runtime_switch_model_persists_and_applies_live(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "collie-home"
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    db = CollieDB(home / "collie.db")
+    runtime = CollieRuntime(port=0, db=db)
+    selected: list[str] = []
+    runtime.loop = SimpleNamespace(
+        runtime_resolver=SimpleNamespace(
+            select_model=lambda name: selected.append(name)
+        )
+    )
+    try:
+        result = await runtime._switch_model("deepseek-v4-flash")
+        assert result == {
+            "switched": True,
+            "model": "deepseek-v4-flash",
+            "previous": None,
+            "applied": True,
+        }
+        assert db.get_setting("provider.model") == "deepseek-v4-flash"
+        assert selected == ["deepseek-v4-flash"]
+
+        again = await runtime._switch_model("deepseek-v4-flash")
+        assert again["unchanged"] is True
+        assert selected == ["deepseek-v4-flash"]
+
+        bad = await runtime._switch_model("   ")
+        assert bad == {"switched": False, "error": "A model name is required."}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_switch_model_without_loop_persists_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "collie-home"
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    db = CollieDB(home / "collie.db")
+    runtime = CollieRuntime(port=0, db=db)
+    try:
+        result = await runtime._switch_model("gpt-5.5")
+        assert result["switched"] is True
+        assert result["applied"] is False
+        assert db.get_setting("provider.model") == "gpt-5.5"
+    finally:
+        db.close()
+
+
+def test_command_guidance_tells_the_agent_about_model_switching(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    (tmp_path / "skills").mkdir(exist_ok=True)
+    builder = ContextBuilder(workspace=tmp_path)
+    builder.command_guidance = True
+    prompt = builder.build_system_prompt()
+    assert "/model" in prompt
+    assert "set_model" in prompt
+    assert "do not invent other model commands" in prompt

--- a/docs/engineering/architecture/mvp-agent-skill-runtime.md
+++ b/docs/engineering/architecture/mvp-agent-skill-runtime.md
@@ -118,6 +118,16 @@ The always-on layer should be deterministic code wherever possible.
    - Stop when the tool or model budget is exhausted.
    - Report a concrete partial result or blocker.
 
+9. **In-chat model switching (`/model` + `set_model`)**
+   - `/model` shows the current model and configured providers; `/model <id>`
+     switches. The agent can also switch via the `set_model` tool.
+   - The change persists `provider.model` and applies live through the loop's
+     runtime resolver (`select_model`) — future turns use the new model, no
+     loop rebuild, no interrupted turn.
+   - Model changes are reversible local writes but stay approval-gated: they
+     mutate provider settings, so they never gain automatic or task-wide
+     authority.
+
 ### Do not turn these into hidden LLM agents
 
 - Permission checking

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,7 +11,7 @@
 
 ## Source inventory
 
-- Core Python files: **474**
+- Core Python files: **475**
 - Core Python test files: **216**
 - Desktop TypeScript/TSX files: **116**
 - Desktop test files: **34**


### PR DESCRIPTION
## What

Fixes the two gaps found in the "Initial Test Message" chat: `/model` didn't exist (the agent hallucinated it and told the user to use it), and the agent had no way to switch models when asked in plain English.

## Changes

- **`/model` command** (`collie_core/commands.py`): no args shows the current model + configured providers; `/model <model-id>` persists `provider.model` and applies it live through the loop's runtime resolver (`select_model`) — the next turn uses the new model, no loop rebuild, no interrupted turn.
- **`set_model` agent tool** (`collie_core/tools/model_switch.py`): lets the agent switch models on plain-English requests, via a boot-time `bind_model_switcher` bridge. Permission: `runtime.set_model`, LOCAL_WRITE, reversible, approval-gated (provider/settings operations never gain automatic authority per `mvp-agent-skill-runtime.md`).
- **Prompt guidance** (`nanobot/agent/context.py`): the "User Commands" section now lists `/model` and tells the agent to use `set_model` / `/model <model-id>` — it must not invent other model commands.
- **Docs**: durable decision note in `docs/engineering/architecture/mvp-agent-skill-runtime.md`; `docs/generated/REPOSITORY_SNAPSHOT.md` regenerated.

## Verification (Linux VM, exact commit `958ada1`)

| Check | Result |
|---|---|
| `tests/collie/test_commands_and_capabilities.py` (incl. 9 new tests) | 23/23 passed |
| Full `tests/collie` suite | 485 passed / 5 failed / 1 skipped |
| Failed tests | documented Windows-only baseline (4× DPAPI credentials, 1× IPC escape-path) |
| ruff (all changed files) | clean |

## Notes

- Created automatically by Hermes via `gh` (fine-grained PAT scoped to this repo, Pull requests read/write only).
- Hermes never merges or approves PRs — Codex review + manual merge on Windows remains the gate.
