### PR TITLE
ci: test-on-push + automated release workflow (launch pipeline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  collie-core:
+    name: collie-core (Python 3.11)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: collie-core
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: collie-core/pyproject.toml
+
+      - name: Install core with dev extras
+        run: python -m pip install -e ".[dev]"
+
+      - name: Install tkinter for the pet tests (best effort)
+        # The desktop pet (tests/collie/test_pet_status.py) is a tkinter GUI.
+        # python3-tk installs for the system Python; the runner Python may or
+        # may not see it — the pytest step below checks the runner Python and
+        # falls back to --ignore only when tkinter is genuinely unavailable.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-tk || echo "python3-tk unavailable; pet tests will be ignored"
+
+      - name: Lint (ruff)
+        run: python -m ruff check nanobot collie_core tests
+
+      - name: Test (tests/collie)
+        run: |
+          set -o pipefail
+          PET=""
+          if python -c "import tkinter" >/dev/null 2>&1; then
+            echo "tkinter available in the runner Python — pet tests included"
+          else
+            echo "tkinter unavailable in the runner Python — ignoring pet tests"
+            PET="--ignore=tests/collie/test_pet_status.py"
+          fi
+          # Documented Linux-only failures are deselected, never masked with
+          # `|| true`:
+          #  - test_services.py credential/connect/disconnect tests exercise
+          #    CredentialStore, which raises "Encrypted service credentials
+          #    require Windows DPAPI." on non-win32 (collie_core/services/
+          #    credentials.py:38).
+          #  - test_ipc.py::test_read_write_file_rejects_escape_paths is
+          #    Windows-shaped and flaky on Linux (documented in
+          #    docs + repo testing notes).
+          python -m pytest tests/collie -q $PET \
+            --deselect tests/collie/test_services.py::test_credential_store_roundtrip \
+            --deselect tests/collie/test_services.py::test_connect_api_key_service \
+            --deselect tests/collie/test_services.py::test_connect_oauth_service \
+            --deselect tests/collie/test_services.py::test_disconnect_service \
+            --deselect tests/collie/test_ipc.py::test_read_write_file_rejects_escape_paths
+
+  collie-ui:
+    name: collie-ui (Node 22)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: collie-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: collie-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests (vitest)
+        run: npx vitest run
+
+      - name: Build (electron-vite)
+        run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,14 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Ensure the managed standalone Python is installed
+        # setup-uv only guarantees the version is *available*; on some
+        # runners the activated venv is built from the setup-python
+        # interpreter and no managed python lands in the uv install dir.
+        # An explicit install makes the staged runtime deterministic.
+        if: matrix.standalone
+        run: uv python install ${{ matrix.python }}
+
       - name: Point COLLIE_PYTHON_HOME at the staged runtime
         shell: bash
         run: |
@@ -91,7 +99,7 @@ jobs:
             # uv-managed pythons are python-build-standalone installs with
             # the portable bin/ + lib/python3.x layout stage-core.cjs expects.
             PBS_DIR=$(uv python dir)
-            DIR=$(ls -d "$PBS_DIR"/cpython-${{ matrix.python }}.* 2>/dev/null | head -1)
+            DIR=$(ls -d "$PBS_DIR"/cpython-${{ matrix.python }}.* 2>/dev/null | head -1 || true)
             if [ -z "$DIR" ] || [ ! -x "$DIR/bin/python3" ]; then
               echo "::error::python-build-standalone ${{ matrix.python }} not found under $PBS_DIR"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
             runners — no human build machine.
 
             ### Artifacts
-            - **Windows x64**: `Collie-Setup-<version>.exe` (NSIS, one-click)
+            - **Windows x64**: `Collie-Setup-<version>.exe` (NSIS, assisted setup wizard)
               + `.blockmap` + `alpha.yml`
             - **macOS (arm64)**: `.dmg` + `.zip` (electron-updater). x64/Intel
               builds are a follow-up — they need a per-arch staged Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
 # Tag-triggered installer pipeline: builds the Windows NSIS installer,
-# macOS dmg+zip, and Linux AppImage entirely on GitHub-hosted runners — no
-# human build machine required. Artifacts are attached to a DRAFT GitHub
-# Release (tag must be pushed by a maintainer; the release stays draft so a
-# human publishes it after the documented release checks).
+# macOS dmg+zip (arm64 for alpha), and Linux AppImage entirely on
+# GitHub-hosted runners — no human build machine required. Artifacts are
+# attached to a DRAFT GitHub Release (tag must be pushed by a maintainer;
+# the release stays draft so a human publishes it after the documented
+# release checks).
 #
 # Signing notes (alpha):
 #  - Windows: the installer is unsigned (no code-signing cert); SmartScreen
@@ -160,17 +161,20 @@ jobs:
         with:
           name: collie-${{ matrix.os }}
           if-no-files-found: error
+          # upload-artifact resolves paths from the repo root (GITHUB_WORKSPACE),
+          # not the job's working-directory — the electron-builder output lives
+          # under collie-ui/dist/.
           path: |
-            dist/Collie-Setup-*.exe*
-            dist/alpha.yml
-            dist/Collie-*.AppImage*
-            dist/alpha-linux.yml
-            dist/Collie-*.dmg*
-            dist/Collie-*.zip*
-            dist/alpha-mac.yml
-            dist/collie-build-provenance.json
-            dist/collie-artifact-provenance.json
-            dist/SHA256SUMS.txt
+            collie-ui/dist/Collie-Setup-*.exe*
+            collie-ui/dist/alpha.yml
+            collie-ui/dist/Collie-*.AppImage*
+            collie-ui/dist/alpha-linux.yml
+            collie-ui/dist/Collie-*.dmg*
+            collie-ui/dist/Collie-*.zip*
+            collie-ui/dist/alpha-mac.yml
+            collie-ui/dist/collie-build-provenance.json
+            collie-ui/dist/collie-artifact-provenance.json
+            collie-ui/dist/SHA256SUMS.txt
 
   release:
     name: Draft GitHub Release
@@ -210,7 +214,9 @@ jobs:
             ### Artifacts
             - **Windows x64**: `Collie-Setup-<version>.exe` (NSIS, one-click)
               + `.blockmap` + `alpha.yml`
-            - **macOS**: `.dmg` + `.zip` for arm64 and x64 (electron-updater)
+            - **macOS (arm64)**: `.dmg` + `.zip` (electron-updater). x64/Intel
+              builds are a follow-up — they need a per-arch staged Python
+              runtime, not yet implemented.
             - **Linux x64**: `.AppImage`
 
             `SHA256SUMS.txt` covers every attached artifact. The Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,10 +158,12 @@ jobs:
           if-no-files-found: error
           path: |
             dist/Collie-Setup-*.exe*
+            dist/alpha.yml
             dist/Collie-*.AppImage*
+            dist/alpha-linux.yml
             dist/Collie-*.dmg*
             dist/Collie-*.zip*
-            dist/*.yml
+            dist/alpha-mac.yml
             dist/collie-build-provenance.json
             dist/collie-artifact-provenance.json
             dist/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,10 @@ jobs:
             collie-ui/dist/alpha-mac.yml
             collie-ui/dist/collie-build-provenance.json
             collie-ui/dist/collie-artifact-provenance.json
-            collie-ui/dist/SHA256SUMS.txt
+            # Note: the Windows job's dist/SHA256SUMS.txt is intentionally not
+            # uploaded — the release job regenerates one combined manifest over
+            # every platform artifact (a per-platform manifest would otherwise
+            # collide and break `sha256sum -c` on the attached file).
 
   release:
     name: Draft GitHub Release
@@ -202,6 +205,9 @@ jobs:
       - name: Generate combined SHA256SUMS.txt
         run: |
           cd artifacts
+          # No per-platform manifest is uploaded, so every file here is a
+          # release artifact; the manifest itself is excluded from its own
+          # glob (shell expands * before the redirect writes the file).
           sha256sum * > SHA256SUMS.txt
           echo "--- SHA256SUMS.txt ---"
           cat SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python }}
-          python-install-dir: ${{ runner.temp }}/pbs-python
 
       - name: Point COLLIE_PYTHON_HOME at the staged runtime
         shell: bash
@@ -90,7 +89,12 @@ jobs:
           if [ "${{ matrix.standalone }}" = "true" ]; then
             # uv-managed pythons are python-build-standalone installs with
             # the portable bin/ + lib/python3.x layout stage-core.cjs expects.
-            DIR=$(ls -d "$RUNNER_TEMP"/pbs-python/cpython-${{ matrix.python }}.* | head -1)
+            PBS_DIR=$(uv python dir)
+            DIR=$(ls -d "$PBS_DIR"/cpython-${{ matrix.python }}.* 2>/dev/null | head -1)
+            if [ -z "$DIR" ] || [ ! -x "$DIR/bin/python3" ]; then
+              echo "::error::python-build-standalone ${{ matrix.python }} not found under $PBS_DIR"
+              exit 1
+            fi
             echo "COLLIE_PYTHON_HOME=$DIR" >> "$GITHUB_ENV"
           else
             # Windows: full setup-python install (python.exe, python312.dll,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,229 @@
+name: Release
+
+# Tag-triggered installer pipeline: builds the Windows NSIS installer,
+# macOS dmg+zip, and Linux AppImage entirely on GitHub-hosted runners — no
+# human build machine required. Artifacts are attached to a DRAFT GitHub
+# Release (tag must be pushed by a maintainer; the release stays draft so a
+# human publishes it after the documented release checks).
+#
+# Signing notes (alpha):
+#  - Windows: the installer is unsigned (no code-signing cert); SmartScreen
+#    may warn. Signing with an EV/OV cert is a follow-up.
+#  - macOS: codesign + notarization are SKIPPED for alpha — there is no Apple
+#    Developer certificate yet (CSC_IDENTITY_AUTO_DISCOVERY=false below).
+#    The unsigned dmg is acceptable for alpha but Gatekeeper will show
+#    "Apple cannot check it for malicious software" — users must
+#    right-click → Open. A $99/yr Apple Developer account + notarytool
+#    secrets (APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID) are the
+#    follow-up.
+#
+# Secrets: only the automatic secrets.GITHUB_TOKEN is used. No real secrets
+# are referenced or committed; APPLE_* / signing certs are placeholders for
+# future work.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            flags: --win
+            # stage-core.cjs stages python312.dll + the .venv/Scripts layout,
+            # so the Windows runtime must be CPython 3.12. COLLIE_PYTHON_HOME
+            # is the full setup-python install ($pythonLocation).
+            python: "3.12"
+            standalone: false
+          - os: macos-latest
+            flags: --mac
+            python: "3.11"
+            # macOS + Linux use a python-build-standalone install as the
+            # staged runtime (bundled Tcl/Tk 9.0 for the pet, portable
+            # layout); the venv wheels must ABI-match it (3.11 = cp311).
+            standalone: true
+          - os: ubuntu-latest
+            flags: --linux
+            python: "3.11"
+            standalone: true
+    env:
+      # Never let electron-builder auto-publish on CI: the `release` job owns
+      # GitHub Release creation. (GITHUB_TOKEN is present on Actions, so
+      # electron-builder would otherwise publish from the build jobs.)
+      CSC_IDENTITY_AUTO_DISCOVERY: "false" # macOS: unsigned alpha builds
+    defaults:
+      run:
+        working-directory: collie-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: collie-ui/package-lock.json
+
+      - name: Install UI dependencies
+        run: npm ci
+
+      - name: Set up Python for the build venv
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install standalone Python runtime (python-build-standalone)
+        if: matrix.standalone
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python }}
+          python-install-dir: ${{ runner.temp }}/pbs-python
+
+      - name: Point COLLIE_PYTHON_HOME at the staged runtime
+        shell: bash
+        run: |
+          if [ "${{ matrix.standalone }}" = "true" ]; then
+            # uv-managed pythons are python-build-standalone installs with
+            # the portable bin/ + lib/python3.x layout stage-core.cjs expects.
+            DIR=$(ls -d "$RUNNER_TEMP"/pbs-python/cpython-${{ matrix.python }}.* | head -1)
+            echo "COLLIE_PYTHON_HOME=$DIR" >> "$GITHUB_ENV"
+          else
+            # Windows: full setup-python install (python.exe, python312.dll,
+            # DLLs/, Lib/, tcl/).
+            echo "COLLIE_PYTHON_HOME=$pythonLocation" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create core venv and install runtime dependencies
+        shell: bash
+        working-directory: collie-core
+        run: |
+          python -m venv .venv
+          if [ "$RUNNER_OS" = "Windows" ]; then PY=".venv/Scripts/python"; else PY=".venv/bin/python"; fi
+          "$PY" -m pip install -e ".[dev]"
+
+      - name: Write build provenance (requires a clean tree)
+        run: npm run provenance:write
+
+      - name: Build renderer + main bundles
+        run: npm run build
+
+      - name: Stage the bundled Python core + MCP runtime
+        env:
+          COLLIE_PYTHON_HOME: ${{ env.COLLIE_PYTHON_HOME }}
+        run: npm run stage:core
+
+      - name: Generate macOS icon set (iconutil, macOS-only)
+        if: runner.os == 'macOS'
+        shell: bash
+        working-directory: collie-ui/build
+        run: |
+          # electron-builder looks for build/icon.icns by default; the repo
+          # tracks only icon.png (1024x1024) + icon.ico. Generate the icns on
+          # the runner so the branded portrait ships in the dmg/zip.
+          mkdir -p icon.iconset
+          for s in 16 32 128 256 512; do
+            sips -z "$s" "$s" icon.png --out "icon.iconset/icon_${s}x${s}.png" >/dev/null
+            sips -z "$((s * 2))" "$((s * 2))" icon.png --out "icon.iconset/icon_${s}x${s}@2x.png" >/dev/null
+          done
+          iconutil -c icns icon.iconset -o icon.icns
+          rm -rf icon.iconset
+
+      - name: Package installer (${{ matrix.flags }})
+        run: npx electron-builder ${{ matrix.flags }} --publish never
+
+      - name: Finalize Windows release directory (provenance + SHA256SUMS)
+        # The repo's artifact-provenance tooling is Windows-shaped (asserts
+        # Collie-Setup-*.exe + alpha.yml). Run it on the Windows job only so
+        # dist/ carries collie-build-provenance.json,
+        # collie-artifact-provenance.json and SHA256SUMS.txt exactly as
+        # docs/operations/release/ documents.
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cp .electron-bundle/build-provenance.json dist/collie-build-provenance.json
+          rm -rf dist/win-unpacked
+          rm -f dist/builder-effective-config.yaml dist/builder-debug.yml
+          COLLIE_RELEASE_DIR=dist npm run artifact-provenance:write
+          ls -la dist
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: collie-${{ matrix.os }}
+          if-no-files-found: error
+          path: |
+            dist/Collie-Setup-*.exe*
+            dist/Collie-*.AppImage*
+            dist/Collie-*.dmg*
+            dist/Collie-*.zip*
+            dist/*.yml
+            dist/collie-build-provenance.json
+            dist/collie-artifact-provenance.json
+            dist/SHA256SUMS.txt
+
+  release:
+    name: Draft GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate combined SHA256SUMS.txt
+        run: |
+          cd artifacts
+          sha256sum * > SHA256SUMS.txt
+          echo "--- SHA256SUMS.txt ---"
+          cat SHA256SUMS.txt
+
+      - name: Create GitHub Release (draft)
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          draft: true
+          prerelease: true
+          body: |
+            ## Collie alpha — automated CI build
+
+            This release was produced end-to-end by the tag-triggered
+            pipeline in `.github/workflows/release.yml` on GitHub-hosted
+            runners — no human build machine.
+
+            ### Artifacts
+            - **Windows x64**: `Collie-Setup-<version>.exe` (NSIS, one-click)
+              + `.blockmap` + `alpha.yml`
+            - **macOS**: `.dmg` + `.zip` for arm64 and x64 (electron-updater)
+            - **Linux x64**: `.AppImage`
+
+            `SHA256SUMS.txt` covers every attached artifact. The Windows
+            build additionally carries `collie-build-provenance.json`
+            (clean-tree git SHA + build time) and
+            `collie-artifact-provenance.json` (per-artifact hashes), written
+            by the repo's own release tooling.
+
+            ### Alpha caveats
+            - **macOS is unsigned** (no Apple Developer certificate yet).
+              Gatekeeper will report "Apple cannot check it for malicious
+              software" — open via right-click → Open, or System Settings →
+              Privacy & Security. Notarization needs a $99/yr Apple Developer
+              account (APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD /
+              APPLE_TEAM_ID secrets) — a follow-up.
+            - **Windows is unsigned**; SmartScreen may warn.
+            - Asset provenance is **incomplete**: per
+              `docs/operations/release/asset-provenance.md`, branded art and
+              third-party marks need a recorded clearance before this build
+              is treated as a general-distribution release.
+            - This is a **draft** release: a maintainer reviews the checksums
+              and publishes it deliberately.

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ coverage/
 # (worktrees commonly symlink node_modules to the main checkout; the release
 # provenance gate requires a clean tree and would otherwise refuse to build).
 node_modules
+.venv
 **/node_modules/
 dist/
 out/

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,10 @@ collie-core/.tmp-pytest-audit/
 coverage/
 
 # Generic dependency, database, and runtime output
-node_modules/
+# No trailing slash: matches real directories AND symlinked node_modules
+# (worktrees commonly symlink node_modules to the main checkout; the release
+# provenance gate requires a clean tree and would otherwise refuse to build).
+node_modules
 **/node_modules/
 dist/
 out/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Collie
 
+[![CI](https://github.com/FoxRick/Collie/actions/workflows/ci.yml/badge.svg)](https://github.com/FoxRick/Collie/actions/workflows/ci.yml)
+
 Collie is a local-first, chat-first Windows AI assistant for nontechnical
 users. It helps people turn plain-English requests into understandable,
 reviewable work while keeping meaningful actions under their control.

--- a/collie-ui/.gitignore
+++ b/collie-ui/.gitignore
@@ -2,4 +2,7 @@
 out/
 dist/
 .electron-bundle/
+# Generated on macOS runners (iconutil) from build/icon.png; the release
+# provenance gate requires a clean tree, so it must stay untracked.
+build/icon.icns
 *.log

--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -38,15 +38,17 @@ linux:
 # macOS: unsigned alpha builds (no Apple certificate yet — the CI workflow
 # disables identity discovery). build/icon.icns is generated on the mac
 # runner from build/icon.png (iconutil) so the branded portrait ships.
+# arch: arm64 only — the CI macos runner stages a native-arm64 Python
+# runtime, and an x64 .app carrying arm64 python/site-packages would not
+# run on Intel Macs. x64/universal2 needs per-arch staged runtimes
+# (follow-up, tracked in docs/operations/release).
 mac:
   target:
     - target: dmg
       arch:
-        - x64
         - arm64
     - target: zip
       arch:
-        - x64
         - arm64
   artifactName: Collie-${version}-${arch}.${ext}
   category: public.app-category.productivity

--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -35,6 +35,21 @@ linux:
   artifactName: Collie-${version}.${ext}
   category: Utility
   maintainer: Collie <hello@heycollie.com>
+# macOS: unsigned alpha builds (no Apple certificate yet — the CI workflow
+# disables identity discovery). build/icon.icns is generated on the mac
+# runner from build/icon.png (iconutil) so the branded portrait ships.
+mac:
+  target:
+    - target: dmg
+      arch:
+        - x64
+        - arm64
+    - target: zip
+      arch:
+        - x64
+        - arm64
+  artifactName: Collie-${version}-${arch}.${ext}
+  category: public.app-category.productivity
 publish:
   provider: github
   owner: FoxRick

--- a/collie-ui/scripts/stage-core.cjs
+++ b/collie-ui/scripts/stage-core.cjs
@@ -223,11 +223,15 @@ function stagePython(pythonHome) {
     stagePythonWindows(pythonHome)
     return
   }
-  if (process.platform === 'linux') {
+  if (process.platform === 'linux' || process.platform === 'darwin') {
+    // Both unix targets use the same python-build-standalone install layout
+    // (bin/python3 + lib/python3.x + bundled Tcl/Tk). macOS standalone
+    // builds ship libpython3.11.dylib under lib/ — copied by the same
+    // whole-lib tree logic.
     stagePythonLinux(pythonHome)
     return
   }
-  fail('The installer staging script currently supports the Windows NSIS and Linux AppImage packages only.')
+  fail('The installer staging script currently supports the Windows NSIS, Linux AppImage, and macOS dmg/zip packages only.')
 }
 
 function verifyPortableBundle() {
@@ -253,13 +257,13 @@ function stageMcpRuntime() {
     }
     return stageMcpRuntimeWindows()
   }
-  if (process.platform === 'linux') {
-    if (process.arch !== 'x64') {
-      fail(`The alpha supports x64 only; this build is ${process.arch}.`)
+  if (process.platform === 'linux' || process.platform === 'darwin') {
+    if (process.arch !== 'x64' && process.arch !== 'arm64') {
+      fail(`The packaged MCP runtime supports x64 and arm64; this build is ${process.arch}.`)
     }
     return stageMcpRuntimeLinux()
   }
-  fail('The packaged MCP runtime currently supports Windows x64 and Linux x64 only.')
+  fail('The packaged MCP runtime currently supports Windows x64, Linux x64, and macOS x64/arm64 only.')
 }
 
 function stageMcpRuntimeWindows() {

--- a/docs/operations/release/README.md
+++ b/docs/operations/release/README.md
@@ -8,6 +8,25 @@ This repository does not currently publish a Windows installer or GitHub
 Release. Building from source does not create an official distribution, and
 mutable local `dist/` output must never be represented as one.
 
+## Release pipeline
+
+Tag-triggered CI (`.github/workflows/release.yml`, tags `v*`) builds the
+installers on GitHub-hosted runners — Windows NSIS x64, macOS dmg/zip
+(arm64 + x64, unsigned for alpha), and Linux AppImage x64 — and attaches them
+to a draft GitHub Release with `SHA256SUMS.txt`. Test-on-push CI
+(`.github/workflows/ci.yml`) runs the collie-core pytest + ruff gates and the
+collie-ui typecheck/vitest/build gates on every push and pull request.
+
+Publishing a release still requires a maintainer to push the version tag and
+publish the draft. The draft must not be published until:
+
+- the asset provenance register below records a clearance for branded art and
+  third-party marks (an installer-distribution blocker), and
+- the release candidate passes the repeatable artifact checks documented in
+  `release-artifact-validation.md` (the Windows job runs the repo's own
+  provenance + checksum tooling; macOS signing/notarization is a follow-up
+  once Apple Developer certificates exist).
+
 - `release-artifact-validation.md` documents the repeatable artifact checks
   required before an installer can be published.
 - `asset-provenance.md` records branding and third-party mark boundaries.

--- a/docs/operations/release/README.md
+++ b/docs/operations/release/README.md
@@ -12,7 +12,8 @@ mutable local `dist/` output must never be represented as one.
 
 Tag-triggered CI (`.github/workflows/release.yml`, tags `v*`) builds the
 installers on GitHub-hosted runners — Windows NSIS x64, macOS dmg/zip
-(arm64 + x64, unsigned for alpha), and Linux AppImage x64 — and attaches them
+(arm64 only for alpha; the staged Python runtime is native-arm64, so Intel
+x64 bundles are a follow-up), and Linux AppImage x64 — and attaches them
 to a draft GitHub Release with `SHA256SUMS.txt`. Test-on-push CI
 (`.github/workflows/ci.yml`) runs the collie-core pytest + ruff gates and the
 collie-ui typecheck/vitest/build gates on every push and pull request.


### PR DESCRIPTION
## What this adds

The repo previously had no `.github/` at all. This PR launches the CI + release pipeline:

- **`.github/workflows/ci.yml`** — test-on-push + PR workflow:
  - `collie-core` (ubuntu-latest, Python 3.11): `pip install -e ".[dev]"`, `ruff check nanobot collie_core tests`, `pytest tests/collie` with the **documented Linux-only failures deselected** (DPAPI credential tests in `test_services.py` + the flaky `test_ipc` escape-path case — never masked with `|| true`). Pet tests run when the runner Python has tkinter (`python3-tk` installed best-effort, dynamic `--ignore` fallback — the runner has tkinter, so they run).
  - `collie-ui` (ubuntu-latest, Node 22): `npm ci`, `npm run typecheck`, `npx vitest run`, `npm run build`.
- **`.github/workflows/release.yml`** — tag-triggered (`v*`) installer pipeline on GitHub-hosted runners, **no human build machine**:
  - Build matrix: **windows-latest** (NSIS x64, full repo provenance + checksum tooling), **macos-latest** (dmg + zip, **arm64 only for alpha** — the runner stages a native-arm64 Python; x64/universal2 needs per-arch runtimes, documented follow-up), **ubuntu-latest** (AppImage x64).
  - macOS **unsigned** (`CSC_IDENTITY_AUTO_DISCOVERY=false`, no Apple certs); Gatekeeper caveat in the release notes.
  - Each job: `npm ci` → Python venv (`.venv` with `.[dev]`) → `provenance:write` → `build` → `stage:core` (unix: python-build-standalone via `setup-uv` + `uv python install`, located with `uv python dir`; Windows: setup-python 3.12 matching `python312.dll` staging) → `electron-builder --publish never` (the release job owns publishing).
  - `release` job attaches every OS artifact + one combined `SHA256SUMS.txt` to a **draft** prerelease via `softprops/action-gh-release`, using only `secrets.GITHUB_TOKEN`.
- **`collie-ui/electron-builder.yml`** — new `mac:` section (dmg + zip; `build/icon.icns` generated on the runner from `icon.png` via iconutil).
- **`collie-ui/scripts/stage-core.cjs`** — darwin support: python-build-standalone unix layout + `bin/node` MCP runtime, arm64 allowed.
- **`.gitignore`** (root) — `node_modules`/`.venv` without trailing slash so symlinked deps (worktree pattern) and setup-uv's root `.venv` don't trip the provenance clean-tree gate. **`collie-ui/.gitignore`** — generated `build/icon.icns`.
- **README** — CI status badge. **`docs/operations/release/README.md`** — documents the pipeline + remaining gates.

## Verification (real runs)

### CI (PR #21 branch) — green on every push
| Gate | Result |
| --- | --- |
| `ruff check nanobot collie_core tests` (local + CI) | ✅ All checks passed |
| `pytest tests/collie` (CI; tkinter available → pet tests included) | ✅ **543 passed, 1 skipped, 5 deselected** (documented Linux-only) |
| `npm run typecheck` (local + CI) | ✅ |
| `npx vitest run` (local + CI) | ✅ 36 files / 179 tests passed |
| `npm run build` (local + CI) | ✅ |
| workflow YAML (PyYAML safe_load) | ✅ ci.yml + release.yml parse |
| snapshot `--check` parity | ✅ counts identical — no regen needed |

### Release pipeline — end-to-end green on a disposable tag (`v0.1.0-ci-test`)
The tag was pushed 4 times; each round fixed a real issue found by the real runner:
1. `setup-uv@v5` has no `python-install-dir` input → managed python located via `uv python dir` + glob, with explicit `uv python install` (macOS hit the missing-managed-python case).
2. `upload-artifact` resolves paths from the repo root, not the job `working-directory` → globs prefixed `collie-ui/dist/` (Windows had already built the installer + provenance + SHA256SUMS; only the upload failed).
3. macOS beforePack provenance gate: the iconutil step's `build/icon.icns` was untracked → ignored now.
4. pipefail-safe glob (`ls | head || true`) — GitHub bash runs `-e -o pipefail`.

**Final run: all 4 jobs green** — `Build (ubuntu-latest)`, `Build (macos-latest)`, `Build (windows-latest)`, `Draft GitHub Release` — and the release job uploaded every artifact:
`Collie-Setup-0.1.0-alpha.4.exe` (+blockmap), `Collie-0.1.0-alpha.4-arm64.dmg`/`.zip` (+blockmaps), `Collie-0.1.0-alpha.4.AppImage`, `alpha.yml` / `alpha-linux.yml` / `alpha-mac.yml`, `collie-build-provenance.json`, `collie-artifact-provenance.json`, `SHA256SUMS.txt`.

Also verified locally on the VM: `provenance:write → build → stage:core → electron-builder --linux AppImage --x64` produced `dist/Collie-0.1.0-alpha.4.AppImage` (376 MB) with bundled-core imports + MCP probe OK.

### Cleanup after the test
The disposable tag was deleted. One **orphaned draft release** (untagged, created for the test tag) remains on the repo — the owner can delete it in the GitHub UI (Releases → draft) in one click; it is invisible to everyone else.

## Known follow-ups
- **macOS signing/notarization**: $99/yr Apple Developer account (`APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` secrets). Unsigned dmg is the alpha posture.
- **macOS Intel (x64) / universal2**: needs per-arch staged Python runtimes.
- **Windows code signing** (SmartScreen): cert follow-up.
- **First real release**: maintainer pushes the `v*` tag and publishes the draft after the release checks; the asset-provenance register still blocks general distribution.
- Coverage badge omitted (full-suite `--cov` + upload target/token needed); cheap to add later.
- `tools/validate_release_artifacts.py` is Windows-shaped; the Windows CI job runs the repo's own artifact-provenance + checksum tooling instead.
