### PR TITLE
feat: linux AppImage packaging (first cross-platform artifact)

### DIFF
--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -26,6 +26,15 @@ nsis:
   oneClick: true
   perMachine: false
   warningsAsErrors: false
+linux:
+  icon: build/icon.png
+  target:
+    - target: AppImage
+      arch:
+        - x64
+  artifactName: Collie-${version}.${ext}
+  category: Utility
+  maintainer: Collie <hello@heycollie.com>
 publish:
   provider: github
   owner: FoxRick

--- a/collie-ui/scripts/stage-core.cjs
+++ b/collie-ui/scripts/stage-core.cjs
@@ -1,4 +1,4 @@
-const { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } = require('fs')
+const { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } = require('fs')
 const { dirname, join, relative, resolve, sep } = require('path')
 const { spawnSync } = require('child_process')
 const {
@@ -146,6 +146,14 @@ function stagePythonWindows(pythonHome) {
   copyVenvSitePackages(join(destination, 'Lib', 'site-packages'))
 }
 
+function isSymbolicLink(path) {
+  try {
+    return lstatSync(path).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
 function stagePythonLinux(pythonHome) {
   // python-build-standalone install layout:
   //   bin/python3(.12), lib/python3.12/…, lib/libpython3.12.so.1.0
@@ -163,20 +171,26 @@ function stagePythonLinux(pythonHome) {
   const destination = join(stageRoot, 'python')
   mkdirSync(destination, { recursive: true })
 
-  copyTree(join(pythonHome, 'bin'), join(destination, 'bin'), (rel) => {
+  // Skip symlinks: python-build-standalone ships absolute aliases (python3,
+  // pip3, idle3, libpython3.11.so → the build machine's paths). Only regular
+  // files are portable; the python3 launcher is recreated below.
+  copyTree(join(pythonHome, 'bin'), join(destination, 'bin'), (rel, source) => {
     if (!rel) return true
-    return !isCacheOrBytecode(rel)
+    if (isCacheOrBytecode(rel)) return false
+    return !isSymbolicLink(source)
   })
-  copyTree(join(pythonHome, 'lib', stdlib), join(destination, 'lib', stdlib), (rel) => {
+  copyTree(join(pythonHome, 'lib', stdlib), join(destination, 'lib', stdlib), (rel, source) => {
     if (!rel) return true
+    if (isSymbolicLink(source)) return false
     const normalized = rel.replaceAll('\\', '/')
     if (normalized === 'site-packages' || normalized.startsWith('site-packages/')) return false
     return !isCacheOrBytecode(normalized)
   })
   for (const entry of readdirSync(join(pythonHome, 'lib'))) {
-    if (entry.startsWith('libpython')) {
-      cpSync(join(pythonHome, 'lib', entry), join(destination, 'lib', entry), { force: true })
-    }
+    if (!entry.startsWith('libpython')) continue
+    const source = join(pythonHome, 'lib', entry)
+    if (isSymbolicLink(source)) continue
+    cpSync(source, join(destination, 'lib', entry), { force: true })
   }
 
   copyVenvSitePackages(join(destination, 'lib', stdlib, 'site-packages'))
@@ -302,8 +316,14 @@ function stageMcpRuntimeLinux() {
   return runtimeRoot
 }
 
+function bundledPythonLauncher() {
+  return process.platform === 'win32'
+    ? join(stageRoot, 'python', 'python.exe')
+    : join(stageRoot, 'python', 'bin', 'python3')
+}
+
 function verifyBundle() {
-  const python = join(stageRoot, 'python', 'python.exe')
+  const python = bundledPythonLauncher()
   const result = spawnSync(
     python,
     [
@@ -337,7 +357,7 @@ stagePython(pythonHome)
 const mcpRuntimeRoot = stageMcpRuntime()
 verifyBundle()
 const mcpProbe = spawnSync(
-  join(stageRoot, 'python', 'python.exe'),
+  bundledPythonLauncher(),
   ['-m', 'collie_core.services.packaged_probe'],
   {
     cwd: stageRoot,

--- a/collie-ui/scripts/stage-core.cjs
+++ b/collie-ui/scripts/stage-core.cjs
@@ -179,19 +179,20 @@ function stagePythonLinux(pythonHome) {
     if (isCacheOrBytecode(rel)) return false
     return !isSymbolicLink(source)
   })
-  copyTree(join(pythonHome, 'lib', stdlib), join(destination, 'lib', stdlib), (rel, source) => {
+  // Whole lib/ tree: stdlib (minus its site-packages, replaced below by the
+  // venv's), shared libs (libpython3.11.so.1.0, libtcl9.0.so, libtcl9tk9.0.so)
+  // and the bundled Tcl/Tk 9.0 script dirs (tcl9.0/, tk9.0/, itcl4.3.5/) the
+  // bundled _tkinter needs to load.
+  copyTree(join(pythonHome, 'lib'), join(destination, 'lib'), (rel, source) => {
     if (!rel) return true
     if (isSymbolicLink(source)) return false
     const normalized = rel.replaceAll('\\', '/')
-    if (normalized === 'site-packages' || normalized.startsWith('site-packages/')) return false
+    if (normalized.startsWith(`${stdlib}/`) && (
+      normalized === `${stdlib}/site-packages` ||
+      normalized.startsWith(`${stdlib}/site-packages/`)
+    )) return false
     return !isCacheOrBytecode(normalized)
   })
-  for (const entry of readdirSync(join(pythonHome, 'lib'))) {
-    if (!entry.startsWith('libpython')) continue
-    const source = join(pythonHome, 'lib', entry)
-    if (isSymbolicLink(source)) continue
-    cpSync(source, join(destination, 'lib', entry), { force: true })
-  }
 
   copyVenvSitePackages(join(destination, 'lib', stdlib, 'site-packages'))
 

--- a/collie-ui/scripts/stage-core.cjs
+++ b/collie-ui/scripts/stage-core.cjs
@@ -1,4 +1,4 @@
-const { cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync } = require('fs')
+const { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } = require('fs')
 const { dirname, join, relative, resolve, sep } = require('path')
 const { spawnSync } = require('child_process')
 const {
@@ -93,11 +93,21 @@ function stageSource() {
   cpSync(join(coreRoot, 'pyproject.toml'), join(stageRoot, 'pyproject.toml'))
 }
 
-function stagePython(pythonHome) {
-  if (process.platform !== 'win32') {
-    fail('The installer staging script currently supports the Windows NSIS package only.')
+function venvSitePackages() {
+  const windows = join(coreRoot, '.venv', 'Lib', 'site-packages')
+  if (existsSync(windows)) return windows
+  const unixLib = join(coreRoot, '.venv', 'lib')
+  if (existsSync(unixLib)) {
+    for (const entry of readdirSync(unixLib, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !/^python3\.\d+$/.test(entry.name)) continue
+      const candidate = join(unixLib, entry.name, 'site-packages')
+      if (existsSync(candidate)) return candidate
+    }
   }
+  fail(`venv site-packages not found under ${coreRoot}/.venv`)
+}
 
+function stagePythonWindows(pythonHome) {
   const pythonExe = join(pythonHome, 'python.exe')
   if (!existsSync(pythonExe)) {
     fail(`Python runtime not found at ${pythonExe}. Set COLLIE_PYTHON_HOME correctly.`)
@@ -133,12 +143,76 @@ function stagePython(pythonHome) {
     })
   }
 
-  const venvSitePackages = join(coreRoot, '.venv', 'Lib', 'site-packages')
-  copyTree(venvSitePackages, join(destination, 'Lib', 'site-packages'), (rel) => {
+  copyVenvSitePackages(join(destination, 'Lib', 'site-packages'))
+}
+
+function stagePythonLinux(pythonHome) {
+  // python-build-standalone install layout:
+  //   bin/python3(.12), lib/python3.12/…, lib/libpython3.12.so.1.0
+  const launcher = join(pythonHome, 'bin', 'python3')
+  if (!existsSync(launcher)) {
+    fail(
+      `Python runtime not found at ${launcher}. Set COLLIE_PYTHON_HOME to a ` +
+        'python-build-standalone install directory (contains bin/python3 and lib/python3.x).'
+    )
+  }
+  const stdlib = readdirSync(join(pythonHome, 'lib'))
+    .find((entry) => /^python3\.\d+$/.test(entry))
+  if (!stdlib) fail(`No python3.x stdlib directory under ${join(pythonHome, 'lib')}.`)
+
+  const destination = join(stageRoot, 'python')
+  mkdirSync(destination, { recursive: true })
+
+  copyTree(join(pythonHome, 'bin'), join(destination, 'bin'), (rel) => {
+    if (!rel) return true
+    return !isCacheOrBytecode(rel)
+  })
+  copyTree(join(pythonHome, 'lib', stdlib), join(destination, 'lib', stdlib), (rel) => {
+    if (!rel) return true
+    const normalized = rel.replaceAll('\\', '/')
+    if (normalized === 'site-packages' || normalized.startsWith('site-packages/')) return false
+    return !isCacheOrBytecode(normalized)
+  })
+  for (const entry of readdirSync(join(pythonHome, 'lib'))) {
+    if (entry.startsWith('libpython')) {
+      cpSync(join(pythonHome, 'lib', entry), join(destination, 'lib', entry), { force: true })
+    }
+  }
+
+  copyVenvSitePackages(join(destination, 'lib', stdlib, 'site-packages'))
+
+  // electron-builder beforePack + the Electron main resolve the launcher as
+  // <resources>/collie-core/python/bin/python3 — make sure it exists.
+  const stagedBin = join(destination, 'bin')
+  if (!existsSync(join(stagedBin, 'python3'))) {
+    const candidates = readdirSync(stagedBin)
+      .filter((name) => /^python3(\.\d+)?$/.test(name))
+      .sort()
+    const launcherBinary = candidates[candidates.length - 1]
+    if (!launcherBinary) fail(`No python3 launcher staged in ${stagedBin}.`)
+    cpSync(join(stagedBin, launcherBinary), join(stagedBin, 'python3'), { force: true })
+  }
+}
+
+function copyVenvSitePackages(destination) {
+  const venvPackages = venvSitePackages()
+  copyTree(venvPackages, destination, (rel) => {
     if (!rel) return true
     if (isCacheOrBytecode(rel)) return false
-    return filterPortableSitePackage(rel, join(venvSitePackages, rel))
+    return filterPortableSitePackage(rel, join(venvPackages, rel))
   })
+}
+
+function stagePython(pythonHome) {
+  if (process.platform === 'win32') {
+    stagePythonWindows(pythonHome)
+    return
+  }
+  if (process.platform === 'linux') {
+    stagePythonLinux(pythonHome)
+    return
+  }
+  fail('The installer staging script currently supports the Windows NSIS and Linux AppImage packages only.')
 }
 
 function verifyPortableBundle() {
@@ -158,13 +232,22 @@ function nodeExecutable() {
 }
 
 function stageMcpRuntime() {
-  if (process.platform !== 'win32') {
-    fail('The packaged MCP runtime currently supports Windows x64 only.')
+  if (process.platform === 'win32') {
+    if (process.arch !== 'x64') {
+      fail(`The alpha supports Windows x64 only; this build is ${process.arch}.`)
+    }
+    return stageMcpRuntimeWindows()
   }
-  if (process.arch !== 'x64') {
-    fail(`The alpha supports Windows x64 only; this build is ${process.arch}.`)
+  if (process.platform === 'linux') {
+    if (process.arch !== 'x64') {
+      fail(`The alpha supports x64 only; this build is ${process.arch}.`)
+    }
+    return stageMcpRuntimeLinux()
   }
+  fail('The packaged MCP runtime currently supports Windows x64 and Linux x64 only.')
+}
 
+function stageMcpRuntimeWindows() {
   const sourceNode = nodeExecutable()
   if (!existsSync(sourceNode)) {
     fail(`Node runtime not found at ${sourceNode}. Set COLLIE_NODE_EXE correctly.`)
@@ -178,6 +261,34 @@ function stageMcpRuntime() {
   rmSync(runtimeRoot, { recursive: true, force: true })
   mkdirSync(join(runtimeRoot, 'node'), { recursive: true })
   cpSync(sourceNode, join(runtimeRoot, 'node', 'node.exe'), { force: true })
+
+  const nodeLicense = join(dirname(sourceNode), 'LICENSE')
+  if (existsSync(nodeLicense)) {
+    cpSync(nodeLicense, join(runtimeRoot, 'node', 'LICENSE'), { force: true })
+  }
+
+  copyTree(
+    join(uiRoot, 'runtime', 'mcp-probe-server'),
+    join(runtimeRoot, 'servers', 'mcp-probe-server')
+  )
+  return runtimeRoot
+}
+
+function stageMcpRuntimeLinux() {
+  const sourceNode = nodeExecutable()
+  if (!existsSync(sourceNode)) {
+    fail(`Node runtime not found at ${sourceNode}. Set COLLIE_NODE_EXE correctly.`)
+  }
+
+  const runtimeRoot = join(stageParent, 'mcp-runtime')
+  const rel = relative(uiRoot, runtimeRoot)
+  if (!rel || rel.startsWith(`..${sep}`) || rel === '..') {
+    fail(`Refusing to reset MCP staging path outside the UI repository: ${runtimeRoot}`)
+  }
+  rmSync(runtimeRoot, { recursive: true, force: true })
+  // packaged_probe resolves the launcher as <mcp-runtime>/node/bin/node on Unix.
+  mkdirSync(join(runtimeRoot, 'node', 'bin'), { recursive: true })
+  cpSync(sourceNode, join(runtimeRoot, 'node', 'bin', 'node'), { force: true })
 
   const nodeLicense = join(dirname(sourceNode), 'LICENSE')
   if (existsSync(nodeLicense)) {

--- a/collie-ui/src/main/python.ts
+++ b/collie-ui/src/main/python.ts
@@ -89,8 +89,13 @@ export async function spawnCore(isDev: boolean): Promise<void> {
   delete env.PYTHONHOME
   delete env.VIRTUAL_ENV
   const nodeDir = join(bundledMcpRuntime(isDev), 'node')
-  if (existsSync(join(nodeDir, 'node.exe'))) {
-    env.PATH = `${nodeDir}${process.platform === 'win32' ? ';' : ':'}${env.PATH ?? ''}`
+  const nodeExecutable = join(
+    nodeDir,
+    process.platform === 'win32' ? 'node.exe' : join('bin', 'node')
+  )
+  if (existsSync(nodeExecutable)) {
+    const nodePathDir = process.platform === 'win32' ? nodeDir : join(nodeDir, 'bin')
+    env.PATH = `${nodePathDir}${process.platform === 'win32' ? ';' : ':'}${env.PATH ?? ''}`
   }
 
   state = 'starting'


### PR DESCRIPTION
## What

First cross-platform packaging: a Linux AppImage target, with the staging
script taught how to bundle a portable Python runtime on Linux. This is the
proving ground for the multi-platform release plan (Windows installer exists
in config only today; Mac is the follow-up). One repo, one electron-builder
config — the `win` NSIS path is **untouched**.

## Changes

| File | Change |
|---|---|
| `collie-ui/electron-builder.yml` | add `linux:` section — AppImage x64, `Collie-${version}.${ext}` |
| `collie-ui/scripts/stage-core.cjs` | platform dispatch for `stagePython`/`stageMcpRuntime`; Linux branch stages a python-build-standalone runtime (stdlib + shared libs + bundled Tcl/Tk 9.0 for the tkinter pet) and merges the venv site-packages; skips absolute symlinks (non-portable dev aliases); `verifyBundle`/MCP probe use `bin/python3` on non-win32 |
| `collie-ui/src/main/python.ts` | bundled Node detection for both layouts (`node.exe` vs `bin/node`) |

## Verification (built + booted on the Linux VM)

| Gate | Result |
|---|---|
| `npm run stage:core` (Linux, COLLIE_PYTHON_HOME=python-build-standalone 3.11) | `Collie bundled core imports OK` + `Collie packaged MCP probe OK` + portability-leak check clean |
| `npx electron-builder --linux AppImage --x64` | `dist/Collie-0.1.0-alpha.4.AppImage` (360 MB) |
| Packaged-app boot (extracted AppImage, Xvfb :10.0) | main window + pet window open; bundled `python3 -m collie_core.runtime --port 3818` → `Collie IPC listening on ws://127.0.0.1:3818` → `COLLIE_READY {"port": 3818}`; bundled pet (tkinter 9.0) alive |
| `npx vitest run` | 36 files / 179 tests passed |
| `npm run typecheck` | OK |

Artifact contents verified: `resources/collie-core/python/bin/python3`,
`lib/python3.11/site-packages` (217 pkgs), `mcp-runtime/node/bin/node`,
`collie-build-provenance.json` (dirty: false).

## Notes / follow-ups (NOT in this PR)

- `npm run dist` / `release-output.cjs` stays Windows-shaped (`.exe`,
  `win-unpacked`, `alpha.yml`) — the CI release workflow that orchestrates
  per-platform artifacts is a separate step.
- Mac (`mac:` targets + macOS staging + signing decision) is the next step,
  needs a Mac runner + Apple Developer cert.
- `desktopName` warning from electron-builder (window association) — cosmetic,
  can set `linux.desktopName` later.
