### PR TITLE
feat(tools): open_file opens harmless local files with the default app

### DIFF
--- a/collie-core/collie_core/tools/open_file.py
+++ b/collie-core/collie_core/tools/open_file.py
@@ -1,0 +1,193 @@
+"""Open local files and folders with the operating system's default app.
+
+Deliberately bounded like ``local_files``: only existing, allowlisted
+artifact types inside the folders allowed for the current turn, opened by
+the OS default handler.  Nothing is written, nothing leaves the device,
+and no executable, script, or shortcut type can be launched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from collie_core.permissions.models import PermissionRequest, Risk, Scope
+
+# Reuse the same canonical scope + path-safety resolution as ``local_files``
+# (workspace roots, symlink/junction refusal, UNC/device refusal) so the two
+# tools can never disagree about what a safe local target is.
+from collie_core.tools.local_files import _LocalFileError, _resolve_local_path
+from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
+from nanobot.security.workspace_policy import WorkspaceBoundaryError
+
+__all__ = ["OpenFileTool"]
+
+# File types that are safe to hand to the OS default handler.  The default
+# app for these (viewer/editor/browser) reads the file locally; nothing is
+# sent to a model provider or anywhere else on the network.
+_OPENABLE_SUFFIXES = frozenset(
+    {
+        # documents & data
+        ".md", ".txt", ".pdf", ".docx", ".xlsx", ".pptx", ".csv", ".rtf",
+        ".html", ".htm", ".json", ".xml", ".yaml", ".yml", ".log", ".toml",
+        ".ini",
+        # images
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg", ".ico",
+        ".avif", ".tif", ".tiff",
+        # audio
+        ".mp3", ".wav", ".m4a", ".ogg", ".oga", ".flac", ".opus", ".aac",
+        # video
+        ".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v", ".ogv",
+    }
+)
+
+# Defense in depth: types that must NEVER be handed to a default handler,
+# even if a future edit accidentally adds them to the allowlist.  These
+# execute code or redirect to an arbitrary target.
+_BLOCKED_SUFFIXES = frozenset(
+    {
+        ".appref-ms", ".bat", ".cpl", ".cmd", ".com", ".exe", ".gadget",
+        ".hta", ".jar", ".jse", ".lnk", ".msi", ".msp", ".pif", ".ps1",
+        ".psm1", ".reg", ".scr", ".sh", ".bash", ".url", ".vbe", ".vbs",
+        ".wsf", ".wsh",
+    }
+)
+
+_LAUNCH_TIMEOUT_S = 30
+
+
+class _OpenError(RuntimeError):
+    """A user-facing failure to launch the default app."""
+
+
+def _open_with_default_app(path: Path) -> None:
+    """Launch the OS default handler for an existing local path."""
+    if sys.platform == "win32":
+        os.startfile(os.fspath(path))  # type: ignore[attr-defined]  # Windows only
+        return
+    if sys.platform == "darwin":
+        subprocess.run(
+            ["open", os.fspath(path)], check=False, capture_output=True, timeout=_LAUNCH_TIMEOUT_S
+        )
+        return
+    opener = shutil.which("xdg-open")
+    if opener is None:
+        raise _OpenError("No default-app opener is available on this system.")
+    try:
+        completed = subprocess.run(
+            [opener, os.fspath(path)],
+            capture_output=True,
+            text=True,
+            timeout=_LAUNCH_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        # The handler was invoked; xdg-open just never reported back.  Treat
+        # a launch that consumed the full budget as a successful open.
+        return
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        raise _OpenError(f"The default app could not open it (exit {completed.returncode}). {detail}")
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "Local file or folder to open with the default app. Must exist and be "
+                    "inside the folders allowed for this task."
+                ),
+                "minLength": 1,
+                "maxLength": 4096,
+            },
+        },
+        "required": ["path"],
+        "additionalProperties": False,
+    }
+)
+class OpenFileTool(Tool):
+    """Open an existing local file or folder with the operating system's default app."""
+
+    @property
+    def name(self) -> str:
+        return "open_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Open an existing local file or folder with the operating system's default app — "
+            "for example a Markdown, PDF, Office, image, audio, or video file in its viewer, "
+            "or a folder in the file explorer. Only harmless, allowlisted file types inside "
+            "the folders allowed for this task can be opened; executables, scripts, and "
+            "shortcuts are refused, as are files outside the allowed folders. Nothing is sent "
+            "anywhere — the file opens locally on this device. Use this when the user asks "
+            "you to open, show, or launch a file they created or that lives in an allowed folder."
+        )
+
+    def permission_request(self, params: dict[str, Any]) -> PermissionRequest:
+        target: Path | None = None
+        try:
+            target, _in_scope = _resolve_local_path(
+                str(params.get("path") or ""), allow_directory=True
+            )
+            resource = str(target)
+        except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError):
+            resource = str(params.get("path") or "local file")
+        kind = "folder" if (target is not None and target.is_dir()) else "file"
+        label = target.name if target is not None else Path(resource).name or resource
+        return PermissionRequest(
+            action="local_file.open",
+            resource=resource,
+            risk=Risk.READ,
+            summary=f"Open {kind} “{label}” with its default app",
+            reversible=True,
+            data_leaving_device=(),
+            suggested_scope=Scope.ONCE,
+            redacted_parameters={
+                "path": resource,
+                "local_only": True,
+                "default_app": True,
+            },
+            # Read-only and bounded to allowlisted types inside the approved
+            # folders: no data leaves the device, nothing is written.  The
+            # execution path revalidates scope and type before every launch.
+            hard_approval=False,
+            approval_free=False,
+            approve_for_me=False,
+        )
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        raw = str(kwargs.get("path") or "")
+        try:
+            target, _in_scope = _resolve_local_path(raw, allow_directory=True)
+        except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
+            return ToolResult.error(f"I couldn't open that: {exc}")
+        if not target.exists():
+            return ToolResult.error("That file or folder does not exist yet.")
+        if target.is_dir():
+            return self._launch(target, "folder")
+        suffix = target.suffix.lower()
+        if suffix in _BLOCKED_SUFFIXES or suffix not in _OPENABLE_SUFFIXES:
+            return ToolResult.error(
+                "I can only open harmless file types with the default app — documents, "
+                "images, audio, and video. Executables, scripts, and shortcuts stay "
+                "off-limits."
+            )
+        return self._launch(target, "file")
+
+    @staticmethod
+    def _launch(target: Path, kind: str) -> ToolResult:
+        try:
+            _open_with_default_app(target)
+        except (_OpenError, OSError) as exc:
+            return ToolResult.error(f"I couldn't open that {kind}: {exc}")
+        return ToolResult(
+            json.dumps({"opened": str(target), "kind": kind, "default_app": True})
+        )

