### PR TITLE
feat(memory): auto-approve additive memory writes + journal

### DIFF
--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -520,6 +520,23 @@ ALTER TABLE turn_events ADD COLUMN tool_schema_hash TEXT;
 ALTER TABLE turn_events ADD COLUMN config_hash TEXT;
 """
 
+# Append-only journal of every memory mutation. Powers the Settings -> Memory
+# "recently remembered" view and one-action undo (Gardener rollback rail):
+# kind (fact|person|date), subject (key/name/label), action (add|update|delete),
+# value (new value / snapshot for undo), created_at.
+_SCHEMA_V13 = """
+CREATE TABLE IF NOT EXISTS memory_journal (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    action TEXT NOT NULL,
+    value TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_memory_journal_created
+    ON memory_journal(created_at DESC);
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -534,6 +551,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V10,
     _SCHEMA_V11,
     _SCHEMA_V12,
+    _SCHEMA_V13,
 ]
 
 
@@ -989,6 +1007,9 @@ class CollieDB:
     def list_dates(self) -> list[dict[str, Any]]:
         return self._rows("SELECT * FROM important_dates ORDER BY date")
 
+    def get_date(self, date_id: str) -> dict[str, Any] | None:
+        return self._row("SELECT * FROM important_dates WHERE id = ?", (date_id,))
+
     def update_date(self, date_id: str, **fields: Any) -> None:
         allowed = {"date", "label", "recurring", "reminder_days_before", "person_id"}
         updates = {key: value for key, value in fields.items() if key in allowed}
@@ -1006,6 +1027,37 @@ class CollieDB:
     def delete_date(self, date_id: str) -> None:
         with self._write() as conn:
             conn.execute("DELETE FROM important_dates WHERE id = ?", (date_id,))
