### PR TITLE
feat(voice): Collie speaks like a friendly person, not a dog

### DIFF
--- a/collie-core/AGENTS.md
+++ b/collie-core/AGENTS.md
@@ -125,7 +125,7 @@ schemas; `tests/collie/test_prompt_hashes.py` covers the hash telemetry
   (`nanobot/pairing`), approved in Settings → Phone via `approve_pairing`.
   The engine data dir (pairing.json, media) is anchored to `~/.collie` by
   `set_config_path` at runtime boot.
-- **Thinking states**: dog-themed phrases in `collie_core/ipc/thinking.py`;
+- **Thinking states**: friendly thinking phrases in `collie_core/ipc/thinking.py`;
   never use corporate language in user-facing strings.
 
 ## Testing
@@ -140,6 +140,6 @@ schemas; `tests/collie/test_prompt_hashes.py` covers the hash telemetry
 
 ## Voice Rules (user-facing strings)
 
-Collie speaks like a smart, loyal dog who can type: warm, first-person,
-playful, never corporate. Errors say things like "Uh oh. I chased my tail on
-that one." — never "An error occurred while processing your request."
+Collie speaks like a warm, friendly person who can type: first-person,
+welcoming, never corporate. Errors say things like "Uh oh. That didn't go
+as planned." — never "An error occurred while processing your request."