--- a/collie-core/collie_core/tools/open_file.py
+++ b/collie-core/collie_core/tools/open_file.py
@@ -2,8 +2,9 @@
 
 Deliberately bounded like ``local_files``: only existing, allowlisted
 artifact types inside the folders allowed for the current turn, opened by
-the OS default handler.  Nothing is written, nothing leaves the device,
-and no executable, script, or shortcut type can be launched.
+the OS default handler.  Nothing is written, and the file's contents are
+never sent to Collie or a model provider — the local default app renders
+it. No executable, script, or shortcut type can be launched.
 """
 
 from __future__ import annotations
@@ -126,8 +127,8 @@ class OpenFileTool(Tool):
             "for example a Markdown, PDF, Office, image, audio, or video file in its viewer, "
             "or a folder in the file explorer. Only harmless, allowlisted file types inside "
             "the folders allowed for this task can be opened; executables, scripts, and "
-            "shortcuts are refused, as are files outside the allowed folders. Nothing is sent "
-            "anywhere — the file opens locally on this device. Use this when the user asks "
+            "shortcuts are refused, as are files outside the allowed folders. The file's contents are "
+            "never sent to Collie or your model provider — it opens locally in your default app. Use this when the user asks "
             "you to open, show, or launch a file they created or that lives in an allowed folder."
         )
 

--- a/collie-core/tests/tools/test_open_file_tool.py
+++ b/collie-core/tests/tools/test_open_file_tool.py
@@ -240,6 +240,17 @@ def test_read_risk_opens_are_allowed_by_default_evaluator() -> None:
     assert decision.effect.value == "allow"
 
 
+def test_description_claims_are_truthful() -> None:
+    """Browser-rendered types (html/svg) can trigger network activity in the
+    default app, so the description must promise provider-silence, not
+    blanket network silence."""
+
+    description = OpenFileTool().description
+
+    assert "never sent to Collie or your model provider" in description
+    assert "Nothing is sent anywhere" not in description
+
+
 def test_open_file_tool_is_discoverable() -> None:
     import collie_core.tools as collie_tools
 

--- a/collie-core/tests/tools/test_open_file_tool.py
+++ b/collie-core/tests/tools/test_open_file_tool.py
@@ -1,0 +1,247 @@
+"""Tests for the bounded default-app opener tool (``open_file``)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import collie_core.tools.open_file as open_file_module
+from collie_core.permissions.evaluator import PermissionEvaluator
+from collie_core.permissions.models import ExecutionContext, Risk
+from collie_core.tools.open_file import OpenFileTool
+from nanobot.agent.tools.loader import ToolLoader
+from nanobot.security.workspace_access import (
+    bind_workspace_scope,
+    build_workspace_scope,
+    reset_workspace_scope,
+)
+
+
+@pytest.fixture
+def scoped_tool(tmp_path: Path):
+    root = tmp_path / "project"
+    root.mkdir()
+    token = bind_workspace_scope(build_workspace_scope(root, "restricted", source_channel="websocket"))
+    try:
+        yield OpenFileTool(), root
+    finally:
+        reset_workspace_scope(token)
+
+
+@pytest.fixture
+def fake_launcher(monkeypatch: pytest.MonkeyPatch):
+    launched: list[Path] = []
+
+    def _fake(path: Path) -> None:
+        launched.append(path)
+
+    monkeypatch.setattr(open_file_module, "_open_with_default_app", _fake)
+    return launched
+
+
+# ---------------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_opens_allowlisted_text_file_with_default_app(scoped_tool, fake_launcher) -> None:
+    tool, root = scoped_tool
+    (root / "features.md").write_text("# My features", encoding="utf-8")
+
+    result = await tool.execute(path="features.md")
+
+    assert not result.is_error
+    payload = json.loads(result)
+    assert payload["opened"] == str(root / "features.md")
+    assert payload["kind"] == "file"
+    assert payload["default_app"] is True
+    assert fake_launcher == [root / "features.md"]
+
+
+@pytest.mark.asyncio
+async def test_opens_binary_document_with_default_app(scoped_tool, fake_launcher) -> None:
+    """The opener may launch Word/PDF viewers even though local_files can't read them."""
+    tool, root = scoped_tool
+    (root / "report.pdf").write_bytes(b"%PDF-1.4 fake")
+
+    result = await tool.execute(path="report.pdf")
+
+    assert not result.is_error
+    assert json.loads(result)["kind"] == "file"
+    assert fake_launcher == [root / "report.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_opens_folder_in_file_explorer(scoped_tool, fake_launcher) -> None:
+    tool, root = scoped_tool
+
+    result = await tool.execute(path=".")
+
+    assert not result.is_error
+    payload = json.loads(result)
+    assert payload["kind"] == "folder"
+    assert payload["opened"] == str(root)
+    assert fake_launcher == [root]
+
+
+# ---------------------------------------------------------------------------
+# refusals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["tool.exe", "setup.msi", "run.bat", "evil.ps1", "go.sh", "x.lnk", "x.url", "x.js"])
+async def test_rejects_executables_scripts_and_shortcuts(scoped_tool, fake_launcher, name: str) -> None:
+    tool, root = scoped_tool
+    (root / name).write_bytes(b"payload")
+
+    result = await tool.execute(path=name)
+
+    assert result.is_error
+    assert "harmless file types" in result
+    assert fake_launcher == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_out_of_scope_path(scoped_tool, tmp_path: Path, fake_launcher) -> None:
+    tool, _root = scoped_tool
+    outside = tmp_path / "outside.md"
+    outside.write_text("private", encoding="utf-8")
+
+    result = await tool.execute(path=str(outside))
+
+    assert result.is_error
+    assert "outside" in result
+    assert fake_launcher == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_nonexistent_file(scoped_tool, fake_launcher) -> None:
+    tool, _root = scoped_tool
+
+    result = await tool.execute(path="missing.md")
+
+    assert result.is_error
+    assert "does not exist" in result
+    assert fake_launcher == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_symlink_escape(scoped_tool, tmp_path: Path, fake_launcher) -> None:
+    tool, root = scoped_tool
+    outside = tmp_path / "outside.md"
+    outside.write_text("private", encoding="utf-8")
+    link = root / "linked.md"
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = await tool.execute(path="linked.md")
+
+    assert result.is_error
+    assert "Symlink" in result
+    assert fake_launcher == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_mapped_windows_drive(
+    scoped_tool, monkeypatch: pytest.MonkeyPatch, fake_launcher
+) -> None:
+    import collie_core.tools.local_files as local_files
+
+    tool, root = scoped_tool
+    (root / "meeting.md").write_text("Agenda", encoding="utf-8")
+    monkeypatch.setattr(local_files, "is_local_filesystem_path", lambda _path: False)
+
+    result = await tool.execute(path="meeting.md")
+
+    assert result.is_error
+    assert "Network drives" in result
+    assert fake_launcher == []
+
+
+@pytest.mark.asyncio
+async def test_friendly_error_when_no_default_opener_exists(scoped_tool, monkeypatch: pytest.MonkeyPatch) -> None:
+    tool, root = scoped_tool
+    (root / "notes.md").write_text("hi", encoding="utf-8")
+    monkeypatch.setattr(open_file_module.sys, "platform", "linux")
+    monkeypatch.setattr(open_file_module.shutil, "which", lambda _name: None)
+
+    result = await tool.execute(path="notes.md")
+
+    assert result.is_error
+    assert "No default-app opener" in result
+
+
+@pytest.mark.asyncio
+async def test_linux_launcher_uses_xdg_open(scoped_tool, monkeypatch: pytest.MonkeyPatch) -> None:
+    tool, root = scoped_tool
+    (root / "notes.md").write_text("hi", encoding="utf-8")
+    monkeypatch.setattr(open_file_module.sys, "platform", "linux")
+    monkeypatch.setattr(open_file_module.shutil, "which", lambda _name: "/usr/bin/xdg-open")
+    launched: list[str] = []
+
+    def _run(argv, **kwargs):
+        launched.append(argv[-1])
+        return type("C", (), {"returncode": 0, "stderr": "", "stdout": ""})()
+
+    monkeypatch.setattr(open_file_module.subprocess, "run", _run)
+
+    result = await tool.execute(path="notes.md")
+
+    assert not result.is_error
+    assert launched == [str(root / "notes.md")]
+
+
+@pytest.mark.asyncio
+async def test_windows_launcher_uses_startfile(scoped_tool, monkeypatch: pytest.MonkeyPatch) -> None:
+    tool, root = scoped_tool
+    (root / "notes.md").write_text("hi", encoding="utf-8")
+    monkeypatch.setattr(open_file_module.sys, "platform", "win32")
+    started: list[str] = []
+    monkeypatch.setattr(open_file_module.os, "startfile", started.append, raising=False)
+
+    result = await tool.execute(path="notes.md")
+
+    assert not result.is_error
+    assert started == [str(root / "notes.md")]
+
+
+# ---------------------------------------------------------------------------
+# permission posture
+# ---------------------------------------------------------------------------
+
+
+def test_permission_request_is_read_only_local_open() -> None:
+    request = OpenFileTool().permission_request({"path": "/home/rick/.collie/workspace/features.md"})
+
+    assert request.action == "local_file.open"
+    assert request.risk == Risk.READ
+    assert request.reversible is True
+    assert request.data_leaving_device == ()
+    assert request.hard_approval is False
+    assert request.approval_free is False
+    assert request.approve_for_me is False
+    assert request.redacted_parameters["local_only"] is True
+    assert request.redacted_parameters["default_app"] is True
+
+
+def test_read_risk_opens_are_allowed_by_default_evaluator() -> None:
+    evaluator = PermissionEvaluator()
+    request = OpenFileTool().permission_request({"path": "/home/rick/.collie/workspace/features.md"})
+    context = ExecutionContext(execution_mode="execute")
+
+    decision = evaluator.evaluate(context, request)
+
+    assert decision.effect.value == "allow"
+
+
+def test_open_file_tool_is_discoverable() -> None:
+    import collie_core.tools as collie_tools
+
+    names = {tool.__name__ for tool in ToolLoader(collie_tools).discover()}
+    assert "OpenFileTool" in names

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -67,7 +67,9 @@ evaluation. The renderer must not receive decrypted long-lived secrets.
 The chat's `file_access_scope` travels through the renderer bridge and Electron
 main process into the core runtime for that turn. Core canonicalizes and
 validates the allowed roots, and the `local_files` tool revalidates them while
-executing. Subagents inherit the same immutable scope and cannot broaden it.
+executing; the `open_file` tool (default-app open of harmless file types and
+folders) shares that same canonical resolution. Subagents inherit the same
+immutable scope and cannot broaden it.
 Full local-file access remains session-only and does not grant connector,
 network, or external-write authority.
 

--- a/docs/engineering/security/approval-matrix.md
+++ b/docs/engineering/security/approval-matrix.md
@@ -68,6 +68,29 @@ grant external authority. The selected scope is carried with the current turn,
 validated again in the core, and inherited by subagents; a child cannot broaden
 it.
 
+## Opening files with the default app
+
+`open_file` opens an existing local file or folder with the operating system's
+default handler (a document/image/audio/video viewer, the browser, or the file
+explorer). It exists so Collie can "show" the user the artifacts it creates,
+without shell access or arbitrary app launching.
+
+- It shares `local_files`' exact scope and path-safety boundary: the same
+  canonical resolution (workspace/project roots, symlink/junction refusal,
+  UNC/device refusal) is reused, so the two tools can never disagree about what
+  a safe local target is.
+- Only an allowlisted set of harmless types can be opened — documents and data
+  (`.md .txt .pdf .docx .xlsx .pptx .csv .rtf .html .json .xml .yaml .log …`),
+  images, audio, and video. A separate denylist (`.exe .bat .cmd .ps1 .vbs
+  .msi .lnk .url .reg .scr .jar …`) is defense in depth so a future allowlist
+  edit can never hand an executable or shortcut to a default handler.
+- It is classified `Risk.READ` with no `data_leaving_device`: the file opens in
+  a local app and nothing is sent to any provider. It is reversible (close the
+  window), never writes, and can only target files that already exist. Within
+  the approved folders, a read-only open is allowed without an approval card;
+  anything outside the allowed folders is refused outright by the tool, and the
+  launch is revalidated at execution time, not just at card time.
+
 ## Interface and ownership map
 
 | Responsibility | Primary implementation |
@@ -76,6 +99,7 @@ it.
 | Classification and evaluation | [`permissions/classifier.py`](../../../collie-core/collie_core/permissions/classifier.py), [`permissions/evaluator.py`](../../../collie-core/collie_core/permissions/evaluator.py) |
 | Approval cards and task-wide rule validation | [`permissions/broker.py`](../../../collie-core/collie_core/permissions/broker.py), [`ApprovalSheet.tsx`](../../../collie-ui/src/renderer/src/components/approvals/ApprovalSheet.tsx) |
 | Local text-file tool | [`tools/local_files.py`](../../../collie-core/collie_core/tools/local_files.py) |
+| Default-app opener tool | [`tools/open_file.py`](../../../collie-core/collie_core/tools/open_file.py) |
 | File-access scope validation and inheritance | [`nanobot/security/workspace_access.py`](../../../collie-core/nanobot/security/workspace_access.py) |
 | Chat transport and composer controls | [`ipc/server.py`](../../../collie-core/collie_core/ipc/server.py), [`ChatScreen.tsx`](../../../collie-ui/src/renderer/src/screens/ChatScreen.tsx), [`ChatInput.tsx`](../../../collie-ui/src/renderer/src/components/ChatInput.tsx) |
 

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,8 +11,8 @@
 
 ## Source inventory
 
-- Core Python files: **477**
-- Core Python test files: **217**
+- Core Python files: **479**
+- Core Python test files: **218**
 - Desktop TypeScript/TSX files: **121**
 - Desktop test files: **36**
 - Active Markdown docs: **21**


### PR DESCRIPTION
## What and why

From the "user says hello to assistant" test chat: the user asked Collie to create a features file and then open it for them — Collie could not, because no tool existed to launch apps or open files. This PR adds a bounded `open_file` tool: Collie can now "show" the user files it creates by opening them with the OS default app (Markdown/PDF/Office/images/audio/video in their viewers, folders in the file explorer).

## Design (security posture)

- Reuses `local_files`' canonical path resolution: same workspace/project roots, symlink/junction refusal, UNC/device refusal — the two tools can never disagree about a safe target.
- Allowlist of harmless types (documents, data, images, audio, video) plus a denylist (exe, bat, cmd, ps1, vbs, msi, lnk, url, reg, scr, jar, ...) as defense in depth.
- `Risk.READ`, `reversible`, `data_leaving_device=()` — the file opens in a local app; nothing is sent to any provider.
- Execution revalidates scope and type; out-of-scope paths are refused outright (never opened).
- Platforms: `os.startfile` (Windows), `open` (macOS), `xdg-open` (Linux).

## Verification (fresh, run on branch tip)

| Gate | Result |
|---|---|
| pytest full suite | 3354 passed / 5 failed (documented Windows-only baseline: DPAPI + 1 IPC escape-path) / 1 skipped |
| pytest tests/collie | 511 passed / 5 baseline failed / 1 skipped |
| pytest tests/tools/test_open_file_tool.py | 21 passed |
| coverage | 74.29% (>=70) |
| ruff (nanobot collie_core tests) | clean |
| snapshot --check | current |
| live | real `xdg-open` opened `~/.collie/workspace/features.md` in Mousepad on the dev VM (screenshot in chat) |

## Files

- `collie-core/collie_core/tools/open_file.py` — new tool (+247)
- `collie-core/tests/tools/test_open_file_tool.py` — 21 tests (+193)
- `docs/engineering/security/approval-matrix.md` — new "Opening files with the default app" section
- `docs/PROJECT_MAP.md` — local-file boundary mentions `open_file`
- `docs/generated/REPOSITORY_SNAPSHOT.md` — regenerated
