### PR TITLE
docs(engineering): evaluation lab plan — benchmarking + prompt optimization

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -4,6 +4,8 @@
   boundaries.
 - `security/` contains security decisions and validated reports that remain
   relevant to the current product.
+- `evaluation/` contains the benchmarking and prompt-optimization laboratory
+  plan and its durable technical decisions.
 
 Implementation truth remains code plus tests. Plans that are completed,
 superseded, or tied to a one-time refactor belong in `../archive/`.

--- a/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
+++ b/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
@@ -74,6 +74,20 @@ This is the critical path for the entire laboratory; nothing can be
 benchmarked until it exists. It is a ~1–2 day change, mostly wiring
 existing composition into a new entry point plus a focused test.
 
+**Why an entry point instead of driving the live IPC protocol?** The
+Electron shell is a WebSocket client, so a bench adapter could drive the
+existing `collie_core.runtime` directly — zero Collie changes, maximum
+fidelity. That path is viable (the e2e phase gates already exercise it),
+but the adapter would have to reimplement the streaming, approval, and
+readiness protocol, chase internal protocol changes, and boot background
+schedulers per trial. The headless entry point trades ~1–2 days of Collie
+work for a stable one-shot JSON contract, deterministic startup (no
+scheduler/reminder/messenger noise), and a trivial adapter — and doubles
+as the CI regression unit and the future optimization loop's task runner.
+No user-facing CLI is added; this is an internal capability. Interim
+option: the first smoke matrix can drive the IPC protocol with zero Collie
+changes while the entry point is built.
+
 ## Parity: the headless engine IS the live app
 
 Headless mode is **not a second implementation** — it is the same engine