--- a/collie-core/collie_core/automations/custom.py
+++ b/collie-core/collie_core/automations/custom.py
@@ -126,7 +126,7 @@ def create_custom_automation(
         structured = parse_structured_schedule(description, timezone_name)
     except ValueError as exc:
         raise ValueError(
-            "I couldn't sniff out a clear schedule. Try 'weekdays at 8am', "
+            "I couldn't work out a clear schedule. Try 'weekdays at 8am', "
             "'every Friday at 5pm', or 'the first day of every month at 9am'. "
             f"{exc}"
         ) from exc

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -447,7 +447,7 @@ class CollieIPCServer:
             safe_message = (
                 str(e)
                 if isinstance(e, (ValueError, VoiceInputError))
-                else "Uh oh. I chased my tail on that one. Try again?"
+                else "Uh oh. That didn't go as planned. Try again?"
             )
             await self._send(connection, {
                 "type": "error", "id": req_id,
@@ -1070,7 +1070,7 @@ class CollieIPCServer:
                 await self._send(connection, {
                     "type": "error", "id": req_id,
                     "message": str(e) if isinstance(e, ValueError) else
-                               "Uh oh. I chased my tail on that one. Try again?",
+                               "Uh oh. That didn't go as planned. Try again?",
                     "detail": str(e),
                 })
                 return
@@ -1308,7 +1308,7 @@ class CollieIPCServer:
         code = str(frame.get("code") or "").strip().upper()
         result = approve_code(code)
         if result is None:
-            raise ValueError("That code didn't match — it may have expired. Sniff again?")
+            raise ValueError("That code didn't match — it may have expired. Try again?")
         channel, sender_id = result
         confirmed = await self._messengers().confirm_pairing(channel, sender_id)
         await self.broadcast({"type": "messenger_pairing", "messenger": channel})
@@ -3032,7 +3032,7 @@ class CollieIPCServer:
             await self.send_thinking(conv_id, "error")
             await self.broadcast({
                 "type": "error", "conversation_id": conv_id,
-                "message": "Uh oh. I chased my tail on that one. Try again?",
+                "message": "Uh oh. That didn't go as planned. Try again?",
                 "detail": str(e),
             })
             return

--- a/collie-core/collie_core/ipc/thinking.py
+++ b/collie-core/collie_core/ipc/thinking.py
@@ -1,7 +1,7 @@
-"""Dog-themed thinking states (spec §3.10, F082-F092).
+"""Thinking states (spec §3.10, F082-F092).
 
-Maps engine activity (tool calls, streaming, errors) to the collie phrases
-shown in the ThinkingBar and mirrored by the desktop pet.
+Maps engine activity (tool calls, streaming, errors) to the friendly
+phrases shown in the ThinkingBar and mirrored by the desktop pet.
 """
 
 from __future__ import annotations
@@ -10,18 +10,18 @@ __all__ = ["PHRASES", "phrase_for_state", "thinking_state_for_tool"]
 
 # state -> (phrase, pet animation)
 PHRASES: dict[str, tuple[str, str]] = {
-    "searching": ("Sniffing out reliable sources…", "walk"),
+    "searching": ("Looking through reliable sources…", "walk"),
     "planning": ("Mapping out the next steps…", "working"),
-    "fetching": ("Fetching what I need…", "walk"),
+    "fetching": ("Getting what I need…", "walk"),
     "generating": ("Writing your answer…", "working"),
     "processing": ("Working through it…", "working"),
     "summarizing": ("Sorting out the important bits…", "working"),
-    "remembering": ("Burying that detail for later…", "working"),
-    "recovering": ("Shaking it off and trying again…", "concerned"),
-    "done": ("All done — tail wag included.", "happy"),
-    "error": ("I hit a snag, but I’m still here.", "concerned"),
+    "remembering": ("Saving that detail for later…", "working"),
+    "recovering": ("Let me try that again…", "concerned"),
+    "done": ("All done!", "happy"),
+    "error": ("I hit a snag, but I'm still here.", "concerned"),
     "idle": ("Ready when you are.", "idle"),
-    "startup": ("Just stretching — ready in a moment.", "working"),
+    "startup": ("Just getting ready — one moment.", "working"),
     "pantry": ("Checking the pantry…", "walk"),
     "mapping": ("Looking over the map…", "walk"),
     "calendar": ("Checking your calendar…", "working"),

--- a/collie-core/collie_core/permissions/evaluator.py
+++ b/collie-core/collie_core/permissions/evaluator.py
@@ -184,7 +184,7 @@ class PermissionEvaluator:
                     return PermissionDecision(
                         Effect.ASK,
                         f"'{request.resource}' is outside the active project. "
-                        "I need your approval before I can poke my nose in there.",
+                        "I need your approval before I can take a look in there.",
                     )
             return PermissionDecision(Effect.ALLOW, "Read-only actions are allowed.")
         if (

--- a/collie-core/collie_core/services/oauth.py
+++ b/collie-core/collie_core/services/oauth.py
@@ -42,7 +42,7 @@ _SUCCESS_PAGE = """<!doctype html>
              height: 100vh; margin: 0;">
 <div style="text-align: center;">
   <div style="font-size: 64px;">&#128021;</div>
-  <h1 style="margin: 8px 0;">Got it! *tail wag*</h1>
+  <h1 style="margin: 8px 0;">Got it!</h1>
   <p style="color: #8C8C8C;">{service} is connected. You can close this tab
   and head back to Collie.</p>
 </div></body></html>"""

--- a/collie-core/collie_core/settings.py
+++ b/collie-core/collie_core/settings.py
@@ -43,12 +43,12 @@ _runtime_api_keys: dict[str, str] = {}
 _DEFAULT_VISION = """# Collie's Personality
 
 You are Collie, a helpful personal assistant. You are direct, warm, and a
-bit playful — a smart, loyal dog who can type. You remember what matters to
+bit playful — a friendly person who can type. You remember what matters to
 your user and proactively help.
 
 You never use jargon or technical terms unless the user does first. You
 explain things simply. You speak in first person and keep a light touch of
-dog humor ("I dug up some results") without overdoing it.
+warm humor without overdoing it.
 
 You never use corporate language. Never say "processing your request",
 "engaging with your query", or "How may I assist you today?".

--- a/collie-core/collie_core/tools/recipes.py
+++ b/collie-core/collie_core/tools/recipes.py
@@ -117,7 +117,7 @@ class RecipesTool(Tool):
         try:
             if action == "search":
                 if not query:
-                    return self.error("What dish should I sniff out?")
+                    return self.error("What dish should I look up?")
                 data = _api_get(f"{_SEARCH_URL}?{urlencode({'s': query})}")
                 meals = data.get("meals") or []
                 if not meals:

--- a/collie-core/collie_core/tools/subagent.py
+++ b/collie-core/collie_core/tools/subagent.py
@@ -90,7 +90,7 @@ class CallSubagentTool(Tool):
             names = [str(r["name"]) for r in loader.db.list_subagents()]
             if names:
                 return (
-                    f"I don't have a helper called '{name}'. My buddies are: "
+                    f"I don't have a helper called '{name}'. My helpers are: "
                     f"{', '.join(names)}. Or make a new one in "
                     "Settings → Subagents!"
                 )
@@ -116,7 +116,7 @@ class CallSubagentTool(Tool):
         limit = min(3, self._manager.max_concurrent_subagents)
         if running >= limit:
             return (
-                f"My buddies have their paws full ({running}/{limit} busy). "
+                f"My helpers are busy right now ({running}/{limit} busy). "
                 "Let one finish before calling in another."
             )
         operator_running = any(

--- a/collie-core/nanobot/channels/discord.py
+++ b/collie-core/nanobot/channels/discord.py
@@ -159,8 +159,8 @@ if DISCORD_AVAILABLE:
                     return
                 await self._reply_ephemeral(
                     interaction,
-                    "Woof! No commands to memorize — just tell me what you need. 🐕\n"
-                    "I can check your calendar, sniff out the weather, set "
+                    "Hi! No commands to memorize — just tell me what you need. 😊\n"
+                    "I can check your calendar, check the weather, set "
                     "reminders, search the web, and remember what matters to you.\n"
                     "This chat is paired with the Collie app on your computer.",
                 )

--- a/collie-core/nanobot/channels/telegram.py
+++ b/collie-core/nanobot/channels/telegram.py
@@ -1113,8 +1113,8 @@ class TelegramChannel(BaseChannel):
             await self._send_pairing_code_if_private(sender_id, update.message, user)
             return
         await update.message.reply_text(
-            "Woof! No commands to memorize — just tell me what you need. 🐕\n\n"
-            "I can check your calendar, sniff out the weather, set reminders, "
+            "Hi! No commands to memorize — just tell me what you need. 😊\n\n"
+            "I can check your calendar, check the weather, set reminders, "
             "search the web, and remember what matters to you.\n\n"
             "This chat is paired with the Collie app on your computer."
         )

--- a/collie-core/nanobot/pairing/store.py
+++ b/collie-core/nanobot/pairing/store.py
@@ -228,7 +228,7 @@ def get_approved(channel: str) -> list[str]:
 def format_pairing_reply(code: str) -> str:
     """Return the pairing-code message sent to unrecognised DM senders."""
     return (
-        "Woof! I only chat with my human. 🐕\n\n"
+        "Hi! I only chat with my human. 😊\n\n"
         f"Your pairing code is: {code}\n\n"
         "If I'm your Collie, open the Collie app on your computer, go to "
         "Settings → Phone, and enter this code. Then message me again!"

--- a/collie-core/nanobot/templates/agent/identity.md
+++ b/collie-core/nanobot/templates/agent/identity.md
@@ -1,7 +1,7 @@
 ## Who you are
 
-You are Collie — a personal AI assistant with the heart of a Border Collie:
-smart, loyal, warm, and a little playful. You help with everyday life:
+You are Collie — a personal AI assistant with a warm, friendly personality:
+smart, loyal, and a little playful. You help with everyday life:
 schedules, email, weather, reminders, ideas, plans, and questions.
 
 Voice rules (always):
@@ -9,8 +9,8 @@ Voice rules (always):
 - Never say "processing your request", "engaging with your query", or
   "How may I assist you today?".
 - Plain language. No jargon unless the user uses it first.
-- Light dog humor is welcome ("I dug up a few options"), but never let it
-  get in the way of being genuinely useful.
+- Light humor is welcome, but never let it get in the way of being
+  genuinely useful.
 - Be concise. Answer first, details after.
 
 ## Runtime

--- a/collie-core/tests/collie/test_custom_automations.py
+++ b/collie-core/tests/collie/test_custom_automations.py
@@ -53,7 +53,7 @@ def test_create_custom_automation(tmp_path: Path) -> None:
         assert "how my week went" in config["prompt"]
         assert len(row["name"]) <= 48
 
-        with pytest.raises(ValueError, match="sniff"):
+        with pytest.raises(ValueError, match="work out"):
             create_custom_automation(db, "do something nice for me")
         with pytest.raises(ValueError):
             create_custom_automation(db, "")
@@ -99,7 +99,7 @@ async def test_automation_ipc_create_and_delete(tmp_path: Path) -> None:
         reply = await _roundtrip(ws, type="create_automation", id="2",
                                  description="whenever you feel like it")
         assert reply["type"] == "error"
-        assert "sniff" in reply["message"] or "sniff" in str(reply.get("detail"))
+        assert "work out" in reply["message"] or "work out" in str(reply.get("detail"))
 
         reply = await _roundtrip(ws, type="delete_automation", id="3",
                                  automation_id=auto["id"])

--- a/collie-core/tests/collie/test_e2e_phase1.py
+++ b/collie-core/tests/collie/test_e2e_phase1.py
@@ -34,7 +34,7 @@ async def _fake_openai_app() -> web.Application:
                 headers={"Content-Type": "text/event-stream"}
             )
             await resp.prepare(request)
-            chunks = ["Woof! ", "You said: ", "hello."]
+            chunks = ["Hi! ", "You said: ", "hello."]
             for i, text in enumerate(chunks):
                 payload = {
                     "id": "chatcmpl-fake",
@@ -66,7 +66,7 @@ async def _fake_openai_app() -> web.Application:
             "model": body["model"],
             "choices": [{
                 "index": 0,
-                "message": {"role": "assistant", "content": "Woof! You said: hello."},
+                "message": {"role": "assistant", "content": "Hi! You said: hello."},
                 "finish_reason": "stop",
             }],
             "usage": {"prompt_tokens": 20, "completion_tokens": 6, "total_tokens": 26},
@@ -139,8 +139,8 @@ async def test_phase1_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
                     pytest.fail(f"IPC error: {frame}")
 
             assert assistant is not None
-            assert "Woof!" in assistant["content"]
-            assert "".join(deltas) == "Woof! You said: hello."
+            assert "Hi!" in assistant["content"]
+            assert "".join(deltas) == "Hi! You said: hello."
             assert "processing" in states
             assert states[-1] == "done"
 

--- a/collie-core/tests/collie/test_e2e_phase3.py
+++ b/collie-core/tests/collie/test_e2e_phase3.py
@@ -36,7 +36,7 @@ async def _fake_openai_app() -> web.Application:
             "model": body["model"],
             "choices": [{
                 "index": 0,
-                "message": {"role": "assistant", "content": "Woof! All set."},
+                "message": {"role": "assistant", "content": "Hi! All set."},
                 "finish_reason": "stop",
             }],
             "usage": {"prompt_tokens": 10, "completion_tokens": 4,
@@ -165,7 +165,7 @@ async def test_phase3_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
                 if frame["type"] == "error":
                     pytest.fail(f"IPC error: {frame}")
             assert assistant is not None
-            assert "Woof!" in assistant["content"]
+            assert "Hi!" in assistant["content"]
 
             # -- search + export + disconnect --------------------------------
             reply = await _roundtrip(ws, type="search_messages", id="q1",

--- a/collie-core/tests/collie/test_e2e_phase4.py
+++ b/collie-core/tests/collie/test_e2e_phase4.py
@@ -39,7 +39,7 @@ async def _fake_openai_app() -> web.Application:
             "model": body["model"],
             "choices": [{
                 "index": 0,
-                "message": {"role": "assistant", "content": "Woof! All set."},
+                "message": {"role": "assistant", "content": "Hi! All set."},
                 "finish_reason": "stop",
             }],
             "usage": {"prompt_tokens": 10, "completion_tokens": 4,
@@ -176,7 +176,7 @@ async def test_phase4_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
             ))
             channel = FakePhoneChannel.instances[-1]
             await _wait_for(lambda: channel.sent)
-            assert "Woof!" in channel.sent[0].content
+            assert "Hi!" in channel.sent[0].content
 
             # ...and it mirrors into a desktop conversation
             conv_id = db.get_setting("messengers.telegram.conversation_id")
@@ -227,7 +227,7 @@ async def test_phase4_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
             assert briefing_conv
             briefing_msgs = db.get_messages(briefing_conv)
             assert briefing_msgs[-1]["role"] == "assistant"
-            assert "Woof!" in briefing_msgs[-1]["content"]
+            assert "Hi!" in briefing_msgs[-1]["content"]
     finally:
         await runtime._shutdown_loop()
         await runtime.ipc.stop()

--- a/collie-core/tests/collie/test_headless.py
+++ b/collie-core/tests/collie/test_headless.py
@@ -41,7 +41,7 @@ def _fake_openai_app(*, delay_s: float = 0.0) -> web.Application:
         if body.get("stream"):
             resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
             await resp.prepare(request)
-            chunks = ["Woof! ", "You said: ", "hello."]
+            chunks = ["Hi! ", "You said: ", "hello."]
             for i, text in enumerate(chunks):
                 payload = {
                     "id": "chatcmpl-fake",
@@ -73,7 +73,7 @@ def _fake_openai_app(*, delay_s: float = 0.0) -> web.Application:
             "model": body["model"],
             "choices": [{
                 "index": 0,
-                "message": {"role": "assistant", "content": "Woof! You said: hello."},
+                "message": {"role": "assistant", "content": "Hi! You said: hello."},
                 "finish_reason": "stop",
             }],
             "usage": {"prompt_tokens": 20, "completion_tokens": 6, "total_tokens": 26},
@@ -166,7 +166,7 @@ async def test_headless_runs_task_and_outputs_contract(
     assert document["conversation_id"]
 
     # Final answer from the fake endpoint, sanitized
-    assert document["final_text"] == "Woof! You said: hello."
+    assert document["final_text"] == "Hi! You said: hello."
 
     # Usage/calls are ints >= 0
     for value in document["usage"].values():

--- a/collie-core/tests/collie/test_ipc.py
+++ b/collie-core/tests/collie/test_ipc.py
@@ -38,9 +38,9 @@ class FakeOutbound:
 
 async def fake_chat_runner(content: str, *, conversation_id: str, on_stream, on_progress):
     await on_progress("", tool_events=[{"phase": "start", "name": "web_search"}])
-    for chunk in ("Woof! ", "Here you go."):
+    for chunk in ("Hi! ", "Here you go."):
         await on_stream(chunk)
-    return FakeOutbound("Woof! Here you go.")
+    return FakeOutbound("Hi! Here you go.")
 
 
 @pytest.fixture()
@@ -65,7 +65,7 @@ async def _connect(srv: CollieIPCServer):
     ws = await websockets.connect(f"ws://127.0.0.1:{srv.port}")
     ready = json.loads(await ws.recv())
     assert ready["type"] == "ready"
-    assert "stretching" in ready["phrase"]
+    assert "getting ready" in ready["phrase"]
     return ws
 
 
@@ -660,8 +660,8 @@ async def test_chat_full_flow(server: CollieIPCServer) -> None:
     assert "searching" in seen_states       # web_search tool event
     assert "generating" in seen_states      # streaming started
     assert seen_states[-1] == "done"
-    assert "".join(deltas) == "Woof! Here you go."
-    assert final_msg["content"] == "Woof! Here you go."
+    assert "".join(deltas) == "Hi! Here you go."
+    assert final_msg["content"] == "Hi! Here you go."
 
     # Conversation auto-titled from first message + both messages persisted
     convs = server.db.list_conversations()
@@ -750,7 +750,7 @@ async def test_chat_without_runner_reports_friendly_error(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_chat_runner_exception_is_dog_themed(tmp_path: Path) -> None:
+async def test_chat_runner_exception_is_friendly(tmp_path: Path) -> None:
     async def broken_runner(content, *, conversation_id, on_stream, on_progress):
         raise RuntimeError("boom")
 
@@ -762,7 +762,7 @@ async def test_chat_runner_exception_is_dog_themed(tmp_path: Path) -> None:
         await _send(ws, type="chat", id="1", content="hello")
         await _recv_until(ws, "ok")
         err = await _recv_until(ws, "error")
-        assert "chased my tail" in err["message"]
+        assert "didn't go as planned" in err["message"]
         await ws.close()
     finally:
         await srv.stop()

--- a/collie-core/tests/collie/test_messengers.py
+++ b/collie-core/tests/collie/test_messengers.py
@@ -182,12 +182,12 @@ async def test_dispatch_final_message_mirrors_and_remembers(db, monkeypatch) -> 
     manager = await _started_manager(db, monkeypatch)
     manager.broadcaster = broadcaster
     handled = await manager.dispatch(
-        OutboundMessage(channel="telegram", chat_id="42", content="Woof, done!")
+        OutboundMessage(channel="telegram", chat_id="42", content="Hi, done!")
     )
     assert handled is True
     channel = manager.channels["telegram"]
     await _wait_until(lambda: len(channel.sent) == 1)
-    assert channel.sent[0].content == "Woof, done!"
+    assert channel.sent[0].content == "Hi, done!"
     await _wait_until(
         lambda: db.get_setting("messengers.telegram.last_chat_id") == "42"
     )
@@ -197,7 +197,7 @@ async def test_dispatch_final_message_mirrors_and_remembers(db, monkeypatch) -> 
     assert conv["title"] == "📱 Telegram"
     messages = db.get_messages(conv_id)
     assert messages[-1]["role"] == "assistant"
-    assert messages[-1]["content"] == "Woof, done!"
+    assert messages[-1]["content"] == "Hi, done!"
     assert any(e["type"] == "message" for e in events)
     await manager.stop()
 
@@ -249,18 +249,18 @@ async def test_dispatch_progress_dropped_streams_forwarded(db, monkeypatch) -> N
 
     # Final streamed response: no re-send, but mirrored to the desktop
     await manager.dispatch(OutboundMessage(
-        channel="telegram", chat_id="42", content="Woof",
+        channel="telegram", chat_id="42", content="Hi",
         event=StreamedResponseEvent(),
     ))
     conv_id = db.get_setting("messengers.telegram.conversation_id")
     await _wait_until(
         lambda: conv_id is not None
         and db.get_messages(conv_id)
-        and db.get_messages(conv_id)[-1]["content"] == "Woof"
+        and db.get_messages(conv_id)[-1]["content"] == "Hi"
     )
     assert channel.sent == []
     messages = db.get_messages(conv_id)
-    assert messages[-1]["content"] == "Woof"
+    assert messages[-1]["content"] == "Hi"
     await manager.stop()
 
 

--- a/collie-core/tests/collie/test_pet_status.py
+++ b/collie-core/tests/collie/test_pet_status.py
@@ -86,9 +86,9 @@ def test_completion_stays_until_acknowledged() -> None:
 def test_explicit_status_state_keeps_bubble_and_animation_in_sync() -> None:
     pet, root, label, states = _pet()
 
-    pet._set_status("Sniffing out reliable sources…", state="walk")
+    pet._set_status("Looking through reliable sources…", state="walk")
 
-    assert label.text == "Sniffing out reliable sources…"
+    assert label.text == "Looking through reliable sources…"
     assert states == ["walk"]
     assert root.scheduled[0][0] == 12_000
 

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -880,7 +880,7 @@ async def test_runtime_records_chat_turn_via_build_loop(
         assert body.get("model")
         resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
         await resp.prepare(request)
-        for i, text in enumerate(["Woof! ", "You said: ", "hello."]):
+        for i, text in enumerate(["Hi! ", "You said: ", "hello."]):
             payload = {
                 "id": "chatcmpl-fake",
                 "object": "chat.completion.chunk",
@@ -978,8 +978,8 @@ class FakeOutbound:
 
 async def fake_chat_runner(content: str, *, conversation_id: str, on_stream, on_progress):
     await on_progress("", tool_events=[{"phase": "start", "name": "web_search"}])
-    await on_stream("Woof!")
-    return FakeOutbound("Woof! Here you go.")
+    await on_stream("Hi!")
+    return FakeOutbound("Hi! Here you go.")
 
 
 async def test_ipc_get_run_records_and_tool_events_round_trip(

--- a/collie-core/tests/collie/test_subagents.py
+++ b/collie-core/tests/collie/test_subagents.py
@@ -219,7 +219,7 @@ async def test_call_subagent_inherits_parent_workspace_scope(
     assert inherited.restrict_to_workspace is True
 
 
-async def test_call_subagent_unknown_name_lists_buddies(loader: SubagentLoader) -> None:
+async def test_call_subagent_unknown_name_lists_helpers(loader: SubagentLoader) -> None:
     loader.create("Writing Coach", "writing")
     bind_subagent_loader(loader)
     tool = CallSubagentTool(FakeManager())
@@ -246,7 +246,7 @@ async def test_call_subagent_respects_concurrency(loader: SubagentLoader) -> Non
 
         reset_request_context(token)
         bind_subagent_loader(None)
-    assert "paws full" in result
+    assert "helpers are busy right now" in result
 
 
 # -- IPC ------------------------------------------------------------------------

--- a/collie-ui/src/renderer/src/components/settings/AutomationsTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/AutomationsTab.tsx
@@ -88,7 +88,7 @@ export default function AutomationsTab({ onNotice }: Props): React.JSX.Element {
     setBusy(true)
     try {
       await collieClient.createAutomation(description.trim())
-      onNotice("Scheduled! I'll be right on time. *tail wag*")
+      onNotice("Scheduled! I'll be right on time.")
       setCreating(false)
       setDescription('')
       await refresh()
@@ -115,7 +115,7 @@ export default function AutomationsTab({ onNotice }: Props): React.JSX.Element {
   if (loading) {
     return (
       <div className="py-8 text-center text-sm" style={{ color: 'var(--collie-paw)' }}>
-        Sniffing out your automations...
+        Looking through your automations...
       </div>
     )
   }
@@ -133,7 +133,7 @@ export default function AutomationsTab({ onNotice }: Props): React.JSX.Element {
     <div>
       <h3 className="mb-1 font-semibold">Automatic Tasks</h3>
       <p className="mb-3 text-sm" style={{ color: 'var(--collie-paw)' }}>
-        Collie can check in on a schedule — like a good dog reminding you to eat.
+        Collie can check in on a schedule — like a good friend reminding you to eat.
       </p>
       <div className="space-y-2">
         {items.map((auto) => (

--- a/collie-ui/src/renderer/src/components/settings/ContextTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/ContextTab.tsx
@@ -29,7 +29,7 @@ export default function ContextTab({ onNotice }: Props): React.JSX.Element {
     try {
       await collieClient.command('write_file', { path: 'AGENTS.md', content: agents })
       setSaved(true)
-      onNotice('Context saved! *tail wag*')
+      onNotice('Context saved!')
       setTimeout(() => setSaved(false), 2000)
     } catch (e) {
       onNotice(e instanceof Error ? e.message : 'Failed to save')
@@ -44,7 +44,7 @@ export default function ContextTab({ onNotice }: Props): React.JSX.Element {
       </p>
       {loading ? (
         <div className="py-8 text-center text-sm" style={{ color: 'var(--collie-paw)' }}>
-          Sniffing out your settings...
+          Looking through your settings...
         </div>
       ) : (
         <>

--- a/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
@@ -114,7 +114,7 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
   }
 
   if (loading) {
-    return <div className="settings-loading">Sniffing out your memories...</div>
+    return <div className="settings-loading">Looking through your memories...</div>
   }
 
   const profileEntries = Object.entries(profile).filter(([, value]) => value && value !== '')

--- a/collie-ui/src/renderer/src/components/settings/ProfileTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/ProfileTab.tsx
@@ -31,7 +31,7 @@ export default function ProfileTab({ onNotice }: Props): React.JSX.Element {
     try {
       await collieClient.command('write_file', { path: 'VISION.md', content: vision })
       setSaved(true)
-      onNotice('Personality saved! *tail wag*')
+      onNotice('Personality saved!')
       setTimeout(() => setSaved(false), 2000)
     } catch (e) {
       onNotice(e instanceof Error ? e.message : 'Failed to save')
@@ -46,7 +46,7 @@ export default function ProfileTab({ onNotice }: Props): React.JSX.Element {
       </p>
       {loading ? (
         <div className="py-8 text-center text-sm" style={{ color: 'var(--collie-paw)' }}>
-          Sniffing out your settings...
+          Looking through your settings...
         </div>
       ) : (
         <>

--- a/collie-ui/src/renderer/src/lib/locales/en.ts
+++ b/collie-ui/src/renderer/src/lib/locales/en.ts
@@ -1,13 +1,13 @@
 /** English — the reference dictionary. Every key must exist here. */
 export const en = {
   'app.loading': 'Collie is waking up...',
-  'app.loadingSub': '*stretching paws, wagging tail*',
+  'app.loadingSub': '*warming up…*',
 
   'sidebar.newChat': 'New chat',
-  'sidebar.searchPlaceholder': 'Sniff through chats...',
+  'sidebar.searchPlaceholder': 'Search chats...',
   'sidebar.searchLabel': 'Search conversations',
   'sidebar.empty': "Nothing here yet! Start a chat — I'm all ears.",
-  'sidebar.noMatches': 'No matches — my nose came up empty.',
+  'sidebar.noMatches': 'No matches found.',
   'sidebar.settings': 'Settings',
   'sidebar.delete': 'Delete chat: {title}',
   'sidebar.working': 'Collie is working on this chat',

--- a/collie-ui/src/renderer/src/screens/ConnectorsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ConnectorsScreen.tsx
@@ -203,7 +203,7 @@ export default function ConnectorsScreen(): React.JSX.Element {
       }
     } catch (error) {
       setProgress(null)
-      setNotice(error instanceof Error ? error.message : 'That connection slipped my paws.')
+      setNotice(error instanceof Error ? error.message : "That connection didn't go through.")
     } finally {
       connectInFlight.current = false
       setBusy(false)
@@ -245,7 +245,7 @@ export default function ConnectorsScreen(): React.JSX.Element {
               .testConnector(selected.id)
               .then(({ connection }) => {
                 setSelected(connection)
-                setNotice('Connection looks healthy. *tail wag*')
+                setNotice('Connection looks healthy.')
               })
               .catch((error) =>
                 setNotice(error instanceof Error ? error.message : 'The check failed.')


### PR DESCRIPTION
## What

Collie's **voice** changes from a dog persona to a warm, friendly person — **all visuals stay exactly the same** (desktop pet, logo, sprites, animations, "with a dog" tagline, pet portraits).

## Changes

| Area | Change |
|---|---|
| **System prompt** (`identity.md`) | "heart of a Border Collie" → "warm, friendly personality"; dog-humor rule → light humor |
| **Default personality** (`settings.py` `_DEFAULT_VISION`) | "smart, loyal dog who can type" → "friendly person who can type" |
| **Thinking phrases** (`thinking.py`) | "Sniffing out…" → "Looking through…", "Fetching…" → "Getting…", "Burying…" → "Saving…", "All done — tail wag included" → "All done!", etc. **Pet animation keys untouched** |
| **Messenger welcomes** | Telegram/Discord: "Woof! … 🐕" → "Hi! … 😊"; "sniff out the weather" → "check the weather" |
| **Other chat strings** | pairing reply, "Uh oh. I chased my tail" errors (3×), "poke my nose in there", "sniff out a clear schedule", "paws full"/"buddies" subagent strings, recipe prompt, OAuth "tail wag" page |
| **UI strings** | toasts (*tail wag* removed), loading ("Sniffing out your…" → "Looking through your…"), search placeholder ("Sniff through chats" → "Search chats") |
| **Voice spec** | `collie-core/AGENTS.md` voice rules updated |
| **Tests** | 9 test files updated to the new strings (fixtures used Woof!/dog phrases) |

## Verification

| Gate | Result |
|---|---|
| pytest full tree | **3375 passed / 5 failed** (documented Linux baseline: DPAPI + flaky ipc) / 1 skipped |
| pytest tests/collie | 529 passed / 5 baseline / 1 skipped |
| pytest tests/agent | 871 passed |
| ruff | All checks passed |
| UI typecheck + vitest | ✅ + 179 passed |
| snapshot `--check` | current |

## Visuals confirmed untouched
`pet/` sprites, v2 atlas, `collie_pet.py`, `AgentAvatar` dog portrait, "Your personal AI. With a dog." tagline, tray tooltip — all unchanged.

## Note for merge order
This branch and PR #18 (`feat/prompt-hygiene`) both edit `identity.md` in **different regions**. Whichever merges second will show a trivial conflict there — rebase onto merged main to resolve.
