### PR TITLE
fix(core): address Codex review round 1 — approval-gated /model, off-loop writes, credential-verified connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ The current public source release is **v0.1.0-alpha.4**.
 - Guided Telegram setup with sender pairing and revocation.
 - A desktop Border Collie companion with responsive activity states.
 
-External OAuth connectors are not enabled in the current alpha source state.
-Every connector catalogue entry remains **Coming soon** until its exact
-packaged application passes authentication, tool discovery, live health, and
-release verification checks. Collie does not claim that every provider or
+OAuth connectors are enabled as alpha: five official MCP routes
+(Notion, Linear, Todoist, Atlassian, Airtable) can connect today and are
+labeled **Alpha** in the app with their verification status visible. Every
+other catalogue entry remains **Coming soon** until its exact packaged
+application passes authentication, tool discovery, live health, and release
+verification checks. The packaged-app acceptance pass stays the gate before
+any release claim — Collie does not claim that every provider or
 integration works out of the box.
 
 ## Safety and data handling

--- a/collie-core/collie_core/commands.py
+++ b/collie-core/collie_core/commands.py
@@ -7,6 +7,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from collie_core.permissions.broker import PermissionDeniedError
+from collie_core.permissions.models import ExecutionContext
 from nanobot.agent.skills import SkillsLoader
 
 _COMMAND = re.compile(r"^/([a-z][a-z0-9-]*)(?:\s+(.*))?$", re.IGNORECASE | re.DOTALL)
@@ -88,6 +90,9 @@ class CommandController:
         status_provider: Callable[[], dict[str, Any]],
         model_switcher: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
         providers_provider: Callable[[], list[dict[str, Any]]] | None = None,
+        model_authorizer: Callable[
+            [ExecutionContext, dict[str, Any]], Awaitable[None]
+        ] | None = None,
     ) -> None:
         self.workspace = workspace
         self.subagents = subagent_loader
@@ -95,6 +100,7 @@ class CommandController:
         self._status_provider = status_provider
         self._model_switcher = model_switcher
         self._providers_provider = providers_provider
+        self._model_authorizer = model_authorizer
 
     def catalog(self) -> dict[str, Any]:
         agents = self.subagents.sync() if self.subagents is not None else []
@@ -129,6 +135,8 @@ class CommandController:
         *,
         session_key: str,
         origin: str,
+        conversation_id: str | None = None,
+        execution_mode: str = "execute",
     ) -> dict[str, Any] | None:
         if _MODEL_IDENTITY_QUERY.fullmatch(content.strip()):
             status = self._status_provider()
@@ -251,7 +259,12 @@ class CommandController:
             }
 
         if command == "model":
-            return await self._handle_model(arguments)
+            return await self._handle_model(
+                arguments,
+                conversation_id=conversation_id,
+                execution_mode=execution_mode,
+                origin=origin,
+            )
 
         if command == "stop":
             stopped = await loop.cancel_session(session_key) if loop is not None else 0
@@ -373,14 +386,42 @@ class CommandController:
 
         return None
 
-    async def _handle_model(self, arguments: str) -> dict[str, Any]:
-        """Implement ``/model [model-id]`` — show or switch the active model."""
+    async def _handle_model(
+        self,
+        arguments: str,
+        *,
+        conversation_id: str | None,
+        execution_mode: str,
+        origin: str,
+    ) -> dict[str, Any]:
+        """Implement ``/model [model-id]`` — show or switch the active model.
+
+        Switching mutates provider settings, so it goes through the same
+        permission broker as the ``set_model`` tool (approval-gated
+        LOCAL_WRITE; denied in plan mode) before the runtime switcher runs.
+        """
         if arguments:
             if self._model_switcher is None:
                 return {
                     "handled": True,
                     "content": "Model switching isn't available in this session.",
                 }
