### PR TITLE
feat(chat): attach task progress to composer

### DIFF
--- a/collie-ui/src/renderer/src/components/ChatInput.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.tsx
@@ -23,7 +23,8 @@ import type {
   ApprovalPreset,
   ExecutionMode,
   FileAccessScope,
-  ProviderInfo
+  ProviderInfo,
+  TaskState
 } from '../lib/ipc'
 import {
   MICROPHONE_STORAGE_KEY,
@@ -31,6 +32,7 @@ import {
   type LocalDictationRecorder
 } from '../lib/audio'
 import BrandLogo from './BrandLogo'
+import TaskProgress from './tasks/TaskProgress'
 
 const ROTATING_PROMPTS = [
   'Create a weekend shopping list and add tomatoes',
@@ -261,6 +263,7 @@ interface Props {
   onTypingChange?: (isTyping: boolean) => void
   onTranscribe: (audio: string) => Promise<string>
   commandCatalog?: CommandCatalog
+  taskProgress?: TaskState | null
 }
 
 export default function ChatInput({
@@ -285,7 +288,8 @@ export default function ChatInput({
   onChooseFileAccessFolders,
   onTypingChange,
   onTranscribe,
-  commandCatalog
+  commandCatalog,
+  taskProgress
 }: Props): React.JSX.Element {
   const [text, setText] = useState('')
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
@@ -632,7 +636,12 @@ export default function ChatInput({
           <small>↑↓ choose · Tab insert · Enter run</small>
         </div>
       )}
-      <div className="composer flex items-end gap-2 px-3 py-2">
+      {taskProgress ? (
+        <TaskProgress task={taskProgress} onStop={onStop} attachedToComposer />
+      ) : null}
+      <div className={`composer flex items-end gap-2 px-3 py-2${
+        taskProgress ? ' composer--with-task-progress' : ''
+      }`}>
         <button
           type="button"
           className="composer-tool"

--- a/collie-ui/src/renderer/src/components/tasks/TaskProgress.test.tsx
+++ b/collie-ui/src/renderer/src/components/tasks/TaskProgress.test.tsx
@@ -69,6 +69,16 @@ describe('TaskProgress', () => {
     expect(onStop).toHaveBeenCalledOnce()
   })
 
+  it('joins the live checklist to the composer when requested', () => {
+    const container = render(
+      <TaskProgress task={activeTask} onStop={vi.fn()} attachedToComposer />
+    )
+
+    const progress = container.querySelector('section[aria-label="Task progress"]')
+    expect(progress?.classList.contains('task-progress--composer')).toBe(true)
+    expect((progress as HTMLElement | null)?.style.width).toBe('100%')
+  })
+
   it('shows completion count and a checkmark for each completed step', () => {
     const completed: TaskState = {
       ...activeTask,

--- a/collie-ui/src/renderer/src/components/tasks/TaskProgress.tsx
+++ b/collie-ui/src/renderer/src/components/tasks/TaskProgress.tsx
@@ -76,10 +76,17 @@ interface Props {
   onStop?: () => void
   /** History summaries remain compact and cannot issue task controls. */
   readOnly?: boolean
+  /** Visually joins live progress to the composer instead of rendering a standalone card. */
+  attachedToComposer?: boolean
 }
 
 /** Compact, accessible user-facing progress for one conversation only. */
-export default function TaskProgress({ task, onStop, readOnly = false }: Props): React.JSX.Element {
+export default function TaskProgress({
+  task,
+  onStop,
+  readOnly = false,
+  attachedToComposer = false
+}: Props): React.JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const detailsId = useId()
   const terminal = isTaskTerminal(task)
@@ -89,8 +96,13 @@ export default function TaskProgress({ task, onStop, readOnly = false }: Props):
   const statusText = `${progress}. ${currentLabel(task)}.`
   return (
     <section
-      className="mx-auto mb-2 rounded-xl border bg-[var(--collie-surface)] shadow-sm"
-      style={{ borderColor: 'var(--collie-border)', width: 'min(calc(100% - 24px), 920px)' }}
+      className={`task-progress mx-auto rounded-xl border bg-[var(--collie-surface)] shadow-sm${
+        attachedToComposer ? ' task-progress--composer' : ' mb-2'
+      }`}
+      style={{
+        borderColor: 'var(--collie-border)',
+        width: attachedToComposer ? '100%' : 'min(calc(100% - 24px), 920px)'
+      }}
       aria-label="Task progress"
     >
       {readOnly ? (

--- a/collie-ui/src/renderer/src/screens/ChatScreen.ordering.test.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.ordering.test.tsx
@@ -2,11 +2,12 @@
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AttachmentDraft, CollieEvent, CollieMessage } from '../lib/ipc'
+import type { AttachmentDraft, CollieEvent, CollieMessage, TaskState } from '../lib/ipc'
 
 interface ChatInputProps {
   onSend: (text: string, attachments: AttachmentDraft[]) => void
   onProjectChange: (path: string) => void
+  taskProgress?: TaskState | null
 }
 
 const hooks = vi.hoisted(() => {
@@ -178,6 +179,38 @@ describe('ChatScreen paced assistant completion order', () => {
       undefined,
       { mode: 'selected_folder' }
     )
+  })
+
+  it('passes active task progress into the chat input window', async () => {
+    const task: TaskState = {
+      id: 'task-1',
+      source: 'checklist',
+      status: 'active',
+      revision: 1,
+      title: 'Prepare the update',
+      completed_count: 0,
+      total_count: 2,
+      current_step_key: 'inspect',
+      steps: [
+        { key: 'inspect', title: 'Inspect the current UI', status: 'in_progress' },
+        { key: 'update', title: 'Update the composer', status: 'pending' }
+      ]
+    }
+
+    await act(async () => {
+      hooks.listener()({
+        type: 'message',
+        conversation_id: conversationId,
+        message: message('user-task', 'user', 'Prepare the update')
+      })
+      await Promise.resolve()
+    })
+    await act(async () => {
+      hooks.listener()({ type: 'task_state', conversation_id: conversationId, task })
+      await Promise.resolve()
+    })
+
+    expect(hooks.chatInput().taskProgress).toEqual(task)
   })
 
   it('starts a fresh General Chat instead of retaining an active project conversation scope', async () => {

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -27,7 +27,7 @@ import ConnectorsScreen from './ConnectorsScreen'
 import type { AppView } from '../lib/navigation'
 import { mergeStreamDelta, nextStreamReveal, visibleStreamText } from '../lib/stream'
 import ApprovalSheet from '../components/approvals/ApprovalSheet'
-import TaskProgress, { isTaskTerminal } from '../components/tasks/TaskProgress'
+import { isTaskTerminal } from '../components/tasks/TaskProgress'
 import {
   applyTaskState,
   beginTaskHydration,
@@ -979,7 +979,6 @@ export default function ChatScreen({
               }
             />
           ))}
-          {activeTask && !isTaskTerminal(activeTask) ? <TaskProgress task={activeTask} onStop={() => void stop()} /> : null}
           <div className="portrait-composer-layout">
             <InteractiveColliePortrait
               thinking={portraitThinking}
@@ -1011,6 +1010,7 @@ export default function ChatScreen({
               onTypingChange={setIsTyping}
               onTranscribe={async (audio) => (await collieClient.transcribe(audio)).text}
               commandCatalog={commandCatalog}
+              taskProgress={activeTask && !isTaskTerminal(activeTask) ? activeTask : null}
             />
           </div>
         </div>

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1712,6 +1712,18 @@ button {
 
 .composer-wrap { position: relative; }
 
+.task-progress--composer {
+  position: relative;
+  z-index: 1;
+  margin-bottom: -1px;
+  border-radius: 16px 16px 0 0;
+  box-shadow: none;
+}
+
+.composer.composer--with-task-progress {
+  border-radius: 0 0 16px 16px;
+}
+
 .slash-palette {
   position: absolute;
   z-index: 30;


### PR DESCRIPTION
## What

- moves the existing live task checklist into the chat input window
- visually joins task progress to the composer, matching the compact task-above-input interaction
- keeps the current durable `task_state` model, conversation isolation, refresh recovery, and accessible expandable checklist
- adds component and screen integration coverage

## Why

`FoxRick/Collie` already has the full task/checklist backend and visual progress component. This update makes that progress feel like part of the active chat input instead of a separate floating card, while avoiding a second or conflicting progress model.

## Verification

- `npm.cmd run typecheck`
- `npm.cmd test` — 169 tests passed
- `npm.cmd run build`
- React best-practices review — no issues found