### PR TITLE
feat(engine): headless mode + prompt-hash telemetry for the evaluation lab

### DIFF
--- a/collie-core/AGENTS.md
+++ b/collie-core/AGENTS.md
@@ -40,6 +40,36 @@ npm run typecheck
 npm run build
 ```
 
+## Headless engine mode (internal benchmarking entry)
+
+`python -m collie_core.headless` runs exactly one task through the real
+agent loop against an isolated `COLLIE_HOME`, prints ONE JSON result
+document (answer, token usage, calls, latency, prompt hashes), and exits.
+It exists so the evaluation lab can benchmark Collie from the outside
+without a UI. It is NOT a user-facing CLI: no `[project.scripts]` entry
+point exists (pyproject: "No CLI entry points"); `python -m` is the entry.
+
+```bash
+.venv/bin/python -m collie_core.headless \
+  --task "…" --home /tmp/bench-home --model deepseek/deepseek-chat \
+  --provider deepseek --api-key-env COLLIE_BENCH_KEY
+```
+
+Exit codes: `0` ok, `1` task/engine error, `2` timeout, `3` usage/config
+error. The API key MUST come from the environment (`--api-key-env`,
+default `COLLIE_PROVIDER_API_KEY`) — never argv, never logged.
+
+**Parity rule (non-negotiable):** `collie_core/headless.py` only *calls*
+`CollieRuntime` methods (`_build_loop`, `_configure_provider_candidate`,
+`_chat`, `_conversation_target`). It never re-composes the loop, tools,
+prompts, permissions, or config — so the bench always measures the exact
+product path. `runtime.run()` is never called (no IPC server/scheduler).
+`tests/collie/test_headless.py` includes the parity test asserting the
+headless path and a direct `_build_loop()` register identical tool
+schemas; `tests/collie/test_prompt_hashes.py` covers the hash telemetry
+(schema V12 adds `prompt_hash`/`tool_schema_hash`/`config_hash` to
+`turn_events`, nullable, `None` defaults at the signature).
+
 ## Architecture Notes
 
 - **Chat flow**: Electron renderer → `collie_core/ipc/server.py` (WebSocket

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -514,6 +514,12 @@ CREATE TABLE IF NOT EXISTS tool_events (
 CREATE INDEX IF NOT EXISTS idx_tool_events_tool ON tool_events(tool_name, status, started_at DESC);
 """
 
+_SCHEMA_V12 = """
+ALTER TABLE turn_events ADD COLUMN prompt_hash TEXT;
+ALTER TABLE turn_events ADD COLUMN tool_schema_hash TEXT;
+ALTER TABLE turn_events ADD COLUMN config_hash TEXT;
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -527,6 +533,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V9,
     _SCHEMA_V10,
     _SCHEMA_V11,
+    _SCHEMA_V12,
 ]
 
 
@@ -3231,6 +3238,9 @@ class CollieDB:
         tokens_out: int = 0,
         latency_ms: int | None = None,
         tool_count: int = 0,
+        prompt_hash: str | None = None,
+        tool_schema_hash: str | None = None,
+        config_hash: str | None = None,
         started_at: str | None = None,
         finished_at: str | None = None,
     ) -> None:
@@ -3257,6 +3267,9 @@ class CollieDB:
                     tokens_out = COALESCE(?, tokens_out),
                     latency_ms = COALESCE(?, latency_ms),
                     tool_count = COALESCE(?, tool_count),
+                    prompt_hash = COALESCE(?, prompt_hash),
+                    tool_schema_hash = COALESCE(?, tool_schema_hash),
+                    config_hash = COALESCE(?, config_hash),
                     started_at = COALESCE(?, started_at),
                     finished_at = COALESCE(?, finished_at)
                 WHERE id = ?
@@ -3264,7 +3277,8 @@ class CollieDB:
                 (
                     conversation_id, session_key, turn_kind, provider, model,
                     status, error_message, tokens_in, tokens_out, latency_ms,
-                    tool_count, started_at, finished_at, turn_id,
+                    tool_count, prompt_hash, tool_schema_hash, config_hash,
+                    started_at, finished_at, turn_id,
                 ),
             )
             if updated.rowcount == 0:
@@ -3273,13 +3287,15 @@ class CollieDB:
                     INSERT INTO turn_events (
                         id, conversation_id, session_key, turn_kind, provider, model,
                         status, error_message, tokens_in, tokens_out, latency_ms,
-                        tool_count, started_at, finished_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        tool_count, prompt_hash, tool_schema_hash, config_hash,
+                        started_at, finished_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         turn_id, conversation_id, session_key, turn_kind or "chat",
                         provider, model, status or "running", error_message,
                         tokens_in, tokens_out, latency_ms, tool_count,
+                        prompt_hash, tool_schema_hash, config_hash,
                         started_at or utc_now(), finished_at,
                     ),
                 )

--- a/collie-core/collie_core/headless.py
+++ b/collie-core/collie_core/headless.py
@@ -1,0 +1,403 @@
+"""Headless engine mode — one task, one JSON result document, exit.
+
+Internal engineering capability for the evaluation lab (see
+``docs/engineering/evaluation/benchmarking-and-prompt-optimization.md``).
+Runs exactly one task through the real agent loop against an isolated
+``COLLIE_HOME``, prints ONE JSON document to stdout, and exits. It is NOT
+a user-facing CLI: no ``[project.scripts]`` entry point exists
+(pyproject: "No CLI entry points"); ``python -m collie_core.headless`` is
+the entry.
+
+Parity rules (non-negotiable):
+- This module only *calls* ``CollieRuntime`` methods (``_build_loop``,
+  ``_configure_provider_candidate``, ``_chat``, ``_conversation_target``).
+  It never re-composes the loop, tools, prompts, permissions, or config.
+- ``runtime.run()`` is never called: the IPC server, scheduler, and
+  reminder loop stay off; the lifecycle is driven manually and torn down
+  in the same order ``run()`` uses.
+
+Exit codes: 0 ok, 1 task/engine error, 2 timeout, 3 usage/config error.
+
+The API key MUST come from the environment (``--api-key-env``, default
+``COLLIE_PROVIDER_API_KEY``) — never from argv, and it is never printed
+or logged. ``build_config`` reads ``COLLIE_<PROVIDER>_API_KEY`` /
+``COLLIE_PROVIDER_API_KEY`` directly, and ``_configure_provider_candidate``
+takes the key from the candidate dict (the exact UI path).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from collie_core.db import CollieDB
+from collie_core.runtime import CollieRuntime
+from collie_core.telemetry.prompt_hashes import (
+    current_config_hash,
+    current_tool_schema_hash,
+)
+from collie_core.telemetry.recorder import RunRecorder, sanitize_text
+
+__all__ = ["main", "run_one"]
+
+_SCHEMA_VERSION = 1
+_HARNESS = "collie"
+
+# Exit codes — stable contract (see module docstring).
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_TIMEOUT = 2
+EXIT_USAGE = 3
+
+# The engine clamps tool iterations to 1..2000 in ``build_config``; never
+# let a garbage flag value reach the engine.
+MAX_ITERATIONS_MIN = 1
+MAX_ITERATIONS_MAX = 2000
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m collie_core.headless",
+        description=(
+            "Run one task through the real Collie agent loop and print one "
+            "JSON result document. Internal engineering capability only."
+        ),
+    )
+    parser.add_argument("--task", required=True, help="The task/user prompt to run.")
+    parser.add_argument(
+        "--home",
+        default=None,
+        help=(
+            "COLLIE_HOME directory (created if missing). Defaults to "
+            "$COLLIE_HOME or a fresh tempfile.mkdtemp()."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model id (e.g. deepseek/deepseek-chat). Defaults to the provider record / settings.",
+    )
+    parser.add_argument(
+        "--provider",
+        default="deepseek",
+        help="Provider name (e.g. deepseek). Default: deepseek.",
+    )
+    parser.add_argument(
+        "--api-base",
+        default=None,
+        help="Custom OpenAI-compatible base URL. Defaults to the provider default.",
+    )
+    parser.add_argument(
+        "--api-key-env",
+        default="COLLIE_PROVIDER_API_KEY",
+        help="Env var holding the API key. Default: COLLIE_PROVIDER_API_KEY.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Wall-clock seconds for the whole turn. Default: 300.",
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=50,
+        help="agent.max_tool_iterations (clamped 1..2000). Default: 50.",
+    )
+    parser.add_argument(
+        "--approval-preset",
+        choices=("allow", "ask", "deny"),
+        default="allow",
+        help=(
+            "Local-write approval preset, wired through the SAME "
+            "set_local_write_preset path as the product (never a bypass). "
+            "Default: allow (the bench sandbox is disposable)."
+        ),
+    )
+    parser.add_argument(
+        "--session-key",
+        default=None,
+        help=(
+            "Engine session key label. The engine resolves the canonical "
+            "desktop session key from the conversation (collie:<id>) — the "
+            "reported session_key is the resolved one, so it joins run records."
+        ),
+    )
+    parser.add_argument(
+        "--json-out",
+        default=None,
+        help="Also write the result document to this file (stdout still gets it).",
+    )
+    return parser.parse_args(argv)
+
+
+async def _noop_stream(_text: str) -> None:
+    """Headless turns have no UI to stream to."""
+
+
+async def _noop_progress(*_args: Any, **_kwargs: Any) -> None:
+    """Headless turns have no UI to report progress to."""
+
+
+def _git_commit() -> str:
+    """Best-effort repo HEAD sha, or 'unknown' outside a git checkout."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _resolve_home(home_flag: str | None) -> Path:
+    """Resolve --home > $COLLIE_HOME > a fresh temp dir, creating it."""
+    root = home_flag or os.environ.get("COLLIE_HOME")
+    if root:
+        path = Path(root).expanduser()
+    else:
+        path = Path(tempfile.mkdtemp(prefix="collie-bench-"))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _normalize_usage(usage: dict[str, Any]) -> dict[str, int]:
+    """Map provider usage keys to the stable contract keys (zero-fill)."""
+    details = usage.get("prompt_tokens_details") or {}
+    return {
+        "input_tokens": int(usage.get("prompt_tokens") or 0),
+        "output_tokens": int(usage.get("completion_tokens") or 0),
+        "cache_read_tokens": int(
+            details.get("cached_tokens")
+            or usage.get("cache_read_input_tokens")
+            or 0
+        ),
+        "cache_write_tokens": int(
+            details.get("cache_creation_input_tokens")
+            or usage.get("cache_creation_input_tokens")
+            or 0
+        ),
+    }
+
+
+def _empty_document(
+    task: str,
+    provider: str,
+    *,
+    model: str | None = None,
+    exit_state: str = "error",
+    error: str | None = None,
+) -> dict[str, Any]:
+    """A complete schema document (all keys present, zero-filled)."""
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "run_id": uuid.uuid4().hex,
+        "harness": _HARNESS,
+        "commit": _git_commit(),
+        "model": model or "",
+        "provider": provider,
+        "task": task,
+        "session_key": "",
+        "conversation_id": "",
+        "prompt_hash": None,
+        "tool_schema_hash": None,
+        "config_hash": None,
+        "final_text": "",
+        "usage": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        },
+        "calls": {
+            "model_calls": 0,
+            "tool_calls": 0,
+            "retries": 0,
+            "no_action_turns": 0,
+        },
+        "latency_ms": 0,
+        "exit_state": exit_state,
+        "error": error,
+    }
+
+
+async def run_one(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    """Run one task through the real agent loop and return (exit_code, doc).
+
+    ``COLLIE_HOME`` is set from ``--home`` / the environment BEFORE any
+    ``CollieDB`` is built, so the bench never touches the real user home.
+    """
+    home = _resolve_home(args.home)
+    os.environ["COLLIE_HOME"] = str(home)
+
+    document = _empty_document(args.task, args.provider)
+    exit_code = EXIT_OK
+
+    # -- usage/config errors ------------------------------------------------
+    key = os.environ.get(args.api_key_env) or ""
+    if not key:
+        document["error"] = (
+            f"No API key found in ${args.api_key_env}. Pass it via the "
+            "environment — the headless entry never accepts keys on argv."
+        )
+        exit_code = EXIT_USAGE
+        _emit(document, args.json_out)
+        return exit_code, document
+
+    db = CollieDB(home / "collie.db")
+    # Approval preset is persisted BEFORE the runtime is constructed so the
+    # PermissionEvaluator reads it at init — the exact same setting the IPC
+    # path writes, never a bypass. (argparse already restricts to
+    # allow|ask|deny.)
+    db.set_setting("permissions.local_write_preset", args.approval_preset)
+    runtime: CollieRuntime | None = None
+    try:
+        runtime = CollieRuntime(port=0, db=db)
+        # -- provider ---------------------------------------------------------
+        # The exact transactional path the UI uses: validate + persist +
+        # rebuild the loop. A bench key flows purely through the environment.
+        candidate: dict[str, Any] = {
+            "provider_id": args.provider,
+            "name": args.provider,
+            "auth_type": "api-key",
+            "model": args.model,
+            "runtime_name": args.provider,
+            "secret_name": args.provider,
+            "protocol": "openai",
+            "api_base": args.api_base,
+            "api_key": key,
+        }
+        configured = await runtime._configure_provider_candidate(candidate)
+        if not configured.get("configured"):
+            document["error"] = sanitize_text(
+                str(configured.get("error") or "provider configuration failed")
+            )
+            exit_code = EXIT_USAGE
+            _emit(document, args.json_out)
+            return exit_code, document
+
+        document["model"] = str(configured.get("model") or args.model or "")
+
+        # -- session + conversation -------------------------------------------
+        conversation = db.create_conversation(title="Bench")
+        conversation_id = str(conversation["id"])
+        # The engine resolves the canonical desktop key for this conversation;
+        # report THAT key so the result joins the telemetry run records.
+        engine_session_key = runtime._conversation_target(conversation_id)[0]
+        document["session_key"] = engine_session_key
+        document["conversation_id"] = conversation_id
+
+        # -- run one turn ------------------------------------------------------
+        run_id = uuid.uuid4().hex
+        started = time.monotonic()
+        outbound: Any = None
+        try:
+            outbound = await asyncio.wait_for(
+                runtime._chat(
+                    args.task,
+                    conversation_id=conversation_id,
+                    on_stream=_noop_stream,
+                    on_progress=_noop_progress,
+                    execution_mode="execute",
+                    run_id=run_id,
+                ),
+                timeout=args.timeout,
+            )
+        except asyncio.TimeoutError:
+            exit_code = EXIT_TIMEOUT
+            document["exit_state"] = "timeout"
+            document["error"] = f"Turn timed out after {args.timeout}s."
+        except Exception as error:  # task/engine error
+            exit_code = EXIT_ERROR
+            document["exit_state"] = "error"
+            document["error"] = sanitize_text(str(error))
+        else:
+            document["exit_state"] = "ok"
+        document["latency_ms"] = int((time.monotonic() - started) * 1000)
+
+        # -- evidence ----------------------------------------------------------
+        # Flush telemetry so the run record (hashes, tool count) is durable
+        # before we read it back; mirrors run()'s flush-then-close ordering.
+        recorder = RunRecorder.active_for(runtime.db)
+        if recorder is not None:
+            recorder.flush()
+
+        usage = getattr(runtime.loop, "_last_usage", None) or {}
+        document["usage"] = _normalize_usage(dict(usage))
+
+        record = {}
+        try:
+            turns = db.list_turn_events(conversation_id=conversation_id, limit=1)
+            if turns:
+                record = turns[0]
+        except Exception:
+            pass
+        document["prompt_hash"] = record.get("prompt_hash")
+        document["tool_schema_hash"] = record.get("tool_schema_hash")
+        document["config_hash"] = record.get("config_hash")
+        # Fall back to the live loop's fingerprints if the row is missing.
+        if document["tool_schema_hash"] is None:
+            document["tool_schema_hash"] = current_tool_schema_hash()
+        if document["config_hash"] is None:
+            document["config_hash"] = current_config_hash()
+
+        final_text = str(getattr(outbound, "content", "") or "")
+        document["final_text"] = sanitize_text(final_text)
+
+        stats = getattr(recorder, "last_turn_stats", None) or {}
+        document["calls"] = {
+            "model_calls": int(stats.get("model_calls") or 0),
+            "tool_calls": int(record.get("tool_count") or 0),
+            "retries": int(stats.get("retries") or 0),
+            "no_action_turns": int(stats.get("no_action_turns") or 0),
+        }
+
+        _emit(document, args.json_out)
+        return exit_code, document
+    finally:
+        # Mirror run()'s shutdown ordering: cancel in-flight work first,
+        # then stop telemetry, then close the database.
+        if runtime is not None:
+            try:
+                await runtime._shutdown_loop()
+            except Exception:
+                pass
+            runtime.approvals.cancel_all()
+            recorder = RunRecorder.active_for(runtime.db)
+            if recorder is not None:
+                recorder.shutdown()
+        db.close()
+
+
+def _emit(document: dict[str, Any], json_out: str | None) -> None:
+    """Print the document as one JSON line; optionally also write it."""
+    line = json.dumps(document, ensure_ascii=False)
+    print(line, flush=True)
+    if json_out:
+        Path(json_out).write_text(line + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: parse args, run one task, return the exit code."""
+    args = _parse_args(argv)
+    exit_code, _document = asyncio.run(run_one(args))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/collie-core/collie_core/headless.py
+++ b/collie-core/collie_core/headless.py
@@ -265,6 +265,12 @@ async def run_one(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     # path writes, never a bypass. (argparse already restricts to
     # allow|ask|deny.)
     db.set_setting("permissions.local_write_preset", args.approval_preset)
+    # --max-iterations maps to agent.max_tool_iterations; build_config clamps
+    # to 1..2000, and the flag must never reach the engine outside that range.
+    db.set_setting(
+        "agent.max_tool_iterations",
+        min(MAX_ITERATIONS_MAX, max(MAX_ITERATIONS_MIN, args.max_iterations)),
+    )
     runtime: CollieRuntime | None = None
     try:
         runtime = CollieRuntime(port=0, db=db)

--- a/collie-core/collie_core/permissions/evaluator.py
+++ b/collie-core/collie_core/permissions/evaluator.py
@@ -62,9 +62,15 @@ class PermissionEvaluator:
         self.set_local_write_preset(local_write_preset)
 
     def set_local_write_preset(self, preset: str) -> None:
-        """Apply a validated local-write preset to future evaluations."""
-        if preset not in {"ask", "allow"}:
-            raise ValueError("local-write preset must be 'ask' or 'allow'")
+        """Apply a validated local-write preset to future evaluations.
+
+        ``deny`` is the engineering/bench posture: local writes are
+        refused outright (no auto-allow, no ask) unless an explicit rule
+        or run-wide approval already granted them. It rides the same
+        setter as the product's ask/allow toggles — never a bypass.
+        """
+        if preset not in {"ask", "allow", "deny"}:
+            raise ValueError("local-write preset must be 'ask', 'allow', or 'deny'")
         self.local_write_preset = preset
 
     def evaluate(
@@ -165,6 +171,13 @@ class PermissionEvaluator:
             and self._approve_for_me_eligible(request)
         ):
             return PermissionDecision(Effect.ALLOW, "The local-write preset allows this action.")
+        # deny is the strict engineering/bench posture: local writes are
+        # refused outright (unless an explicit allow rule or run-wide
+        # approval already granted them above). Reads stay allowed.
+        if request.risk == Risk.LOCAL_WRITE and self.local_write_preset == "deny":
+            return PermissionDecision(
+                Effect.DENY, "The local-write preset denies local changes."
+            )
         if ordinary_safe:
             return PermissionDecision(
                 Effect.ALLOW,

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -214,6 +214,28 @@ class CollieRuntime:
         loop.authorizer = self.approvals
         loop.subagents.authorizer = self.approvals
         logger.info("Registered Collie tools: {}", registered)
+        # Fingerprint this exact loop for run telemetry: the tool schemas the
+        # model will see and the config values (model/provider/generation/
+        # limits) it ran under. The telemetry hook reads these per turn.
+        from collie_core.telemetry.prompt_hashes import bind_prompt_hash_sources
+
+        defaults = config.agents.defaults
+        bind_prompt_hash_sources(
+            tool_schemas=loop.tools.get_definitions(),
+            model=str(defaults.model),
+            provider=str(defaults.provider),
+            generation={
+                "temperature": defaults.temperature,
+                "max_tokens": defaults.max_tokens,
+                "reasoning_effort": defaults.reasoning_effort,
+            },
+            limits={
+                "max_tool_iterations": defaults.max_tool_iterations,
+                "max_tool_result_chars": defaults.max_tool_result_chars,
+                "context_window_tokens": defaults.context_window_tokens,
+                "max_concurrent_subagents": defaults.max_concurrent_subagents,
+            },
+        )
         return loop
 
     async def _run_command(

--- a/collie-core/collie_core/telemetry/hook.py
+++ b/collie-core/collie_core/telemetry/hook.py
@@ -17,6 +17,11 @@ from typing import Any
 
 from collie_core.db import CollieDB, new_id
 from collie_core.permissions.classifier import classify_tool
+from collie_core.telemetry.prompt_hashes import (
+    current_config_hash,
+    current_tool_schema_hash,
+    hash_system_prompt,
+)
 from collie_core.telemetry.recorder import RunRecorder
 from nanobot.agent.hook import (
     AgentHook,
@@ -95,6 +100,8 @@ class TelemetryHook(AgentHook):
         self._turn_started: float = 0.0
         self._finished = False
         self._tool_count = 0
+        self._model_calls = 0
+        self._no_action_turns = 0
         self._tool_ids: dict[str, str] = {}
         self._tool_starts: dict[str, float] = {}
 
@@ -103,11 +110,23 @@ class TelemetryHook(AgentHook):
     async def before_run(self, context: AgentRunHookContext) -> None:
         self._turn_id = new_id()
         self._turn_started = time.monotonic()
+        # Hash what the model actually received: the assembled system-role
+        # messages at run start (the rendered prompt), plus the live loop's
+        # tool schemas and config. Hashes are stable fingerprints — never
+        # secrets — but the rendered prompt they summarize must not be logged.
+        system_prompts = [
+            str(message.get("content") or "")
+            for message in context.messages
+            if message.get("role") == "system"
+        ]
         self._recorder.start_turn(
             turn_id=self._turn_id,
             session_key=self._session_key,
             conversation_id=conversation_id_for_session_key(self._session_key),
             turn_kind=resolve_turn_kind(self._session_key, self._metadata),
+            prompt_hash=hash_system_prompt(system_prompts) if system_prompts else None,
+            tool_schema_hash=current_tool_schema_hash(),
+            config_hash=current_config_hash(),
         )
 
     async def after_run(self, context: AgentRunHookContext) -> None:
@@ -132,6 +151,13 @@ class TelemetryHook(AgentHook):
         self._tool_ids.clear()
 
     # -- tool lifecycle ----------------------------------------------------------
+
+    async def before_iteration(self, context: AgentHookContext) -> None:
+        self._model_calls += 1
+
+    async def after_iteration(self, context: AgentHookContext) -> None:
+        if not context.tool_calls and not context.final_content:
+            self._no_action_turns += 1
 
     async def before_execute_tool(
         self,
@@ -241,6 +267,8 @@ class TelemetryHook(AgentHook):
             tokens_out=int(usage.get("completion_tokens") or 0),
             latency_ms=int((time.monotonic() - self._turn_started) * 1000),
             tool_count=self._tool_count,
+            model_calls=self._model_calls,
+            no_action_turns=self._no_action_turns,
         )
 
     async def _finish_tool(

--- a/collie-core/collie_core/telemetry/prompt_hashes.py
+++ b/collie-core/collie_core/telemetry/prompt_hashes.py
@@ -1,0 +1,132 @@
+"""Stable prompt/tool-schema/config hashing for run telemetry.
+
+Pure, stdlib-only helpers that fingerprint exactly what a turn used:
+
+- ``hash_system_prompt`` — the rendered system prompt text the model
+  received (hashed at the point messages are final, never reconstructed).
+- ``hash_tool_schema`` — the tool definitions presented to the model
+  (``loop.tools.get_definitions()`` after registration).
+- ``hash_config`` — model + provider + generation settings + limits from
+  the ``build_config`` output, not raw SQLite rows.
+
+All hashes are ``sha256:<hex>`` strings over stable JSON (sorted keys, no
+whitespace) so identical inputs always hash identically across runs and
+machines. Hashes are not secrets and need no redaction, but the values fed
+to them (rendered prompts) must never be logged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+__all__ = [
+    "bind_prompt_hash_sources",
+    "current_config_hash",
+    "current_tool_schema_hash",
+    "hash_config",
+    "hash_system_prompt",
+    "hash_tool_schema",
+    "sha256_hex",
+]
+
+
+def sha256_hex(text: str) -> str:
+    """Return ``sha256:<hex>`` for a text payload."""
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def hash_system_prompt(system_messages: list[str]) -> str:
+    """Hash the rendered system prompt(s) for a turn.
+
+    ``system_messages`` is the assembled system-role text the model
+    actually received (typically one entry; multi-system turns join with
+    a stable separator). Hashing the final rendered text — not a
+    reconstruction from parts — keeps the fingerprint exact.
+    """
+    return sha256_hex("\n\n---\n\n".join(system_messages))
+
+
+def hash_tool_schema(schemas: list[dict[str, Any]]) -> str:
+    """Hash the tool schemas presented to the model.
+
+    Stable ordering (``sort_keys``) means the same registry always hashes
+    the same, regardless of insertion order.
+    """
+    return sha256_hex(_stable_json(schemas))
+
+
+def hash_config(
+    model: str,
+    provider: str,
+    generation: dict[str, Any],
+    limits: dict[str, Any],
+) -> str:
+    """Hash the model/provider/generation/limits a turn ran under."""
+    return sha256_hex(
+        _stable_json(
+            {
+                "model": model,
+                "provider": provider,
+                "generation": generation,
+                "limits": limits,
+            }
+        )
+    )
+
+
+# -- live loop sources -------------------------------------------------------
+#
+# The telemetry hook is per-turn and has no loop reference, so the runtime
+# binds the *current* loop's tool schemas + config here after every
+# ``_build_loop()`` (the module-binding pattern used by ``bind_life_db``).
+# Hashes are computed lazily at read time so a stale reference can never
+# leak a previous loop's fingerprint.
+
+_current_tool_schemas: list[dict[str, Any]] | None = None
+_current_model: str | None = None
+_current_provider: str | None = None
+_current_generation: dict[str, Any] | None = None
+_current_limits: dict[str, Any] | None = None
+
+
+def bind_prompt_hash_sources(
+    *,
+    tool_schemas: list[dict[str, Any]],
+    model: str,
+    provider: str,
+    generation: dict[str, Any],
+    limits: dict[str, Any],
+) -> None:
+    """Point the telemetry hook at the live loop's schemas and config."""
+    global _current_tool_schemas, _current_model, _current_provider
+    global _current_generation, _current_limits
+    _current_tool_schemas = list(tool_schemas)
+    _current_model = model
+    _current_provider = provider
+    _current_generation = dict(generation)
+    _current_limits = dict(limits)
+
+
+def current_tool_schema_hash() -> str | None:
+    """Hash of the live loop's tool schemas, or ``None`` before any build."""
+    if _current_tool_schemas is None:
+        return None
+    return hash_tool_schema(_current_tool_schemas)
+
+
+def current_config_hash() -> str | None:
+    """Hash of the live loop's config, or ``None`` before any build."""
+    if _current_model is None or _current_provider is None:
+        return None
+    return hash_config(
+        _current_model,
+        _current_provider,
+        _current_generation or {},
+        _current_limits or {},
+    )

--- a/collie-core/collie_core/telemetry/recorder.py
+++ b/collie-core/collie_core/telemetry/recorder.py
@@ -142,6 +142,7 @@ class RunRecorder:
         self._stopped = False
         self._suspended = False
         self.dropped_writes = 0
+        self.last_turn_stats: dict[str, int] = {}
         self._queue: queue.Queue[Callable[[], None] | None] = queue.Queue(
             maxsize=MAX_QUEUED_WRITES
         )
@@ -236,6 +237,9 @@ class RunRecorder:
         session_key: str | None = None,
         conversation_id: str | None = None,
         turn_kind: str = "chat",
+        prompt_hash: str | None = None,
+        tool_schema_hash: str | None = None,
+        config_hash: str | None = None,
     ) -> None:
         db = self._db
         # Event-time snapshot: captured before enqueueing so backlog cannot
@@ -254,6 +258,9 @@ class RunRecorder:
                     model=model,
                     status="running",
                     started_at=started_at,
+                    prompt_hash=prompt_hash,
+                    tool_schema_hash=tool_schema_hash,
+                    config_hash=config_hash,
                 )
             except Exception:
                 logger.exception("telemetry start_turn failed")
@@ -270,9 +277,21 @@ class RunRecorder:
         tokens_out: int = 0,
         latency_ms: int | None = None,
         tool_count: int = 0,
+        model_calls: int = 0,
+        retries: int = 0,
+        no_action_turns: int = 0,
     ) -> None:
         db = self._db
         finished_at = utc_now()
+        # Event-time snapshot for the headless result document (never
+        # persisted — the run record stores tool_count; the call counters
+        # are engineering evidence for the bench harness).
+        self.last_turn_stats = {
+            "model_calls": model_calls,
+            "tool_calls": tool_count,
+            "retries": retries,
+            "no_action_turns": no_action_turns,
+        }
 
         def _write() -> None:
             try:

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 11
+    assert db.schema_version == 12
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,7 +25,7 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 11
+    assert d2.schema_version == 12
     d2.close()
 
 
@@ -35,7 +35,7 @@ def test_incremental_migrations_v1_through_v11(tmp_path: Path) -> None:
 
     import collie_core.db as db_mod
 
-    for target in range(1, 12):
+    for target in range(1, 13):
         path = tmp_path / f"v{target}.db"
         conn = sqlite3.connect(path)
         conn.executescript(db_mod._SCHEMA_V1)
@@ -51,7 +51,7 @@ def test_incremental_migrations_v1_through_v11(tmp_path: Path) -> None:
         conn.close()
 
         upgraded = CollieDB(path)
-        assert upgraded.schema_version == 11, f"v{target} did not reach v11"
+        assert upgraded.schema_version == 12, f"v{target} did not reach v12"
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
         upgraded.close()
 
@@ -76,7 +76,7 @@ def test_migration_failure_rolls_back_atomically(
     with pytest.raises(sqlite3.OperationalError):
         CollieDB(path)
 
-    # The failed migration rolled everything back: version still 10 and the
+    # The failed migration rolled everything back: version still 12 and the
     # partial table is gone, so a normal boot migrates cleanly again.
     conn = sqlite3.connect(path)
     try:
@@ -86,11 +86,11 @@ def test_migration_failure_rolls_back_atomically(
         ).fetchone()
     finally:
         conn.close()
-    assert version == 11
+    assert version == 12
     assert half is None
     monkeypatch.undo()
     fresh = CollieDB(path)
-    assert fresh.schema_version == 11
+    assert fresh.schema_version == 12
     fresh.close()
 
 
@@ -131,7 +131,7 @@ def test_v8_removes_only_legacy_system_subagent_allow(tmp_path: Path) -> None:
         row["name"] for row in migrated._rows("PRAGMA table_info(messages)")
     }
     assert "task_state" in columns
-    assert migrated.schema_version == 11
+    assert migrated.schema_version == 12
     migrated.close()
 
 
@@ -179,7 +179,7 @@ def test_v9_upgrade_adds_plan_change_terminal_message_id(tmp_path: Path) -> None
             row["name"]
             for row in upgraded._rows("PRAGMA table_info(plan_change_requests)")
         }
-        assert upgraded.schema_version == 11
+        assert upgraded.schema_version == 12
         assert "terminal_message_id" in columns
         assert request is not None
         assert request["reason"] == "Change it"
@@ -345,7 +345,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.set_profile("dietary", "vegan")
     db.add_person("Sam")
     data = db.export_all()
-    assert data["schema_version"] == 11
+    assert data["schema_version"] == 12
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_headless.py
+++ b/collie-core/tests/collie/test_headless.py
@@ -1,0 +1,311 @@
+"""Headless engine mode (evaluation lab enabler).
+
+Runs ``collie_core.headless`` against a local fake OpenAI-compatible
+endpoint (the same pattern as ``test_e2e_phase1``) and asserts the stable
+result-document contract: exit codes, schema keys, hashes, isolation, and
+parity with the live IPC loop path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+import collie_core.headless as headless
+from collie_core.db import CollieDB, collie_home
+from collie_core.telemetry.prompt_hashes import hash_tool_schema
+
+FAKE_KEY = "sk-bench-secret-0123456789abcdef"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _fake_openai_app(*, delay_s: float = 0.0) -> web.Application:
+    """OpenAI-compatible chat completions endpoint mirroring the e2e fake."""
+
+    async def chat_completions(request: web.Request) -> web.StreamResponse:
+        if delay_s:
+            await asyncio.sleep(delay_s)
+        body = await request.json()
+        assert body.get("model")
+        if body.get("stream"):
+            resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await resp.prepare(request)
+            chunks = ["Woof! ", "You said: ", "hello."]
+            for i, text in enumerate(chunks):
+                payload = {
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion.chunk",
+                    "model": body["model"],
+                    "choices": [{
+                        "index": 0,
+                        "delta": ({"role": "assistant", "content": text}
+                                  if i == 0 else {"content": text}),
+                        "finish_reason": None,
+                    }],
+                }
+                await resp.write(f"data: {json.dumps(payload)}\n\n".encode())
+            done = {
+                "id": "chatcmpl-fake",
+                "object": "chat.completion.chunk",
+                "model": body["model"],
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 6,
+                          "total_tokens": 26},
+            }
+            await resp.write(f"data: {json.dumps(done)}\n\n".encode())
+            await resp.write(b"data: [DONE]\n\n")
+            await resp.write_eof()
+            return resp
+        return web.json_response({
+            "id": "chatcmpl-fake",
+            "object": "chat.completion",
+            "model": body["model"],
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Woof! You said: hello."},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 6, "total_tokens": 26},
+        })
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", chat_completions)
+    return app
+
+
+async def _serve(app: web.Application) -> tuple[web.AppRunner, int]:
+    llm_port = _free_port()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", llm_port)
+    await site.start()
+    return runner, llm_port
+
+
+def _args(
+    tmp_path: Path,
+    llm_port: int,
+    *,
+    task: str = "hello",
+    timeout: int = 60,
+    api_key_env: str = "COLLIE_BENCH_KEY",
+    approval_preset: str = "allow",
+    **overrides: Any,
+) -> Any:
+    """Build headless args pointing at the fake endpoint + an isolated home."""
+    values: dict[str, Any] = {
+        "task": task,
+        "home": str(tmp_path / "bench-home"),
+        "model": "collie-test-model",
+        "provider": "custom",
+        "api_base": f"http://127.0.0.1:{llm_port}/v1",
+        "api_key_env": api_key_env,
+        "timeout": timeout,
+        "max_iterations": 50,
+        "approval_preset": approval_preset,
+        "session_key": None,
+        "json_out": None,
+    }
+    values.update(overrides)
+    return headless._parse_args([
+        f"--task={values['task']}",
+        f"--home={values['home']}",
+        f"--model={values['model']}",
+        f"--provider={values['provider']}",
+        f"--api-base={values['api_base']}",
+        f"--api-key-env={values['api_key_env']}",
+        f"--timeout={values['timeout']}",
+        f"--max-iterations={values['max_iterations']}",
+        f"--approval-preset={values['approval_preset']}",
+    ] + ([f"--session-key={values['session_key']}"] if values["session_key"] else [])
+      + ([f"--json-out={values['json_out']}"] if values["json_out"] else []))
+
+
+@pytest.mark.asyncio
+async def test_headless_runs_task_and_outputs_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+
+    runner, llm_port = await _serve(_fake_openai_app())
+    try:
+        exit_code, document = await headless.run_one(_args(tmp_path, llm_port))
+    finally:
+        await runner.cleanup()
+
+    assert exit_code == 0
+    assert document["exit_state"] == "ok"
+    assert document["error"] is None
+
+    # Stable contract keys
+    for key in (
+        "schema_version", "run_id", "harness", "commit", "model", "provider",
+        "task", "session_key", "conversation_id", "prompt_hash",
+        "tool_schema_hash", "config_hash", "final_text", "usage", "calls",
+        "latency_ms", "exit_state", "error",
+    ):
+        assert key in document, f"missing contract key {key}"
+    assert document["schema_version"] == 1
+    assert document["harness"] == "collie"
+    assert document["model"] == "collie-test-model"
+    assert document["provider"] == "custom"
+    assert document["task"] == "hello"
+    assert document["session_key"].startswith("collie:")
+    assert document["conversation_id"]
+
+    # Final answer from the fake endpoint, sanitized
+    assert document["final_text"] == "Woof! You said: hello."
+
+    # Usage/calls are ints >= 0
+    for value in document["usage"].values():
+        assert isinstance(value, int) and value >= 0
+    for value in document["calls"].values():
+        assert isinstance(value, int) and value >= 0
+    assert document["usage"]["input_tokens"] == 20
+    assert document["usage"]["output_tokens"] == 6
+
+    # Hashes are non-empty sha256 fingerprints
+    for key in ("prompt_hash", "tool_schema_hash", "config_hash"):
+        value = document[key]
+        assert value and value.startswith("sha256:"), f"{key} missing"
+
+    # The secret never leaves the process
+    captured = capsys.readouterr()
+    assert FAKE_KEY not in captured.out
+    assert FAKE_KEY not in captured.err
+
+    # One JSON line on stdout
+    lines = [line for line in captured.out.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["exit_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_headless_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+
+    runner, llm_port = await _serve(_fake_openai_app(delay_s=30))
+    try:
+        exit_code, document = await headless.run_one(
+            _args(tmp_path, llm_port, timeout=1)
+        )
+    finally:
+        await runner.cleanup()
+
+    assert exit_code == 2
+    assert document["exit_state"] == "timeout"
+    assert "timed out" in (document["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_headless_missing_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    # No key in the environment at all.
+    monkeypatch.delenv("COLLIE_BENCH_KEY", raising=False)
+    monkeypatch.delenv("COLLIE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+
+    exit_code, document = await headless.run_one(_args(tmp_path, 9999))
+
+    assert exit_code == 3
+    assert document["exit_state"] == "error"
+    assert document["error"] and "API key" in document["error"]
+    captured = capsys.readouterr()
+    assert "COLLIE_BENCH_KEY" in document["error"]
+    assert FAKE_KEY not in captured.out
+    assert FAKE_KEY not in captured.err
+    # The key never appears in the JSON either
+    assert FAKE_KEY not in json.dumps(document)
+
+
+@pytest.mark.asyncio
+async def test_headless_parity_tool_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The headless path and a direct runtime build register the same tools."""
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+
+    runner, llm_port = await _serve(_fake_openai_app())
+    try:
+        exit_code, document = await headless.run_one(_args(tmp_path, llm_port))
+    finally:
+        await runner.cleanup()
+    assert exit_code == 0
+
+    # Direct runtime build from the SAME settings — identical schemas must
+    # produce the identical fingerprint the headless run recorded.
+    home = tmp_path / "bench-home"
+    db = CollieDB(home / "collie.db")
+    from collie_core.runtime import CollieRuntime
+
+    runtime = CollieRuntime(port=0, db=db)
+    try:
+        loop = runtime._build_loop()
+        definitions = loop.tools.get_definitions()
+        assert hash_tool_schema(definitions) == document["tool_schema_hash"]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_headless_isolated_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--home wins over the real user home; the default home stays untouched."""
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+    real_home = tmp_path / "real-home"
+    monkeypatch.setenv("HOME", str(real_home))
+
+    runner, llm_port = await _serve(_fake_openai_app())
+    try:
+        exit_code, document = await headless.run_one(_args(tmp_path, llm_port))
+    finally:
+        await runner.cleanup()
+    assert exit_code == 0
+
+    # collie_home() points inside --home (COLLIE_HOME was set by run_one)
+    assert collie_home().resolve() == (tmp_path / "bench-home").resolve()
+    assert document["conversation_id"]
+
+    # The real user home never gained a collie DB
+    assert not (real_home / ".collie" / "collie.db").exists()
+
+
+@pytest.mark.asyncio
+async def test_headless_json_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+
+    runner, llm_port = await _serve(_fake_openai_app())
+    out_file = tmp_path / "result.json"
+    try:
+        exit_code, document = await headless.run_one(
+            _args(tmp_path, llm_port, json_out=str(out_file))
+        )
+    finally:
+        await runner.cleanup()
+
+    assert exit_code == 0
+    written = json.loads(out_file.read_text())
+    assert written == document
+    assert written["exit_state"] == "ok"

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 11
+    assert db.schema_version == 12
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -1,0 +1,257 @@
+"""Prompt-hash telemetry (evaluation lab enabler, Part B).
+
+Covers ``collie_core/telemetry/prompt_hashes.py`` pure functions, the
+schema V12 migration (additive NULL columns), and the end-to-end wiring:
+a real turn records non-NULL prompt/tool-schema/config hashes on its run
+record row.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import sqlite3
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+import collie_core.db as db_mod
+from collie_core.db import CollieDB
+from collie_core.telemetry.prompt_hashes import (
+    hash_config,
+    hash_system_prompt,
+    hash_tool_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_hash_changes_with_template(tmp_path: Path) -> None:
+    """Hashing the rendered system prompt is sensitive to template changes."""
+    from nanobot.agent.context import ContextBuilder
+
+    def build(agents_text: str) -> str:
+        (tmp_path / "VISION.md").write_text("# Vision\n\nSame vision.\n", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text(agents_text, encoding="utf-8")
+        builder = ContextBuilder(tmp_path)
+        return builder.build_system_prompt()
+
+    baseline = build("Instructions: be helpful.")
+    changed = build("Instructions: be VERY helpful.")
+    assert baseline != changed
+    assert hash_system_prompt([baseline]) != hash_system_prompt([changed])
+    # Deterministic: identical input hashes identically.
+    assert hash_system_prompt([baseline]) == hash_system_prompt([baseline])
+
+
+def test_tool_schema_hash_stable() -> None:
+    a = [{"name": "read_file", "parameters": {"type": "object"}}]
+    b = [{"name": "write_file", "parameters": {"type": "object"}}]
+    assert hash_tool_schema(a) == hash_tool_schema([dict(a[0])])
+    assert hash_tool_schema(a) != hash_tool_schema(b)
+    assert hash_tool_schema([]) != hash_tool_schema(a)
+
+
+def test_config_hash_stable() -> None:
+    generation = {"temperature": 0.1, "max_tokens": 8192}
+    limits = {"max_tool_iterations": 50, "context_window_tokens": 200_000}
+    assert hash_config("deepseek-chat", "deepseek", generation, limits) == (
+        hash_config("deepseek-chat", "deepseek", dict(generation), dict(limits))
+    )
+    assert hash_config("deepseek-chat", "deepseek", generation, limits) != (
+        hash_config("deepseek-chat", "deepseek", generation, {"max_tool_iterations": 51})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema V12 migration
+# ---------------------------------------------------------------------------
+
+
+def _build_db_at_version(path: Path, version: int) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(db_mod._SCHEMA_V1)
+    for migration in db_mod._MIGRATIONS[1:version]:
+        conn.executescript(migration)
+    conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (?)", (version,))
+    conn.commit()
+    conn.close()
+
+
+def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    try:
+        assert db.schema_version == 12
+        columns = {
+            row["name"]
+            for row in db._rows("PRAGMA table_info(turn_events)")
+        }
+        assert {"prompt_hash", "tool_schema_hash", "config_hash"} <= columns
+    finally:
+        db.close()
+
+
+def test_old_rows_null_hashes(tmp_path: Path) -> None:
+    """Pre-migration turn rows read back with NULL hashes and upsert works."""
+    path = tmp_path / "v11.db"
+    _build_db_at_version(path, 11)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO turn_events (id, turn_kind, status, started_at) "
+        "VALUES ('old1', 'chat', 'ok', '2026-08-01T00:00:00+00:00')"
+    )
+    conn.commit()
+    conn.close()
+
+    upgraded = CollieDB(path)
+    try:
+        assert upgraded.schema_version == 12
+        rows = upgraded.list_turn_events()
+        assert len(rows) == 1
+        assert rows[0]["prompt_hash"] is None
+        assert rows[0]["tool_schema_hash"] is None
+        assert rows[0]["config_hash"] is None
+
+        # Upsert still works and can now carry hashes.
+        upgraded.record_turn_event(
+            turn_id="old1",
+            turn_kind="chat",
+            status="ok",
+            prompt_hash="sha256:aaa",
+            tool_schema_hash="sha256:bbb",
+            config_hash="sha256:ccc",
+            finished_at="2026-08-01T00:00:05+00:00",
+        )
+        rows = upgraded.list_turn_events()
+        assert rows[0]["prompt_hash"] == "sha256:aaa"
+        assert rows[0]["tool_schema_hash"] == "sha256:bbb"
+        assert rows[0]["config_hash"] == "sha256:ccc"
+        assert rows[0]["turn_kind"] == "chat"
+    finally:
+        upgraded.close()
+
+
+def test_start_turn_hashes_not_clobbered_by_finish(tmp_path: Path) -> None:
+    """finish_turn (no hash kwargs) must not wipe hashes set at start."""
+    db = CollieDB(tmp_path / "collie.db")
+    try:
+        db.record_turn_event(
+            turn_id="t1",
+            turn_kind="chat",
+            status="running",
+            prompt_hash="sha256:start",
+            tool_schema_hash="sha256:tools",
+            config_hash="sha256:cfg",
+            started_at="2026-08-02T00:00:00+00:00",
+        )
+        db.record_turn_event(
+            turn_id="t1",
+            turn_kind="chat",
+            status="ok",
+            tokens_in=5,
+            finished_at="2026-08-02T00:00:01+00:00",
+        )
+        row = db.list_turn_events()[0]
+        assert row["prompt_hash"] == "sha256:start"
+        assert row["tool_schema_hash"] == "sha256:tools"
+        assert row["config_hash"] == "sha256:cfg"
+        assert row["status"] == "ok"
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a real turn records non-NULL hashes
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _fake_openai_app() -> web.Application:
+    async def chat_completions(request: web.Request) -> web.StreamResponse:
+        body = await request.json()
+        if body.get("stream"):
+            resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await resp.prepare(request)
+            payload = {
+                "id": "chatcmpl-fake",
+                "object": "chat.completion.chunk",
+                "model": body["model"],
+                "choices": [{"index": 0, "delta": {"content": "ok"},
+                             "finish_reason": "stop"}],
+            }
+            await resp.write(f"data: {json.dumps(payload)}\n\n".encode())
+            await resp.write(b"data: [DONE]\n\n")
+            await resp.write_eof()
+            return resp
+        return web.json_response({
+            "id": "chatcmpl-fake",
+            "object": "chat.completion",
+            "model": body["model"],
+            "choices": [{"index": 0,
+                         "message": {"role": "assistant", "content": "ok"},
+                         "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+        })
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", chat_completions)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_run_record_has_hash_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real turn through the runtime records non-NULL hashes."""
+    import collie_core.headless as headless
+    from collie_core.telemetry.recorder import RunRecorder
+
+    monkeypatch.setenv("COLLIE_BENCH_KEY", "sk-bench-secret-0123456789abcdef")
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+
+    llm_port = _free_port()
+    runner = web.AppRunner(await _fake_openai_app())
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", llm_port)
+    await site.start()
+    try:
+        exit_code, document = await headless.run_one(headless._parse_args([
+            "--task=hello",
+            f"--home={tmp_path / 'bench-home'}",
+            "--model=collie-test-model",
+            "--provider=custom",
+            f"--api-base=http://127.0.0.1:{llm_port}/v1",
+            "--api-key-env=COLLIE_BENCH_KEY",
+        ]))
+    finally:
+        await runner.cleanup()
+
+    assert exit_code == 0
+    assert document["exit_state"] == "ok"
+    for key in ("prompt_hash", "tool_schema_hash", "config_hash"):
+        assert document[key] and document[key].startswith("sha256:")
+
+    # The run record row itself carries the hashes (not just the doc).
+    db = CollieDB(tmp_path / "bench-home" / "collie.db")
+    try:
+        rows = db.list_turn_events(conversation_id=document["conversation_id"])
+        assert rows, "expected a turn record"
+        row = rows[0]
+        assert row["prompt_hash"] == document["prompt_hash"]
+        assert row["tool_schema_hash"] == document["tool_schema_hash"]
+        assert row["config_hash"] == document["config_hash"]
+        assert row["finished_at"] is not None
+    finally:
+        recorder = RunRecorder.active_for(db)
+        if recorder is not None:
+            recorder.shutdown()
+        db.close()

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -94,7 +94,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 11
+    assert db.schema_version == 12
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -116,7 +116,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 11
+        assert upgraded.schema_version == 12
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_safe_execution.py
+++ b/collie-core/tests/collie/test_safe_execution.py
@@ -37,6 +37,52 @@ def test_plan_mode_hard_denies_mutation(tmp_path: Path) -> None:
     db.close()
 
 
+def test_deny_preset_denies_local_writes_but_keeps_reads(tmp_path: Path) -> None:
+    """The bench 'deny' posture refuses local writes; reads stay allowed."""
+    db = CollieDB(tmp_path / "db.sqlite")
+    evaluator = PermissionEvaluator(PermissionStore(db), local_write_preset="deny")
+
+    denied = evaluator.evaluate(
+        ExecutionContext(execution_mode="execute"),
+        _request(risk=Risk.LOCAL_WRITE),
+    )
+    assert denied.effect == Effect.DENY
+
+    # Even an otherwise ordinary-safe local write is denied under deny.
+    safe_write = PermissionRequest(
+        action="file.write",
+        resource="C:/work/notes.txt",
+        risk=Risk.LOCAL_WRITE,
+        summary="Write a note",
+        reversible=True,
+        approval_free=True,
+        approve_for_me=True,
+    )
+    assert evaluator.evaluate(
+        ExecutionContext(execution_mode="execute"), safe_write
+    ).effect == Effect.DENY
+
+    # Reads are unaffected by the deny preset.
+    read = evaluator.evaluate(
+        ExecutionContext(execution_mode="execute"),
+        _request(risk=Risk.READ),
+    )
+    assert read.effect == Effect.ALLOW
+
+    # An explicit allow rule still wins over the deny preset.
+    db.add_approval_rule(
+        action="file.write",
+        resource_pattern="C:/work/notes.txt",
+        effect="allow",
+        scope_type="global",
+    )
+    allowed = evaluator.evaluate(
+        ExecutionContext(execution_mode="execute"), safe_write
+    )
+    assert allowed.effect == Effect.ALLOW
+    db.close()
+
+
 def test_read_only_specialist_hard_denies_mutation(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "db.sqlite")
     evaluator = PermissionEvaluator(PermissionStore(db), local_write_preset="allow")

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 11
+    assert db.schema_version == 12
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -29,7 +29,9 @@ are not part of this public source tree.
 
 - `collie_core/` owns storage, settings, memory, permissions, plans, tools,
   connectors, agents, routines, messengers, pet control, IPC, telemetry
-  (run records), and runtime composition.
+  (run records), runtime composition, and the internal headless engine
+  mode (`collie_core/headless.py` — one task, one JSON result document,
+  exit; an engineering-only benchmark entry, not a user-facing CLI).
 - `nanobot/` contains the adapted upstream engine. Changes should remain
   surgical and preserve third-party attribution.
 - `tests/` contains Python unit, integration, IPC, safety, and end-to-end

--- a/docs/engineering/evaluation/headless-mode-implementation.md
+++ b/docs/engineering/evaluation/headless-mode-implementation.md
@@ -1,0 +1,360 @@
+# Implementation brief: Collie headless engine mode + prompt-hash telemetry
+
+**Repo:** `FoxRick/Collie` (collie-main)
+**Parent plan:** `docs/engineering/evaluation/benchmarking-and-prompt-optimization.md`
+**Status:** implementation spec — build it, then PR it
+
+This brief is self-contained: read the referenced files, implement the two
+changes below, add the tests, run the gates, open a PR. Do NOT create the
+`collie-bench` repo — that is a separate task in a separate chat (see
+`docs/engineering/evaluation/collie-bench-implementation.md`).
+
+---
+
+## Goal
+
+Make Collie benchmarkable from the outside without changing the product:
+
+1. **Headless engine mode** (`python -m collie_core.headless`): run one
+   task through the real agent loop, print one JSON result document
+   (answer, token usage, calls, latency, prompt hashes), exit. Internal
+   engineering capability only — **no user-facing CLI, no
+   `[project.scripts]` entry points** (preserves the VISION "no dev shell"
+   non-goal and the pyproject "No CLI entry points" stance).
+2. **Prompt-hash telemetry**: additive columns on the existing run-record
+   telemetry so every turn knows which rendered system prompt, tool
+   schema, and config it used.
+
+## Architecture facts (verified — read these files first)
+
+- `collie_core/runtime.py` — `CollieRuntime` composes everything:
+  - `__init__(port, db, ipc_token)` → DB, workspace, profile, tools
+    bindings, permission evaluator, `CollieIPCServer`, `ApprovalBroker`,
+    scheduler, messengers.
+  - `_build_loop()` → `collie_settings.build_config(db, mcp_servers=...)`
+    → `AgentLoop.from_config(...)` with `hook_factories=[create_telemetry_hook_factory(db)]`,
+    registers Collie tools via `ToolLoader(collie_tools).load(ctx, loop.tools)`,
+    sets `loop.subagents.hook_factories`, registers a runtime-context
+    provider, `loop.context.command_guidance = True`.
+  - `_configure()` / `_configure_locked()` → builds loop, starts
+    `loop.run()` task, outbound consumer, messengers. Returns
+    `{"configured": True, "model": ...}`.
+  - `_configure_provider_candidate(candidate)` → transactional provider
+    setup: `_validated_provider_candidate()` normalizes (fields:
+    `provider_id, name, auth_type="api-key", model, runtime_name,
+    secret_name, protocol, api_base, api_key`), `collie_settings.set_api_key(secret_name, key)`
+    for the transient in-memory key, `db.configure_provider_candidate_record(**normalized)`
+    persists, then rebuilds the loop. **Reuse this — it is the same path
+    the UI uses.**
+  - `_chat(...)` → calls `self.loop.process_direct(content, session_key,
+    channel, chat_id, on_stream=..., on_superseded_response=...,
+    on_progress=..., media=..., message_metadata=...,
+    permission_context={execution_mode, conversation_id, run_id, plan_id,
+    plan_version, origin, model_provider}, workspace_scope=...)`. After
+    the call: `usage = getattr(self.loop, "_last_usage", None) or {}`,
+    then `db.record_usage(provider_id, messages=1,
+    tokens=int(usage.get("total_tokens") or 0))`.
+  - `run()` → starts IPC server + scheduler + reminder checker, prints
+    `COLLIE_READY {"port": ...}`, blocks. Shutdown order matters:
+    `ipc.stop()` → scheduler/reminder cancel → `_shutdown_loop()` →
+    `approvals.cancel_all()` → `RunRecorder.active_for(db).shutdown()` →
+    `db.close()`.
+  - `main(argv)` → argparse `--port`; `_env_port()` honors
+    `COLLIE_IPC_PORT`.
+- `collie_core/settings.py`:
+  - `build_config(db, mcp_servers=None)` reads SQLite settings keys:
+    `provider.name` (default "openai"), `provider.secret_name`,
+    `provider.model`, `provider.api_base`, `agent.timezone`,
+    `agent.bot_name`, `agent.max_tool_iterations` (clamped 1..2000).
+  - API key resolution: transient `set_api_key()` first, then env
+    `COLLIE_<PROVIDER>_API_KEY`, then `COLLIE_PROVIDER_API_KEY`. **So a
+    bench key can be passed purely via environment — no IPC needed.**
+  - `ensure_workspace()` creates `~/.collie/workspace` with default
+    VISION.md / AGENTS.md. `collie_home()` lives in `collie_core/db.py`
+    and honors `COLLIE_HOME` (verified in AGENTS.md).
+  - Permission preset setting: `permissions.local_write_preset`
+    (default "ask") is read in `CollieRuntime.__init__` and applied to
+    `PermissionEvaluator`; `set_local_write_preset` is the existing
+    setter used by the IPC path.
+- `collie_core/telemetry/recorder.py` — `RunRecorder` (fire-and-forget
+  writer thread, bounded queue `MAX_QUEUED_WRITES=500`, `suspend()`,
+  `flush()`, `shutdown()`, `sanitize_text()`, `summarize()`). Turn
+  lifecycle: `start_turn(turn_id, session_key, conversation_id,
+  turn_kind)`. Registry: `RunRecorder.for_db(db)` /
+  `active_for(db)`. Hook factory: `collie_core/telemetry/hook.py`
+  `create_telemetry_hook_factory(db)`.
+- `nanobot/agent/context.py` — `ContextBuilder` renders the system
+  prompt: `BOOTSTRAP_FILES = ["VISION.md", "AGENTS.md", "MEMORY.md"]`
+  from the workspace, plus Jinja2 templates under
+  `nanobot/templates/agent/*.md` rendered via
+  `nanobot/utils/prompt_templates.py::render_template`.
+- `nanobot/agent/loop.py` — `AgentLoop.from_config(config, bus,
+  session_manager, hook_factories=..., provider=...)`,
+  `process_direct(...)`, `_last_usage`.
+- Tests to mirror: `tests/collie/test_e2e_phase1..4.py` (full IPC → loop
+  → fake OpenAI endpoint → SQLite round trips; patch the provider, never
+  hit a real API). `tests/collie/test_pet_status.py` needs tkinter —
+  ignore it in gates.
+
+---
+
+## Part A — Headless engine mode
+
+### A.1 Contract
+
+New module: `collie_core/headless.py` (run via `python -m
+collie_core.headless`). It boots a `CollieRuntime`-equivalent composition
+against an **isolated `COLLIE_HOME`** (never `~/.collie` by default), runs
+exactly one task, prints ONE JSON document to stdout, and exits.
+
+Arguments (argparse):
+
+| Flag | Meaning | Default |
+|---|---|---|
+| `--task` (required) | The task/user prompt to run | — |
+| `--home` | `COLLIE_HOME` dir (created if missing) | fresh `tempfile.mkdtemp()` |
+| `--model` | model id (e.g. `deepseek/deepseek-chat`) | from provider record / settings |
+| `--provider` | provider name (e.g. `deepseek`) | `deepseek` |
+| `--api-base` | custom OpenAI-compatible base URL | provider default |
+| `--api-key-env` | env var name holding the key (e.g. `COLLIE_BENCH_KEY`) | `COLLIE_PROVIDER_API_KEY` |
+| `--timeout` | wall-clock seconds for the whole turn | `300` |
+| `--max-iterations` | maps to `agent.max_tool_iterations` (clamped 1..2000) | `50` |
+| `--approval-preset` | `allow` \| `ask` \| `deny` — wired through the SAME `set_local_write_preset` path, never a bypass | `allow` (bench sandbox is disposable) |
+| `--session-key` | engine session key (defaults to `bench-<uuid>`) | auto |
+| `--json-out` | also write the result document to this file | stdout only |
+
+Environment: the API key MUST come from env (see `--api-key-env`);
+never accept a key via argv, never log it. `build_config` already reads
+`COLLIE_<PROVIDER>_API_KEY` / `COLLIE_PROVIDER_API_KEY` directly.
+
+Exit codes: `0` ok, `1` task/engine error, `2` timeout, `3` usage/config
+error (bad args, missing key, provider config failed).
+
+### A.2 Implementation steps
+
+1. In `collie_core/headless.py`:
+   - `main(argv)` parses args, resolves `--home` (+ `COLLIE_HOME` env),
+     sets `os.environ["COLLIE_HOME"]` **before** importing/building
+     `CollieDB`, then `asyncio.run(run_one(...))`.
+   - Build `CollieRuntime` (reuse it — do not re-compose). Skip the
+     long-running parts: do NOT call `runtime.run()` (which starts the
+     IPC server/scheduler/reminders). Instead drive the lifecycle
+     manually:
+     a. Provider: build the candidate dict (provider_id, name,
+        auth_type="api-key", model, runtime_name, secret_name, protocol,
+        api_base, api_key from env) and call
+        `await runtime._configure_provider_candidate(candidate)`. If
+        `configured` is False → print error JSON, exit 3. (This reuses
+        validation + transactional rebuild — the exact UI path.)
+     b. Approval preset: `runtime.db.set_setting("permissions.local_write_preset", preset)`
+        BEFORE `_configure_provider_candidate` (the evaluator reads it at
+        init) — or call the evaluator's `set_local_write_preset` after.
+     c. Session: `session_key = args.session_key or f"bench-{uuid4().hex}"`;
+        create a conversation via `runtime.db.create_conversation(title="Bench")`.
+     d. Run: `await asyncio.wait_for(runtime._chat(...), timeout=args.timeout)`
+        with `conversation_id=...`, `execution_mode="execute"`, and a
+        `permission_context` shaped exactly like `_chat`'s (origin
+        "bench" is acceptable; keep model_provider from the provider
+        record). Catch `asyncio.TimeoutError` → exit_state "timeout",
+        exit 2.
+     e. Usage: `loop._last_usage` (same read as `_chat`); also read the
+        run record from telemetry for prompt/config hashes (Part B) or
+        compute them in-process.
+     f. Flush telemetry: `RunRecorder.active_for(runtime.db)` → `flush()`
+        then `shutdown()`; then `runtime.db.close()`. Mirror the shutdown
+        ordering in `runtime.run()` (cancel in-flight work first).
+   - Assemble the JSON result (schema below), print as a single line to
+     stdout, return exit code.
+2. Do NOT touch `pyproject.toml` entry points. `python -m
+   collie_core.headless` works without a `[project.scripts]` entry.
+
+### A.3 Result document (stable contract — do not change field names)
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "<uuid>",
+  "harness": "collie",
+  "commit": "<git sha, or 'unknown'>",
+  "model": "<model id>",
+  "provider": "<provider id>",
+  "task": "<the task text>",
+  "session_key": "...",
+  "conversation_id": "...",
+  "prompt_hash": "sha256:...",
+  "tool_schema_hash": "sha256:...",
+  "config_hash": "sha256:...",
+  "final_text": "<sanitized final assistant text>",
+  "usage": {"input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0},
+  "calls": {"model_calls": 0, "tool_calls": 0,
+            "retries": 0, "no_action_turns": 0},
+  "latency_ms": 0,
+  "exit_state": "ok|timeout|error",
+  "error": null
+}
+```
+
+- `final_text` and any error text MUST pass through the telemetry
+  `sanitize_text()` (secrets never leave the process).
+- Usage fields come from `loop._last_usage` where present; map what the
+  provider returned (input/output/cache keys may vary by provider —
+  normalize to the schema keys, zero-fill missing).
+
+### A.4 Parity rules (non-negotiable)
+
+1. **One-entry-point rule**: headless code only *calls* `CollieRuntime`
+   methods (`_build_loop`, `_configure_provider_candidate`, `_chat`,
+   `_conversation_target`). It never re-composes the loop, tools,
+   prompts, permissions, or config. Review must enforce this.
+2. **Consistency test**: assert both paths produce identical tool
+   registries and rendered system prompts from the same settings.
+3. **Phase-gate e2e through headless**: the existing
+   `tests/collie/test_e2e_phase1..4.py` fake-OpenAI pattern must also run
+   against the headless entry (same assertions) so drift fails CI.
+
+### A.5 Tests (new file `tests/collie/test_headless.py`)
+
+- `test_headless_runs_task_and_outputs_contract` — fake OpenAI endpoint
+  (reuse the e2e patching pattern), assert: exit 0, JSON parses, all
+  schema keys present, `exit_state == "ok"`, `final_text` non-empty,
+  usage/calls are ints ≥ 0, prompt_hash/tool_schema_hash/config_hash are
+  non-empty sha256 strings.
+- `test_headless_timeout` — fake endpoint that sleeps past `--timeout`;
+  assert exit 2, `exit_state == "timeout"`.
+- `test_headless_missing_key` — no key in env; assert exit 3 and error
+  JSON; assert the key never appears in stdout/stderr.
+- `test_headless_parity_tool_registry` — build loop via runtime
+  `_build_loop()` and via the headless path; assert identical registered
+  tool names/schemas.
+- `test_headless_isolated_home` — assert `collie_home()` points inside
+  `--home` and the real user home is untouched (no rows in the default
+  DB).
+- Run the e2e phase gates through headless (see A.4.3).
+
+---
+
+## Part B — Prompt-hash telemetry
+
+### B.1 DB changes
+
+Run-record table (find it via `collie_core/telemetry/recorder.py` +
+`collie_core/db.py` — the turn/tool record tables) gains three columns,
+all **nullable with `None` default at the signature** (review lesson: any
+non-None default on an UPDATE clobbers existing values via COALESCE):
+
+- `prompt_hash TEXT NULL` — sha256 of the rendered system prompt(s) for
+  the turn
+- `tool_schema_hash TEXT NULL` — sha256 of the tool schemas presented to
+  the model
+- `config_hash TEXT NULL` — sha256 of model id + provider + generation
+  settings + limits
+
+Migration: additive `ALTER TABLE ... ADD COLUMN ... NULL` in the existing
+migration path; old rows stay NULL. Add a migration test asserting old
+rows read back with NULLs and existing upsert behavior is unchanged.
+
+### B.2 Hash computation — new module `collie_core/telemetry/prompt_hashes.py`
+
+Small pure functions (stdlib only, `hashlib.sha256` over stable JSON):
+
+- `hash_system_prompt(system_messages: list[str]) -> str` — sha256 of the
+  joined rendered system prompt text (the assembled system messages for
+  the turn).
+- `hash_tool_schema(schemas: list[dict]) -> str` — sha256 of
+  `json.dumps(schemas, sort_keys=True, separators=(",", ":"))`.
+- `hash_config(model: str, provider: str, generation: dict, limits: dict)
+  -> str` — same stable-JSON approach.
+
+**Where to capture the rendered system prompt:** the turn hook factory
+(`collie_core/telemetry/hook.py`) sees turn events; find where the built
+context/messages are available (pointers: `nanobot/agent/context.py`
+`ContextBuilder` — `BOOTSTRAP_FILES`, `render_template`; the loop's turn
+hooks receive the assembled context). Hash what the model actually
+received, not a reconstruction. If the exact hook point is ambiguous,
+prefer hashing at the point where system messages are final before the
+provider call.
+
+Tool schema hash: hash `loop.tools` schemas after `_build_loop()`
+registration (the same schemas the provider receives).
+
+Config hash: from the values in `build_config` output (model, provider,
+maxToolIterations, generation settings, limits) — not raw SQLite rows.
+
+### B.3 Hook integration
+
+- Extend `RunRecorder.start_turn(...)` with the three hash kwargs
+  (default `None`), stored in the turn record row.
+- In the telemetry hook, compute/attach the hashes when available and
+  enqueue the write through the existing fire-and-forget writer. Do NOT
+  add a new writer or an awaited write.
+- Hashes are not secrets and need no redaction, but the values fed to
+  them (rendered prompts) must never be logged.
+
+### B.4 Tests
+
+- `test_prompt_hash_changes_with_template` — render `identity.md` +
+  bootstrap files, hash; mutate a template copy; assert hash differs.
+- `test_tool_schema_hash_stable` — same schema dict → same hash
+  (sort_keys), different schema → different hash.
+- `test_config_hash_stable` — same config → same hash.
+- `test_run_record_has_hash_columns` — run a turn via the fake-OpenAI
+  e2e path, assert the run record row has non-NULL prompt_hash /
+  tool_schema_hash / config_hash.
+- `test_old_rows_null_hashes` — pre-migration row reads back with NULLs.
+- Run the full telemetry review checklist (see
+  `collie-branch-review` skill → `references/telemetry-review-lessons.md`):
+  None defaults, event-time timestamps, no awaited writes, sanitizer
+  coverage for any new stored text.
+
+---
+
+## Acceptance criteria
+
+1. `python -m collie_core.headless --task "..." --home <tmp> --model
+   deepseek/deepseek-chat --api-key-env COLLIE_BENCH_KEY` runs a real
+   turn against a fake endpoint and prints the full JSON contract with
+   exit 0; timeout and missing-key paths behave per contract.
+2. The headless path and the live IPC path register the same tools and
+   render the same system prompt (consistency test green).
+3. Run records contain non-NULL prompt/tool-schema/config hashes after a
+   turn; pre-existing rows remain NULL; migration test green.
+4. No user-facing CLI: `pyproject.toml` gains no `[project.scripts]`.
+5. Secrets never appear in headless stdout/stderr/logs (sanitizer +
+   env-only key).
+
+## Gates (from `collie-core/`, venv at `collie-core/.venv`)
+
+```bash
+.venv/bin/python -m pytest tests/collie -q --ignore=tests/collie/test_pet_status.py
+.venv/bin/python -m ruff check nanobot collie_core tests
+.venv/bin/python -m pytest tests/collie --cov=nanobot --cov=collie_core --cov-report=term-missing -q --ignore=tests/collie/test_pet_status.py 2>&1 | tail -5
+```
+
+Coverage `fail_under = 70`. Healthy Linux baseline ≈ 475 passed / ~5
+expected Windows-only failures / ~1 skipped — report the delta vs your
+run.
+
+## Documentation-impact check (docs/WORKFLOW.md)
+
+- New interface (headless entry) → update `docs/PROJECT_MAP.md` runtime
+  ownership (one line: headless engine mode under `collie_core/`) and
+  `collie-core/AGENTS.md` (how to run headless + the parity rule).
+- No VISION change (internal capability, not a product surface).
+- Regenerate the snapshot:
+  `collie-core/.venv/bin/python tools/update_project_snapshot.py` then
+  `--check`.
+
+## Pitfalls
+
+- Never call `runtime.run()` in headless (starts IPC + schedulers).
+- Set `COLLIE_HOME` before first `CollieDB()` import.
+- `agent.max_tool_iterations` is clamped 1..2000 by `build_config` — a
+  0/negative flag value must not reach the engine.
+- The approval preset must go through `set_local_write_preset` /
+  `PermissionEvaluator` — a bypass violates the product's central-gating
+  invariant and will fail review.
+- `loop._last_usage` is a dict and may be empty — zero-fill.
+- Do not add `[project.scripts]`; `python -m` is the entry.
+- Merge conflicts on `docs/generated/REPOSITORY_SNAPSHOT.md` with other
+  open docs PRs are expected — resolve by re-running the snapshot tool.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,11 +11,11 @@
 
 ## Source inventory
 
-- Core Python files: **479**
-- Core Python test files: **218**
+- Core Python files: **483**
+- Core Python test files: **220**
 - Desktop TypeScript/TSX files: **121**
 - Desktop test files: **36**
-- Active Markdown docs: **21**
+- Active Markdown docs: **23**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups


### PR DESCRIPTION
# Headless engine mode + prompt-hash telemetry (evaluation lab enabler)

Implements [`docs/engineering/evaluation/headless-mode-implementation.md`](https://github.com/FoxRick/Collie/blob/feat/headless-engine-prompt-hashes/docs/engineering/evaluation/headless-mode-implementation.md) — the Collie-side enabler for the evaluation lab (parent plan: #10). Lets a bench harness drive **one real Collie turn from outside** and get a stable JSON result document with prompt fingerprints.

## Part A — Headless engine mode (`collie_core/headless.py`)

- `python -m collie_core.headless` runs **one task** through the real agent loop against an isolated `COLLIE_HOME`, prints **ONE JSON result document**, exits. Not a user-facing CLI: no `[project.scripts]` entry point.
- **Parity rule enforced:** only calls `CollieRuntime` methods (`_build_loop`, `_configure_provider_candidate`, `_chat`, `_conversation_target`) — never re-composes loop/tools/prompts/permissions/config. `runtime.run()` is never called (no IPC server/scheduler).
- Exit codes: `0` ok · `1` task/engine error · `2` timeout · `3` usage/config error.
- API key comes **only from the environment** (`--api-key-env`, default `COLLIE_PROVIDER_API_KEY`) — never argv, never logged; `final_text`/errors pass through the telemetry sanitizer.
- Result document: run_id, commit, model, provider, session/conversation ids, `prompt_hash`/`tool_schema_hash`/`config_hash`, sanitized `final_text`, normalized usage, calls, latency, `exit_state`.

## Part B — Prompt-hash telemetry

- New `collie_core/telemetry/prompt_hashes.py`: deterministic `sha256:` fingerprints over sorted-key JSON for the rendered system prompt, tool schemas, and config (model/provider/generation/limits).
- **Schema V12** adds `prompt_hash`/`tool_schema_hash`/`config_hash` to `turn_events` — nullable, `None` defaults at the signature so the finish-upsert (COALESCE) never clobbers start values.
- `TelemetryHook.before_run` hashes what the model actually received; `runtime._build_loop` binds the live tool schemas + config (module-binding pattern, no import cycle).
- `RunRecorder` now snapshots `model_calls`/`no_action_turns` in-memory for the bench document (not persisted).
- `PermissionEvaluator` accepts a **`deny`** local-write preset (bench posture) — explicit allow rules, run-wide approval, and reads still win.

## Tests (+14)

- `tests/collie/test_headless.py` (6): contract keys, timeout→exit 2, missing-key→exit 3 (key never in stdout/stderr), tool-registry parity vs direct `_build_loop()`, isolated home, `--json-out`.
- `tests/collie/test_prompt_hashes.py` (7): hash stability/sensitivity, V12 migration, old rows read back NULL, finish-upsert preserves start hashes, end-to-end hashes on a real turn.
- `test_safe_execution.py`: deny-preset behavior.
- Schema-version assertions updated to V12 in `test_db.py`, `test_run_records.py`, `test_task_checklists.py`, `test_message_attachments.py`.

## Verification (fresh, off current main `433b08b`)

| Gate | Result |
|---|---|
| `pytest tests/collie` | **515 passed** / 5 Windows-only baseline / 1 skipped |
| Full suite `--cov` | **3359 passed** / 5 baseline / **73.82%** (≥70) |
| `ruff check nanobot collie_core tests` | clean |
| Snapshot | regenerated, `--check` fresh |
| Manual CLI e2e (fake OpenAI endpoint) | exit 0, full contract, hashes populated, key absent from output |
| Missing key | exit 3, error JSON, no key leak |

Baseline Windows-only failures unchanged (4 DPAPI credential tests + 1 IPC escape-path case).

## Docs

- `docs/PROJECT_MAP.md`: headless mode under `collie_core/` ownership.
- `collie-core/AGENTS.md`: headless section (usage, exit codes, parity rule, tests).
- `docs/generated/REPOSITORY_SNAPSHOT.md` regenerated.
