### PR TITLE
fix(pet): guard Windows-only -transparentcolor so the pet opens on Linux

### DIFF
--- a/collie-core/collie_core/pet/collie_pet.py
+++ b/collie-core/collie_core/pet/collie_pet.py
@@ -268,9 +268,15 @@ class ColliePet:
 
         # Transparency via color key. A near-black key prevents the bright
         # magenta fringe Windows otherwise shows around alpha-smoothed sprites.
+        # Color-key transparency is Windows-only; other platforms (X11, macOS)
+        # reject the attribute, so the pet must still open there — it just
+        # shows an opaque window instead of a transparent one.
         self._chroma_key = "#010203"
         self.root.config(bg=self._chroma_key)
-        self.root.wm_attributes("-transparentcolor", self._chroma_key)
+        try:
+            self.root.wm_attributes("-transparentcolor", self._chroma_key)
+        except tk.TclError:
+            pass
 
         # Try to keep off the taskbar (Windows)
         try:

--- a/collie-core/tests/collie/test_pet_status.py
+++ b/collie-core/tests/collie/test_pet_status.py
@@ -73,7 +73,8 @@ def test_completion_stays_until_acknowledged() -> None:
     pet._set_status("Finished. Your result is ready.")
 
     assert label.manager == "pack"
-    assert states == ["happy"]
+    # v2 pet feature (d14110e) renamed the completion state to "completion".
+    assert states == ["completion"]
     assert root.scheduled == []
 
     pet._set_status("dismiss")
@@ -140,6 +141,74 @@ def test_non_windows_work_area_uses_screen_bounds(monkeypatch) -> None:
     monkeypatch.setattr(pet_module.sys, "platform", "linux")
 
     assert pet_module._screen_work_area(_Screen()) == (0, 0, 1920, 1080)
+
+
+class _FakeRoot:
+    """Minimal Tk root double: records wm_attributes calls, optionally
+    rejecting -transparentcolor exactly like Linux/X11 tkinter does."""
+
+    def __init__(self, reject_transparentcolor: bool) -> None:
+        self.reject_transparentcolor = reject_transparentcolor
+        self.attribute_calls: list[str] = []
+        self.bg: str | None = None
+
+    def title(self, _title: str) -> None:
+        pass
+
+    def overrideredirect(self, _value: bool) -> None:
+        pass
+
+    def wm_attributes(self, *args) -> None:
+        self.attribute_calls.append(args[0])
+        if args[0] == "-transparentcolor" and self.reject_transparentcolor:
+            raise pet_module.tk.TclError(
+                'bad attribute "-transparentcolor": must be -alpha, '
+                "-fullscreen, -topmost, -type, or -zoomed"
+            )
+
+    def config(self, **kwargs) -> None:
+        self.bg = kwargs.get("bg")
+
+
+class _FakeLabel:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def pack(self, *_args, **_kwargs) -> None:
+        pass
+
+    def bind(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def test_build_window_survives_missing_transparentcolor_support(monkeypatch) -> None:
+    """Linux/X11 tkinter rejects -transparentcolor; the pet must still open.
+
+    Regression: the unguarded call crashed the whole pet process on non-Windows
+    (exit 1 -> Electron's respawn cap -> no pet ever appears).
+    """
+    monkeypatch.setattr(pet_module.tk, "Label", _FakeLabel)
+    root = _FakeRoot(reject_transparentcolor=True)
+
+    pet = ColliePet.__new__(ColliePet)
+    pet.root = root
+    pet._build_window()
+
+    assert "-transparentcolor" in root.attribute_calls
+    assert root.bg == "#010203"
+
+
+def test_build_window_applies_transparentcolor_when_supported(monkeypatch) -> None:
+    """Windows accepts the attribute, so the chroma key must still be set."""
+    monkeypatch.setattr(pet_module.tk, "Label", _FakeLabel)
+    root = _FakeRoot(reject_transparentcolor=False)
+
+    pet = ColliePet.__new__(ColliePet)
+    pet.root = root
+    pet._build_window()
+
+    assert "-transparentcolor" in root.attribute_calls
+    assert root.bg == "#010203"
 
 
 def test_saving_position_preserves_enabled_preference(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## What

The desktop pet **never appeared on Linux** (the dev VM) — not even when spawned from Settings.

**Root cause:** `collie_pet.py:273` calls `wm_attributes("-transparentcolor", …)`, a **Windows-only** tkinter attribute. On Linux/X11 tkinter raises `TclError` → the pet process crashed at startup (exit 1) → Electron's respawn cap (3 tries) gave up → no pet, ever. The `-toolwindow` call right below already had a try/except guard; `-transparentcolor` never got one.

## Fix

- Guard the call with `try/except tk.TclError` — Windows keeps the chroma-key transparency, Linux/macOS fall back to an opaque window and the pet actually runs.
- 2 new regression tests (fake root rejects the attribute exactly like Linux tkinter; plus a test that Windows still applies the chroma key).
- Also fixed a **pre-existing** failing test on main: the v2 pet feature (d14110e) renamed the completion state to `"completion"` but the test still expected `"happy"`.

## Verification

| Gate | Result |
|------|--------|
| pytest tests/collie | **511 passed** / 5 failed (documented Windows-only baseline, identical on main) / 1 skipped |
| ruff (nanobot, collie_core, tests) | All checks passed |
| Live pet on DISPLAY=:10.0 | **alive after 6s** (was instant exit-1 crash) |
| Regression tests | RED before fix → GREEN after |

Note: on Windows `-transparentcolor` IS supported, so the pet should already spawn there — if it doesn't, that's a separate Windows-side issue worth its own investigation.
