### PR TITLE
docs(product): park Share Collie — deferred, not in current plan

### DIFF
--- a/docs/product/features/share-collie.md
+++ b/docs/product/features/share-collie.md
@@ -1,7 +1,8 @@
 # Share Collie
 
-**Status:** Accepted product direction; implementation pending
+**Status:** parked — deferred, not in the current plan; spec kept for future reference
 **Date:** 2026-08-01
+**Parked:** 2026-08-03
 **Applies to:** Post-alpha multiplayer and shared-chat work
 
 ## Outcome


### PR DESCRIPTION
# Branch review: docs/park-share-collie (vs origin/main)

**Date:** 2026-08-03 · **Commits:** 66efcb1

## Checklist
- ✅ **Vision** — no product-intent change (VISION untouched); parking an unshipped feature direction, spec preserved for future reference
- ✅ **Docs** — status updated at the top of the single canonical file (`docs/product/features/share-collie.md`); no hand-edits of `generated/`; repository snapshot verified current
- ✅ **Secrets** — secret scan clean, no credential-ish files
- ✅ **Scope** — 1 file, +2/−1 (status line + parked date)
- ✅ **Gates** — docs-only change; no code touched → pytest/ruff/UI gates unaffected

## Verdict
✅ **READY TO MERGE** — trivially small, parks Share Collie as requested. Reopen whenever multiplayer becomes relevant.