--- a/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
+++ b/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
@@ -1,0 +1,216 @@
+# Benchmarking and prompt-optimization laboratory
+
+**Status:** proposed
+**Audience:** product, engineering, evaluation, and release owners
+
+## Outcome
+
+Make Collie measurably better on every iteration by running it against
+open-source agent harnesses under controlled conditions. The laboratory
+answers one question per change: *did this Collie prompt, instruction, or
+engine tweak improve task completion — and at what token and cost cost?*
+
+The end state is an evidence-gated loop:
+
+```text
+bench (Harbor, fixed cohort + model)
+  -> cluster failures (tool choice, context loss, looping, permissions, ...)
+  -> one hypothesis -> patch a prompt template or engine behavior
+  -> re-bench candidate vs baseline side-by-side
+  -> keep or revert (predeclared gates, human approves the merge)
+```
+
+## Locked decisions (from the 2026-08-02 evaluation discussion)
+
+These were agreed and verified in the earlier session; they are the
+foundation and should not be re-litigated:
+
+| Decision | Choice | Why |
+|---|---|---|
+| Trial runner | **Harbor Framework** (`harbor-framework/harbor`, from the Terminal-Bench team) | Isolated Docker environments per trial, agent adapters, versioned datasets, trajectory/artifact/usage collection, RL-rollout support for the endgame |
+| Lab location | **Separate `collie-bench` repo**, Linux-native on the VM | Keeps untrusted harness code and generated commands away from the Windows-maintained Collie workflow; the benchmark VM is not a production Collie machine |
+| Phase 1 scope | 45 trials = 3 harnesses × 5 deterministic tasks × 3 reps | Proves measurement before building anything bigger |
+| First model | One cheap model (DeepSeek-class, OpenAI-compatible) | Cost discipline is a feature; cheap models amplify harness-quality differences |
+| Metered gateway | **Deferred** | Per-trial API keys + usage parsed from API responses give ~80% of the value at ~10% of the cost |
+| Normalized-tool mode | Deferred to Phase 2 | Native-harness mode alone measures the product users actually run |
+| SWE-bench / heavy anchor suites | Deferred | Image storage and runtime are a monster; deterministic product tasks first |
+| Cohort | Collie, Hermes, Codex CLI first | Hermes is CLI-scriptable, Codex has a built-in Harbor adapter. CommandCode v0.1.1 has no CLI (`bin: None`) — revisit when a headless build exists |
+| Scoring | Hidden deterministic verifiers check **state**, not prose | Kills self-serving scoring; LLM judging only where objective verification is impossible |
+| Security boundary | Non-root container, no host mounts, egress only to the gateway + simulated services, fresh filesystem per trial | Every downloaded harness and generated command is untrusted |
+
+## The Collie-side gap: no headless mode
+
+`collie-core` states in `pyproject.toml`: *"Collie is launched by the
+Electron shell as a managed subprocess. No CLI entry points."* The agent
+loop, providers, tools, permissions, and telemetry all exist and are tested
+(`collie_core.runtime` boots them); they are simply only ever started by the
+UI.
+
+Benchmarking needs a process that runs **one task and exits with evidence**.
+Proposed engineering capability (not a user-facing product CLI — the
+"no dev shell" non-goal in `VISION.md` is preserved):
+
+```text
+python -m collie_core.headless --task "..." --model deepseek/... \
+    --provider-id <id> --api-key-env COLLIE_BENCH_KEY \
+    --workspace <tmp> --home <tmp> [--session-key bench-<run>] \
+    [--max-iterations N] [--timeout S]
+```
+
+Behavior:
+
+- Boots `CollieRuntime`-equivalent composition against an isolated
+  `COLLIE_HOME`/workspace (no real user data touched).
+- Runs one prompt through `AgentLoop.process_direct` (the same path the UI
+  uses), streams nothing to a UI.
+- Prints a single JSON document on exit: final message, per-turn usage
+  (input/output/reasoning/cache tokens from provider responses), tool calls,
+  wall-clock time, and exit state (`ok` / `timeout` / `error`).
+- Accepts an API key via environment variable only — never on the command
+  line, never in logs.
+
+This is the critical path for the entire laboratory; nothing can be
+benchmarked until it exists. It is a ~1–2 day change, mostly wiring
+existing composition into a new entry point plus a focused test.
+
+## Collie-side enabler: prompt-hash telemetry
+
+Reproducibility requires knowing *which* system prompt and tool schema a
+run used. Collie's prompts are Jinja2 templates under
+`nanobot/templates/agent/` (plus the workspace bootstrap files
+`VISION.md`, `AGENTS.md`, `MEMORY.md`), so they are already data files that
+can be hashed.
+
+Extend the existing run-record telemetry (`collie_core/telemetry/recorder.py`)
+with a small, additive field set per turn:
+
+- `prompt_hash` — stable hash of the rendered system prompt (template set
+  + version + rendered content);
+- `tool_schema_hash` — hash of the tool schemas presented to the model;
+- `config_hash` — hash of model id, provider, generation settings, limits.
+
+These are one-line-per-record writes through the existing fire-and-forget
+writer; no schema migration beyond new columns with `None` defaults.
+
+## The laboratory (`collie-bench` repo)
+
+```text
+collie-bench/
+|-- agents/       Harbor adapters for Collie (headless mode), Hermes, Codex
+|-- datasets/     Public dev tasks + pinned external benchmark subsets
+|-- scorers/      Deterministic public verifiers (state-checking)
+|-- configs/      Frozen experiment matrices (cohort, model, reps)
+|-- manifests/    Commit, image digest, model, prompt-hash, dataset identity
+|-- reports/      Generated comparisons and failure summaries
+`-- scripts/      build, run, analyze, report entry points
+```
+
+Private holdout tasks and hidden verifier material live in a separate
+private repo/service; the optimization loop never reads them.
+
+## The small comparison tool
+
+A deliberately tiny (~300–500 lines, stdlib-only) reporter that turns a
+directory of trial manifests into the side-by-side overview. It is *not* a
+framework — Harbor is the runner, this is the dashboard.
+
+**Input:** one JSON-lines file per run (or a directory of them). Every
+trial record carries:
+
+```json
+{
+  "run_id": "2026-08-03T10:00:00Z-collie-reminder-1",
+  "harness": "collie", "version": "0.2.2+abc123",
+  "model": "deepseek/deepseek-chat", "task": "reminder-set",
+  "prompt_hash": "sha256:...", "tool_schema_hash": "sha256:...",
+  "passed": true, "exit_state": "ok",
+  "usage": {"input": 1200, "output": 310, "cache_read": 0, "cache_write": 0},
+  "calls": {"model": 4, "tool": 7, "retries": 0},
+  "latency_ms": 18400, "cost_usd": 0.0042,
+  "failure_cluster": null, "trajectory_path": "runs/.../trajectory.jsonl"
+}
+```
+
+**Output:** markdown + terminal tables:
+
+| harness | task | pass | tokens in | tokens out | cost | p50 lat | tool calls | failure cluster |
+|---|---|---|---|---|---|---|---|---|
+| collie | reminder-set | ✅ 3/3 | 3.4k | 1.1k | $0.013 | 18s | 7 | — |
+| hermes | reminder-set | ✅ 2/3 | 4.1k | 1.3k | $0.016 | 21s | 9 | context-loss |
+| codex | reminder-set | ❌ 1/3 | 5.2k | 0.9k | $0.019 | 29s | 12 | looping |
+
+Plus a Pareto frontier (pass rate × cost per solve), a paired baseline-vs-
+candidate delta view (the *only* view used for promotion decisions), and a
+failure-cluster histogram. One command: `python bench_report.py runs/`.
+
+Where it lives: `collie-bench/scripts/bench_report.py` (it is a lab tool,
+not a product feature). If a future UI wants it, the markdown output is
+already embeddable.
+
+## Iteration loop and the "1% per day" reality check
+
+- With 5–10 tasks × 3 reps, the measurement noise floor is ~10–15%. A
+  single-point delta below ~5% is not measurable; do not chase it.
+- Iterate daily if desired, but measure **failure-cluster shrink** (did
+  this task type's failures drop?) rather than a single percentage.
+- Every candidate re-bench runs the **baseline side-by-side** in the same
+  session; the second benchmark is meaningless without the first.
+- Promote only when quality improves without disproportionate cost growth,
+  or cost-per-solve falls materially with non-inferior quality — thresholds
+  declared *before* the run, not after viewing it.
+
+## Phased delivery
+
+### Phase 1 — measurement proof (the milestone this plan enables)
+- Headless Collie mode + prompt-hash telemetry (Collie repo PRs).
+- `collie-bench` repo: 5 deterministic product tasks (reminders, calendar
+  conflict, file edit, doc extraction, multi-step plan) with pytest-style
+  state verifiers, 100% oracle pass.
+- Adapters for Collie headless, Hermes CLI, Codex CLI; one DeepSeek model.
+- 45-trial matrix; one command reproduces it; report shows quality, tokens,
+  cost, caching, calls, latency, failure categories.
+
+### Phase 2 — regression laboratory
+- 20 deterministic product tasks; add OpenCode, Aider (+ NanoBot family
+  harnesses as they become CLI-benchable).
+- Nightly runs, paired statistics, frozen regression cohort + refreshed
+  ecosystem cohort, public reports.
+
+### Phase 3 — guarded optimization
+- Private holdout scorer; failure analysis + candidate-patch generation.
+- Predeclared promotion gates, holdout query limits, human approval.
+- This is where "adapt Collie's system prompts automatically" becomes safe
+  reality — and only after Phases 1–2 prove the measurements are trustworthy.
+
+### Phase 4 — platform coverage
+- Windows Collie acceptance lane; model families; native/normalized
+  protocol experiments; reproducible methodology publication.
+
+## Acceptance criteria (Phase 1 done when)
+
+- One command reproduces the frozen 45-trial matrix.
+- Every trial uses a clean environment + immutable run manifest.
+- Collie, Hermes, and Codex receive the same task snapshot and enforced model.
+- Verifiers score artifacts without agent access; infrastructure failures
+  are not counted as task failures.
+- The report shows quality, tokens, cost, caching, calls, latency, and
+  failure categories — the small tool's output.
+- A second operator can reproduce the result from documented inputs.
+
+## Open decisions
+
+- Benchmark VM: dedicated Linux box (Hetzner/OVH-class, 4 vCPU/16 GB is
+  enough for Phase 1); the current Hermes VM is off-limits (it runs the
+  Telegram gateway — untrusted harness code stays away).
+- First exact model id + provider (DeepSeek v4 flash, OpenAI-compatible).
+- `collie-bench` repo public vs private at Phase 1 (recommend public dev
+  suite, private holdouts).
+- Retention policy for full prompts and trajectories.
+
+## Follow-up PR roadmap (Collie repo)
+
+1. **This plan** (current PR) — review and merge the direction.
+2. **Headless mode** — `collie_core/headless.py` entry point + test + docs
+   (engineering decision: internal capability, not a product CLI).
+3. **Prompt-hash telemetry** — additive run-record fields + migration test.
+4. (Lab repo, after 2–3 merge) adapters, tasks, verifiers, `bench_report.py`.

--- a/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
+++ b/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
@@ -28,6 +28,7 @@ foundation and should not be re-litigated:
 | Decision | Choice | Why |
 |---|---|---|
 | Trial runner | **Harbor Framework** (`harbor-framework/harbor`, from the Terminal-Bench team) | Isolated Docker environments per trial, agent adapters, versioned datasets, trajectory/artifact/usage collection, RL-rollout support for the endgame |
+| Recording + visualization | **Harbor's built-in web viewer** (`harbor view`) — not a custom tool | Verified in Harbor source: job/trial lists, full trajectory inspection (input/output text per step), input/cached/output token counts, **cost in USD** via LiteLLM pricing, verifier results, per-job LLM analysis, run history, and launching runs from the UI. We only add a thin cross-run regression layer on top (below) |
 | Lab location | **Separate `collie-bench` repo**, Linux-native on the VM | Keeps untrusted harness code and generated commands away from the Windows-maintained Collie workflow; the benchmark VM is not a production Collie machine |
 | Phase 1 scope | 45 trials = 3 harnesses × 5 deterministic tasks × 3 reps | Proves measurement before building anything bigger |
 | First model | One cheap model (DeepSeek-class, OpenAI-compatible) | Cost discipline is a feature; cheap models amplify harness-quality differences |
@@ -108,44 +109,40 @@ collie-bench/
 Private holdout tasks and hidden verifier material live in a separate
 private repo/service; the optimization loop never reads them.
 
-## The small comparison tool
+## Recording and visualization (Harbor first)
 
-A deliberately tiny (~300–500 lines, stdlib-only) reporter that turns a
-directory of trial manifests into the side-by-side overview. It is *not* a
-framework — Harbor is the runner, this is the dashboard.
+**Harbor already records and visualizes the per-run detail the user wants
+to see.** Verified against Harbor source (`src/harbor/viewer/server.py`,
+`src/harbor/cli/view.py`):
 
-**Input:** one JSON-lines file per run (or a directory of them). Every
-trial record carries:
+- **Per trial, recorded automatically:** the full trajectory (every
+  input/output/tool-call step in the standard Agent Trajectory Interchange
+  Format), input / cached-input / output token counts, **cost in USD**
+  (LiteLLM pricing table), verifier pass/fail, artifacts, latency, and
+  environment metadata.
+- **Built-in web viewer** (`harbor view`): a FastAPI + React app that
+  lists jobs and trials, shows each trial's trajectory (input text, output
+  text, tool calls), usage and cost stats, per-job LLM analysis
+  (`/api/jobs/{job}/analysis`), run history, and can even start runs from
+  the browser.
 
-```json
-{
-  "run_id": "2026-08-03T10:00:00Z-collie-reminder-1",
-  "harness": "collie", "version": "0.2.2+abc123",
-  "model": "deepseek/deepseek-chat", "task": "reminder-set",
-  "prompt_hash": "sha256:...", "tool_schema_hash": "sha256:...",
-  "passed": true, "exit_state": "ok",
-  "usage": {"input": 1200, "output": 310, "cache_read": 0, "cache_write": 0},
-  "calls": {"model": 4, "tool": 7, "retries": 0},
-  "latency_ms": 18400, "cost_usd": 0.0042,
-  "failure_cluster": null, "trajectory_path": "runs/.../trajectory.jsonl"
-}
-```
+So the "something visual/recording" requirement is Harbor's job, not a
+custom dashboard. What Harbor does **not** provide out of the box is the
+*cross-run* view: "benchmark from last week vs today, per harness and per
+prompt version, side by side — and did prompt v3 beat prompt v2?" That is
+the one thin layer we add in `collie-bench`:
 
-**Output:** markdown + terminal tables:
+- `collie-bench/scripts/bench_report.py` (~300–500 lines, stdlib-only):
+  reads Harbor's stored job/trial records, renders side-by-side tables
+  (harness × task: pass rate, tokens in/out/cache, cost, p50 latency, tool
+  calls, failure cluster), a Pareto frontier, and the **baseline-vs-candidate
+  delta view** used for keep/revert decisions.
+- Later: a small time-series page (HTML) on top of the same records so
+  re-runs over weeks visibly show improvement — fed entirely by Harbor's
+  data, never re-measured.
 
-| harness | task | pass | tokens in | tokens out | cost | p50 lat | tool calls | failure cluster |
-|---|---|---|---|---|---|---|---|---|
-| collie | reminder-set | ✅ 3/3 | 3.4k | 1.1k | $0.013 | 18s | 7 | — |
-| hermes | reminder-set | ✅ 2/3 | 4.1k | 1.3k | $0.016 | 21s | 9 | context-loss |
-| codex | reminder-set | ❌ 1/3 | 5.2k | 0.9k | $0.019 | 29s | 12 | looping |
-
-Plus a Pareto frontier (pass rate × cost per solve), a paired baseline-vs-
-candidate delta view (the *only* view used for promotion decisions), and a
-failure-cluster histogram. One command: `python bench_report.py runs/`.
-
-Where it lives: `collie-bench/scripts/bench_report.py` (it is a lab tool,
-not a product feature). If a future UI wants it, the markdown output is
-already embeddable.
+Harbor runs the trials and records everything; the report layer only
+aggregates and compares what Harbor already stored.
 
 ## Iteration loop and the "1% per day" reality check
 
@@ -194,7 +191,8 @@ already embeddable.
 - Verifiers score artifacts without agent access; infrastructure failures
   are not counted as task failures.
 - The report shows quality, tokens, cost, caching, calls, latency, and
-  failure categories — the small tool's output.
+  failure categories — Harbor viewer for per-run detail, `bench_report.py`
+  for the cross-run side-by-side.
 - A second operator can reproduce the result from documented inputs.
 
 ## Open decisions
@@ -213,4 +211,5 @@ already embeddable.
 2. **Headless mode** — `collie_core/headless.py` entry point + test + docs
    (engineering decision: internal capability, not a product CLI).
 3. **Prompt-hash telemetry** — additive run-record fields + migration test.
-4. (Lab repo, after 2–3 merge) adapters, tasks, verifiers, `bench_report.py`.
+4. (Lab repo, after 2–3 merge) adapters, tasks, verifiers, and the
+   cross-run report layer on top of Harbor's viewer data.

--- a/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
+++ b/docs/engineering/evaluation/benchmarking-and-prompt-optimization.md
@@ -74,6 +74,54 @@ This is the critical path for the entire laboratory; nothing can be
 benchmarked until it exists. It is a ~1–2 day change, mostly wiring
 existing composition into a new entry point plus a focused test.
 
+## Parity: the headless engine IS the live app
+
+Headless mode is **not a second implementation** — it is the same engine
+without a window. Collie's architecture already guarantees this:
+
+- The Electron shell is only a client: renderer → preload → main →
+  localhost WebSocket → `collie_core.runtime`. All agent behavior (loop,
+  prompts, tools, permissions, memory, telemetry) lives in collie-core;
+  the UI contains no engine logic.
+- Headless mode reuses the exact same composition: `CollieRuntime._build_loop()`
+  (same `build_config` from settings, same `ToolLoader(collie_tools)`
+  discovery, same Jinja2 templates) and the same `AgentLoop.process_direct`
+  call the IPC server uses for every chat message. Only the entry point
+  differs; the engine does not.
+
+Anti-drift guarantees (so parity is enforced, not hoped for):
+
+1. **One-entry-point rule** — headless code may only reuse
+   `CollieRuntime` methods; it never re-composes the loop, tools, prompts,
+   or permissions. Enforced in review and by a consistency test asserting
+   both paths produce identical tool registries and rendered system
+   prompts from the same settings.
+2. **Phase-gate e2e tests run through the headless entry point too** —
+   the existing fake-OpenAI e2e gates (`tests/collie/test_e2e_phase1..4.py`)
+   already guard the live chat path; the same assertions run against
+   `collie_core.headless`, so any drift fails CI.
+3. **Prompt/config hashes in every trial** — the prompt-hash telemetry
+   makes parity visible in the data: each run records which rendered
+   system prompt and config it measured. When prompts change, the next
+   run's hash changes, and comparisons always know exactly what they
+   compared.
+4. **Pinned commit per run** — Harbor trials launch a pinned Collie
+   checkout (commit + image digest in the manifest), so a benchmark
+   measures the exact code the app runs at that commit. Prompts and tools
+   are data files in that checkout; nothing is copied into the lab.
+
+What "equal" does not cover: the UI layer itself (renderer, tray, pet,
+notifications) and Windows packaging/OS integrations stay out of the
+headless lane by design — the Windows acceptance lane covers the shell.
+The agent brain — loop, prompts, tools, permissions, settings, memory,
+telemetry — is identical.
+
+**The "no redoing" answer:** changes flow one way. Edit a prompt template,
+tool, or engine behavior in collie-core once; both the app and the next
+bench run read the same files at build time. The lab never copies Collie's
+prompts or tools — it only launches the pinned engine. The only thing that
+changes between runs is the recorded commit hash.
+
 ## Collie-side enabler: prompt-hash telemetry
 
 Reproducibility requires knowing *which* system prompt and tool schema a

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -15,7 +15,7 @@
 - Core Python test files: **217**
 - Desktop TypeScript/TSX files: **121**
 - Desktop test files: **36**
-- Active Markdown docs: **21**
+- Active Markdown docs: **22**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups


### PR DESCRIPTION
# Evaluation lab plan: benchmarking + prompt optimization

## What this is

A plan (docs-only) to make Collie measurably better on every iteration by
benchmarking it against open-source harnesses (Hermes, Codex CLI, OpenCode,
NanoBot family) under controlled conditions — and using the evidence to
improve Collie's system prompts, instructions, and engine behavior.

Recalled from the 2026-08-02 discussion and locked in:

- **Harbor Framework** as the trial runner AND the recording/visualization
  layer: isolated Docker environments, agent adapters, versioned datasets,
  and a **built-in web viewer** (`harbor view`) that shows every job and
  trial — full trajectory (input/output text per step), input/cached/output
  token counts, **cost in USD** (LiteLLM pricing), verifier pass/fail,
  per-job LLM analysis, and run history. Verified against Harbor source.
- **Separate `collie-bench` repo** (Linux VM), not inside Collie.
- **Phase 1 = 45 trials** (3 harnesses × 5 deterministic product tasks × 3
  reps) on one cheap DeepSeek model (~$5).
- **Hidden deterministic verifiers** check state, not prose.
- Metered gateway, normalized-tool mode, SWE-bench deferred.

## The two Collie-side enablers the plan identifies

1. **Headless engine mode** — Collie has *no CLI* (`pyproject.toml`: "No
   CLI entry points") and can't be benchmarked until it can run one task
   and exit with evidence. Proposed as an internal engineering capability
   (`python -m collie_core.headless --task ...`), not a user-facing product
   CLI — the VISION "no dev shell" non-goal is preserved.
2. **Prompt-hash telemetry** — additive fields on existing run records so
   every trial knows exactly which system prompt (Jinja2 templates in
   `nanobot/templates/agent/`) and tool schema it used.

## Visual / recording — Harbor first, one thin layer on top

Harbor's viewer already gives the per-run detail (input, output, verifier
result, tokens, cost, analysis). What Harbor does NOT give out of the box
is the **cross-run improvement view**: "last week vs today, per harness and
per prompt version, side by side — did prompt v3 beat prompt v2?" That is
the only custom piece: a ~300–500 line report script in `collie-bench`
that reads Harbor's stored records and renders side-by-side tables, a
Pareto frontier, and a baseline-vs-candidate delta view — plus later a
small time-series HTML page so improvements over weeks are visible.

## Reality check on "1% improvement per day"

With 5–10 tasks × 3 reps the noise floor is ~10–15% — a sub-5% delta is
not measurable. Iterate daily if you want, but measure failure-cluster
shrink and always re-run the baseline side-by-side.

## Follow-up PRs (after this plan merges)

1. Headless mode (`collie_core/headless.py` + test + docs)
2. Prompt-hash telemetry (additive run-record fields)
3. `collie-bench` repo: adapters, 5 tasks, verifiers, report layer on top
   of Harbor's viewer data

Full detail: `docs/engineering/evaluation/benchmarking-and-prompt-optimization.md`