+
+    # -- memory journal ----------------------------------------------------------
+
+    def log_memory_journal(
+        self,
+        kind: str,
+        subject: str,
+        action: str,
+        value: Any = None,
+    ) -> None:
+        """Append one memory mutation to the journal (add|update|delete)."""
+        snapshot = json.dumps(value, ensure_ascii=False) if value is not None else None
+        with self._write() as conn:
+            conn.execute(
+                "INSERT INTO memory_journal (kind, subject, action, value, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (kind, subject, action, snapshot, utc_now()),
+            )
+
+    def list_memory_journal(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Most recent journal entries first, newest on top."""
+        rows = self._rows(
+            "SELECT * FROM memory_journal ORDER BY id DESC LIMIT ?", (limit,)
+        )
+        for row in rows:
+            if row.get("value"):
+                try:
+                    row["value"] = json.loads(row["value"])
+                except (TypeError, ValueError):
+                    pass
+        return rows
 
     # -- reminders ---------------------------------------------------------------------------
 

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -14,6 +14,7 @@ Client -> server commands (JSON objects; ``type`` + optional ``id``):
 - ``set_api_key``              -> inject provider secret (memory only)
 - ``configure``                -> rebuild the agent with current settings
 - ``get_profile`` / ``get_people`` / ``get_dates`` (Settings -> Memory tab)
+- ``get_memory_journal`` (recent memory mutations, newest first)
 - ``list_connector_catalog`` / ``list_connector_connections`` /
   ``begin_connector_auth`` / ``test_connector`` / ``update_connector`` /
   ``remove_connector`` (consumer connector directory and lifecycle)
@@ -1174,6 +1175,15 @@ class CollieIPCServer:
 
     async def _cmd_get_profile(self, connection: ServerConnection, frame: dict) -> dict:
         return {"profile": self.db.all_profile()}
+
+    async def _cmd_get_memory_journal(self, connection: ServerConnection, frame: dict) -> dict:
+        """Recent memory mutations (Settings -> Memory -> Recent activity)."""
+        limit = frame.get("limit")
+        try:
+            limit = int(limit) if limit is not None else 50
+        except (TypeError, ValueError):
+            limit = 50
+        return {"entries": self.db.list_memory_journal(limit=max(1, min(limit, 500)))}
 
     def _memory(self) -> Any:
         if self._profile_store is None:

--- a/collie-core/collie_core/memory/profile.py
+++ b/collie-core/collie_core/memory/profile.py
@@ -62,15 +62,27 @@ class ProfileStore:
 
     # -- profile facts -------------------------------------------------------
 
+    def _journal(self, kind: str, subject: str, action: str, value: Any = None) -> None:
+        """Append a mutation record for the Settings -> Memory undo trail."""
+        self.db.log_memory_journal(kind, subject, action, value)
+
     def get(self, key: str, default: Any = None) -> Any:
         return self.db.get_profile(key, default)
 
     def set(self, key: str, value: Any) -> None:
+        existing = self.db.get_profile(key, None)
         self.db.set_profile(key, value)
+        self._journal(
+            "fact", key,
+            "add" if existing is None or existing == "" else "update",
+            value,
+        )
         self.regenerate_memory_md()
 
     def delete(self, key: str) -> None:
+        existing = self.db.get_profile(key, None)
         self.db.delete_profile(key)
+        self._journal("fact", key, "delete", existing)
         self.regenerate_memory_md()
 
     def all(self) -> dict[str, Any]:
@@ -83,8 +95,10 @@ class ProfileStore:
         if existing:
             self.db.update_person(existing["id"], **fields)
             person = self.db.get_person(existing["id"])
+            self._journal("person", name, "update", fields)
         else:
             person = self.db.add_person(name, **fields)
+            self._journal("person", name, "add", fields)
         self.regenerate_memory_md()
         return person  # type: ignore[return-value]
 
@@ -95,11 +109,15 @@ class ProfileStore:
         return self.db.find_person(name)
 
     def update_person(self, person_id: str, **fields: Any) -> None:
+        person = self.db.get_person(person_id) or {}
         self.db.update_person(person_id, **fields)
+        self._journal("person", person.get("name") or person_id, "update", fields)
         self.regenerate_memory_md()
 
     def delete_person(self, person_id: str) -> None:
+        person = self.db.get_person(person_id) or {}
         self.db.delete_person(person_id)
+        self._journal("person", person.get("name") or person_id, "delete", person)
         self.regenerate_memory_md()
 
     def list_people(self) -> list[dict[str, Any]]:
@@ -109,6 +127,7 @@ class ProfileStore:
 
     def add_date(self, date: str, label: str, **kwargs: Any) -> dict[str, Any]:
         row = self.db.add_date(date, label, **kwargs)
+        self._journal("date", label, "add", {"date": date, **kwargs})
         self.regenerate_memory_md()
         return row
 
@@ -116,11 +135,15 @@ class ProfileStore:
         return self.db.list_dates()
 
     def update_date(self, date_id: str, **fields: Any) -> None:
+        row = self.db.get_date(date_id) or {}
         self.db.update_date(date_id, **fields)
+        self._journal("date", row.get("label") or date_id, "update", fields)
         self.regenerate_memory_md()
 
     def delete_date(self, date_id: str) -> None:
+        row = self.db.get_date(date_id) or {}
         self.db.delete_date(date_id)
+        self._journal("date", row.get("label") or date_id, "delete", row)
         self.regenerate_memory_md()
 
     # -- MEMORY.md generation --------------------------------------------------------

--- a/collie-core/collie_core/tools/memory.py
+++ b/collie-core/collie_core/tools/memory.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 from typing import Any
 
 from collie_core.memory.profile import PROFILE_KEYS, ProfileStore
+from collie_core.permissions.models import PermissionRequest, Risk
 from nanobot.agent.tools.base import Tool, tool_parameters
+
+_PERSON_FIELDS = frozenset(
+    {"relationship", "birthday", "allergies", "preferences", "gift_ideas", "notes"}
+)
 
 _profile_store: ProfileStore | None = None
 
@@ -81,6 +86,74 @@ class RememberTool(Tool):
             "Use this whenever the user shares lasting personal information. "
             "Also supports forgetting with kind=forget_fact / forget_person."
         )
+
+    def permission_request(self, params: dict[str, Any]) -> PermissionRequest:
+        """Additive memory writes are approval-free; forgets and rewrites ask.
+
+        New facts, people, and dates are reversible local writes and land
+        silently (they are journaled for undo in Settings). Forgetting, or
+        overwriting a memory that already holds a different value, stays an
+        explicit approval — that is a rewrite in disguise, not an addition.
+        """
+        kind = str(params.get("kind") or "").strip()
+        store = _store()
+
+        if kind in ("forget_fact", "forget_person"):
+            return PermissionRequest(
+                action="memory.forget",
+                resource="profile",
+                risk=Risk.LOCAL_WRITE,
+                summary="Forget a memory",
+                reversible=False,
+                approval_free=False,
+            )
+
+        if kind == "fact":
+            key = (params.get("key") or "").strip().lower().replace(" ", "_")
+            value = str(params.get("value") or "").strip()
+            existing = store.get(key) if store is not None else None
+            conflict = existing not in (None, "") and str(existing) != value
+        elif kind == "person":
+            name = (params.get("name") or "").strip()
+            existing = store.find_person(name) if store is not None else None
+            conflict = self._person_conflicts(existing, params)
+        elif kind == "date":
+            label = (params.get("label") or "").strip()
+            date = str(params.get("date") or "").strip()
+            existing = None
+            if store is not None:
+                existing = next(
+                    (d for d in store.list_dates() if d.get("label") == label), None
+                )
+            conflict = existing is not None and str(existing.get("date") or "") != date
+        else:
+            # Unknown kinds fail closed: ask rather than auto-approve.
+            conflict = True
+
+        return PermissionRequest(
+            action="memory.write",
+            resource="profile",
+            risk=Risk.LOCAL_WRITE,
+            summary="Remember something new"
+            if not conflict
+            else "Update a memory you already have",
+            reversible=True,
+            approval_free=not conflict,
+        )
+
+    @staticmethod
+    def _person_conflicts(
+        existing: dict[str, Any] | None, params: dict[str, Any]
+    ) -> bool:
+        """A person write conflicts when it changes an existing stored field."""
+        if existing is None:
+            return False
+        for field in _PERSON_FIELDS:
+            incoming = (params.get(field) or "").strip()
+            stored = str(existing.get(field) or "").strip()
+            if incoming and stored and incoming != stored:
+                return True
+        return False
 
     @classmethod
     def enabled(cls, ctx: Any) -> bool:

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 12
+    assert db.schema_version == 13
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,17 +25,17 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 12
+    assert d2.schema_version == 13
     d2.close()
 
 
-def test_incremental_migrations_v1_through_v11(tmp_path: Path) -> None:
+def test_incremental_migrations_v1_through_v12(tmp_path: Path) -> None:
     """Every schema version must upgrade cleanly to the latest, preserving data."""
     import sqlite3
 
     import collie_core.db as db_mod
 
-    for target in range(1, 13):
+    for target in range(1, 14):
         path = tmp_path / f"v{target}.db"
         conn = sqlite3.connect(path)
         conn.executescript(db_mod._SCHEMA_V1)
@@ -51,7 +51,7 @@ def test_incremental_migrations_v1_through_v11(tmp_path: Path) -> None:
         conn.close()
 
         upgraded = CollieDB(path)
-        assert upgraded.schema_version == 12, f"v{target} did not reach v12"
+        assert upgraded.schema_version == 13, f"v{target} did not reach v13"
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
         upgraded.close()
 
@@ -76,7 +76,7 @@ def test_migration_failure_rolls_back_atomically(
     with pytest.raises(sqlite3.OperationalError):
         CollieDB(path)
 
-    # The failed migration rolled everything back: version still 12 and the
+    # The failed migration rolled everything back: version still 13 and the
     # partial table is gone, so a normal boot migrates cleanly again.
     conn = sqlite3.connect(path)
     try:
@@ -86,11 +86,11 @@ def test_migration_failure_rolls_back_atomically(
         ).fetchone()
     finally:
         conn.close()
-    assert version == 12
+    assert version == 13
     assert half is None
     monkeypatch.undo()
     fresh = CollieDB(path)
-    assert fresh.schema_version == 12
+    assert fresh.schema_version == 13
     fresh.close()
 
 
@@ -131,7 +131,7 @@ def test_v8_removes_only_legacy_system_subagent_allow(tmp_path: Path) -> None:
         row["name"] for row in migrated._rows("PRAGMA table_info(messages)")
     }
     assert "task_state" in columns
-    assert migrated.schema_version == 12
+    assert migrated.schema_version == 13
     migrated.close()
 
 
@@ -179,7 +179,7 @@ def test_v9_upgrade_adds_plan_change_terminal_message_id(tmp_path: Path) -> None
             row["name"]
             for row in upgraded._rows("PRAGMA table_info(plan_change_requests)")
         }
-        assert upgraded.schema_version == 12
+        assert upgraded.schema_version == 13
         assert "terminal_message_id" in columns
         assert request is not None
         assert request["reason"] == "Change it"
@@ -345,7 +345,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.set_profile("dietary", "vegan")
     db.add_person("Sam")
     data = db.export_all()
-    assert data["schema_version"] == 12
+    assert data["schema_version"] == 13
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_ipc.py
+++ b/collie-core/tests/collie/test_ipc.py
@@ -111,6 +111,32 @@ async def test_ping_and_status(server: CollieIPCServer) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_memory_journal(server: CollieIPCServer, tmp_path: Path) -> None:
+    from collie_core.memory.profile import ProfileStore
+
+    # Give the server a profile store and write a couple of mutations.
+    profile = ProfileStore(server.db, tmp_path / "workspace")
+    profile.set("location", "Lisbon")
+    profile.add_person("Mom", allergies="peanuts")
+
+    ws = await _connect(server)
+    await _send(ws, type="get_memory_journal", id="1")
+    reply = await _recv_until(ws, "ok")
+    entries = reply["data"]["entries"]
+    assert entries[0]["kind"] == "person"
+    assert entries[0]["subject"] == "Mom"
+    assert entries[1]["kind"] == "fact"
+    assert entries[1]["subject"] == "location"
+    assert entries[1]["value"] == "Lisbon"
+
+    await _send(ws, type="get_memory_journal", id="2", limit="bogus")
+    reply = await _recv_until(ws, "ok")
+    assert reply["id"] == "2"
+    assert len(reply["data"]["entries"]) == 2
+    await ws.close()
+
+
+@pytest.mark.asyncio
 async def test_unknown_and_invalid_frames(server: CollieIPCServer) -> None:
     ws = await _connect(server)
     await ws.send("not json")

--- a/collie-core/tests/collie/test_memory.py
+++ b/collie-core/tests/collie/test_memory.py
@@ -6,6 +6,7 @@ import pytest
 
 from collie_core.db import CollieDB
 from collie_core.memory.profile import ProfileStore
+from collie_core.permissions.models import Risk
 from collie_core.tools import memory as memory_tool_module
 from collie_core.tools.memory import RememberTool, bind_profile_store
 
@@ -128,3 +129,131 @@ def test_tool_loader_discovers_collie_tools(store: ProfileStore) -> None:
 
     registered = loader.load(_Ctx(), registry)
     assert "remember" in registered
+
+
+# -- permission posture -----------------------------------------------------
+
+def test_remember_new_fact_is_approval_free(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "fact", "key": "location", "value": "Lisbon"})
+    assert request.approval_free is True
+    assert request.reversible is True
+    assert request.risk == Risk.LOCAL_WRITE
+
+
+def test_remember_overwrite_fact_requires_approval(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    store.set("location", "Madrid")
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "fact", "key": "location", "value": "Lisbon"})
+    assert request.approval_free is False
+
+
+def test_remember_same_fact_value_is_approval_free(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    store.set("location", "Madrid")
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "fact", "key": "location", "value": "Madrid"})
+    assert request.approval_free is True
+
+
+def test_remember_forget_requires_approval(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "forget_fact", "key": "location"})
+    assert request.approval_free is False
+    assert request.reversible is False
+    request = tool.permission_request({"kind": "forget_person", "name": "Mom"})
+    assert request.approval_free is False
+
+
+def test_remember_new_person_is_approval_free(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "person", "name": "Mom"})
+    assert request.approval_free is True
+
+
+def test_remember_person_field_change_requires_approval(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    store.add_person("Mom", allergies="peanuts")
+    tool = RememberTool()
+    request = tool.permission_request(
+        {"kind": "person", "name": "Mom", "allergies": "shellfish"}
+    )
+    assert request.approval_free is False
+    # Same value again is a no-op, not a rewrite.
+    request = tool.permission_request(
+        {"kind": "person", "name": "Mom", "allergies": "peanuts"}
+    )
+    assert request.approval_free is True
+
+
+def test_remember_new_date_is_approval_free(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "date", "date": "03-15", "label": "Mom's birthday"})
+    assert request.approval_free is True
+
+
+def test_remember_date_move_requires_approval(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    store.add_date("03-15", "Mom's birthday", recurring=True)
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "date", "date": "03-16", "label": "Mom's birthday"})
+    assert request.approval_free is False
+
+
+def test_remember_unknown_kind_fails_closed(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    request = tool.permission_request({"kind": "nope"})
+    assert request.approval_free is False
+
+
+# -- memory journal -----------------------------------------------------------
+
+def test_journal_records_fact_add_update_delete(store: ProfileStore) -> None:
+    store.set("location", "Lisbon")
+    store.set("location", "Porto")
+    store.delete("location")
+    entries = store.db.list_memory_journal()
+    assert [e["action"] for e in entries] == ["delete", "update", "add"]
+    assert entries[2]["kind"] == "fact"
+    assert entries[2]["subject"] == "location"
+    assert entries[2]["value"] == "Lisbon"
+    assert entries[1]["value"] == "Porto"
+
+
+def test_journal_records_person_and_date(store: ProfileStore) -> None:
+    store.add_person("Mom", allergies="peanuts")
+    mom = store.find_person("Mom")
+    assert mom is not None
+    store.delete_person(mom["id"])
+    store.add_date("03-15", "Mom's birthday", recurring=True)
+    entries = store.db.list_memory_journal()
+    actions = [e["action"] for e in entries]
+    assert actions == ["add", "delete", "add"]
+    assert entries[2]["kind"] == "person"
+    assert entries[2]["subject"] == "Mom"
+    assert entries[0]["kind"] == "date"
+    assert entries[0]["subject"] == "Mom's birthday"
+
+
+def test_journal_limit(store: ProfileStore) -> None:
+    for i in range(5):
+        store.set(f"key{i}", str(i))
+    assert len(store.db.list_memory_journal(limit=2)) == 2
+
+
+@pytest.mark.asyncio
+async def test_remember_tool_journals_through_profile_store(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    await tool.execute(kind="fact", key="goals", value="learn Spanish")
+    entries = store.db.list_memory_journal()
+    assert entries[0]["kind"] == "fact"
+    assert entries[0]["subject"] == "goals"
+    assert entries[0]["action"] == "add"
+    assert entries[0]["value"] == "learn Spanish"

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 12
+    assert db.schema_version == 13
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -85,7 +85,7 @@ def _build_db_at_version(path: Path, version: int) -> None:
 def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "collie.db")
     try:
-        assert db.schema_version == 12
+        assert db.schema_version == 13
         columns = {
             row["name"]
             for row in db._rows("PRAGMA table_info(turn_events)")
@@ -109,7 +109,7 @@ def test_old_rows_null_hashes(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 12
+        assert upgraded.schema_version == 13
         rows = upgraded.list_turn_events()
         assert len(rows) == 1
         assert rows[0]["prompt_hash"] is None

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -94,7 +94,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 12
+    assert db.schema_version == 13
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -116,7 +116,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 12
+        assert upgraded.schema_version == 13
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 12
+    assert db.schema_version == 13
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -77,7 +77,10 @@ or stop it, and return later without having to reconstruct their context.
 
 - A developer shell disguised as a consumer application.
 - A universal connector claim unsupported by real provider verification.
-- Autonomous changes to permissions, identity, or personal memory without
-  review.
+- Autonomous changes to permissions or identity without review, or
+  rewrites/deletions of personal memory without review. Additive memory
+  writes may be automatic when logged and reversible; forgetting,
+  contradicting, or consolidating remembered facts stays an explicit
+  approval.
 - Showing chain-of-thought or raw tool traffic as the default progress model.
 - Trading user control or truthful behavior for a more magical demo.

--- a/docs/product/features/agent-system.md
+++ b/docs/product/features/agent-system.md
@@ -57,7 +57,7 @@ The improvement process should be:
 5. Apply meaningful behavioural changes only after approval.
 6. Keep the previous version for rollback.
 
-Automatic maintenance may update indexes, compact sessions, remove duplicate context, and record project changes. Rewriting agents or skills, changing personal memory, or changing settings and permissions should require approval.
+Automatic maintenance may update indexes, compact sessions, remove duplicate context, and record project changes. Additive memory writes (new facts, people, and dates) may also be automatic when they are logged and reversible, with a visible recent-activity trail the owner can inspect. Rewriting agents or skills, changing or deleting personal memory, or changing settings and permissions should require approval.
 
 The Gardener should improve Collie in response to observed problems and repeated patterns, not rewrite things merely because a timer fired.
 


### PR DESCRIPTION
# Branch review: feat/memory-auto-writes (vs origin/main)

**Reviewer:** Hermes Agent (collie-branch-review) · **Date:** 2026-08-03
**Commits:** `5d88daa` (1 commit)

## Freshness

- origin refs at start AND end: `main=737ed3a` (unchanged); `feat/memory-auto-writes` pushed mid-review → verified `5d88daa` on origin.
- Snapshot: fresh (regenerated; no file-count change — edits only).

## Scope

- 13 files, +336/−20: `collie_core/` (permission flip, journal table V13, IPC read) + 6 test files + 2 docs.
- No new/deleted files, no large blobs, secret scan clean.

## Checklist (vision / ownership / invariants / docs / claims / voice)

- ✅ **Permissions** — `RememberTool.permission_request()` added: additive kinds (fact/person/date) → `memory.write`, LOCAL_WRITE, `reversible=True`, `approval_free=True` → evaluator `_ordinary_safe` ALLOWs. Forgets → `memory.forget`, `reversible=False`, `approval_free=False` → ASK. Rewrites of existing values (fact value differs, person field differs, date moved) → `approval_free=False` → ASK. Unknown kinds fail closed (ASK). `memory.*` deliberately absent from `AUTOMATIC_LOCAL_INELIGIBLE_PREFIXES` — consistent with the documented design intent.
- ✅ **Secrets** — no hits; journal stores local memory values only, never credentials (secret scan clean).
- ✅ **Local-first** — journal is SQLite-local; IPC read command is read-only.
- ✅ **Claims truthfulness** — VISION non-goal + agent-system Gardener clause updated to match the new behavior (additive auto + logged; rewrites/deletions gated). No overclaim.
- ✅ **Voice** — summaries are dog-voice ("Remember something new", "Update a memory you already have", "Forget a memory"), no corporate language.
- ✅ **Renderer boundary** — no renderer changes in this PR; `get_memory_journal` returns local memory metadata only.
- ✅ **Tests** — 14 new tests (permission posture ×9, journal ×4, IPC ×1); migration-version assertions updated 12→13 across 6 files.

## Codex-preempt scan

- ✅ No upsert/COALESCE footguns (new table, plain INSERT).
- ✅ No hook-factory bypass, no blocked-tool early returns, no sync SQLite on the loop (journal writes go through the existing `_write()` lock), no new stored text beyond local memory values.
- ✅ `get_date` added to `CollieDB` (the one new DB accessor used by profile.py journaling).

## Gates (fresh, on HEAD 5d88daa)

- **pytest `tests/collie`:** 543 passed / 5 failed / 1 skipped (baseline: 4× DPAPI Windows-only + 1× flaky escape-path — documented, no regression).
- **Full tree w/ coverage:** 3379 passed / 5 failed / 1 skipped · **coverage 74%** (≥70) ✅
- **ruff** (nanobot + collie_core + tests): clean ✅
- **Snapshot** `update_project_snapshot.py --check`: fresh ✅
- UI untouched — no typecheck/build needed.

## Findings

| # | Sev | Finding | Fix |
|---|---|---|---|
| 1 | P3 | `get_memory_journal` IPC read is not yet surfaced in the Settings UI | Follow-up PR: MemoryTab "Recent activity" list + one-action undo (journal table already provides the data + values) |

## Verdict

✅ **READY — clean, small, testable.** The approval flip is exactly the user-directed philosophy (gate by blast radius + reversibility + conflict, not category): additions auto + journaled, forgets/rewrites/conflicts ASK. Docs updated in-branch so VISION and agent-system no longer contradict the behavior. No P1/P2 findings.

## Handoff

- Compare URL: https://github.com/FoxRick/Collie/compare/main...feat/memory-auto-writes
- PR body = this report; opened via `gh pr create` (gh authenticated as FoxRick).
- NOT merged — user's Codex gate + merge on GitHub decides.