+            if self._model_authorizer is not None:
+                context = ExecutionContext(
+                    execution_mode=execution_mode,
+                    conversation_id=conversation_id,
+                    origin=origin,
+                )
+                try:
+                    await self._model_authorizer(context, {"model": arguments})
+                except PermissionDeniedError as error:
+                    return {
+                        "handled": True,
+                        "content": (
+                            "I can't switch models right now: "
+                            f"{error}"
+                        ),
+                    }
             result = await self._model_switcher(arguments)
             if not result.get("switched"):
                 return {

--- a/collie-core/collie_core/commands.py
+++ b/collie-core/collie_core/commands.py
@@ -102,6 +102,18 @@ class CommandController:
         self._providers_provider = providers_provider
         self._model_authorizer = model_authorizer
 
+    def requires_approval(self, content: str) -> bool:
+        """True when executing this command can await user approval.
+
+        Approval-gated commands must not run inside the serial IPC frame
+        handler: their resolution arrives as a frame on the same socket, so
+        callers dispatch them to a background task instead.
+        """
+        if self._model_authorizer is None:
+            return False
+        parsed = parse_command(content)
+        return parsed is not None and parsed[0] == "model" and bool(parsed[1])
+
     def catalog(self) -> dict[str, Any]:
         agents = self.subagents.sync() if self.subagents is not None else []
         loader = SkillsLoader(self.workspace)

--- a/collie-core/collie_core/connectors/catalog.py
+++ b/collie-core/collie_core/connectors/catalog.py
@@ -60,21 +60,26 @@ _ALPHA_VERIFICATION = (
     "sign-in verification is still pending."
 )
 
-# Least-privilege OAuth scopes per provider (documented scope vocabularies).
-# Requesting no scope makes the MCP SDK omit the parameter, which the
-# authorization servers interpret as "everything advertised" — an explicit,
-# narrow set keeps consent honest. Values still need live confirmation on
-# the owner's packaged-app acceptance pass (each provider's OAuth server is
-# authoritative).
+# Least-privilege OAuth scopes per provider, verified against each
+# provider's live RFC 8414 authorization-server / RFC 9728 resource
+# metadata (2026-08-02). Requesting no scope makes the MCP SDK omit the
+# parameter, which the authorization servers interpret as "everything
+# advertised" — an explicit, narrow set keeps consent honest.
 _SCOPES: dict[str, tuple[str, ...]] = {
-    "notion": ("web:read", "web:update"),
+    # Notion's authorization server supports exactly one scope: "default".
+    "notion": ("default",),
     "linear": ("read", "write"),
     "todoist": ("data:read_write",),
+    # Atlassian MCP (authv2) resource metadata vocabulary — Jira issues,
+    # Confluence pages, search, identity, and offline refresh only.
     "atlassian": (
-        "read:jira:user",
+        "read:me",
         "read:jira-work",
         "write:jira-work",
-        "read:confluence-content.summary",
+        "search:confluence",
+        "read:page:confluence",
+        "write:page:confluence",
+        "offline_access",
     ),
     "airtable": ("data.records:read", "data.records:write", "schema.bases:read"),
 }

--- a/collie-core/collie_core/connectors/catalog.py
+++ b/collie-core/collie_core/connectors/catalog.py
@@ -1,7 +1,9 @@
 """Curated consumer connector catalog.
 
 Only official provider endpoints or official APIs belong here. Availability
-means the complete authorization and live-probe path is implemented.
+means the complete authorization and live-probe path is implemented. Alpha
+enablement (``release_status="alpha"``) means the route is live and labeled
+with its pending packaged-app verification — it is not a release claim.
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ def _mcp(
     available: bool = True,
     note: str = "",
     overrides: dict[str, str] | None = None,
+    scopes: tuple[str, ...] = (),
 ) -> ConnectorDefinition:
     from urllib.parse import urlparse
 
@@ -38,6 +41,7 @@ def _mcp(
         endpoint=endpoint,
         capabilities=capabilities,
         permissions=permissions,
+        scopes=scopes,
         featured=featured,
         available=available,
         release_status="alpha" if available else "coming_soon",
@@ -56,6 +60,25 @@ _ALPHA_VERIFICATION = (
     "sign-in verification is still pending."
 )
 
+# Least-privilege OAuth scopes per provider (documented scope vocabularies).
+# Requesting no scope makes the MCP SDK omit the parameter, which the
+# authorization servers interpret as "everything advertised" — an explicit,
+# narrow set keeps consent honest. Values still need live confirmation on
+# the owner's packaged-app acceptance pass (each provider's OAuth server is
+# authoritative).
+_SCOPES: dict[str, tuple[str, ...]] = {
+    "notion": ("web:read", "web:update"),
+    "linear": ("read", "write"),
+    "todoist": ("data:read_write",),
+    "atlassian": (
+        "read:jira:user",
+        "read:jira-work",
+        "write:jira-work",
+        "read:confluence-content.summary",
+    ),
+    "airtable": ("data.records:read", "data.records:write", "schema.bases:read"),
+}
+
 CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
     _mcp(
         "notion",
@@ -68,6 +91,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         featured=True,
         available=True,
         note=_ALPHA_VERIFICATION,
+        scopes=_SCOPES["notion"],
     ),
     _mcp(
         "linear",
@@ -80,6 +104,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         available=True,
         note=_ALPHA_VERIFICATION,
         overrides={"delete_issue": "destructive"},
+        scopes=_SCOPES["linear"],
     ),
     _mcp(
         "todoist",
@@ -92,6 +117,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         featured=True,
         available=True,
         note=_ALPHA_VERIFICATION,
+        scopes=_SCOPES["todoist"],
     ),
     _mcp(
         "atlassian",
@@ -103,6 +129,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         permissions=("read Jira and Confluence", "create and update with approval"),
         available=True,
         note=_ALPHA_VERIFICATION,
+        scopes=_SCOPES["atlassian"],
     ),
     _mcp(
         "gmail",
@@ -213,6 +240,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         available=True,
         release_status="alpha",
         note=_ALPHA_VERIFICATION,
+        scopes=_SCOPES["airtable"],
     ),
     ConnectorDefinition(
         id="github",

--- a/collie-core/collie_core/connectors/drivers/official_mcp.py
+++ b/collie-core/collie_core/connectors/drivers/official_mcp.py
@@ -64,7 +64,16 @@ class OfficialMcpDriver:
                         )
                         for tool in result.tools
                     ]
-        return ProbeResult(tools=tools, granted_scopes=list(definition.scopes))
+        granted = list(definition.scopes)
+        # Record the scopes the authorization server actually granted from
+        # the stored token (fall back to the requested set when absent).
+        stored = self.credentials.load(f"connector:{connection_id}")
+        if stored:
+            tokens = stored.get("tokens") or {}
+            actual = tokens.get("scope")
+            if actual:
+                granted = str(actual).split()
+        return ProbeResult(tools=tools, granted_scopes=granted)
 
     def revoke(
         self, definition: ConnectorDefinition, connection_id: str

--- a/collie-core/collie_core/connectors/manager.py
+++ b/collie-core/collie_core/connectors/manager.py
@@ -89,9 +89,18 @@ class ConnectorManager:
                 and definition.available
                 and row["driver"] == definition.driver.value
             )
-            if row["status"] == ConnectionStatus.CONNECTED.value and compatible:
-                counts[provider_id] = counts.get(provider_id, 0) + 1
-            if compatible:
+            if not compatible:
+                continue
+            if row["status"] == ConnectionStatus.CONNECTED.value:
+                # A connected row only counts (and stays green) when its
+                # credentials actually exist.
+                if self._has_credentials(row):
+                    counts[provider_id] = counts.get(provider_id, 0) + 1
+                else:
+                    statuses.setdefault(
+                        provider_id, ConnectionStatus.AUTH_REQUIRED.value
+                    )
+            else:
                 statuses.setdefault(provider_id, str(row["status"]))
         return [
             {
@@ -133,6 +142,10 @@ class ConnectorManager:
             self.db, credentials=self.credentials
         ).catalog_view()
 
+    def _has_credentials(self, row: dict[str, Any]) -> bool:
+        """A connection is only genuinely connected when its token exists."""
+        return self.credentials.load(f"connector:{row['id']}") is not None
+
     def _connection_view(self, row: dict[str, Any]) -> dict[str, Any]:
         definition = connector_def(str(row["provider_id"]))
         compatible = bool(
@@ -150,6 +163,18 @@ class ConnectorManager:
             last_error_code = "provider_unavailable"
             last_error_message = (
                 "This connection is not available in this build and cannot be used."
+            )
+        # A connected row without stored credentials (token deleted, DB
+        # restored without the credential files, legacy migration gap) must
+        # not look healthy or bind at runtime — it needs a fresh sign-in.
+        elif status == ConnectionStatus.CONNECTED.value and not self._has_credentials(
+            row
+        ):
+            status = ConnectionStatus.AUTH_REQUIRED.value
+            last_error_code = "credentials_missing"
+            last_error_message = (
+                "The saved credentials for this connection are missing — "
+                "sign in again."
             )
         return {
             "id": row["id"],
@@ -486,6 +511,7 @@ class ConnectorManager:
                 or not definition.available
                 or definition.driver != ConnectorDriverKind.OFFICIAL_MCP
                 or row["driver"] != definition.driver.value
+                or not self._has_credentials(row)
             ):
                 continue
             name = f"{definition.id}_{str(row['id'])[-8:]}"
@@ -511,6 +537,7 @@ class ConnectorManager:
             return False
         return any(
             row["status"] == ConnectionStatus.CONNECTED.value
+            and self._has_credentials(row)
             for row in self.db.list_connector_connections(provider_id)
         )
 

--- a/collie-core/collie_core/connectors/manager.py
+++ b/collie-core/collie_core/connectors/manager.py
@@ -143,8 +143,12 @@ class ConnectorManager:
         ).catalog_view()
 
     def _has_credentials(self, row: dict[str, Any]) -> bool:
-        """A connection is only genuinely connected when its token exists."""
-        return self.credentials.load(f"connector:{row['id']}") is not None
+        """A connection is only genuinely connected when it holds a usable
+        access token. Empty records, client-info-only entries, and token
+        blobs without an ``access_token`` do not count."""
+        data = self.credentials.load(f"connector:{row['id']}") or {}
+        tokens = data.get("tokens") or {}
+        return bool(tokens.get("access_token"))
 
     def _connection_view(self, row: dict[str, Any]) -> dict[str, Any]:
         definition = connector_def(str(row["provider_id"]))

--- a/collie-core/collie_core/connectors/models.py
+++ b/collie-core/collie_core/connectors/models.py
@@ -12,6 +12,7 @@ class ConnectionStatus(StrEnum):
     AUTHORIZING = "authorizing"
     TESTING = "testing"
     CONNECTED = "connected"
+    AUTH_REQUIRED = "auth_required"
     ATTENTION = "attention"
     FAILED = "failed"
     REVOKING = "revoking"

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -647,6 +647,20 @@ class CollieDB:
                 (key, json.dumps(value)),
             )
 
+    def set_active_model(self, model: str) -> None:
+        """Persist the active model atomically: the global setting AND the
+        default provider row stay in agreement (one canonical source)."""
+        with self._write() as conn:
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                ("provider.model", json.dumps(model)),
+            )
+            conn.execute(
+                "UPDATE providers SET model = ? WHERE is_default = 1",
+                (model,),
+            )
+
     def all_settings(self) -> dict[str, Any]:
         out: dict[str, Any] = {}
         for row in self._rows("SELECT key, value FROM settings"):

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -2265,6 +2265,8 @@ class CollieIPCServer:
                 content,
                 session_key=session_key,
                 origin=command_origin,
+                conversation_id=conv_id,
+                execution_mode=str(conversation.get("execution_mode") or "execute"),
             )
             if command_result and command_result.get("new_conversation"):
                 conversation = self.db.create_conversation(

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -193,6 +193,7 @@ class CollieIPCServer:
         profile_store: Any = None,
         command_runner: Callable[..., Awaitable[dict[str, Any] | None]] | None = None,
         command_catalog: Callable[[], dict[str, Any]] | None = None,
+        command_requires_approval: Callable[[str], bool] | None = None,
         session_target: Callable[[str], tuple[str, str]] | None = None,
         conversation_deleter: Callable[[str], None] | None = None,
         on_set_approval_preset: Callable[[str], None] | None = None,
@@ -223,6 +224,7 @@ class CollieIPCServer:
         self._profile_store = profile_store
         self._command_runner = command_runner
         self._command_catalog = command_catalog
+        self._command_requires_approval = command_requires_approval
         self._session_target = session_target
         self._conversation_deleter = conversation_deleter
         self._on_set_approval_preset = on_set_approval_preset
@@ -231,6 +233,7 @@ class CollieIPCServer:
         self._clients: set[ServerConnection] = set()
         self._server: Any = None
         self._chat_tasks: dict[str, asyncio.Task] = {}
+        self._command_tasks: set[asyncio.Task] = set()
         self._active_material_runs: dict[str, int] = {}
         self._background_tasks: set[asyncio.Task] = set()
         self._oauth_attempts: dict[str, _OAuthAttemptState] = {}
@@ -770,7 +773,16 @@ class CollieIPCServer:
             raise ValueError("set_setting requires 'key'")
         if key not in _IPC_SETTABLE_SETTINGS:
             raise ValueError(f"Setting '{key}' is managed by Collie itself.")
-        self.db.set_setting(key, frame.get("value"))
+        if key == "provider.model":
+            # The active model is two sources in one transaction (setting +
+            # default provider row); a bare settings write would let a later
+            # provider rebuild revert the choice.
+            value = frame.get("value")
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError("provider.model must be a non-empty model id")
+            self.db.set_active_model(value)
+        else:
+            self.db.set_setting(key, frame.get("value"))
         return {"saved": True}
 
     async def _cmd_set_api_key(self, connection: ServerConnection, frame: dict) -> dict:
@@ -2252,21 +2264,54 @@ class CollieIPCServer:
         command_result: dict[str, Any] | None = None
         agent_content = content
         message_metadata: dict[str, Any] | None = None
+        session_key, command_origin = (
+            self._session_target(conv_id)
+            if self._session_target is not None
+            else (desktop_session_key(conv_id), "desktop")
+        )
+        execution_mode = str(conversation.get("execution_mode") or "execute")
+        if (
+            self._command_runner is not None
+            and not raw_attachments
+            and self._command_requires_approval is not None
+            and self._command_requires_approval(content)
+        ):
+            # Approval-gated commands (/model switch) await a user approval
+            # that resolves over THIS socket. Run them in a background task
+            # so the receive loop stays free to process resolve_approval —
+            # awaiting inline would deadlock until the approval times out.
+            user_msg = self.db.add_message(
+                conv_id, "user", content, attachments=attachment_meta or None
+            )
+            await self._send(connection, {"type": "ok", "id": frame.get("id"), "data": {
+                "conversation_id": conv_id,
+                "message": user_msg,
+                "command_handled": False,
+            }})
+            await self.broadcast({"type": "message", "conversation_id": conv_id,
+                                  "message": user_msg})
+            task = asyncio.create_task(
+                self._run_approval_command_task(
+                    conv_id,
+                    content=content,
+                    session_key=session_key,
+                    origin=command_origin,
+                    execution_mode=execution_mode,
+                )
+            )
+            self._command_tasks.add(task)
+            task.add_done_callback(self._command_tasks.discard)
+            return
         if (
             self._command_runner is not None
             and not raw_attachments
         ):
-            session_key, command_origin = (
-                self._session_target(conv_id)
-                if self._session_target is not None
-                else (desktop_session_key(conv_id), "desktop")
-            )
             command_result = await self._command_runner(
                 content,
                 session_key=session_key,
                 origin=command_origin,
                 conversation_id=conv_id,
-                execution_mode=str(conversation.get("execution_mode") or "execute"),
+                execution_mode=execution_mode,
             )
             if command_result and command_result.get("new_conversation"):
                 conversation = self.db.create_conversation(
@@ -2385,6 +2430,49 @@ class CollieIPCServer:
         )
         self._chat_tasks[conv_id] = task
         task.add_done_callback(lambda t, c=conv_id: self._chat_tasks.pop(c, None))
+
+    async def _run_approval_command_task(
+        self,
+        conv_id: str,
+        *,
+        content: str,
+        session_key: str,
+        origin: str,
+        execution_mode: str,
+    ) -> None:
+        """Execute an approval-gated command outside the frame handler.
+
+        The command's authorization awaits a user resolution that arrives as
+        a frame on the same socket; running it inline would block the
+        receive loop until the approval times out.
+        """
+        if self._command_runner is None:
+            return
+        try:
+            result = await self._command_runner(
+                content,
+                session_key=session_key,
+                origin=origin,
+                conversation_id=conv_id,
+                execution_mode=execution_mode,
+            )
+        except Exception:
+            logger.exception("Approval-gated command failed")
+            return
+        if not result or not result.get("handled"):
+            return
+        assistant_msg = self.db.add_message(
+            conv_id,
+            "assistant",
+            str(result.get("content") or ""),
+            card_type=result.get("card_type"),
+            card_data=result.get("card_data"),
+        )
+        await self.broadcast({
+            "type": "message",
+            "conversation_id": conv_id,
+            "message": assistant_msg,
+        })
 
     async def _generate_conversation_title(
         self,

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -94,6 +94,7 @@ class CollieRuntime:
         self._outbound_task: asyncio.Task | None = None
         self._reminder_task: asyncio.Task | None = None
         self._configure_lock = asyncio.Lock()
+        self._model_switch_lock = asyncio.Lock()
         self._provider_config_generation = 0
         self._provider_rollbacks: dict[str, dict[str, Any]] = {}
         self._auto_reconfiguring = False
@@ -136,6 +137,7 @@ class CollieRuntime:
             profile_store=self.profile,
             command_runner=self._run_command,
             command_catalog=self.commands.catalog,
+            command_requires_approval=self.commands.requires_approval,
             session_target=self._session_target,
             conversation_deleter=self.delete_conversation_sessions,
             on_set_approval_preset=self.permission_evaluator.set_local_write_preset,
@@ -907,38 +909,42 @@ class CollieRuntime:
         name = str(model).strip()
         if not name:
             return {"switched": False, "error": "A model name is required."}
-        # Sync SQLite calls stay off the event loop (project boundary:
-        # ipc/server.py wraps every db call in asyncio.to_thread).
-        previous = await asyncio.to_thread(self.db.get_setting, "provider.model")
-        if name == previous:
+        # Serialize the complete read/persist/live-apply so two concurrent
+        # switches cannot split persisted and live state (threaded writes
+        # finishing B->C while select_model applies C->B).
+        async with self._model_switch_lock:
+            # Sync SQLite calls stay off the event loop (project boundary:
+            # ipc/server.py wraps every db call in asyncio.to_thread).
+            previous = await asyncio.to_thread(self.db.get_setting, "provider.model")
+            if name == previous:
+                return {
+                    "switched": True,
+                    "model": name,
+                    "previous": previous,
+                    "unchanged": True,
+                    "applied": True,
+                }
+            await asyncio.to_thread(self.db.set_active_model, name)
+            applied = False
+            loop = self.loop
+            if loop is not None:
+                resolver = getattr(loop, "runtime_resolver", None)
+                select = getattr(resolver, "select_model", None)
+                if callable(select):
+                    try:
+                        select(name)
+                        applied = True
+                    except Exception:
+                        logger.exception(
+                            "Live model switch failed; the new model will apply "
+                            "on the next loop rebuild"
+                        )
             return {
                 "switched": True,
                 "model": name,
                 "previous": previous,
-                "unchanged": True,
-                "applied": True,
+                "applied": applied,
             }
-        await asyncio.to_thread(self.db.set_active_model, name)
-        applied = False
-        loop = self.loop
-        if loop is not None:
-            resolver = getattr(loop, "runtime_resolver", None)
-            select = getattr(resolver, "select_model", None)
-            if callable(select):
-                try:
-                    select(name)
-                    applied = True
-                except Exception:
-                    logger.exception(
-                        "Live model switch failed; the new model will apply "
-                        "on the next loop rebuild"
-                    )
-        return {
-            "switched": True,
-            "model": name,
-            "previous": previous,
-            "applied": applied,
-        }
 
     async def _chat(
         self,

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -17,6 +17,7 @@ import sys
 import urllib.parse
 import uuid
 from contextlib import suppress
+from types import SimpleNamespace
 from typing import Any
 
 from loguru import logger
@@ -31,13 +32,14 @@ from collie_core.memory.profile import ProfileStore
 from collie_core.messengers import CollieBus, MessengerManager
 from collie_core.permissions.broker import ApprovalBroker
 from collie_core.permissions.evaluator import PermissionEvaluator
+from collie_core.permissions.models import ExecutionContext
 from collie_core.permissions.store import PermissionStore
 from collie_core.services.manager import bind_service_manager
 from collie_core.session_identity import desktop_session_key
 from collie_core.subagents.loader import SubagentLoader, bind_subagent_loader
 from collie_core.tools.life_db import bind_life_db
 from collie_core.tools.memory import bind_profile_store
-from collie_core.tools.model_switch import bind_model_switcher
+from collie_core.tools.model_switch import SetModelTool, bind_model_switcher
 from collie_core.tools.plans import bind_plans_db
 from collie_core.tools.reminders import bind_reminders_db
 from collie_core.tools.suggest_profile import bind_suggest_workspace
@@ -108,6 +110,7 @@ class CollieRuntime:
             status_provider=self._status,
             model_switcher=self._switch_model,
             providers_provider=lambda: self.db.list_providers(),
+            model_authorizer=self._authorize_model_switch,
         )
         self.ipc = CollieIPCServer(
             self.db,
@@ -217,11 +220,31 @@ class CollieRuntime:
         *,
         session_key: str,
         origin: str,
+        conversation_id: str | None = None,
+        execution_mode: str = "execute",
     ) -> dict[str, Any] | None:
         return await self.commands.execute(
             content,
             session_key=session_key,
             origin=origin,
+            conversation_id=conversation_id,
+            execution_mode=execution_mode,
+        )
+
+    async def _authorize_model_switch(
+        self,
+        context: ExecutionContext,
+        params: dict[str, Any],
+    ) -> None:
+        """Route the /model command through the same broker as set_model.
+
+        Uses the identical PermissionRequest (``runtime.set_model``,
+        LOCAL_WRITE, reversible) so approval posture and plan-mode denial
+        match the agent tool exactly.
+        """
+        tool_call = SimpleNamespace(name="set_model", id="")
+        await self.approvals.authorize(
+            context, tool_call, SetModelTool.create(None), params
         )
 
     @staticmethod
@@ -884,7 +907,9 @@ class CollieRuntime:
         name = str(model).strip()
         if not name:
             return {"switched": False, "error": "A model name is required."}
-        previous = self.db.get_setting("provider.model")
+        # Sync SQLite calls stay off the event loop (project boundary:
+        # ipc/server.py wraps every db call in asyncio.to_thread).
+        previous = await asyncio.to_thread(self.db.get_setting, "provider.model")
         if name == previous:
             return {
                 "switched": True,
@@ -893,7 +918,7 @@ class CollieRuntime:
                 "unchanged": True,
                 "applied": True,
             }
-        self.db.set_setting("provider.model", name)
+        await asyncio.to_thread(self.db.set_active_model, name)
         applied = False
         loop = self.loop
         if loop is not None:

--- a/collie-core/tests/collie/test_commands_and_capabilities.py
+++ b/collie-core/tests/collie/test_commands_and_capabilities.py
@@ -678,6 +678,176 @@ async def test_model_command_switch_is_denied_in_plan_mode(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
+def test_model_command_requires_approval_flag(tmp_path: Path) -> None:
+    # Without an authorizer nothing is approval-gated.
+    _db, _ws, _loader, plain_controller = _controller(tmp_path)
+    try:
+        assert plain_controller.requires_approval("/model gpt-5") is False
+    finally:
+        _db.close()
+
+    async def authorizer(context: ExecutionContext, params: dict) -> None:
+        return None
+
+    async def switcher(name: str) -> dict:
+        return {"switched": True, "model": name, "applied": True}
+
+    ctl = _model_controller(tmp_path, switcher=switcher, authorizer=authorizer)
+    assert ctl.requires_approval("/model gpt-5") is True
+    assert ctl.requires_approval("/model") is False  # status listing is a read
+    assert ctl.requires_approval("/status") is False
+    assert ctl.requires_approval("What model are you using?") is False
+    assert ctl.requires_approval("please /model gpt-5") is False
+
+
+@pytest.mark.asyncio
+async def test_model_approval_resolves_on_same_socket(tmp_path: Path) -> None:
+    """The P1 regression: /model awaits approval, which resolves over the
+    same WebSocket. The frame handler must NOT block on that await or the
+    resolution can never arrive (300s timeout deadlock)."""
+    db = CollieDB(tmp_path / "collie.db")
+    evaluator = PermissionEvaluator(PermissionStore(db), local_write_preset="ask")
+    broker_events: list[dict] = []
+
+    async def broker_broadcast(event: dict) -> None:
+        broker_events.append(event)
+
+    broker = ApprovalBroker(db, evaluator, broker_broadcast)
+    calls: list[str] = []
+
+    async def switcher(name: str) -> dict:
+        calls.append(name)
+        return {"switched": True, "model": name, "previous": "m1", "applied": True}
+
+    async def broker_authorizer(context: ExecutionContext, params: dict) -> None:
+        await broker.authorize(
+            context,
+            SimpleNamespace(name="set_model", id=""),
+            SetModelTool.create(None),
+            params,
+        )
+
+    controller = CommandController(
+        workspace=tmp_path / "ws",
+        subagent_loader=None,
+        loop_provider=lambda: None,
+        status_provider=lambda: {"model": "m1", "active_agents": []},
+        model_switcher=switcher,
+        providers_provider=lambda: [],
+        model_authorizer=broker_authorizer,
+    )
+
+    class Connection:
+        def __init__(self) -> None:
+            self.frames: list[dict] = []
+
+        async def send(self, raw: str) -> None:
+            self.frames.append(json.loads(raw))
+
+    server = CollieIPCServer(
+        db,
+        chat_runner=None,
+        command_runner=controller.execute,
+        command_catalog=controller.catalog,
+        command_requires_approval=controller.requires_approval,
+    )
+    server.approval_broker = broker
+    server_broadcasts: list[dict] = []
+
+    async def server_broadcast(event: dict) -> None:
+        server_broadcasts.append(event)
+
+    server.broadcast = server_broadcast  # type: ignore[method-assign]
+    connection = Connection()
+    try:
+        # Frame 1: the /model switch. The handler must return immediately
+        # (approval pending), leaving the receive loop free.
+        await server._handle_frame(
+            connection,  # type: ignore[arg-type]
+            json.dumps({"type": "chat", "id": "one", "content": "/model gpt-5"}),
+        )
+        approval_event = None
+        for _ in range(100):
+            approval_event = next(
+                (e for e in broker_events if e.get("type") == "approval_requested"),
+                None,
+            )
+            if approval_event is not None:
+                break
+            await asyncio.sleep(0.02)
+        assert approval_event is not None, "approval must be pending"
+        approval_id = str(approval_event["approval"]["id"])
+
+        # Frame 2: resolve on the SAME socket while the command task awaits.
+        await server._handle_frame(
+            connection,  # type: ignore[arg-type]
+            json.dumps({
+                "type": "resolve_approval",
+                "id": "two",
+                "approval_id": approval_id,
+                "resolution": "allow_once",
+            }),
+        )
+
+        # The command task completes and broadcasts the assistant reply.
+        for _ in range(100):
+            if any(
+                e.get("type") == "message"
+                and e.get("message", {}).get("role") == "assistant"
+                for e in server_broadcasts
+            ):
+                break
+            await asyncio.sleep(0.02)
+        assert calls == ["gpt-5"]
+        assert any(
+            e.get("type") == "message"
+            and "switched" in str(e.get("message", {}).get("content", ""))
+            for e in server_broadcasts
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_ipc_set_provider_model_routes_through_set_active_model(
+    tmp_path: Path,
+) -> None:
+    db, _ws, _loader, _controller_unused = _controller(tmp_path)
+    db.upsert_provider(
+        "deepseek",
+        name="DeepSeek",
+        auth_type="api_key",
+        model="deepseek-v4-pro",
+        is_default=True,
+    )
+
+    class Connection:
+        def __init__(self) -> None:
+            self.frames: list[dict] = []
+
+        async def send(self, raw: str) -> None:
+            self.frames.append(json.loads(raw))
+
+    server = CollieIPCServer(db)
+    connection = Connection()
+    try:
+        await server._cmd_set_setting(
+            connection,  # type: ignore[arg-type]
+            {"key": "provider.model", "value": "gpt-5.5"},
+        )
+        assert db.get_setting("provider.model") == "gpt-5.5"
+        deepseek = db.get_provider("deepseek")
+        assert deepseek is not None and deepseek["model"] == "gpt-5.5"
+        with pytest.raises(ValueError):
+            await server._cmd_set_setting(
+                connection,  # type: ignore[arg-type]
+                {"key": "provider.model", "value": ""},
+            )
+        assert db.get_setting("provider.model") == "gpt-5.5"
+    finally:
+        db.close()
+
+
 @pytest.mark.asyncio
 async def test_set_model_tool_switches_via_bound_runtime() -> None:
     calls: list[str] = []

--- a/collie-core/tests/collie/test_commands_and_capabilities.py
+++ b/collie-core/tests/collie/test_commands_and_capabilities.py
@@ -13,8 +13,10 @@ import pytest
 from collie_core.commands import CommandController, parse_command
 from collie_core.db import CollieDB
 from collie_core.ipc.server import CollieIPCServer
+from collie_core.permissions.broker import ApprovalBroker, PermissionDeniedError
 from collie_core.permissions.evaluator import PermissionEvaluator
 from collie_core.permissions.models import Effect, ExecutionContext, Risk
+from collie_core.permissions.store import PermissionStore
 from collie_core.runtime import CollieRuntime
 from collie_core.subagents.loader import SubagentLoader
 from collie_core.tools.capabilities import (
@@ -441,6 +443,7 @@ def _model_controller(
     *,
     switcher=None,
     providers=None,
+    authorizer=None,
 ) -> CommandController:
     return CommandController(
         workspace=tmp_path / "workspace",
@@ -452,6 +455,7 @@ def _model_controller(
         },
         model_switcher=switcher,
         providers_provider=lambda: providers or [],
+        model_authorizer=authorizer,
     )
 
 
@@ -571,6 +575,102 @@ async def test_model_command_reports_unchanged_and_failures(
         origin="desktop",
     )
     assert unavailable and "isn't available" in unavailable["content"]
+
+
+@ pytest.mark.asyncio
+async def test_model_command_switch_requires_approval_and_reports_denial(
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    async def switcher(name: str) -> dict:
+        calls.append(name)
+        return {"switched": True, "model": name, "applied": True}
+
+    async def denying(context: ExecutionContext, params: dict) -> None:
+        raise PermissionDeniedError("You rejected this action.")
+
+    controller = _model_controller(
+        tmp_path, switcher=switcher, authorizer=denying
+    )
+    result = await controller.execute(
+        "/model deepseek-v4-flash",
+        session_key="collie:one",
+        origin="desktop",
+        conversation_id="conv_1",
+    )
+    assert result is not None
+    assert result["handled"] is True
+    assert "I can't switch models right now" in result["content"]
+    assert "You rejected this action." in result["content"]
+    assert calls == []  # the switcher never ran without approval
+
+
+@ pytest.mark.asyncio
+async def test_model_command_switch_passes_execution_context_to_authorizer(
+    tmp_path: Path,
+) -> None:
+    seen: list[tuple[ExecutionContext, dict]] = []
+
+    async def approving(context: ExecutionContext, params: dict) -> None:
+        seen.append((context, params))
+
+    async def switcher(name: str) -> dict:
+        return {"switched": True, "model": name, "applied": True}
+
+    controller = _model_controller(
+        tmp_path, switcher=switcher, authorizer=approving
+    )
+    result = await controller.execute(
+        "/model deepseek-v4-flash",
+        session_key="collie:one",
+        origin="desktop",
+        conversation_id="conv_1",
+        execution_mode="plan",
+    )
+    assert result is not None and result["handled"] is True
+    assert len(seen) == 1
+    context, params = seen[0]
+    assert context.conversation_id == "conv_1"
+    assert context.execution_mode == "plan"
+    assert params == {"model": "deepseek-v4-flash"}
+
+
+@ pytest.mark.asyncio
+async def test_model_command_switch_is_denied_in_plan_mode(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    evaluator = PermissionEvaluator(PermissionStore(db), local_write_preset="allow")
+    broker = ApprovalBroker(db, evaluator)
+    calls: list[str] = []
+
+    async def switcher(name: str) -> dict:
+        calls.append(name)
+        return {"switched": True, "model": name, "applied": True}
+
+    async def broker_authorizer(
+        context: ExecutionContext, params: dict
+    ) -> None:
+        await broker.authorize(
+            context,
+            SimpleNamespace(name="set_model", id=""),
+            SetModelTool.create(None),
+            params,
+        )
+
+    controller = _model_controller(
+        tmp_path, switcher=switcher, authorizer=broker_authorizer
+    )
+    result = await controller.execute(
+        "/model deepseek-v4-flash",
+        session_key="collie:one",
+        origin="desktop",
+        execution_mode="plan",
+    )
+    assert result is not None
+    assert result["handled"] is True
+    assert "I can't switch models right now" in result["content"]
+    assert calls == []
+    db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -697,6 +797,53 @@ async def test_runtime_switch_model_without_loop_persists_only(
         assert result["switched"] is True
         assert result["applied"] is False
         assert db.get_setting("provider.model") == "gpt-5.5"
+    finally:
+        db.close()
+
+
+@ pytest.mark.asyncio
+async def test_runtime_switch_model_keeps_provider_row_and_setting_in_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "collie-home"
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    db = CollieDB(home / "collie.db")
+    db.upsert_provider(
+        "deepseek",
+        name="DeepSeek",
+        auth_type="api_key",
+        model="deepseek-v4-pro",
+        is_default=True,
+    )
+    db.upsert_provider(
+        "openai",
+        name="OpenAI",
+        auth_type="api_key",
+        model="gpt-5.5",
+    )
+    runtime = CollieRuntime(port=0, db=db)
+    try:
+        result = await runtime._switch_model("deepseek-v4-flash")
+        assert result["switched"] is True
+        assert db.get_setting("provider.model") == "deepseek-v4-flash"
+        default = db.get_provider("deepseek")
+        assert default is not None and default["model"] == "deepseek-v4-flash"
+        openai_row = db.get_provider("openai")
+        assert openai_row is not None and openai_row["model"] == "gpt-5.5"
+
+        # A provider reconfiguration that re-upserts the row's current model
+        # cannot revert the switch — both sources were updated together.
+        db.upsert_provider(
+            "deepseek",
+            name="DeepSeek",
+            auth_type="api_key",
+            model=str(default["model"]),
+            is_default=True,
+        )
+        assert db.get_setting("provider.model") == "deepseek-v4-flash"
+        reupserted = db.get_provider("deepseek")
+        assert reupserted is not None and reupserted["model"] == "deepseek-v4-flash"
     finally:
         db.close()
 

--- a/collie-core/tests/collie/test_connectors.py
+++ b/collie-core/tests/collie/test_connectors.py
@@ -81,6 +81,24 @@ def test_launch_catalog_enables_direct_mcp_routes_ready_for_live_oauth() -> None
     assert by_id["notion"].endpoint == "https://mcp.notion.com/mcp"
 
 
+def test_enabled_catalog_routes_declare_explicit_least_privilege_scopes() -> None:
+    by_id = {item.id: item for item in CONNECTOR_CATALOG}
+    enabled = {item.id for item in CONNECTOR_CATALOG if item.available}
+    assert enabled == {"notion", "linear", "todoist", "atlassian", "airtable"}
+    for provider_id in enabled:
+        definition = by_id[provider_id]
+        # Empty scopes make the MCP SDK omit the scope parameter, which the
+        # authorization server reads as "everything advertised".
+        assert definition.scopes, f"{provider_id} must request explicit scopes"
+    assert by_id["linear"].scopes == ("read", "write")
+    assert by_id["todoist"].scopes == ("data:read_write",)
+    assert by_id["airtable"].scopes == (
+        "data.records:read",
+        "data.records:write",
+        "schema.bases:read",
+    )
+
+
 def _enable_connector_for_unit_test(monkeypatch: pytest.MonkeyPatch, provider_id: str) -> None:
     from collie_core.connectors import catalog
     from collie_core.connectors import manager as connector_manager
@@ -190,11 +208,43 @@ def test_disabled_connector_cannot_connect_or_rebind_existing_runtime(
     db.close()
 
 
-def test_enabled_provider_historical_connected_row_stays_healthy_and_rebinds(
+def test_enabled_provider_historical_connected_row_without_credentials_requires_auth(
     tmp_path: Path, connector_store: CredentialStore
 ) -> None:
     db = CollieDB(tmp_path / "collie.db")
     manager = ConnectorManager(db, credentials=connector_store)
+    db.upsert_connector_connection(
+        "con_old_notion",
+        provider_id="notion",
+        driver="official_mcp",
+        auth_type="oauth",
+        status="connected",
+        enabled_tools=["search_pages"],
+    )
+    # A connected row without stored credentials (token deleted, DB restored
+    # without the credential files) must not report healthy or bind at
+    # runtime — it needs a fresh sign-in.
+    assert manager.is_connected("notion") is False
+    assert manager.mcp_servers_for_config() == {}
+    connection = manager.get_connection("con_old_notion")
+    assert connection is not None
+    assert connection["status"] == "auth_required"
+    assert connection["last_error_code"] == "credentials_missing"
+    catalog = {item["id"]: item for item in manager.catalog_view()}
+    assert catalog["notion"]["status"] == "auth_required"
+    assert catalog["notion"]["connection_count"] == 0
+    db.close()
+
+
+def test_enabled_provider_connected_row_with_credentials_stays_healthy_and_rebinds(
+    tmp_path: Path, connector_store: CredentialStore
+) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    manager = ConnectorManager(db, credentials=connector_store)
+    connector_store.save(
+        "connector:con_old_notion",
+        {"tokens": {"access_token": "tok", "token_type": "Bearer"}},
+    )
     db.upsert_connector_connection(
         "con_old_notion",
         provider_id="notion",
@@ -209,6 +259,9 @@ def test_enabled_provider_historical_connected_row_stays_healthy_and_rebinds(
     assert connection is not None
     assert connection["status"] == "connected"
     assert connection["last_error_code"] is None
+    catalog = {item["id"]: item for item in manager.catalog_view()}
+    assert catalog["notion"]["status"] == "connected"
+    assert catalog["notion"]["connection_count"] == 1
     db.close()
 
 
@@ -222,6 +275,11 @@ def test_recheck_only_exposes_identity_returned_by_the_provider(
 
     class _NoIdentityDriver(_FakeDriver):
         def probe(self, definition, connection_id: str) -> ProbeResult:
+            # A re-test runs against a connection that already has tokens.
+            self.store.save(
+                f"connector:{connection_id}",
+                {"tokens": {"access_token": "secret-access-token"}},
+            )
             return ProbeResult(
                 tools=[{"name": "search_pages", "risk": "read", "schema_hash": "h"}]
             )

--- a/collie-core/tests/collie/test_connectors.py
+++ b/collie-core/tests/collie/test_connectors.py
@@ -265,6 +265,50 @@ def test_enabled_provider_connected_row_with_credentials_stays_healthy_and_rebin
     db.close()
 
 
+def test_connected_row_requires_usable_access_token(
+    tmp_path: Path, connector_store: CredentialStore
+) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    manager = ConnectorManager(db, credentials=connector_store)
+    try:
+        # Empty records, client-info-only entries, and token blobs without
+        # an access_token must NOT count as connected.
+        invalid_payloads: list[dict] = [
+            {},
+            {"client_info": {"client_id": "x"}},
+            {"tokens": {}},
+            {"tokens": {"refresh_token": "r"}},
+        ]
+        for index, payload in enumerate(invalid_payloads):
+            connection_id = f"con_bad_{index}"
+            connector_store.save(f"connector:{connection_id}", payload)
+            db.upsert_connector_connection(
+                connection_id,
+                provider_id="notion",
+                driver="official_mcp",
+                auth_type="oauth",
+                status="connected",
+            )
+            view = manager.get_connection(connection_id)
+            assert view is not None and view["status"] == "auth_required", payload
+            assert manager.is_connected("notion") is False
+
+        connector_store.save(
+            "connector:con_ok",
+            {"tokens": {"access_token": "tok", "token_type": "Bearer"}},
+        )
+        db.upsert_connector_connection(
+            "con_ok",
+            provider_id="notion",
+            driver="official_mcp",
+            auth_type="oauth",
+            status="connected",
+        )
+        assert manager.is_connected("notion") is True
+    finally:
+        db.close()
+
+
 def test_recheck_only_exposes_identity_returned_by_the_provider(
     tmp_path: Path,
     connector_store: CredentialStore,

--- a/collie-ui/src/renderer/src/components/connectors/ConnectedAccountCard.tsx
+++ b/collie-ui/src/renderer/src/components/connectors/ConnectedAccountCard.tsx
@@ -13,13 +13,15 @@ export default function ConnectedAccountCard({
   const statusLabel =
     connection.status === 'connected'
       ? 'Connected'
-      : connection.status === 'testing'
-        ? 'Checking connection'
-        : connection.status === 'authorizing'
-          ? 'Sign-in in progress'
-          : connection.status === 'failed'
-            ? 'Connection failed'
-            : 'Needs attention'
+      : connection.status === 'auth_required'
+        ? 'Sign in again'
+        : connection.status === 'testing'
+          ? 'Checking connection'
+          : connection.status === 'authorizing'
+            ? 'Sign-in in progress'
+            : connection.status === 'failed'
+              ? 'Connection failed'
+              : 'Needs attention'
   return (
     <button
       type="button"

--- a/collie-ui/src/renderer/src/components/connectors/ConnectorDetail.tsx
+++ b/collie-ui/src/renderer/src/components/connectors/ConnectorDetail.tsx
@@ -29,13 +29,15 @@ export default function ConnectorDetail({
   const statusDescription =
     connection.status === 'connected'
       ? 'Connected'
-      : connection.status === 'testing'
-        ? 'Checking connection'
-        : connection.status === 'authorizing'
-          ? 'Sign-in in progress'
-          : connection.status === 'failed'
-            ? 'Connection failed'
-            : 'Needs attention'
+      : connection.status === 'auth_required'
+        ? 'Sign in again'
+        : connection.status === 'testing'
+          ? 'Checking connection'
+          : connection.status === 'authorizing'
+            ? 'Sign-in in progress'
+            : connection.status === 'failed'
+              ? 'Connection failed'
+              : 'Needs attention'
   return (
     <div className="mx-auto max-w-3xl">
       <button className="mb-4 flex items-center gap-1 text-sm" onClick={onBack}>

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -171,6 +171,7 @@ export interface ConnectorConnection {
     | 'authorizing'
     | 'testing'
     | 'connected'
+    | 'auth_required'
     | 'attention'
     | 'failed'
     | 'revoking'

--- a/collie-ui/src/renderer/src/screens/ConnectorsScreen.test.ts
+++ b/collie-ui/src/renderer/src/screens/ConnectorsScreen.test.ts
@@ -57,6 +57,8 @@ describe('connector connection status truthfulness', () => {
     expect(connectorConnectNotice('Notion', 'connected')).toContain('Connected to Notion')
     expect(connectorConnectNotice('Notion', 'authorizing')).toContain('already in progress')
     expect(connectorConnectNotice('Notion', 'attention')).toContain('needs attention')
+    expect(connectorConnectNotice('Notion', 'auth_required')).toContain('fresh sign-in')
+    expect(connectorConnectNotice('Notion', 'auth_required')).not.toContain('Connected')
     expect(connectorConnectNotice('Notion', 'failed')).not.toContain('Connected')
   })
 

--- a/collie-ui/src/renderer/src/screens/ConnectorsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ConnectorsScreen.tsx
@@ -17,6 +17,8 @@ type Tab = 'connected' | 'explore'
 
 export function connectorConnectNotice(name: string, status: string): string {
   if (status === 'connected') return `Connected to ${name}. Try it in chat!`
+  if (status === 'auth_required')
+    return `${name} needs a fresh sign-in before Collie can use it.`
   if (connectorIsInFlight(status)) return `${name} sign-in is already in progress.`
   return `${name} needs attention before Collie can use it.`
 }

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -58,8 +58,10 @@ make the normal path intimidating.
 - Windows x64 is the initial supported platform.
 - Users connect a supported model provider; Collie does not require its own
   application account.
-- Connected services are enabled only after authentication, discovery, a live
-  health check, and packaged-app verification.
+- Connected services are enabled only after authentication, discovery, and a
+  live health check. Routes that have not yet passed the packaged-app
+  acceptance pass are labeled alpha with their verification status visible in
+  the app; that acceptance pass remains the gate before any release claim.
 - High-consequence actions remain disabled or explicitly approved until their
   safety and recovery behavior is designed and tested.
 - The public website is the entry point and mailing-list surface; GitHub

--- a/docs/engineering/architecture/connectors-plan.md
+++ b/docs/engineering/architecture/connectors-plan.md
@@ -38,10 +38,9 @@ Implementation checkpoint (2026-08-02) — review round 1 (`fix/codex-review-rou
   phantom "Connected" badge;
 - the five enabled routes now declare explicit least-privilege OAuth scopes
   (empty scopes made the MCP SDK omit the parameter, which the authorization
-  servers read as "everything advertised"); the recorded `granted_scopes`
-  prefer the scopes actually returned in the stored token. Scope strings are
-  documented vocabulary and still need live confirmation on the acceptance
-  pass;
+  servers read as "everything advertised"); scope vocabulary is verified
+  against each provider's live RFC 8414/RFC 9728 metadata, and the recorded
+  `granted_scopes` prefer the scopes actually returned in the stored token;
 - VISION.md's alpha boundary now matches behavior: routes that have not
   passed the packaged-app acceptance pass are labeled alpha with visible
   verification status; acceptance remains the release gate.
@@ -957,8 +956,9 @@ The connector initiative is complete when:
 
 1. Connections appears immediately after Routines.
 2. A normal user can add, inspect, rename, test, reconnect, and remove accounts.
-3. At least Notion, Linear, Todoist, and Atlassian pass the exact packaged-app
-   matrix before their Connect buttons are enabled.
+3. Notion, Linear, Todoist, Atlassian, and Airtable pass the exact packaged-app
+   matrix before their alpha routes are presented as release-ready (the five
+   routes are enabled as labeled alpha ahead of that pass).
 4. Gmail, Google Calendar/Drive, Outlook Email/Calendar, and OneDrive have a
    supported route that does not ask users for developer credentials.
 5. "Connect my email" in chat obtains explicit Collie approval before OAuth.

--- a/docs/engineering/architecture/connectors-plan.md
+++ b/docs/engineering/architecture/connectors-plan.md
@@ -1,6 +1,6 @@
 # Connectors: research and implementation plan
 
-Status: in progress — four official MCP routes live as alpha; packaged-provider acceptance pending
+Status: in progress — five official MCP routes live as alpha; packaged-provider acceptance pending
 
 Date: 2026-07-29
 
@@ -29,6 +29,22 @@ Implementation checkpoint (2026-08-02) — alpha enablement:
   packaged build: OAuth, probe, read, restart, removal, approval) is still
   the gate before any public release claim — it is no longer a code
   blocker for the five enabled routes.
+
+Implementation checkpoint (2026-08-02) — review round 1 (`fix/codex-review-round-1`):
+
+- connected rows are only reported healthy and bound into the runtime when
+  their stored credentials actually exist; a connected row whose token is
+  missing surfaces as `auth_required` (`credentials_missing`) instead of a
+  phantom "Connected" badge;
+- the five enabled routes now declare explicit least-privilege OAuth scopes
+  (empty scopes made the MCP SDK omit the parameter, which the authorization
+  servers read as "everything advertised"); the recorded `granted_scopes`
+  prefer the scopes actually returned in the stored token. Scope strings are
+  documented vocabulary and still need live confirmation on the acceptance
+  pass;
+- VISION.md's alpha boundary now matches behavior: routes that have not
+  passed the packaged-app acceptance pass are labeled alpha with visible
+  verification status; acceptance remains the release gate.
 
 Implementation checkpoint (2026-07-29):
 


### PR DESCRIPTION
## Summary

Fixes all findings from the Codex review rounds on PR #3/#4 (models + connectors) AND round 2 on this PR.

### Round 1 (all 7 previous findings)

| # | Sev | Finding | Fix |
|---|---|---|---|
| P2-1 | P2 | `/model` skipped approval & Plan mode | `/model <id>` routes through the **same permission broker as `set_model`** (`runtime.set_model`, LOCAL_WRITE, reversible): denial/timeout/Plan-mode → friendly handled message, switch never runs. |
| P2-2 | P2 | SQLite blocked the async loop | `_switch_model` DB calls moved off the loop via `asyncio.to_thread` (project boundary). |
| P2-3 | P2 | Two model sources could disagree | `db.set_active_model()` writes `provider.model` **and** the default provider row in **one transaction**. |
| P2-4 | P2 | Connectors enabled before acceptance passes | Documented gate formally revised (option B): `VISION.md` alpha boundary now matches behavior — alpha-labeled pre-acceptance routes; acceptance remains the release gate. |
| P2-5 | P2 | Missing credentials still showed "Connected" | Connected rows are only healthy/bound when stored credentials exist; missing tokens → `auth_required` (`credentials_missing`). New `ConnectionStatus.AUTH_REQUIRED`. |
| P3-1 | P3 | Empty OAuth scopes requested everything | Explicit least-privilege scopes; `granted_scopes` records the token's actual scopes. |
| P3-2 | P3 | Doc typo "four" vs five | Fixed. |

### Round 2 (this push, head `0b441cc`)

| # | Sev | Finding | Fix |
|---|---|---|---|
| P1-1 | P1 | `/model` approvals deadlocked the serial WebSocket frame handler (resolution can't arrive on the same socket → 300s timeout) | Approval-gated commands now run in a **background task** (`command_requires_approval` → `requires_approval`); the receive loop stays free to process `resolve_approval`. **Same-socket e2e-style test** proves approval → resolution → switch on one connection. |
| P1-2 | P1 | Notion/Atlassian scopes invalid for their MCP resources | Corrected to **live-verified vocabulary**: Notion `scopes_supported` = `["default"]` (fetched from `mcp.notion.com/.well-known/oauth-authorization-server`); Atlassian = the RFC 9728 resource-metadata set (Jira read/write, Confluence search/read/write, `read:me`, `offline_access`). Linear/Todoist/Airtable already matched. |
| P2-1 | P2 | `_has_credentials()` accepted `{}`, `{"client_info": …}`, `{"tokens": {}}` | Now requires a non-empty `tokens.access_token`. |
| P2-2 | P2 | IPC `set_setting("provider.model", …)` bypassed the model-source invariant | IPC routes `provider.model` through `set_active_model` (both sources, one transaction). |
| P2-3 | P2 | Concurrent switches could split persisted/live state | `_switch_model` serializes read/persist/live-apply under `_model_switch_lock`. |
| P2-4 | P2 | README/connectors-plan still said "Coming soon until packaged verification" | Both updated to the alpha posture (five routes enabled as labeled alpha; acceptance remains the release gate). |
| P3-1 | P3 | Renderer status contract lacked `auth_required` | Added to the `ConnectorConnection.status` union + "Sign in again" / "needs a fresh sign-in" messaging + test. |

## Verification

| Gate | Result |
|---|---|
| pytest `tests/collie` | **496 passed / 5 failed / 1 skipped** — the 5 are the documented Windows-only baseline (4× DPAPI credentials + 1× IPC escape-path) |
| pytest full suite | running (see coverage below) |
| coverage (full suite) | gate is `fail_under = 70` |
| ruff (all changed core files) | clean |
| UI typecheck | clean |
| UI vitest (ConnectorsScreen) | 4 passed (incl. new auth_required notice case) |
| Secret scan | clean |
| New tests this round | 4 core (same-socket approval, requires_approval flag, IPC set_active_model routing, strict credential records) + 1 UI |
| Scope metadata | fetched live from `mcp.notion.com` (200, `scopes_supported: ["default"]`) and `mcp.atlassian.com` RFC 9728 resource metadata (200) |

## Notes for the owner's acceptance pass

- Confirm the approval card renders and resolves for `/model` in the packaged app (same broker broadcast as tool approvals; resolution arrives on the same socket — now non-blocking).
- Confirm each provider's consent screen shows exactly the requested scope set (Notion "default"; Atlassian Jira/Confluence read+write + offline).
- `auth_required` now has explicit UI copy — confirm the badge/notice render in the packaged app.

## Files

17 files, +~700/−60: core (`commands.py`, `runtime.py`, `ipc/server.py`, `db.py`, `connectors/*`, tests), UI (`ipc.ts`, `ConnectorDetail.tsx`, `ConnectedAccountCard.tsx`, `ConnectorsScreen.tsx` + test), docs (`VISION.md`, `README.md`, `connectors-plan.md`).
