### PR TITLE
feat: Gardener phases 2-4 — versioned rollback, dream memory, self-improvement MVP

### DIFF
--- a/collie-core/collie_core/automations/scheduler.py
+++ b/collie-core/collie_core/automations/scheduler.py
@@ -20,7 +20,11 @@ from collie_core.db import CollieDB, utc_now
 from collie_core.routines.models import Schedule
 from collie_core.routines.schedule import next_occurrence
 
-__all__ = ["AutomationScheduler", "seed_builtin_automations"]
+__all__ = [
+    "AutomationScheduler",
+    "seed_builtin_automations",
+    "seed_gardener_automations",
+]
 
 BUILTIN_AUTOMATIONS = [
     {
@@ -136,6 +140,62 @@ def seed_builtin_automations(db: CollieDB) -> None:
     db.set_setting("automations.builtins_seeded", True)
 
 
+# Gardener-family built-ins (PR 3 + PR 4 of the Gardener Foundations plan).
+# Seeded under their own flag so installs that already ran
+# ``seed_builtin_automations`` still get them — and, like all built-ins,
+# a user deletion is never resurrected.
+GARDENER_AUTOMATIONS = [
+    {
+        "id": "collie-memory-maintenance",
+        "name": "Memory maintenance",
+        "description": "Weekly memory consolidation (Dream)",
+        "schedule": "Sun 09:00",
+        "action_type": "memory_maintenance",
+        "action_config": {
+            "kind": "dream",
+            "prompt": "",
+        },
+        "enabled": False,
+        "delivery_channels": ["in_app"],
+    },
+    {
+        "id": "collie-gardener-suggestions",
+        "name": "Improvement suggestions",
+        "description": "Weekly improvement suggestions from run records",
+        "schedule": "Sun 10:00",
+        "action_type": "gardener",
+        "action_config": {
+            "kind": "gardener",
+            "prompt": "",
+        },
+        "enabled": False,
+        "delivery_channels": ["in_app"],
+    },
+]
+
+
+def seed_gardener_automations(db: CollieDB) -> None:
+    """Seed the Gardener automations once (never resurrect deletions)."""
+    if db.get_setting("automations.gardener_seeded", False):
+        return
+    existing = {a["id"] for a in db.list_automations()}
+    for auto in GARDENER_AUTOMATIONS:
+        if auto["id"] in existing:
+            continue
+        db.add_automation(
+            auto["name"],
+            automation_id=auto["id"],
+            description=auto["description"],
+            schedule=auto["schedule"],
+            action_type=auto["action_type"],
+            action_config=auto["action_config"],
+            enabled=bool(auto.get("enabled", False)),
+            delivery_channels=auto["delivery_channels"],
+        )
+        logger.info("Seeded automation: {}", auto["name"])
+    db.set_setting("automations.gardener_seeded", True)
+
+
 def _match_schedule(schedule_str: str, now: datetime) -> bool:
     """Check if ``now`` matches a schedule string.
 
@@ -184,6 +244,7 @@ class AutomationScheduler:
 
     async def start(self) -> None:
         seed_builtin_automations(self.db)
+        seed_gardener_automations(self.db)
         stale_before = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(
             timespec="seconds"
         )

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -537,6 +537,31 @@ CREATE INDEX IF NOT EXISTS idx_memory_journal_created
     ON memory_journal(created_at DESC);
 """
 
+# Versioned artifact store (PR 2 of the Gardener Foundations plan): every
+# user-visible artifact edit (subagent files, VISION.md / AGENTS.md /
+# MEMORY.md, dream consolidations, Gardener applies) is snapshotted with a
+# before/after text pair + unified diff so any change can be rolled back
+# without clobbering newer owner edits. Complementary to the memory_journal
+# (which records per-key memory mutations) — this records full-file states.
+_SCHEMA_V14 = """
+CREATE TABLE IF NOT EXISTS artifact_versions (
+  id TEXT PRIMARY KEY,
+  artifact_type TEXT NOT NULL,      -- subagent|vision|agents|memory_profile|memory_dream|skill
+  artifact_key TEXT NOT NULL,       -- subagent filename | "VISION.md" | "AGENTS.md" | "MEMORY.md" | "memory/MEMORY.md"
+  version INTEGER NOT NULL,
+  before_text TEXT,
+  after_text TEXT,
+  diff_text TEXT,                   -- difflib.unified_diff
+  evidence_json TEXT,               -- Gardener trigger evidence (run ids, tool stats)
+  source TEXT NOT NULL DEFAULT 'user',  -- user|collie|gardener
+  status TEXT NOT NULL DEFAULT 'applied', -- applied|rolled_back
+  created_at TEXT NOT NULL,
+  UNIQUE(artifact_type, artifact_key, version)
+);
+CREATE INDEX IF NOT EXISTS idx_artifact_versions_type
+  ON artifact_versions(artifact_type, artifact_key, version DESC);
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -552,6 +577,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V11,
     _SCHEMA_V12,
     _SCHEMA_V13,
+    _SCHEMA_V14,
 ]
 
 
@@ -3480,6 +3506,99 @@ class CollieDB:
             for row in rows
         ]
 
+    # -- artifact versions (Gardener rollback rail) ---------------------------------------------
+
+    def snapshot_artifact(
+        self,
+        artifact_type: str,
+        artifact_key: str,
+        before_text: str,
+        after_text: str,
+        diff_text: str,
+        evidence: Any = None,
+        source: str = "user",
+    ) -> dict[str, Any]:
+        """Append a version row for an artifact edit; returns the new row."""
+        with self._write_immediate() as conn:
+            row = conn.execute(
+                "SELECT MAX(version) AS v FROM artifact_versions "
+                "WHERE artifact_type = ? AND artifact_key = ?",
+                (artifact_type, artifact_key),
+            ).fetchone()
+            version = int(row["v"] or 0) + 1
+            version_id = new_id()
+            conn.execute(
+                "INSERT INTO artifact_versions (id, artifact_type, artifact_key, "
+                "version, before_text, after_text, diff_text, evidence_json, "
+                "source, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, "
+                "'applied', ?)",
+                (
+                    version_id,
+                    artifact_type,
+                    artifact_key,
+                    version,
+                    before_text,
+                    after_text,
+                    diff_text,
+                    json.dumps(evidence, ensure_ascii=False) if evidence is not None else None,
+                    source,
+                    utc_now(),
+                ),
+            )
+            return {
+                "id": version_id,
+                "artifact_type": artifact_type,
+                "artifact_key": artifact_key,
+                "version": version,
+                "status": "applied",
+            }
+
+    def latest_artifact_version(
+        self, artifact_type: str, artifact_key: str
+    ) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT MAX(version) AS v FROM artifact_versions "
+                "WHERE artifact_type = ? AND artifact_key = ?",
+                (artifact_type, artifact_key),
+            ).fetchone()
+            return int(row["v"] or 0) if row else 0
+
+    def list_artifact_versions(
+        self,
+        artifact_type: str | None = None,
+        artifact_key: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List artifact versions, most recent first, with optional filters."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if artifact_type:
+            clauses.append("artifact_type = ?")
+            params.append(artifact_type)
+        if artifact_key:
+            clauses.append("artifact_key = ?")
+            params.append(artifact_key)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+        return self._rows(
+            f"SELECT * FROM artifact_versions {where} "
+            "ORDER BY created_at DESC, version DESC LIMIT ?",
+            tuple(params),
+        )
+
+    def get_artifact_version(self, version_id: str) -> dict[str, Any] | None:
+        return self._row(
+            "SELECT * FROM artifact_versions WHERE id = ?", (version_id,)
+        )
+
+    def mark_artifact_rolled_back(self, version_id: str) -> None:
+        with self._write() as conn:
+            conn.execute(
+                "UPDATE artifact_versions SET status = 'rolled_back' WHERE id = ?",
+                (version_id,),
+            )
+
     # -- data management ----------------------------------------------------------------------------
 
     def export_all(self) -> dict[str, Any]:
@@ -3525,6 +3644,12 @@ class CollieDB:
             "tool_events": self._rows(
                 "SELECT * FROM tool_events ORDER BY started_at"
             ),
+            "memory_journal": self._rows(
+                "SELECT * FROM memory_journal ORDER BY created_at"
+            ),
+            "artifact_versions": self._rows(
+                "SELECT * FROM artifact_versions ORDER BY created_at, version"
+            ),
             "approval_rules": self.list_approval_rules(),
             "approval_requests": self._rows(
                 "SELECT * FROM approval_requests ORDER BY requested_at"
@@ -3563,6 +3688,7 @@ class CollieDB:
                 "task_checklist_steps", "task_checklists", "conversation_review_gates",
                 "plan_change_requests", "run_task_state_revisions",
                 "tool_events", "turn_events",
+                "artifact_versions",
                 "run_steps",
                 "approval_requests", "approval_rules", "runs", "plans",
                 "messages", "conversations", "profile", "people", "important_dates",

--- a/collie-core/collie_core/gardener/__init__.py
+++ b/collie-core/collie_core/gardener/__init__.py
@@ -1,0 +1,28 @@
+"""Gardener — Collie's self-improvement loop (evidence → propose → review).
+
+The Gardener reads run-record telemetry, proposes conservative
+improvements to agent instruction files and long-term memory, and applies
+them only through the versioned rollback rail after human approval.
+
+MVP scope: no sandbox replay (documented deferral) — deterministic scope
+validation + human approval stand in for it.
+"""
+
+from collie_core.gardener.evidence import collect_evidence
+from collie_core.gardener.propose import (
+    ALLOWED_ARTIFACT_TYPES,
+    ProposalValidationError,
+    propose,
+    validate_suggestion,
+)
+from collie_core.gardener.runner import apply_suggestion, run_gardener
+
+__all__ = [
+    "ALLOWED_ARTIFACT_TYPES",
+    "ProposalValidationError",
+    "apply_suggestion",
+    "collect_evidence",
+    "propose",
+    "run_gardener",
+    "validate_suggestion",
+]

--- a/collie-core/collie_core/gardener/evidence.py
+++ b/collie-core/collie_core/gardener/evidence.py
@@ -1,0 +1,202 @@
+"""Gardener evidence queries — read-only signals over run-record telemetry.
+
+The Gardener's evidence layer answers four questions from the telemetry
+tables (``turn_events`` / ``tool_events``) plus the workspace files:
+
+1. **Repeated tool failures** — tools that error or are denied often enough
+   to be worth a fix (e.g. a tool description tweak).
+2. **Repeated workflows** — tool sequences that appear again and again, a
+   sign the user repeats a multi-step task that could become a routine.
+3. **Denied / stopped turns** — turns the user stopped or that the model
+   ended early, a signal of friction.
+4. **Memory bloat** — ``memory/MEMORY.md`` (long-term) and ``MEMORY.md``
+   (profile mirror) growing past sensible sizes or accumulating duplicate
+   headings.
+
+Everything here is **read-only**: no writes to the DB and no writes to the
+workspace. The Gardener's proposal step consumes the summary and the
+apply step goes through the versioned rollback rail.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "collect_evidence",
+    "memory_bloat",
+    "recent_failures",
+    "repeated_workflows",
+    "user_stops",
+]
+
+# A tool is "failing" when it errors or is denied by the permission layer.
+_FAILING_STATUSES = ("error", "denied", "timeout")
+
+# Tool sequences shorter than this are too trivial to be a workflow.
+_MIN_WORKFLOW_LEN = 2
+# A workflow must appear at least this often to be "repeated".
+_MIN_WORKFLOW_REPEATS = 3
+# A failing tool must trip at least this often before the Gardener bothers.
+_MIN_FAILURE_COUNT = 2
+
+# Memory files the Gardener watches for bloat.
+_MEMORY_FILES = (
+    ("memory", "memory/MEMORY.md"),  # nanobot long-term memory (Dream target)
+    ("profile", "MEMORY.md"),  # ProfileStore mirror
+)
+
+# Soft caps (characters) — above these the Gardener may suggest tidying.
+_SOFT_CAPS: dict[str, int] = {"memory": 12_000, "profile": 12_000}
+
+
+def _since(days: int = 14) -> str:
+    """ISO timestamp ``days`` ago (UTC), the default evidence window."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(
+        timespec="seconds"
+    )
+
+
+def recent_failures(
+    db: Any, since: str | None = None, min_count: int = _MIN_FAILURE_COUNT
+) -> list[dict[str, Any]]:
+    """Per-tool failure counts with sample messages, most failing first."""
+    events = db.list_tool_events(limit=500)
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for event in events:
+        started = str(event.get("started_at") or "")
+        if since and started and started < since:
+            continue
+        if str(event.get("status") or "") not in _FAILING_STATUSES:
+            continue
+        name = str(event.get("tool_name") or "unknown")
+        buckets.setdefault(name, []).append(event)
+
+    rows: list[dict[str, Any]] = []
+    for name, items in buckets.items():
+        if len(items) < min_count:
+            continue
+        samples = [
+            (str(item.get("error_message") or "") or None)
+            for item in items[:3]
+            if item.get("error_message")
+        ]
+        rows.append(
+            {
+                "tool_name": name,
+                "failures": len(items),
+                "statuses": sorted({str(i.get("status") or "") for i in items}),
+                "sample_errors": [s for s in samples if s][:3],
+                "last_seen": max(str(i.get("started_at") or "") for i in items),
+            }
+        )
+    rows.sort(key=lambda r: r["failures"], reverse=True)
+    return rows
+
+
+def repeated_workflows(
+    db: Any,
+    since: str | None = None,
+    min_repeats: int = _MIN_WORKFLOW_REPEATS,
+) -> list[dict[str, Any]]:
+    """Tool sequences (by turn) that recur often enough to suggest a routine.
+
+    A workflow is the ordered list of tool names in one turn (collapsed
+    repeats). Sequences shorter than ``_MIN_WORKFLOW_LEN`` are ignored.
+    """
+    turns = db.list_turn_events(limit=200)
+    sequences: dict[tuple[str, ...], int] = {}
+    for turn in turns:
+        started = str(turn.get("started_at") or "")
+        if since and started and started < since:
+            continue
+        tool_events = db.list_tool_events(turn_id=turn["id"], limit=100)
+        names: list[str] = []
+        for event in tool_events:
+            name = str(event.get("tool_name") or "")
+            if name and (not names or names[-1] != name):
+                names.append(name)
+        if len(names) >= _MIN_WORKFLOW_LEN:
+            key = tuple(names)
+            sequences[key] = sequences.get(key, 0) + 1
+
+    return [
+        {
+            "workflow": list(key),
+            "repeats": count,
+        }
+        for key, count in sorted(
+            sequences.items(), key=lambda item: item[1], reverse=True
+        )
+        if count >= min_repeats
+    ]
+
+
+def user_stops(db: Any, since: str | None = None) -> list[dict[str, Any]]:
+    """Turns the user stopped or that never completed (friction signals)."""
+    turns = db.list_turn_events(limit=200)
+    stopped: list[dict[str, Any]] = []
+    for turn in turns:
+        started = str(turn.get("started_at") or "")
+        if since and started and started < since:
+            continue
+        if str(turn.get("status") or "") in ("stopped", "cancelled"):
+            stopped.append(
+                {
+                    "turn_id": turn["id"],
+                    "status": turn["status"],
+                    "started_at": started,
+                    "conversation_id": str(turn.get("conversation_id") or ""),
+                }
+            )
+    stopped.sort(key=lambda r: r["started_at"], reverse=True)
+    return stopped
+
+
+def memory_bloat(workspace: Path) -> list[dict[str, Any]]:
+    """Size + duplicate-heading signals for the memory files.
+
+    Returns one entry per watched file that exists, with ``bloated`` set
+    when the file exceeds its soft cap or contains repeated ``#``-headings.
+    """
+    workspace = Path(workspace)
+    findings: list[dict[str, Any]] = []
+    for kind, rel in _MEMORY_FILES:
+        path = workspace / rel
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        headings = [
+            line.strip().lstrip("#").strip().lower()
+            for line in text.splitlines()
+            if line.strip().startswith("#") and line.strip().lstrip("#").strip()
+        ]
+        dupes = {
+            heading for heading in headings if headings.count(heading) > 1
+        }
+        bloated = len(text) > _SOFT_CAPS.get(kind, 12_000) or bool(dupes)
+        findings.append(
+            {
+                "kind": kind,
+                "path": rel,
+                "chars": len(text),
+                "lines": len(text.splitlines()),
+                "duplicate_headings": sorted(dupes)[:10],
+                "bloated": bloated,
+            }
+        )
+    return findings
+
+
+def collect_evidence(db: Any, workspace: Path, since: str | None = None) -> dict[str, Any]:
+    """Aggregate the Gardener's evidence into one bounded summary dict."""
+    since = since or _since()
+    return {
+        "since": since,
+        "failures": recent_failures(db, since=since),
+        "workflows": repeated_workflows(db, since=since),
+        "user_stops": user_stops(db, since=since),
+        "memory": memory_bloat(workspace),
+    }

--- a/collie-core/collie_core/gardener/propose.py
+++ b/collie-core/collie_core/gardener/propose.py
@@ -1,0 +1,365 @@
+"""Gardener proposal step — bounded subagent call + strict validation.
+
+The Gardener runs one **bounded, read-only** subagent turn (a single model
+call, no tools, ``read_only`` posture — the same machinery the Dream runner
+uses) with a fixed prompt: the evidence summary and the current agent /
+memory texts go in, a structured JSON list of suggestions comes out.
+
+Nothing the model says is trusted: every suggestion passes through
+:func:`validate_suggestion`, a deterministic gate that enforces
+
+* **artifact allowlist** — only ``subagent``, ``agents``, ``vision`` and
+  ``memory_dream`` targets may be proposed;
+* **key safety** — artifact keys must be plain filenames (no path
+  traversal) and must match the artifact type;
+* **size budgets** — proposed text and rationale are length-capped;
+* **keyword gate** — proposed text mentioning permissions, settings,
+  secrets, connectors, credentials or anything out of the Gardener's
+  scope is rejected outright.
+
+Suggestions that fail validation are dropped with a reason; the runner
+reports how many were rejected.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.runner import AgentRunSpec
+from nanobot.agent.tools.registry import ToolRegistry
+
+__all__ = [
+    "ALLOWED_ARTIFACT_TYPES",
+    "FORBIDDEN_TERMS",
+    "MAX_PROPOSED_CHARS",
+    "MAX_RATIONALE_CHARS",
+    "MAX_SUGGESTIONS",
+    "ProposalValidationError",
+    "propose",
+    "validate_suggestion",
+]
+
+# The only artifact types the Gardener may touch (scope guard from the
+# plan: agent instructions + memory consolidation, nothing else).
+ALLOWED_ARTIFACT_TYPES: tuple[str, ...] = (
+    "subagent",
+    "agents",
+    "vision",
+    "memory_dream",
+)
+
+# Deterministic keyword gate: any of these in a proposed text (or
+# rationale) is out of scope and the suggestion is rejected. Deliberately
+# conservative and plain-worded — the Gardener never proposes changes to
+# permissions, settings, secrets, or connectors.
+FORBIDDEN_TERMS: tuple[str, ...] = (
+    "permission",
+    "approval",
+    "approve",
+    "auto-approv",
+    "settings",
+    "setting",
+    "secret",
+    "password",
+    "credential",
+    "api key",
+    "apikey",
+    "token",
+    "connector",
+    "oauth",
+    "billing",
+    "payment",
+    "credit card",
+    "model provider",
+    "provider key",
+)
+
+# Size budgets (characters).
+MAX_PROPOSED_CHARS = 4_000
+MAX_RATIONALE_CHARS = 500
+MAX_SUGGESTIONS = 3
+
+# Evidence summary length budget for the prompt (≈2k tokens of text).
+MAX_EVIDENCE_CHARS = 8_000
+# Per-artifact current-text budget fed to the model.
+MAX_ARTIFACT_TEXT_CHARS = 6_000
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
+
+_GARDENER_SYSTEM_PROMPT = (
+    "You are Collie's improvement Gardener. Follow the instructions in the "
+    "user message exactly, and output only the requested JSON."
+)
+
+_GARDENER_PROMPT_TEMPLATE = """You help Collie (a local-first AI assistant for non-coders) improve itself.
+
+Below is evidence from Collie's recent run records (tool failures, repeated
+workflows, stopped turns, memory size) and the current text of a few agent
+instruction / memory files.
+
+## Evidence
+{evidence}
+
+## Current files
+{artifacts}
+
+## Your task
+Propose up to {max_suggestions} concrete, conservative improvements. Each
+suggestion must do exactly ONE of:
+
+- rewrite one agent instruction file (AGENTS.md, VISION.md) so Collie's
+  instructions match observed friction (e.g. a tool that keeps failing,
+  a workflow the user repeats),
+- tighten one subagent prompt (subagents/<name>.md),
+- tidy the long-term memory file (memory/MEMORY.md): merge duplicates,
+  prune stale entries, keep facts atomic.
+
+Output ONLY a JSON array (no markdown, no commentary):
+[{{"artifact_type": "subagent|agents|vision|memory_dream",
+   "artifact_key": "<plain filename>",
+   "proposed_text": "<full new file content>",
+   "rationale": "<1-2 sentences, referencing the evidence>",
+   "evidence_ids": ["<short labels from the evidence, e.g. 'failures:web_fetch'>"]}}]
+
+Rules:
+- Never propose changes to permissions, settings, secrets, credentials,
+  connectors, billing, or providers. Those are out of scope.
+- Never invent facts. Base every change on the evidence above.
+- Keep proposed_text complete (the whole file), not a patch.
+- If nothing is worth changing, output an empty array: []
+"""
+
+
+class ProposalValidationError(Exception):
+    """Raised when a Gardener suggestion violates the scope guard."""
+
+
+def _normalise_key(key: str) -> str:
+    return (key or "").strip().lstrip("/")
+
+
+def validate_suggestion(suggestion: dict[str, Any]) -> dict[str, Any]:
+    """Strictly validate one model-proposed suggestion (deterministic).
+
+    Returns the cleaned suggestion, or raises
+    :class:`ProposalValidationError` with a human reason. This is the
+    Gardener's security boundary: nothing a model says is ever applied
+    without passing through here (the apply path re-validates too).
+    """
+    artifact_type = str(suggestion.get("artifact_type") or "").strip()
+    if artifact_type not in ALLOWED_ARTIFACT_TYPES:
+        raise ProposalValidationError(
+            f"'{artifact_type or '(missing)'}' is not a target the Gardener "
+            "may change."
+        )
+
+    key = _normalise_key(str(suggestion.get("artifact_key") or ""))
+    if not key or "/" in key or "\\" in key or key in (".", ".."):
+        raise ProposalValidationError(
+            f"'{key}' is not a safe artifact key (plain filenames only)."
+        )
+
+    if artifact_type == "subagent":
+        if not key.endswith(".md"):
+            raise ProposalValidationError(
+                "Subagent suggestions must target a '.md' file."
+            )
+    elif artifact_type in ("agents", "vision"):
+        expected = "AGENTS.md" if artifact_type == "agents" else "VISION.md"
+        if key != expected:
+            raise ProposalValidationError(
+                f"{artifact_type} suggestions must target '{expected}'."
+            )
+    elif artifact_type == "memory_dream":
+        if key != "MEMORY.md":
+            raise ProposalValidationError(
+                "Memory suggestions must target 'MEMORY.md'."
+            )
+
+    proposed = str(suggestion.get("proposed_text") or "")
+    if not proposed.strip():
+        raise ProposalValidationError(
+            "The proposed text is empty — there's nothing to apply."
+        )
+    if len(proposed) > MAX_PROPOSED_CHARS:
+        raise ProposalValidationError(
+            f"The proposed text is {len(proposed)} characters — over the "
+            f"{MAX_PROPOSED_CHARS}-character budget."
+        )
+    rationale = str(suggestion.get("rationale") or "")
+    if len(rationale) > MAX_RATIONALE_CHARS:
+        raise ProposalValidationError(
+            f"The rationale is {len(rationale)} characters — over the "
+            f"{MAX_RATIONALE_CHARS}-character budget."
+        )
+
+    evidence_ids = suggestion.get("evidence_ids") or []
+    if not isinstance(evidence_ids, list):
+        evidence_ids = []
+    evidence_ids = [str(item) for item in evidence_ids][:10]
+
+    # Keyword gate on the actual content (case-insensitive, word-bounded
+    # where it matters). This is the deterministic scope guard.
+    haystack = f"{proposed}\n{rationale}".lower()
+    for term in FORBIDDEN_TERMS:
+        if term in haystack:
+            raise ProposalValidationError(
+                f"The proposal mentions '{term}', which is out of scope for "
+                "the Gardener (permissions, settings, secrets, and "
+                "connectors are never auto-suggested)."
+            )
+
+    return {
+        "artifact_type": artifact_type,
+        "artifact_key": key,
+        "proposed_text": proposed,
+        "rationale": rationale,
+        "evidence_ids": evidence_ids,
+    }
+
+
+def _extract_json(response: str) -> list[dict[str, Any]]:
+    """Pull the suggestion array out of a model response, best-effort."""
+    text = (response or "").strip()
+    match = _FENCE_RE.search(text)
+    if match:
+        text = match.group(1).strip()
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError):
+        start, end = text.find("["), text.rfind("]")
+        if start == -1 or end <= start:
+            return []
+        try:
+            parsed = json.loads(text[start : end + 1])
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def _artifact_text(workspace: Path, artifact_type: str, key: str) -> str:
+    """Read a (validated) artifact's current text for the prompt."""
+    base = Path(workspace)
+    if artifact_type == "subagent":
+        path = base / "subagents" / key
+    elif artifact_type == "memory_dream":
+        path = base / "memory" / key
+    else:
+        path = base / key
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def build_prompt(evidence: dict[str, Any], workspace: Path) -> str:
+    """Render the Gardener prompt (bounded: evidence + current texts)."""
+    evidence_text = json.dumps(evidence, ensure_ascii=False, indent=1)
+    if len(evidence_text) > MAX_EVIDENCE_CHARS:
+        evidence_text = evidence_text[:MAX_EVIDENCE_CHARS] + "\n…(truncated)"
+
+    sections: list[str] = []
+    for artifact_type in ALLOWED_ARTIFACT_TYPES:
+        if artifact_type == "subagent":
+            sub_dir = Path(workspace) / "subagents"
+            if not sub_dir.exists():
+                continue
+            for path in sorted(sub_dir.glob("*.md")):
+                text = path.read_text(encoding="utf-8")
+                sections.append(
+                    f"### subagents/{path.name}\n{text[:MAX_ARTIFACT_TEXT_CHARS]}"
+                )
+        elif artifact_type == "memory_dream":
+            path = Path(workspace) / "memory" / "MEMORY.md"
+            if path.exists():
+                text = path.read_text(encoding="utf-8")
+                sections.append(
+                    f"### memory/MEMORY.md\n{text[:MAX_ARTIFACT_TEXT_CHARS]}"
+                )
+        else:
+            key = "AGENTS.md" if artifact_type == "agents" else "VISION.md"
+            path = Path(workspace) / key
+            if path.exists():
+                text = path.read_text(encoding="utf-8")
+                sections.append(f"### {key}\n{text[:MAX_ARTIFACT_TEXT_CHARS]}")
+
+    return _GARDENER_PROMPT_TEMPLATE.format(
+        evidence=evidence_text,
+        artifacts="\n\n".join(sections) if sections else "(no files yet)",
+        max_suggestions=MAX_SUGGESTIONS,
+    )
+
+
+async def propose(
+    loop: Any,
+    workspace: Path,
+    evidence: dict[str, Any],
+    session_key: str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run the bounded Gardener turn; return (valid, rejected) suggestions.
+
+    ``valid`` is the validated, cleaned suggestion list; ``rejected`` is a
+    list of ``{"reason": str, "artifact_type": str, "artifact_key": str}``
+    for the suggestions the deterministic gate refused. Both are safe to
+    render.
+    """
+    workspace = Path(workspace)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    gardener_key = session_key or f"gardener:{stamp}"
+
+    spec = AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": _GARDENER_SYSTEM_PROMPT},
+            {"role": "user", "content": build_prompt(evidence, workspace)},
+        ],
+        tools=ToolRegistry(),  # no tools: bounded, read-only by construction
+        runtime=loop.llm_runtime(),
+        max_iterations=1,
+        max_tool_result_chars=4000,
+        hook=None,
+        session_key=gardener_key,
+        workspace=workspace,
+        execution_posture="read_only",
+    )
+
+    try:
+        result = await loop.subagents.runner.run(spec)
+    except Exception:
+        logger.exception("Gardener proposal turn failed")
+        return [], [{"reason": "turn_error", "artifact_type": "", "artifact_key": ""}]
+
+    if getattr(result, "stop_reason", None) != "completed":
+        logger.warning(
+            "Gardener proposal turn did not complete (stop_reason={})",
+            getattr(result, "stop_reason", None),
+        )
+        return [], [
+            {
+                "reason": f"stop_reason:{getattr(result, 'stop_reason', 'unknown')}",
+                "artifact_type": "",
+                "artifact_key": "",
+            }
+        ]
+
+    raw = _extract_json(getattr(result, "final_content", None) or "")
+    valid: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for suggestion in raw[: MAX_SUGGESTIONS + 2]:
+        try:
+            valid.append(validate_suggestion(suggestion))
+        except ProposalValidationError as exc:
+            rejected.append(
+                {
+                    "reason": str(exc),
+                    "artifact_type": str(suggestion.get("artifact_type") or ""),
+                    "artifact_key": str(suggestion.get("artifact_key") or ""),
+                }
+            )
+    return valid[:MAX_SUGGESTIONS], rejected

--- a/collie-core/collie_core/gardener/runner.py
+++ b/collie-core/collie_core/gardener/runner.py
@@ -1,0 +1,164 @@
+"""Gardener runner — evidence → proposals → review cards → versioned apply.
+
+The runner ties the Gardener story together:
+
+1. :func:`run_gardener` collects evidence (read-only telemetry queries),
+   runs the bounded proposal turn, validates every suggestion, and returns
+   the suggestion list for the review surface (chat cards with
+   Approve/Dismiss).
+2. :func:`apply_suggestion` applies ONE approved suggestion through the
+   versioned rollback rail: the current artifact text is snapshotted with
+   the proposed text (``source="gardener"``), the new text is written, and
+   dependent state (the subagent loader's disk→DB mirror) is re-synced.
+   Rejected-while-applying is impossible: the suggestion is re-validated
+   here, so even a hand-crafted IPC frame cannot bypass the scope guard.
+
+The MVP deliberately has **no sandbox replay** (running a proposed change
+in a sandbox before applying it) — that needs run-record history volume the
+product doesn't have yet, and the deterministic scope guard + human
+approval stand in for it. This is a documented deferral, not a gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from collie_core.gardener.evidence import collect_evidence
+from collie_core.gardener.propose import propose, validate_suggestion
+from collie_core.versions import make_diff
+
+__all__ = ["apply_suggestion", "run_gardener"]
+
+_MAX_SUGGESTIONS_IN_CARD = 3
+
+
+def _target_path(workspace: Path, artifact_type: str, key: str) -> Path:
+    """Resolve a validated artifact type+key to its workspace path."""
+    base = Path(workspace)
+    if artifact_type == "subagent":
+        return base / "subagents" / key
+    if artifact_type == "memory_dream":
+        return base / "memory" / key
+    return base / key
+
+
+def apply_suggestion(
+    *,
+    workspace: Path,
+    suggestion: dict[str, Any],
+    version_store: Any = None,
+    subagent_loader: Any = None,
+) -> dict[str, Any]:
+    """Apply one approved (re-validated) suggestion, versioned + undoable.
+
+    Returns ``{"applied": True, "version_id": ..., "diff_text": ...}``.
+    Raises :class:`ProposalValidationError` when the suggestion is out of
+    scope, and :class:`ValueError` when the target cannot be written.
+    """
+    # Re-validate at apply time: the review card data could have been
+    # forged or edited between propose and approve.
+    cleaned = validate_suggestion(suggestion)
+
+    workspace = Path(workspace)
+    target = _target_path(workspace, cleaned["artifact_type"], cleaned["artifact_key"])
+    before = target.read_text(encoding="utf-8") if target.exists() else ""
+
+    proposed = cleaned["proposed_text"]
+    new_text = proposed if proposed.endswith("\n") else proposed + "\n"
+    if before == new_text:
+        return {
+            "applied": True,
+            "no_change": True,
+            "version_id": None,
+            "diff_text": "",
+            "artifact_type": cleaned["artifact_type"],
+            "artifact_key": cleaned["artifact_key"],
+        }
+
+    version_id: str | None = None
+    if version_store is not None:
+        try:
+            version_id = version_store.snapshot(
+                cleaned["artifact_type"],
+                cleaned["artifact_key"],
+                before,
+                new_text,
+                evidence={
+                    "evidence_ids": cleaned.get("evidence_ids") or [],
+                    "rationale": cleaned.get("rationale") or "",
+                },
+                source="gardener",
+            )
+        except Exception:
+            # Versioning is a rollback rail — never block the apply.
+            logger.exception("gardener apply version snapshot failed (swallowed)")
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(new_text, encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"I couldn't write the change: {exc}") from exc
+
+    # Subagent edits live in both the file and the loader's DB mirror;
+    # reconcile disk -> DB so the two never disagree.
+    if cleaned["artifact_type"] == "subagent" and subagent_loader is not None:
+        try:
+            subagent_loader.sync()
+        except Exception:
+            logger.exception("subagent re-sync after gardener apply failed (swallowed)")
+
+    return {
+        "applied": True,
+        "no_change": False,
+        "version_id": version_id,
+        "diff_text": make_diff(before, new_text, cleaned["artifact_key"]),
+        "artifact_type": cleaned["artifact_type"],
+        "artifact_key": cleaned["artifact_key"],
+    }
+
+
+async def run_gardener(
+    *,
+    workspace: Path,
+    db: Any,
+    loop: Any,
+    version_store: Any = None,
+    since: str | None = None,
+) -> dict[str, Any]:
+    """Run one Gardener pass: evidence → proposals → validated suggestions.
+
+    Returns ``{"suggestions": [...], "rejected": [...], "message": str,
+    "evidence": {...}}``. ``suggestions`` is the validated list for the
+    review cards; ``rejected`` reports what the scope guard refused.
+    """
+    workspace = Path(workspace)
+    evidence = collect_evidence(db, workspace, since=since)
+
+    if not (evidence["failures"] or evidence["workflows"] or
+            evidence["user_stops"] or any(m.get("bloated") for m in evidence["memory"])):
+        return {
+            "suggestions": [],
+            "rejected": [],
+            "evidence": evidence,
+            "message": "No improvement signals this week — run records look healthy.",
+        }
+
+    valid, rejected = await propose(loop, workspace, evidence)
+    suggestions = valid[:_MAX_SUGGESTIONS_IN_CARD]
+    if not suggestions:
+        message = "I looked at the run records but nothing rose to a suggestion worth your time."
+    else:
+        message = (
+            f"I found {len(suggestions)} suggestion"
+            f"{'' if len(suggestions) == 1 else 's'} from the last two weeks "
+            "of run records. Review each one — you can approve or dismiss."
+        )
+    return {
+        "suggestions": suggestions,
+        "rejected": rejected,
+        "evidence": evidence,
+        "message": message,
+    }

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -201,6 +201,8 @@ class CollieIPCServer:
         on_set_approval_preset: Callable[[str], None] | None = None,
         legacy_oauth_root: Path | None = None,
         token: str | None = None,
+        dream_runner: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+        gardener_runner: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     ) -> None:
         self.db = db
         self.host = host
@@ -232,6 +234,8 @@ class CollieIPCServer:
         self._on_set_approval_preset = on_set_approval_preset
         self._legacy_oauth_root = Path(legacy_oauth_root or legacy_oauth_data_root())
         self._token = token
+        self._dream_runner = dream_runner
+        self._gardener_runner = gardener_runner
         self._clients: set[ServerConnection] = set()
         self._server: Any = None
         self._chat_tasks: dict[str, asyncio.Task] = {}
@@ -1185,6 +1189,52 @@ class CollieIPCServer:
             limit = 50
         return {"entries": self.db.list_memory_journal(limit=max(1, min(limit, 500)))}
 
+    async def _cmd_run_dream(self, connection: ServerConnection, frame: dict) -> dict:
+        """Manual trigger: run one Dream consolidation pass now."""
+        if self._dream_runner is None:
+            raise ValueError("The memory review isn't available right now.")
+        outcome = await self._dream_runner()
+        return dict(outcome or {})
+
+    async def _cmd_get_dream_history(self, connection: ServerConnection, frame: dict) -> dict:
+        """Past Dream consolidations (memory_dream versions), newest first."""
+        versions = await asyncio.to_thread(
+            self.db.list_artifact_versions,
+            artifact_type="memory_dream",
+            limit=50,
+        )
+        return {"versions": versions}
+
+    async def _cmd_run_gardener(self, connection: ServerConnection, frame: dict) -> dict:
+        """Manual trigger: run one Gardener pass (evidence → suggestions)."""
+        if self._gardener_runner is None:
+            raise ValueError("The improvement suggestions aren't available right now.")
+        outcome = await self._gardener_runner()
+        return dict(outcome or {})
+
+    async def _cmd_apply_gardener_suggestion(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        """Approve one suggestion: re-validate, apply, version (undoable)."""
+        from collie_core.gardener.propose import ProposalValidationError
+        from collie_core.gardener.runner import apply_suggestion
+        from collie_core.versions import VersionStore
+
+        suggestion = frame.get("suggestion")
+        if not isinstance(suggestion, dict):
+            raise ValueError("A suggestion is required to approve.")
+        try:
+            result = await asyncio.to_thread(
+                apply_suggestion,
+                workspace=collie_home() / "workspace",
+                suggestion=suggestion,
+                version_store=VersionStore(self.db),
+                subagent_loader=self._subagent_loader,
+            )
+        except ProposalValidationError as exc:
+            raise ValueError(str(exc)) from exc
+        return result
+
     def _memory(self) -> Any:
         if self._profile_store is None:
             raise ValueError("memory is not available")
@@ -1440,8 +1490,117 @@ class CollieIPCServer:
         file_path = self._resolve_workspace_path(str(frame.get("path") or ""))
         content = str(frame.get("content") or "")
         file_path.parent.mkdir(parents=True, exist_ok=True)
+        before = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
+        artifact = self._classify_workspace_artifact(file_path)
+        version_id: str | None = None
+        diff_text: str | None = None
+        if artifact is not None and before != content:
+            from collie_core.versions import VersionStore, make_diff
+
+            version_id = VersionStore(self.db).snapshot(
+                artifact[0], artifact[1], before, content, source="user"
+            )
+            if version_id is not None:
+                diff_text = make_diff(before, content, artifact[1])
         file_path.write_text(content, encoding="utf-8")
-        return {"saved": True}
+        return {
+            "saved": True,
+            "version_id": version_id,
+            "diff_text": diff_text,
+        }
+
+    def _classify_workspace_artifact(self, file_path: Path) -> tuple[str, str] | None:
+        """Map a workspace file to a versioned artifact type, if it is one."""
+        workspace = Path(os.path.normpath(collie_home() / "workspace"))
+        try:
+            rel = file_path.relative_to(workspace)
+        except ValueError:
+            return None
+        parts = rel.parts
+        if parts == ("VISION.md",):
+            return ("vision", "VISION.md")
+        if parts == ("AGENTS.md",):
+            return ("agents", "AGENTS.md")
+        if parts == ("MEMORY.md",):
+            return ("memory_profile", "MEMORY.md")
+        if parts == ("memory", "MEMORY.md"):
+            return ("memory_dream", "MEMORY.md")
+        if len(parts) == 2 and parts[0] == "subagents" and parts[1].endswith(".md"):
+            return ("subagent", parts[1])
+        return None
+
+    def _artifact_target(self, artifact_type: str, key: str) -> Path:
+        """Resolve an artifact type+key to its workspace path (strict)."""
+        if not key or "/" in key or "\\" in key or key in (".", ".."):
+            raise ValueError("Invalid artifact key")
+        workspace = Path(os.path.normpath(collie_home() / "workspace"))
+        if artifact_type == "subagent":
+            target = workspace / "subagents" / key
+        elif artifact_type == "memory_dream":
+            target = workspace / "memory" / key
+        elif artifact_type in ("vision", "agents", "memory_profile", "skill"):
+            target = workspace / key
+        else:
+            raise ValueError(f"Unknown artifact type: {artifact_type}")
+        if not target.is_relative_to(workspace):
+            raise ValueError("Invalid artifact path")
+        return target
+
+    async def _cmd_list_versions(self, connection: ServerConnection, frame: dict) -> dict:
+        """List artifact versions (most recent first) — read-only rollback rail."""
+        artifact_type = str(frame.get("artifact_type") or "") or None
+        artifact_key = str(frame.get("artifact_key") or "") or None
+        limit = frame.get("limit")
+        try:
+            limit = int(limit) if limit is not None else 100
+        except (TypeError, ValueError):
+            limit = 100
+        versions = await asyncio.to_thread(
+            self.db.list_artifact_versions,
+            artifact_type=artifact_type,
+            artifact_key=artifact_key,
+            limit=max(1, min(limit, 500)),
+        )
+        return {"versions": versions}
+
+    async def _cmd_rollback_artifact(self, connection: ServerConnection, frame: dict) -> dict:
+        """Undo one artifact version (no-clobber guarded) and re-sync state."""
+        from collie_core.versions import VersionConflictError, VersionStore
+
+        version_id = str(frame.get("version_id") or "")
+        row = self.db.get_artifact_version(version_id)
+        if row is None:
+            raise ValueError("I can't find that change — it may have been cleaned up.")
+        artifact_type = str(row["artifact_type"])
+        key = str(row["artifact_key"])
+        target = self._artifact_target(artifact_type, key)
+        current = target.read_text(encoding="utf-8") if target.exists() else ""
+        try:
+            result = VersionStore(self.db).rollback(
+                artifact_type,
+                key,
+                to_version=int(row["version"]),
+                current_text=current,
+            )
+        except VersionConflictError as exc:
+            raise ValueError(str(exc)) from exc
+        restored = result["restored_text"]
+        if restored:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(restored, encoding="utf-8")
+        elif target.exists():
+            target.unlink()
+        # A subagent rollback also restores the database row (or renames it
+        # back): the loader reconciles disk -> DB.
+        if artifact_type == "subagent" and self._subagent_loader is not None:
+            await asyncio.to_thread(self._subagent_loader.sync)
+        return {
+            "rolled_back": True,
+            "version_id": result["version_id"],
+            "artifact_type": artifact_type,
+            "artifact_key": key,
+            "version": result["version"],
+        }
 
     async def _cmd_list_automations(self, connection: ServerConnection, frame: dict) -> dict:
         return {"automations": self.db.list_automations()}

--- a/collie-core/collie_core/memory/dream.py
+++ b/collie-core/collie_core/memory/dream.py
@@ -1,0 +1,226 @@
+"""Collie's Dream runner — episodic memory consolidation (Gardener PR 3).
+
+Wires nanobot's already-vendored Dream machinery (cursor, prompt builder,
+session keys, pruning) into Collie:
+
+1. Build the Dream prompt from unprocessed conversation history via
+   ``MemoryStore.build_dream_prompt()``.
+2. Run a **bounded, read-only** loop turn under a ``dream:<ts>`` session key
+   using the subagent runner machinery (one model call, no tools, no
+   approvals, read-only posture). Collie has no file-editing tools, so the
+   model outputs the full proposed new ``memory/MEMORY.md`` as its final
+   response.
+3. If the proposed content differs from the current file, write it and
+   snapshot it via the version store (``artifact_type="memory_dream"``) so
+   the change is reviewable and undoable in Settings → Memory.
+4. Advance the dream cursor **only on success** (a completed turn — even
+   one that produced no change — so history is never re-processed).
+5. Prune old Dream sessions (keep 10) after each run.
+
+Never touches ProfileStore (the structured profile memory) — Dream
+consolidates nanobot's long-term ``memory/MEMORY.md`` only.
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.runner import AgentRunSpec
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.agent.turn_hooks import AgentTurnHookContext
+
+__all__ = ["run_dream"]
+
+# Collie has no file-editing tools; the Dream model must return the file
+# content directly instead of editing on disk.
+_DREAM_OUTPUT_CONTRACT = """
+
+## Collie output contract
+Collie has no file-editing tools, so you cannot edit files directly. Do not
+try to call any tool. Analyze the Conversation History and the current
+memory files above, then output ONLY the full new content of
+``memory/MEMORY.md`` — the complete file, nothing else. No commentary, no
+preamble, no markdown code fences. Preserve every fact that is still true,
+prune stale entries, and keep facts atomic and non-duplicated.
+"""
+
+_DREAM_SYSTEM_PROMPT = (
+    "You are Collie's memory consolidation engine. Follow the instructions "
+    "in the user message exactly, and output only the requested file content."
+)
+
+_FENCE_RE = re.compile(r"```[a-zA-Z0-9_-]*\s*\n(.*?)```", re.DOTALL)
+
+
+def _extract_file_content(response: str) -> str:
+    """Pull the proposed file content out of a model response."""
+    text = (response or "").strip()
+    match = _FENCE_RE.search(text)
+    if match:
+        return match.group(1).strip()
+    return text
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix="MEMORY.md.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with open(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        Path(tmp_name).replace(path)
+    finally:
+        with suppress(FileNotFoundError):
+            Path(tmp_name).unlink()
+
+
+def _build_turn_hook(loop: Any, session_key: str) -> Any | None:
+    """Compose the loop's telemetry hook factories (best-effort, like
+    ``SubagentManager._run_subagent``) so Dream turns are recorded."""
+    try:
+        factories = getattr(loop.subagents, "hook_factories", None) or []
+        if not factories:
+            return None
+        from nanobot.agent.hook import CompositeHook
+
+        turn_context = AgentTurnHookContext(
+            on_progress=None,
+            workspace=Path(loop.workspace or "."),
+            channel="collie",
+            chat_id="dream",
+            message_id=None,
+            session_key=session_key,
+            metadata={"turn_kind": "automation"},
+        )
+        extra = [factory(turn_context) for factory in factories]
+        extra = [hook for hook in extra if hook is not None]
+        return CompositeHook(extra) if extra else None
+    except Exception:
+        logger.exception("dream telemetry hook build failed (swallowed)")
+        return None
+
+
+async def run_dream(
+    *,
+    workspace: Path,
+    db: Any,
+    loop: Any,
+    version_store: Any = None,
+    session_key: str | None = None,
+) -> dict[str, Any]:
+    """Run one Dream consolidation pass; returns a result summary dict."""
+    from collie_core.versions import make_diff
+
+    store: MemoryStore = loop.context.memory
+    built = store.build_dream_prompt()
+    if built is None:
+        return {
+            "changed": False,
+            "reason": "no_new_history",
+            "message": "Nothing new to review — memory is already up to date.",
+        }
+
+    prompt, cursor = built
+    dream_key = session_key or MemoryStore.dream_session_key()
+
+    spec = AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": _DREAM_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt + _DREAM_OUTPUT_CONTRACT},
+        ],
+        tools=ToolRegistry(),  # no tools: bounded, read-only by construction
+        runtime=loop.llm_runtime(),
+        max_iterations=1,
+        max_tool_result_chars=4000,
+        hook=_build_turn_hook(loop, dream_key),
+        session_key=dream_key,
+        workspace=workspace,
+        execution_posture="read_only",
+    )
+    try:
+        result = await loop.subagents.runner.run(spec)
+    except Exception:
+        logger.exception("Dream turn failed")
+        return {
+            "changed": False,
+            "reason": "turn_error",
+            "message": "The memory review hit a snag — I'll try again later.",
+        }
+
+    if result.stop_reason != "completed":
+        logger.warning(
+            "Dream turn did not complete (stop_reason={}); cursor not advanced",
+            result.stop_reason,
+        )
+        return {
+            "changed": False,
+            "reason": f"stop_reason:{result.stop_reason}",
+            "message": "The memory review didn't finish — I'll try again later.",
+        }
+
+    proposed = _extract_file_content(result.final_content or "")
+    if not proposed:
+        return {
+            "changed": False,
+            "reason": "empty_response",
+            "message": "The memory review came back empty — I'll try again later.",
+        }
+
+    memory_file = Path(workspace) / "memory" / "MEMORY.md"
+    before = memory_file.read_text(encoding="utf-8") if memory_file.exists() else ""
+    new_text = proposed.rstrip() + "\n"
+
+    if before.strip() == new_text.strip():
+        # The run succeeded; history is processed even when nothing changed.
+        store.set_last_dream_cursor(cursor)
+        _prune(workspace)
+        return {
+            "changed": False,
+            "reason": "no_content_change",
+            "cursor": cursor,
+            "message": "Memory review done — everything was already tidy.",
+        }
+
+    _atomic_write(memory_file, new_text)
+    version_id = None
+    if version_store is not None:
+        try:
+            version_id = version_store.snapshot(
+                "memory_dream",
+                "MEMORY.md",
+                before,
+                new_text,
+                evidence={"cursor": cursor, "session_key": dream_key},
+                source="collie",
+            )
+        except Exception:
+            logger.exception("dream version snapshot failed (swallowed)")
+
+    # Success path only: the content is durable and versioned, so the
+    # processed history is marked done.
+    store.set_last_dream_cursor(cursor)
+    _prune(workspace)
+
+    return {
+        "changed": True,
+        "version_id": version_id,
+        "cursor": cursor,
+        "diff": make_diff(before, proposed, "memory/MEMORY.md"),
+        "message": "Memory review done — I tidied up my long-term memory.",
+    }
+
+
+def _prune(workspace: Path) -> None:
+    """Keep only the 10 most recent Dream sessions (best-effort)."""
+    try:
+        MemoryStore.prune_dream_sessions(Path(workspace) / "sessions", keep=10)
+    except Exception:
+        logger.exception("dream session prune failed (swallowed)")

--- a/collie-core/collie_core/memory/profile.py
+++ b/collie-core/collie_core/memory/profile.py
@@ -19,6 +19,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from collie_core.db import CollieDB
 
 __all__ = ["ProfileStore", "PROFILE_KEYS"]
@@ -55,10 +57,33 @@ PROFILE_KEYS: dict[str, str] = {
 class ProfileStore:
     """Structured profile memory backed by SQLite, mirrored to MEMORY.md."""
 
-    def __init__(self, db: CollieDB, workspace: Path):
+    def __init__(
+        self, db: CollieDB, workspace: Path, version_store: Any = None
+    ) -> None:
         self.db = db
         self.workspace = workspace
         self.memory_file = workspace / "MEMORY.md"
+        self._version_store = version_store
+
+    # -- versioning (Gardener rollback rail) --------------------------------
+
+    def _snapshot_memory(self) -> None:
+        """Snapshot MEMORY.md before a regeneration; never breaks the write."""
+        if self._version_store is None:
+            return
+        try:
+            before = ""
+            if self.memory_file.exists():
+                before = self.memory_file.read_text(encoding="utf-8")
+            after = self.memory_markdown()
+            if before != after:
+                self._version_store.snapshot(
+                    "memory_profile", "MEMORY.md", before, after, source="user"
+                )
+        except Exception:
+            # Versioning is a rollback rail — a failure must never block a
+            # memory write the user asked for.
+            logger.exception("memory version snapshot failed (swallowed)")
 
     # -- profile facts -------------------------------------------------------
 
@@ -77,12 +102,14 @@ class ProfileStore:
             "add" if existing is None or existing == "" else "update",
             value,
         )
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def delete(self, key: str) -> None:
         existing = self.db.get_profile(key, None)
         self.db.delete_profile(key)
         self._journal("fact", key, "delete", existing)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def all(self) -> dict[str, Any]:
@@ -99,6 +126,7 @@ class ProfileStore:
         else:
             person = self.db.add_person(name, **fields)
             self._journal("person", name, "add", fields)
+        self._snapshot_memory()
         self.regenerate_memory_md()
         return person  # type: ignore[return-value]
 
@@ -112,12 +140,14 @@ class ProfileStore:
         person = self.db.get_person(person_id) or {}
         self.db.update_person(person_id, **fields)
         self._journal("person", person.get("name") or person_id, "update", fields)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def delete_person(self, person_id: str) -> None:
         person = self.db.get_person(person_id) or {}
         self.db.delete_person(person_id)
         self._journal("person", person.get("name") or person_id, "delete", person)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def list_people(self) -> list[dict[str, Any]]:
@@ -128,6 +158,7 @@ class ProfileStore:
     def add_date(self, date: str, label: str, **kwargs: Any) -> dict[str, Any]:
         row = self.db.add_date(date, label, **kwargs)
         self._journal("date", label, "add", {"date": date, **kwargs})
+        self._snapshot_memory()
         self.regenerate_memory_md()
         return row
 
@@ -138,12 +169,14 @@ class ProfileStore:
         row = self.db.get_date(date_id) or {}
         self.db.update_date(date_id, **fields)
         self._journal("date", row.get("label") or date_id, "update", fields)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def delete_date(self, date_id: str) -> None:
         row = self.db.get_date(date_id) or {}
         self.db.delete_date(date_id)
         self._journal("date", row.get("label") or date_id, "delete", row)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     # -- MEMORY.md generation --------------------------------------------------------

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import json
 import os
 import sys
 import urllib.parse
@@ -63,7 +64,12 @@ class CollieRuntime:
         set_config_path(collie_home() / "config.json")
         self.workspace = collie_settings.ensure_workspace()
         bind_suggest_workspace(self.workspace)
-        self.profile = ProfileStore(self.db, self.workspace)
+        from collie_core.versions import VersionStore
+
+        self.versions = VersionStore(self.db)
+        self.profile = ProfileStore(
+            self.db, self.workspace, version_store=self.versions
+        )
         self.profile.regenerate_memory_md()
         bind_profile_store(self.profile)
         bind_reminders_db(self.db)
@@ -142,6 +148,8 @@ class CollieRuntime:
             conversation_deleter=self.delete_conversation_sessions,
             on_set_approval_preset=self.permission_evaluator.set_local_write_preset,
             token=ipc_token,
+            dream_runner=self._run_dream_manual,
+            gardener_runner=self._run_gardener_manual,
         )
         self.approvals = ApprovalBroker(
             self.db, self.permission_evaluator, self.ipc.broadcast
@@ -729,18 +737,24 @@ class CollieRuntime:
                 action_config = _json.loads(action_config)
             except (TypeError, ValueError):
                 action_config = {}
+        action_type = str(auto.get("action_type") or "")
+
+        # Gardener-family automations run their own bounded pipelines
+        # instead of a free-form prompt turn.
+        if action_type == "memory_maintenance":
+            await self._run_memory_maintenance(auto)
+            return
+        if action_type == "gardener":
+            await self._run_gardener(auto)
+            return
+
         prompt = ""
         if isinstance(action_config, dict):
             prompt = str(action_config.get("prompt") or "")
         if not prompt:
             return
 
-        conv_key = f"automations.{auto_id}.conversation_id"
-        conv_id = str(self.db.get_setting(conv_key, "") or "")
-        if not conv_id or self.db.get_conversation(conv_id) is None:
-            conv = self.db.create_conversation(title=f"🔔 {name}")
-            conv_id = conv["id"]
-            self.db.set_setting(conv_key, conv_id)
+        conv_id = self._automation_conversation_id(auto)
 
         outbound = await self.loop.process_direct(
             prompt,
@@ -784,6 +798,150 @@ class CollieRuntime:
         targets.update(self.messengers.automation_targets())
         for target in sorted(targets):
             await self.messengers.deliver(target, f"🔔 {name}\n\n{content}")
+
+    # -- Gardener-family automation pipelines ------------------------------------
+
+    def _automation_conversation_id(self, auto: dict[str, Any]) -> str:
+        """Resolve (or create) the per-automation 🔔 conversation."""
+        auto_id = str(auto.get("id") or "")
+        name = str(auto.get("name") or "Automation")
+        conv_key = f"automations.{auto_id}.conversation_id"
+        conv_id = str(self.db.get_setting(conv_key, "") or "")
+        if not conv_id or self.db.get_conversation(conv_id) is None:
+            conv = self.db.create_conversation(title=f"🔔 {name}")
+            conv_id = conv["id"]
+            self.db.set_setting(conv_key, conv_id)
+        return conv_id
+
+    async def _announce_automation_result(
+        self, auto: dict[str, Any], conv_id: str, content: str
+    ) -> None:
+        """Persist + broadcast + fan out an automation result message."""
+        auto_id = str(auto.get("id") or "")
+        name = str(auto.get("name") or "Automation")
+        if not content:
+            return
+        assistant = self.db.add_message(conv_id, "assistant", content)
+        await self.ipc.broadcast({
+            "type": "message", "conversation_id": conv_id, "message": assistant,
+        })
+        await self.ipc.broadcast({
+            "type": "automation",
+            "automation_id": auto_id,
+            "name": name,
+            "conversation_id": conv_id,
+            "content": content,
+        })
+        deliveries = auto.get("delivery_channels")
+        if isinstance(deliveries, str):
+            try:
+                deliveries = json.loads(deliveries)
+            except (TypeError, ValueError):
+                deliveries = []
+        targets = {
+            str(d) for d in (deliveries or [])
+            if str(d) in self.messengers.channels
+        }
+        targets.update(self.messengers.automation_targets())
+        for target in sorted(targets):
+            await self.messengers.deliver(target, f"🔔 {name}\n\n{content}")
+
+    async def _run_dream_manual(self) -> dict[str, Any]:
+        """Manual 'Review now' trigger (Settings -> Memory)."""
+        if self.loop is None:
+            result = await self._configure()
+            if not result.get("configured"):
+                return {
+                    "changed": False,
+                    "reason": "not_configured",
+                    "message": "I need a model provider set up before I can review my memory.",
+                }
+        from collie_core.memory.dream import run_dream
+
+        return await run_dream(
+            workspace=self.workspace,
+            db=self.db,
+            loop=self.loop,
+            version_store=self.versions,
+        )
+
+    async def _run_gardener_manual(self) -> dict[str, Any]:
+        """Manual 'Suggest improvements' trigger (Settings -> Memory).
+
+        Runs the same pipeline as the weekly automation and publishes the
+        review cards into the 🔔 conversation, so a manual run has the same
+        review surface as the scheduled one.
+        """
+        auto = {
+            "id": "collie-gardener-suggestions",
+            "name": "Improvement suggestions",
+            "delivery_channels": ["in_app"],
+        }
+        return await self._run_gardener(auto) or {}
+
+    async def _run_memory_maintenance(self, auto: dict[str, Any]) -> None:
+        """Weekly Dream pass: consolidate long-term memory, versioned + undoable."""
+        if self.loop is None:
+            result = await self._configure()
+            if not result.get("configured"):
+                logger.info("Memory maintenance skipped — no provider configured yet")
+                return
+        from collie_core.memory.dream import run_dream
+
+        conv_id = self._automation_conversation_id(auto)
+        outcome = await run_dream(
+            workspace=self.workspace,
+            db=self.db,
+            loop=self.loop,
+            version_store=self.versions,
+        )
+        content = str(outcome.get("message") or "Memory maintenance ran.")
+        if outcome.get("changed"):
+            content += (
+                "\n\nChanged my long-term memory file. You can review the diff "
+                "and undo it in Settings → Memory → History."
+            )
+        await self._announce_automation_result(auto, conv_id, content)
+
+    async def _run_gardener(self, auto: dict[str, Any]) -> dict[str, Any] | None:
+        """Weekly Gardener pass: evidence → suggestions → review cards."""
+        if self.loop is None:
+            result = await self._configure()
+            if not result.get("configured"):
+                logger.info("Gardener skipped — no provider configured yet")
+                return None
+        from collie_core.gardener.runner import run_gardener
+
+        conv_id = self._automation_conversation_id(auto)
+        outcome = await run_gardener(
+            workspace=self.workspace,
+            db=self.db,
+            loop=self.loop,
+            version_store=self.versions,
+        )
+        content = str(outcome.get("message") or "Gardener ran.")
+        suggestions = outcome.get("suggestions") or []
+        if suggestions:
+            card = self.db.add_message(
+                conv_id,
+                "assistant",
+                content,
+                card_type="gardener_suggestion",
+                card_data={"suggestions": suggestions},
+            )
+            await self.ipc.broadcast({
+                "type": "message", "conversation_id": conv_id, "message": card,
+            })
+            await self.ipc.broadcast({
+                "type": "automation",
+                "automation_id": str(auto.get("id") or ""),
+                "name": str(auto.get("name") or "Automation"),
+                "conversation_id": conv_id,
+                "content": content,
+            })
+            return outcome
+        await self._announce_automation_result(auto, conv_id, content)
+        return outcome
 
     async def _shutdown_loop(self) -> None:
         await self.messengers.stop()

--- a/collie-core/collie_core/subagents/loader.py
+++ b/collie-core/collie_core/subagents/loader.py
@@ -23,6 +23,7 @@ import yaml
 from loguru import logger
 
 from collie_core.db import CollieDB
+from collie_core.versions import VersionStore
 
 __all__ = [
     "STARTERS",
@@ -117,6 +118,26 @@ class SubagentLoader:
     def __init__(self, workspace: Path, db: CollieDB) -> None:
         self.dir = workspace / "subagents"
         self.db = db
+
+    # -- versioning (Gardener rollback rail) --------------------------------
+
+    def _snapshot(
+        self, filename: str, before: str, after: str, *, source: str = "user"
+    ) -> str | None:
+        """Snapshot a subagent file edit; never breaks the write on failure."""
+        try:
+            return VersionStore(self.db).snapshot(
+                "subagent", filename, before, after, source=source
+            )
+        except Exception:
+            logger.exception("subagent version snapshot failed (swallowed)")
+            return None
+
+    def latest_version_id(self, filename: str) -> str | None:
+        try:
+            return VersionStore(self.db).latest_version_id("subagent", filename)
+        except Exception:
+            return None
 
     # -- disk <-> db sync ----------------------------------------------------
 
@@ -235,6 +256,7 @@ class SubagentLoader:
             filename=filename,
             execution_posture=execution_posture,
         )
+        self._snapshot(filename, "", path.read_text(encoding="utf-8"))
         logger.info("Subagent created: {}", filename)
         return row
 
@@ -278,9 +300,14 @@ class SubagentLoader:
             if old_path.exists():
                 old_path.rename(self.dir / new_filename)
             filename = new_filename
-        (self.dir / filename).write_text(
+        before = ""
+        target_path = self.dir / filename
+        if target_path.exists():
+            before = target_path.read_text(encoding="utf-8")
+        target_path.write_text(
             self._render(new_name, new_desc, new_prompt, posture), encoding="utf-8"
         )
+        self._snapshot(filename, before, target_path.read_text(encoding="utf-8"))
         return self.db.upsert_subagent(
             new_name,
             description=new_desc,
@@ -299,7 +326,9 @@ class SubagentLoader:
         if filename:
             file_path = self.dir / filename
             if file_path.exists():
+                before = file_path.read_text(encoding="utf-8")
                 file_path.unlink()
+                self._snapshot(filename, before, "")
         self.db.delete_subagent(subagent_id)
         logger.info("Subagent deleted: {}", filename or subagent_id)
 

--- a/collie-core/collie_core/versions.py
+++ b/collie-core/collie_core/versions.py
@@ -1,0 +1,151 @@
+"""Versioned artifact store — snapshot, diff, and roll back Collie artifacts.
+
+Every user-visible artifact edit (subagent files, ``VISION.md`` /
+``AGENTS.md`` / ``MEMORY.md``, dream consolidations, Gardener applies) is
+snapshotted into the ``artifact_versions`` table with a before/after text
+pair and a unified diff. The one-action rollback restores the prior text
+**only when the current content still matches the snapshotted ``after``
+text** — a newer owner edit is never clobbered (the no-clobber guard).
+
+The store is deliberately text-generic: reading the current artifact text
+and writing the restored text is the caller's job (each artifact type has
+its own on-disk location and re-sync rules). This keeps ``VersionStore``
+independent of the workspace layout.
+"""
+
+from __future__ import annotations
+
+import difflib
+from typing import Any
+
+from collie_core.db import CollieDB
+
+__all__ = ["VersionStore", "VersionConflictError"]
+
+
+class VersionConflictError(Exception):
+    """Raised when a rollback would clobber newer content than the version."""
+
+
+def make_diff(before: str, after: str, key: str) -> str:
+    """Build a unified diff between two texts (empty when identical)."""
+    return "".join(
+        difflib.unified_diff(
+            (before or "").splitlines(keepends=True),
+            (after or "").splitlines(keepends=True),
+            fromfile=f"{key} (before)",
+            tofile=f"{key} (after)",
+        )
+    )
+
+
+class VersionStore:
+    """Snapshot artifact edits and roll them back without clobbering."""
+
+    def __init__(self, db: CollieDB) -> None:
+        self.db = db
+
+    # -- snapshot ------------------------------------------------------------
+
+    def snapshot(
+        self,
+        artifact_type: str,
+        key: str,
+        current_text: str,
+        new_text: str,
+        *,
+        evidence: Any = None,
+        source: str = "user",
+    ) -> str | None:
+        """Record a version for an artifact edit; returns the version id.
+
+        Returns ``None`` when the texts are identical (nothing changed).
+        ``evidence`` is an optional JSON-serializable dict (e.g. Gardener
+        trigger evidence: run ids, tool stats).
+        """
+        before = current_text or ""
+        after = new_text or ""
+        if before == after:
+            return None
+        row = self.db.snapshot_artifact(
+            artifact_type,
+            key,
+            before,
+            after,
+            make_diff(before, after, key),
+            evidence=evidence,
+            source=source,
+        )
+        return str(row["id"])
+
+    def latest_version_id(self, artifact_type: str, key: str) -> str | None:
+        """Return the newest applied version id for an artifact, if any."""
+        rows = self.db.list_artifact_versions(
+            artifact_type=artifact_type, artifact_key=key, limit=1
+        )
+        if not rows:
+            return None
+        for row in rows:
+            if row.get("status") == "applied":
+                return str(row["id"])
+        return None
+
+    # -- rollback ------------------------------------------------------------
+
+    def rollback(
+        self,
+        artifact_type: str,
+        key: str,
+        *,
+        to_version: int | None = None,
+        current_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Prepare a rollback to ``before_text`` of the target version.
+
+        * ``to_version`` — the version to undo (defaults to the newest
+          applied version of the artifact).
+        * ``current_text`` — the artifact's current content, read by the
+          caller before calling. When it differs from the target version's
+          ``after_text`` the rollback is refused (never clobber newer
+          owner edits).
+
+        The version row is marked ``rolled_back`` and the caller writes the
+        returned ``restored_text`` to the artifact (and re-syncs as needed).
+        """
+        rows = self.db.list_artifact_versions(
+            artifact_type=artifact_type, artifact_key=key, limit=200
+        )
+        applied = [r for r in rows if r.get("status") == "applied"]
+        if not applied:
+            raise VersionConflictError("There's nothing to undo for this item yet.")
+        target: dict[str, Any] | None = None
+        if to_version is not None:
+            target = next(
+                (r for r in applied if int(r.get("version") or 0) == to_version),
+                None,
+            )
+        else:
+            target = max(applied, key=lambda r: int(r.get("version") or 0))
+        if target is None:
+            raise VersionConflictError(
+                f"Version {to_version} was already undone or never existed."
+            )
+
+        after_text = target.get("after_text") or ""
+        current = current_text if current_text is not None else ""
+        if current != after_text:
+            raise VersionConflictError(
+                "That edit has already been changed since — I won't overwrite "
+                "the newer version. Undo the most recent change first."
+            )
+
+        restored = target.get("before_text") or ""
+        self.db.mark_artifact_rolled_back(str(target["id"]))
+        return {
+            "version_id": str(target["id"]),
+            "artifact_type": artifact_type,
+            "artifact_key": key,
+            "version": int(target.get("version") or 0),
+            "restored_text": restored,
+            "status": "rolled_back",
+        }

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 13
+    assert db.schema_version == 14
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,17 +25,18 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 13
+    assert d2.schema_version == 14
     d2.close()
 
 
-def test_incremental_migrations_v1_through_v12(tmp_path: Path) -> None:
+def test_incremental_migrations_v1_through_latest(tmp_path: Path) -> None:
     """Every schema version must upgrade cleanly to the latest, preserving data."""
     import sqlite3
 
     import collie_core.db as db_mod
 
-    for target in range(1, 14):
+    latest = len(db_mod._MIGRATIONS)
+    for target in range(1, latest + 1):
         path = tmp_path / f"v{target}.db"
         conn = sqlite3.connect(path)
         conn.executescript(db_mod._SCHEMA_V1)
@@ -51,7 +52,7 @@ def test_incremental_migrations_v1_through_v12(tmp_path: Path) -> None:
         conn.close()
 
         upgraded = CollieDB(path)
-        assert upgraded.schema_version == 13, f"v{target} did not reach v13"
+        assert upgraded.schema_version == latest, f"v{target} did not reach v{latest}"
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
         upgraded.close()
 
@@ -76,8 +77,9 @@ def test_migration_failure_rolls_back_atomically(
     with pytest.raises(sqlite3.OperationalError):
         CollieDB(path)
 
-    # The failed migration rolled everything back: version still 13 and the
-    # partial table is gone, so a normal boot migrates cleanly again.
+    # The failed migration rolled everything back: version still at the
+    # pre-failure latest and the partial table is gone, so a normal boot
+    # migrates cleanly again.
     conn = sqlite3.connect(path)
     try:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
@@ -86,11 +88,11 @@ def test_migration_failure_rolls_back_atomically(
         ).fetchone()
     finally:
         conn.close()
-    assert version == 13
+    assert version == len(db_mod._MIGRATIONS) - 1
     assert half is None
     monkeypatch.undo()
     fresh = CollieDB(path)
-    assert fresh.schema_version == 13
+    assert fresh.schema_version == len(db_mod._MIGRATIONS)
     fresh.close()
 
 
@@ -131,7 +133,7 @@ def test_v8_removes_only_legacy_system_subagent_allow(tmp_path: Path) -> None:
         row["name"] for row in migrated._rows("PRAGMA table_info(messages)")
     }
     assert "task_state" in columns
-    assert migrated.schema_version == 13
+    assert migrated.schema_version == len(db_mod._MIGRATIONS)
     migrated.close()
 
 
@@ -179,7 +181,7 @@ def test_v9_upgrade_adds_plan_change_terminal_message_id(tmp_path: Path) -> None
             row["name"]
             for row in upgraded._rows("PRAGMA table_info(plan_change_requests)")
         }
-        assert upgraded.schema_version == 13
+        assert upgraded.schema_version == len(db_mod._MIGRATIONS)
         assert "terminal_message_id" in columns
         assert request is not None
         assert request["reason"] == "Change it"
@@ -345,7 +347,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.set_profile("dietary", "vegan")
     db.add_person("Sam")
     data = db.export_all()
-    assert data["schema_version"] == 13
+    assert data["schema_version"] == 14
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_dream_collie.py
+++ b/collie-core/tests/collie/test_dream_collie.py
@@ -1,0 +1,292 @@
+"""Dream wiring tests (Gardener Foundations PR 3).
+
+Covers ``collie_core/memory/dream.py`` against a fake loop/provider:
+memory consolidation updates ``memory/MEMORY.md``, the cursor advances only
+on success, a no-change run is a no-op, rollback restores the prior file,
+dream sessions are pruned, and the built-in automation seeds correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from collie_core.automations.scheduler import (
+    GARDENER_AUTOMATIONS,
+    seed_gardener_automations,
+)
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.memory.dream import run_dream
+from collie_core.versions import VersionStore
+from nanobot.agent.memory import MemoryStore
+from nanobot.session.manager import SessionManager
+
+
+class FakeRunner:
+    """Stands in for ``SubagentManager.runner``; returns queued results."""
+
+    def __init__(self) -> None:
+        self.responses: list[Any] = []
+        self.specs: list[Any] = []
+
+    async def run(self, spec: Any) -> Any:
+        self.specs.append(spec)
+        return self.responses.pop(0)
+
+
+class FakeSubagents:
+    def __init__(self) -> None:
+        self.runner = FakeRunner()
+        self.hook_factories: list[Any] = []
+
+
+class FakeLoop:
+    """Minimal AgentLoop stand-in with a real MemoryStore."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.context = SimpleNamespace(memory=MemoryStore(workspace))
+        self.subagents = FakeSubagents()
+
+    def llm_runtime(self) -> Any:
+        return SimpleNamespace(model="fake-model")
+
+    @property
+    def sessions(self) -> Any:
+        return SimpleNamespace(sessions_dir=Path(self.workspace) / "sessions")
+
+
+def _result(content: str, stop_reason: str = "completed") -> Any:
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        final_content=content,
+        tools_used=[],
+        messages=[],
+        error=None,
+    )
+
+
+def _seed_dream_sessions(workspace: Path, count: int) -> None:
+    sessions_dir = workspace / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        key = f"dream:20260805-{100000 + i:06d}"
+        path = sessions_dir / f"{SessionManager._storage_key(key)}.jsonl"
+        path.write_text('{"_type": "metadata"}\n', encoding="utf-8")
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+async def test_dream_updates_memory_and_advances_cursor(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("User prefers concise replies.")
+    built = store.build_dream_prompt()
+    assert built is not None
+    _, cursor = built
+
+    proposed = "# Long-term Memory\n- User prefers concise replies.\n- Projects: Collie"
+    loop.subagents.runner.responses.append(_result(proposed))
+
+    versions = VersionStore(db)
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=versions
+    )
+
+    assert outcome["changed"] is True
+    assert outcome["version_id"] is not None
+    memory_file = workspace / "memory" / "MEMORY.md"
+    assert memory_file.read_text(encoding="utf-8").strip() == proposed.strip()
+
+    # Bounded, read-only, tool-less turn: exactly one model call.
+    spec = loop.subagents.runner.specs[0]
+    assert spec.max_iterations == 1
+    assert spec.execution_posture == "read_only"
+    assert spec.session_key.startswith("dream:")
+    assert not spec.tools.get_definitions()
+
+    # Cursor advanced only on success.
+    assert store.get_last_dream_cursor() == cursor
+
+    # Versioned as memory_dream with a diff.
+    rows = db.list_artifact_versions(artifact_type="memory_dream")
+    assert len(rows) == 1
+    assert rows[0]["artifact_key"] == "MEMORY.md"
+    assert rows[0]["source"] == "collie"
+    assert "-" in rows[0]["diff_text"] and "+" in rows[0]["diff_text"]
+    evidence = json.loads(rows[0]["evidence_json"])
+    assert evidence["cursor"] == cursor
+
+
+async def test_dream_no_new_history_is_noop(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is False
+    assert outcome["reason"] == "no_new_history"
+    assert not (workspace / "memory" / "MEMORY.md").exists()
+
+
+async def test_dream_no_change_second_run_advances_cursor(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("First entry.")
+    built = store.build_dream_prompt()
+    _, cursor1 = built
+    proposed = "# Long-term Memory\n- First entry."
+    loop.subagents.runner.responses.append(_result(proposed))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+    assert store.get_last_dream_cursor() == cursor1
+
+    # New history arrives, but the model proposes identical content.
+    store.append_history("Second entry.")
+    built = store.build_dream_prompt()
+    assert built is not None
+    _, cursor2 = built
+    loop.subagents.runner.responses.append(_result(proposed))
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is False
+    assert outcome["reason"] == "no_content_change"
+    # History is processed even when nothing changed — no re-processing loop.
+    assert store.get_last_dream_cursor() == cursor2
+    # No extra version rows for a no-op run.
+    assert len(db.list_artifact_versions(artifact_type="memory_dream")) == 1
+
+
+async def test_dream_error_does_not_advance_cursor_or_write(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("", stop_reason="error"))
+
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is False
+    assert store.get_last_dream_cursor() == 0
+    assert not (workspace / "memory" / "MEMORY.md").exists()
+    assert db.list_artifact_versions(artifact_type="memory_dream") == []
+
+
+async def test_dream_rollback_restores_prior_memory(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("User prefers concise replies.")
+    proposed = "# Long-term Memory\n- User prefers concise replies."
+    loop.subagents.runner.responses.append(_result(proposed))
+    versions = VersionStore(db)
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=versions)
+
+    memory_file = workspace / "memory" / "MEMORY.md"
+    current = memory_file.read_text(encoding="utf-8")
+    result = versions.rollback(
+        "memory_dream", "MEMORY.md", current_text=current
+    )
+    memory_file.write_text(result["restored_text"], encoding="utf-8")
+    assert memory_file.read_text(encoding="utf-8").strip() == ""
+    assert db.list_artifact_versions(artifact_type="memory_dream")[0]["status"] == "rolled_back"
+
+
+async def test_dream_prune_keeps_10(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _seed_dream_sessions(workspace, 12)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("# Long-term Memory\n- Entry."))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+
+    remaining = list((workspace / "sessions").glob("*.jsonl"))
+    assert len(remaining) == 10
+
+
+async def test_dream_fenced_response_is_extracted(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(
+        _result("```markdown\n# Long-term Memory\n- Entry.\n```")
+    )
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is True
+    memory_file = workspace / "memory" / "MEMORY.md"
+    assert "# Long-term Memory" in memory_file.read_text(encoding="utf-8")
+    assert "```" not in memory_file.read_text(encoding="utf-8")
+
+
+def test_seed_gardener_automations_once_and_never_resurrects(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    seed_gardener_automations(db)
+    automations = {a["id"]: a for a in db.list_automations()}
+    assert "collie-memory-maintenance" in automations
+    assert "collie-gardener-suggestions" in automations
+    assert automations["collie-memory-maintenance"]["action_type"] == "memory_maintenance"
+    assert automations["collie-gardener-suggestions"]["action_type"] == "gardener"
+
+    # Deleting one built-in never resurrects it on later seeds.
+    db.delete_automation("collie-memory-maintenance")
+    seed_gardener_automations(db)
+    ids = {a["id"] for a in db.list_automations()}
+    assert "collie-memory-maintenance" not in ids
+    assert "collie-gardener-suggestions" in ids
+
+    # The seed data matches the builtin list shape.
+    assert {a["id"] for a in GARDENER_AUTOMATIONS} == {
+        "collie-memory-maintenance",
+        "collie-gardener-suggestions",
+    }
+
+
+async def test_ipc_run_dream_and_history(tmp_path: Path, db: CollieDB) -> None:
+    class _FakeConn:
+        async def send(self, payload: dict[str, Any]) -> None:
+            pass
+
+    async def fake_dream_runner() -> dict[str, Any]:
+        return {"changed": False, "reason": "no_new_history", "message": "All tidy."}
+
+    srv = CollieIPCServer(db, port=0, dream_runner=fake_dream_runner)
+    conn = _FakeConn()
+    outcome = await srv._cmd_run_dream(conn, {})
+    assert outcome["changed"] is False
+    history = await srv._cmd_get_dream_history(conn, {})
+    assert history["versions"] == []
+
+    unset = CollieIPCServer(db, port=0)
+    with pytest.raises(ValueError):
+        await unset._cmd_run_dream(conn, {})

--- a/collie-core/tests/collie/test_gardener_mvp.py
+++ b/collie-core/tests/collie/test_gardener_mvp.py
@@ -1,0 +1,561 @@
+"""Gardener MVP tests (Gardener Foundations PR 4).
+
+Covers ``collie_core/gardener/`` against seeded telemetry rows:
+
+- evidence queries (repeated failures, repeated workflows, stopped turns,
+  memory bloat) read the seeded ``turn_events`` / ``tool_events``;
+- proposal validation rejects out-of-scope targets (permissions, settings,
+  secrets, connectors, non-allowlisted artifact types, unsafe keys, size
+  overruns) deterministically;
+- the bounded proposal turn (fake loop) returns validated suggestions and
+  reports rejected ones;
+- approve applies + versions through the rollback rail; dismiss applies
+  nothing; rollback restores the prior text and marks the version.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.gardener.evidence import (
+    collect_evidence,
+    memory_bloat,
+    recent_failures,
+    repeated_workflows,
+    user_stops,
+)
+from collie_core.gardener.propose import (
+    MAX_PROPOSED_CHARS,
+    ProposalValidationError,
+    propose,
+    validate_suggestion,
+)
+from collie_core.gardener.runner import apply_suggestion, run_gardener
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.versions import VersionStore
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / "memory").mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _seed_turn(db: CollieDB, turn_id: str, status: str = "ok", **extra: Any) -> None:
+    db.record_turn_event(
+        turn_id=turn_id,
+        conversation_id=extra.pop("conversation_id", "conv-1"),
+        turn_kind="chat",
+        status=status,
+        started_at=extra.pop("started_at", "2026-07-25T10:00:00"),
+        finished_at="2026-07-25T10:00:30",
+        **extra,
+    )
+
+
+def _seed_tool(
+    db: CollieDB,
+    tool_id: str,
+    turn_id: str,
+    tool_name: str,
+    status: str = "ok",
+    error_message: str | None = None,
+    started_at: str = "2026-07-25T10:00:05",
+) -> None:
+    db.record_tool_event(
+        tool_id=tool_id,
+        turn_id=turn_id,
+        tool_name=tool_name,
+        status=status,
+        error_message=error_message,
+        started_at=started_at,
+        finished_at="2026-07-25T10:00:10",
+    )
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.responses: list[Any] = []
+        self.specs: list[Any] = []
+
+    async def run(self, spec: Any) -> Any:
+        self.specs.append(spec)
+        return self.responses.pop(0)
+
+
+class FakeSubagents:
+    def __init__(self) -> None:
+        self.runner = FakeRunner()
+        self.hook_factories: list[Any] = []
+
+
+class FakeLoop:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.subagents = FakeSubagents()
+
+    def llm_runtime(self) -> Any:
+        return SimpleNamespace(model="fake-model")
+
+
+def _result(content: str, stop_reason: str = "completed") -> Any:
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        final_content=content,
+        tools_used=[],
+        messages=[],
+        error=None,
+    )
+
+
+def _valid_subagent_suggestion(**overrides: Any) -> dict[str, Any]:
+    suggestion = {
+        "artifact_type": "subagent",
+        "artifact_key": "helper.md",
+        "proposed_text": "# Helper\n\nYou help with research tasks.\n",
+        "rationale": "The user repeats multi-step research; a specialist helps.",
+        "evidence_ids": ["workflows:search,web_fetch"],
+    }
+    suggestion.update(overrides)
+    return suggestion
+
+
+# -- evidence queries -------------------------------------------------------
+
+
+def test_recent_failures_counts_and_samples(db: CollieDB) -> None:
+    _seed_turn(db, "t1")
+    for i in range(3):
+        _seed_tool(
+            db,
+            f"tool-{i}",
+            "t1",
+            "web_fetch",
+            status="error",
+            error_message=f"HTTP 500 attempt {i}",
+        )
+    _seed_tool(db, "ok-tool", "t1", "web_search", status="ok")
+
+    failures = recent_failures(db)
+    assert len(failures) == 1
+    row = failures[0]
+    assert row["tool_name"] == "web_fetch"
+    assert row["failures"] == 3
+    assert row["statuses"] == ["error"]
+    assert "HTTP 500" in row["sample_errors"][0]
+    # Successful tools never appear.
+    assert all(r["tool_name"] != "web_search" for r in failures)
+
+
+def test_recent_failures_respects_since_window(db: CollieDB) -> None:
+    _seed_turn(db, "t1")
+    _seed_tool(db, "old", "t1", "web_fetch", status="error", started_at="2026-06-01T10:00:05")
+    failures = recent_failures(db, since="2026-07-01T00:00:00")
+    assert failures == []
+
+
+def test_repeated_workflows_groups_tool_sequences(db: CollieDB) -> None:
+    for i in range(3):
+        turn_id = f"turn-{i}"
+        _seed_turn(db, turn_id)
+        _seed_tool(db, f"{turn_id}-a", turn_id, "web_search", status="ok")
+        _seed_tool(db, f"{turn_id}-b", turn_id, "web_fetch", status="ok")
+
+    workflows = repeated_workflows(db)
+    assert len(workflows) == 1
+    assert workflows[0]["workflow"] == ["web_search", "web_fetch"]
+    assert workflows[0]["repeats"] == 3
+
+
+def test_repeated_workflows_ignores_singletons(db: CollieDB) -> None:
+    for i in range(3):
+        turn_id = f"turn-{i}"
+        _seed_turn(db, turn_id)
+        _seed_tool(db, f"{turn_id}-a", turn_id, "web_search", status="ok")
+    assert repeated_workflows(db) == []
+
+
+def test_user_stops_lists_stopped_turns(db: CollieDB) -> None:
+    _seed_turn(db, "ok-turn", status="ok")
+    _seed_turn(db, "stopped-turn", status="stopped")
+    _seed_turn(db, "cancelled-turn", status="cancelled")
+
+    stops = user_stops(db)
+    assert {s["turn_id"] for s in stops} == {"stopped-turn", "cancelled-turn"}
+
+
+def test_memory_bloat_flags_size_and_duplicate_headings(workspace: Path) -> None:
+    (workspace / "memory" / "MEMORY.md").write_text(
+        "# Memory\n- fact one\n" * 200, encoding="utf-8"
+    )
+    (workspace / "MEMORY.md").write_text(
+        "# About\n# About\n- duplicate heading\n", encoding="utf-8"
+    )
+
+    findings = {f["kind"]: f for f in memory_bloat(workspace)}
+    assert findings["memory"]["bloated"] is True  # size
+    assert findings["profile"]["bloated"] is True  # duplicate heading
+    assert "about" in findings["profile"]["duplicate_headings"]
+
+
+def test_collect_evidence_aggregates(db: CollieDB, workspace: Path) -> None:
+    _seed_turn(db, "t1")
+    _seed_tool(db, "x1", "t1", "web_fetch", status="error", error_message="boom")
+    _seed_tool(db, "x2", "t1", "web_fetch", status="error", error_message="boom")
+    (workspace / "memory" / "MEMORY.md").write_text("# M\n- a\n" * 100, encoding="utf-8")
+
+    evidence = collect_evidence(db, workspace)
+    assert evidence["failures"][0]["tool_name"] == "web_fetch"
+    assert evidence["memory"][0]["kind"] == "memory"
+    assert evidence["since"]
+
+
+# -- proposal validation ----------------------------------------------------
+
+
+def test_validate_suggestion_accepts_allowlisted_targets() -> None:
+    for artifact_type, key in (
+        ("subagent", "helper.md"),
+        ("agents", "AGENTS.md"),
+        ("vision", "VISION.md"),
+        ("memory_dream", "MEMORY.md"),
+    ):
+        cleaned = validate_suggestion(
+            {
+                "artifact_type": artifact_type,
+                "artifact_key": key,
+                "proposed_text": "# New content\n",
+                "rationale": "Based on evidence.",
+                "evidence_ids": ["failures:web_fetch"],
+            }
+        )
+        assert cleaned["artifact_type"] == artifact_type
+        assert cleaned["artifact_key"] == key
+
+
+@pytest.mark.parametrize(
+    "artifact_type,key",
+    [
+        ("settings", "anything"),
+        ("skill", "resume-writer.md"),
+        ("connectors", "notion"),
+        ("subagent", "../escape.md"),
+        ("subagent", "nested/path.md"),
+        ("agents", "OTHER.md"),
+        ("vision", "AGENTS.md"),
+        ("memory_dream", "memory/MEMORY.md"),
+    ],
+)
+def test_validate_suggestion_rejects_out_of_scope_targets(
+    artifact_type: str, key: str
+) -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(
+            {
+                "artifact_type": artifact_type,
+                "artifact_key": key,
+                "proposed_text": "# Content\n",
+                "rationale": "Reason.",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Change the permission model to allow file writes.",
+        "Update the api key handling in settings.",
+        "Reconfigure the notion connector.",
+        "Store credentials in the profile.",
+        "Turn on auto-approve for tools.",
+    ],
+)
+def test_validate_suggestion_rejects_forbidden_language(text: str) -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(_valid_subagent_suggestion(proposed_text=text))
+
+
+def test_validate_suggestion_rejects_oversize_proposal() -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(
+            _valid_subagent_suggestion(proposed_text="x" * (MAX_PROPOSED_CHARS + 1))
+        )
+
+
+def test_validate_suggestion_rejects_empty_proposal() -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(_valid_subagent_suggestion(proposed_text=""))
+
+
+# -- bounded proposal turn --------------------------------------------------
+
+
+async def test_propose_returns_validated_suggestions(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(
+        _result(
+            json.dumps(
+                [
+                    _valid_subagent_suggestion(),
+                    {
+                        "artifact_type": "memory_dream",
+                        "artifact_key": "MEMORY.md",
+                        "proposed_text": "# Long-term Memory\n- tidy\n",
+                        "rationale": "Memory had duplicate headings.",
+                        "evidence_ids": ["memory:bloat"],
+                    },
+                ]
+            )
+        )
+    )
+    evidence = collect_evidence(db, workspace)
+    valid, rejected = await propose(loop, workspace, evidence)
+    assert len(valid) == 2
+    spec = loop.subagents.runner.specs[0]
+    assert spec.max_iterations == 1
+    assert spec.execution_posture == "read_only"
+    assert not spec.tools.get_definitions()
+    assert spec.session_key.startswith("gardener:")
+    assert rejected == []
+
+
+async def test_propose_drops_out_of_scope_and_reports(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(
+        _result(
+            json.dumps(
+                [
+                    _valid_subagent_suggestion(),
+                    {
+                        "artifact_type": "settings",
+                        "artifact_key": "provider",
+                        "proposed_text": "Switch the provider key.",
+                        "rationale": "Nope.",
+                    },
+                    {
+                        "artifact_type": "subagent",
+                        "artifact_key": "helper.md",
+                        "proposed_text": "Allow auto-approve for everything.",
+                        "rationale": "Faster.",
+                    },
+                ]
+            )
+        )
+    )
+    valid, rejected = await propose(loop, workspace, collect_evidence(db, workspace))
+    assert len(valid) == 1
+    assert len(rejected) == 2
+    reasons = [r["reason"] for r in rejected]
+    assert any("settings" in reason for reason in reasons)
+    assert any("approve" in reason for reason in reasons)
+
+
+async def test_propose_empty_json_is_empty(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(_result("[]"))
+    valid, rejected = await propose(loop, workspace, collect_evidence(db, workspace))
+    assert valid == []
+    assert rejected == []
+
+
+async def test_propose_turn_error_is_rejected(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(_result("", stop_reason="error"))
+    valid, rejected = await propose(loop, workspace, collect_evidence(db, workspace))
+    assert valid == []
+    assert any(r["reason"].startswith("stop_reason") for r in rejected)
+
+
+# -- runner: run -> review -> apply -> rollback -----------------------------
+
+
+async def test_run_gardener_no_signals_is_quiet(db: CollieDB, workspace: Path) -> None:
+    loop = FakeLoop(workspace)
+    outcome = await run_gardener(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["suggestions"] == []
+    assert "healthy" in outcome["message"]
+
+
+async def test_run_gardener_with_signals_proposes(db: CollieDB, workspace: Path) -> None:
+    _seed_turn(db, "t1")
+    _seed_tool(db, "f1", "t1", "web_fetch", status="error", error_message="500")
+    _seed_tool(db, "f2", "t1", "web_fetch", status="error", error_message="500")
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(_result(json.dumps([_valid_subagent_suggestion()])))
+
+    outcome = await run_gardener(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert len(outcome["suggestions"]) == 1
+    assert outcome["suggestions"][0]["artifact_type"] == "subagent"
+    assert "2 suggestion" in outcome["message"] or "1 suggestion" in outcome["message"]
+
+
+def test_apply_suggestion_writes_and_versions(db: CollieDB, workspace: Path) -> None:
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    original = "# Helper\n\nOld instructions.\n"
+    (sub_dir / "helper.md").write_text(original, encoding="utf-8")
+
+    result = apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(
+            proposed_text="# Helper\n\nNew research instructions.\n"
+        ),
+        version_store=VersionStore(db),
+    )
+    assert result["applied"] is True
+    assert result["version_id"] is not None
+    assert (sub_dir / "helper.md").read_text(encoding="utf-8") == (
+        "# Helper\n\nNew research instructions.\n"
+    )
+
+    rows = db.list_artifact_versions(artifact_type="subagent")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["artifact_key"] == "helper.md"
+    assert row["source"] == "gardener"
+    assert row["status"] == "applied"
+    assert row["before_text"] == original
+    assert "-" in row["diff_text"] and "+" in row["diff_text"]
+
+
+def test_apply_suggestion_revalidates_forged_input(db: CollieDB, workspace: Path) -> None:
+    with pytest.raises(ProposalValidationError):
+        apply_suggestion(
+            workspace=workspace,
+            suggestion=_valid_subagent_suggestion(
+                proposed_text="Change permission settings to allow everything."
+            ),
+            version_store=VersionStore(db),
+        )
+    assert db.list_artifact_versions() == []
+
+
+def test_apply_suggestion_no_change_is_noop(db: CollieDB, workspace: Path) -> None:
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    (sub_dir / "helper.md").write_text("# Helper\n\nSame text.\n", encoding="utf-8")
+    result = apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(proposed_text="# Helper\n\nSame text."),
+        version_store=VersionStore(db),
+    )
+    assert result["no_change"] is True
+    assert result["version_id"] is None
+    assert db.list_artifact_versions() == []
+
+
+def test_dismiss_applies_nothing(db: CollieDB, workspace: Path) -> None:
+    """Dismiss is a review-surface decision: no core write, no version."""
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    original = "# Helper\n\nOld instructions.\n"
+    (sub_dir / "helper.md").write_text(original, encoding="utf-8")
+
+    # run_gardener produced suggestions, but the user dismisses: nothing is
+    # applied and nothing is versioned.
+    outcome = {"suggestions": [_valid_subagent_suggestion()]}
+    assert outcome["suggestions"]
+    assert (sub_dir / "helper.md").read_text(encoding="utf-8") == original
+    assert db.list_artifact_versions() == []
+
+
+def test_rollback_restores_prior_text(db: CollieDB, workspace: Path) -> None:
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    original = "# Helper\n\nOld instructions.\n"
+    (sub_dir / "helper.md").write_text(original, encoding="utf-8")
+
+    versions = VersionStore(db)
+    apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(
+            proposed_text="# Helper\n\nNew research instructions.\n"
+        ),
+        version_store=versions,
+    )
+
+    current = (sub_dir / "helper.md").read_text(encoding="utf-8")
+    rollback = versions.rollback("subagent", "helper.md", current_text=current)
+    (sub_dir / "helper.md").write_text(rollback["restored_text"], encoding="utf-8")
+
+    assert (sub_dir / "helper.md").read_text(encoding="utf-8") == original
+    row = db.list_artifact_versions(artifact_type="subagent")[0]
+    assert row["status"] == "rolled_back"
+
+
+def test_rollback_refuses_when_current_diverges(db: CollieDB, workspace: Path) -> None:
+    from collie_core.versions import VersionConflictError
+
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    (sub_dir / "helper.md").write_text("# Helper\n\nOld.\n", encoding="utf-8")
+    versions = VersionStore(db)
+    apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(proposed_text="# Helper\n\nNew.\n"),
+        version_store=versions,
+    )
+    # A newer owner edit lands on top.
+    (sub_dir / "helper.md").write_text("# Helper\n\nUser's own newer edit.\n", encoding="utf-8")
+
+    with pytest.raises(VersionConflictError):
+        versions.rollback(
+            "subagent", "helper.md", current_text=(sub_dir / "helper.md").read_text()
+        )
+
+
+# -- IPC surface ------------------------------------------------------------
+
+
+async def test_ipc_run_gardener_and_apply(db: CollieDB, workspace: Path) -> None:
+    class _FakeConn:
+        async def send(self, payload: dict[str, Any]) -> None:
+            pass
+
+    async def fake_gardener_runner() -> dict[str, Any]:
+        return {"suggestions": [_valid_subagent_suggestion()], "message": "One idea."}
+
+    srv = CollieIPCServer(db, port=0, gardener_runner=fake_gardener_runner)
+    conn = _FakeConn()
+    outcome = await srv._cmd_run_gardener(conn, {})
+    assert outcome["suggestions"]
+    assert "message" in outcome
+
+    unset = CollieIPCServer(db, port=0)
+    with pytest.raises(ValueError):
+        await unset._cmd_run_gardener(conn, {})
+
+    # Apply through the IPC command path (uses the real apply + versioning).
+    srv_with_apply = CollieIPCServer(db, port=0, gardener_runner=fake_gardener_runner)
+    with pytest.raises(ValueError):
+        await srv_with_apply._cmd_apply_gardener_suggestion(conn, {})
+    with pytest.raises(ValueError):
+        await srv_with_apply._cmd_apply_gardener_suggestion(
+            conn,
+            {
+                "suggestion": {
+                    "artifact_type": "settings",
+                    "artifact_key": "x",
+                    "proposed_text": "y",
+                }
+            },
+        )

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 13
+    assert db.schema_version == 14
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -85,7 +85,7 @@ def _build_db_at_version(path: Path, version: int) -> None:
 def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "collie.db")
     try:
-        assert db.schema_version == 13
+        assert db.schema_version == 14
         columns = {
             row["name"]
             for row in db._rows("PRAGMA table_info(turn_events)")
@@ -109,7 +109,7 @@ def test_old_rows_null_hashes(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 13
+        assert upgraded.schema_version == 14
         rows = upgraded.list_turn_events()
         assert len(rows) == 1
         assert rows[0]["prompt_hash"] is None

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -94,7 +94,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 13
+    assert db.schema_version == 14
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -116,7 +116,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 13
+        assert upgraded.schema_version == 14
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 13
+    assert db.schema_version == 14
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/collie-core/tests/collie/test_versions.py
+++ b/collie-core/tests/collie/test_versions.py
@@ -1,0 +1,376 @@
+"""Versioned artifact store tests (Gardener Foundations PR 2).
+
+Covers the ``artifact_versions`` schema (V14), the ``VersionStore`` API
+(snapshot/diff/rollback + no-clobber guard), the write-path wiring
+(subagent loader, ProfileStore, workspace file writes) and the IPC
+surface (list_versions / rollback_artifact).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.memory.profile import ProfileStore
+from collie_core.subagents.loader import SubagentLoader
+from collie_core.versions import VersionConflictError, VersionStore
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+class _FakeConn:
+    """Minimal stand-in for a ServerConnection (direct handler calls)."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+
+# -- schema -------------------------------------------------------------------
+
+
+def test_v14_creates_artifact_versions_on_fresh_db(db: CollieDB) -> None:
+    assert db.schema_version == 14
+    rows = db._rows("SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'")
+    assert len(rows) == 1
+    columns = {row["name"] for row in db._rows("PRAGMA table_info(artifact_versions)")}
+    assert {
+        "id", "artifact_type", "artifact_key", "version", "before_text",
+        "after_text", "diff_text", "evidence_json", "source", "status",
+        "created_at",
+    } <= columns
+
+
+def test_v13_db_upgrades_to_v14_preserving_data(tmp_path: Path) -> None:
+    import collie_core.db as db_mod
+
+    path = tmp_path / "v13.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(db_mod._SCHEMA_V1)
+    for migration in db_mod._MIGRATIONS[1:13]:
+        conn.executescript(migration)
+    conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (13)")
+    conn.commit()
+    conn.close()
+
+    upgraded = CollieDB(path)
+    try:
+        assert upgraded.schema_version == 14
+        assert upgraded._rows(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
+        )
+    finally:
+        upgraded.close()
+
+
+# -- DB methods ----------------------------------------------------------------
+
+
+def test_snapshot_versions_are_monotonic_per_artifact(db: CollieDB) -> None:
+    r1 = db.snapshot_artifact("subagent", "researcher.md", "", "v1", "- +v1")
+    r2 = db.snapshot_artifact("subagent", "researcher.md", "v1", "v2", "- +v2")
+    r3 = db.snapshot_artifact("subagent", "analyst.md", "", "a1", "- +a1")
+    assert (r1["artifact_type"], r1["artifact_key"], r1["version"]) == ("subagent", "researcher.md", 1)
+    assert (r2["artifact_type"], r2["artifact_key"], r2["version"]) == ("subagent", "researcher.md", 2)
+    assert (r3["artifact_type"], r3["artifact_key"], r3["version"]) == ("subagent", "analyst.md", 1)
+    assert db.latest_artifact_version("subagent", "researcher.md") == 2
+
+    rows = db.list_artifact_versions(artifact_type="subagent", artifact_key="researcher.md")
+    assert [r["version"] for r in rows] == [2, 1]
+    assert rows[0]["status"] == "applied"
+    assert rows[0]["source"] == "user"
+
+    got = db.get_artifact_version(r2["id"])
+    assert got is not None and got["after_text"] == "v2"
+    db.mark_artifact_rolled_back(r2["id"])
+    assert db.get_artifact_version(r2["id"])["status"] == "rolled_back"
+
+
+def test_snapshot_unique_constraint_per_version(db: CollieDB) -> None:
+    """(type, key, version) is unique — enforced at the DB level."""
+    r1 = db.snapshot_artifact("vision", "VISION.md", "", "a", "- +a")
+    # The API auto-increments, so a collision requires a direct insert.
+    with pytest.raises(sqlite3.IntegrityError):
+        db._conn.execute(
+            "INSERT INTO artifact_versions (id, artifact_type, artifact_key, "
+            "version, before_text, after_text, diff_text, source, status, "
+            "created_at) VALUES (?, ?, ?, ?, '', '', '', 'user', 'applied', ?)",
+            ("dup", "vision", "VISION.md", r1["version"], "2026-01-01"),
+        )
+    # Clear the failed transaction so later statements succeed.
+    db._conn.rollback()
+    # Same type, same version, different key is fine; different type same key fine.
+    db.snapshot_artifact("vision", "AGENTS.md", "", "a", "- +a")
+
+
+# -- VersionStore --------------------------------------------------------------
+
+
+def test_snapshot_returns_id_and_diff(db: CollieDB) -> None:
+    store = VersionStore(db)
+    vid = store.snapshot("agents", "AGENTS.md", "old", "new", source="user")
+    assert vid is not None
+    row = db.get_artifact_version(vid)
+    assert row is not None
+    assert row["before_text"] == "old"
+    assert row["after_text"] == "new"
+    assert "-old" in row["diff_text"] and "+new" in row["diff_text"]
+
+    assert store.snapshot("agents", "AGENTS.md", "new", "new") is None
+
+
+def test_rollback_restores_before_text(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("subagent", "researcher.md", "", "v1")
+    store.snapshot("subagent", "researcher.md", "v1", "v2")
+
+    result = store.rollback("subagent", "researcher.md", current_text="v2")
+    assert result["version"] == 2
+    assert result["restored_text"] == "v1"
+    assert db.get_artifact_version(result["version_id"])["status"] == "rolled_back"
+
+    # Next rollback targets the remaining applied version.
+    result = store.rollback("subagent", "researcher.md", current_text="v1")
+    assert result["version"] == 1
+    assert result["restored_text"] == ""
+
+    with pytest.raises(VersionConflictError):
+        store.rollback("subagent", "researcher.md", current_text="anything")
+
+
+def test_rollback_no_clobber_guard(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("agents", "AGENTS.md", "old", "new")
+    # The file was edited again after the snapshot -> refuse.
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", current_text="newer edit")
+    # Still applied (nothing was marked).
+    assert db.get_artifact_version(store.latest_version_id("agents", "AGENTS.md") or "")["status"] == "applied"
+
+
+def test_rollback_targets_specific_version(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("agents", "AGENTS.md", "", "a")
+    store.snapshot("agents", "AGENTS.md", "a", "b")
+    store.snapshot("agents", "AGENTS.md", "b", "c")
+    # Undoing an older version while a newer edit sits on top refuses: current
+    # text ("c") no longer matches the older version's after_text ("b").
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", to_version=2, current_text="c")
+    # Undo the latest first, then the older one becomes undoable.
+    result = store.rollback("agents", "AGENTS.md", current_text="c")
+    assert result["version"] == 3
+    assert result["restored_text"] == "b"
+    result = store.rollback("agents", "AGENTS.md", to_version=2, current_text="b")
+    assert result["version"] == 2
+    assert result["restored_text"] == "a"
+    # Undoing an already-rolled-back version is refused.
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", to_version=2, current_text="a")
+
+
+# -- subagent loader wiring ------------------------------------------------------
+
+
+def test_subagent_edit_versions_and_rollback_restores_file_and_db(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    loader = SubagentLoader(workspace, db)
+    created = loader.create("Researcher", "researches", "You research things.")
+    filename = created["filename"]
+    versions = db.list_artifact_versions(artifact_type="subagent", artifact_key=filename)
+    assert len(versions) == 1
+    assert versions[0]["before_text"] == ""
+    assert "You research things." in versions[0]["after_text"]
+
+    loader.update(created["id"], system_prompt="You research very carefully.")
+    versions = db.list_artifact_versions(artifact_type="subagent", artifact_key=filename)
+    assert len(versions) == 2
+    assert versions[0]["before_text"].strip().endswith("You research things.")
+
+    # Roll back the update: file restored, DB row in sync via sync().
+    target = workspace / "subagents" / filename
+    current = target.read_text(encoding="utf-8")
+    result = VersionStore(db).rollback(
+        "subagent", filename, current_text=current
+    )
+    target.write_text(result["restored_text"], encoding="utf-8")
+    loader.sync()
+    row = loader.find("Researcher")
+    assert row is not None
+    assert "You research things." in row["system_prompt"]
+
+    # Delete snapshots an empty after; rollback restores the file + row.
+    loader.delete(created["id"])
+    assert not target.exists()
+    versions = db.list_artifact_versions(artifact_type="subagent", artifact_key=filename)
+    assert versions[0]["after_text"] == ""
+    result = VersionStore(db).rollback(
+        "subagent", filename, current_text=""
+    )
+    target.write_text(result["restored_text"], encoding="utf-8")
+    loader.sync()
+    assert target.exists()
+    assert loader.find("Researcher") is not None
+
+
+def test_subagent_sync_is_not_versioned(tmp_path: Path, db: CollieDB) -> None:
+    """Reconciliation (sync) must not create version rows — only user edits."""
+    workspace = tmp_path / "workspace"
+    loader = SubagentLoader(workspace, db)
+    loader.create("Analyst", "analyzes", "You analyze.")
+    before = len(db.list_artifact_versions(artifact_type="subagent"))
+    loader.sync()
+    assert len(db.list_artifact_versions(artifact_type="subagent")) == before
+
+
+# -- ProfileStore wiring ---------------------------------------------------------
+
+
+def test_profile_edit_versions_memory_md(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    store = ProfileStore(db, workspace, version_store=VersionStore(db))
+    store.regenerate_memory_md()
+    store.set("dietary", "vegan")
+    versions = db.list_artifact_versions(
+        artifact_type="memory_profile", artifact_key="MEMORY.md"
+    )
+    assert len(versions) == 1
+    assert "vegan" in versions[0]["after_text"]
+    # The before snapshot is the prior generated file (the empty-state text).
+    assert "Nothing here yet" in versions[0]["before_text"]
+
+    # Rollback restores the prior MEMORY.md text.
+    result = VersionStore(db).rollback(
+        "memory_profile", "MEMORY.md", current_text=versions[0]["after_text"]
+    )
+    (workspace / "MEMORY.md").write_text(result["restored_text"], encoding="utf-8")
+    assert "vegan" not in (workspace / "MEMORY.md").read_text(encoding="utf-8")
+
+
+def test_profile_edit_without_version_store_still_works(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    store = ProfileStore(db, workspace)
+    store.set("location", "Berlin")
+    assert "Berlin" in (workspace / "MEMORY.md").read_text(encoding="utf-8")
+
+
+# -- IPC surface -----------------------------------------------------------------
+
+
+def _make_server(tmp_path: Path, db: CollieDB) -> CollieIPCServer:
+    workspace = tmp_path / "workspace"
+    loader = SubagentLoader(workspace, db)
+    srv = CollieIPCServer(db, port=0, subagent_loader=loader)
+    srv._test_loader = loader  # type: ignore[attr-defined]
+    return srv
+
+
+async def test_ipc_list_versions_and_rollback(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path))
+    db = CollieDB(tmp_path / "collie.db")
+    srv = _make_server(tmp_path, db)
+    try:
+        loader: SubagentLoader = srv._test_loader  # type: ignore[attr-defined]
+        created = loader.create("Researcher", "researches", "You research things.")
+        filename = created["filename"]
+
+        conn = _FakeConn()
+        result = await srv._cmd_list_versions(conn, {"artifact_type": "subagent"})
+        versions = result["versions"]
+        assert len(versions) == 1
+        assert versions[0]["artifact_key"] == filename
+
+        # Update the subagent (v2), then roll it back through the IPC path.
+        loader.update(created["id"], system_prompt="You research very carefully.")
+        target = tmp_path / "workspace" / "subagents" / filename
+        current = target.read_text(encoding="utf-8")
+        assert "very carefully" in current
+        rolled = await srv._cmd_rollback_artifact(
+            conn,
+            {"version_id": db.list_artifact_versions(
+                artifact_type="subagent", artifact_key=filename, limit=1
+            )[0]["id"]},
+        )
+        assert rolled["rolled_back"] is True
+        assert "very carefully" not in target.read_text(encoding="utf-8")
+        assert "You research things." in target.read_text(encoding="utf-8")
+        # DB row is back in sync with the restored file.
+        assert loader.find("Researcher") is not None
+
+        # A newer owner edit must be refused (no-clobber guard).
+        create_version = db.list_artifact_versions(
+            artifact_type="subagent", artifact_key=filename, limit=2
+        )[1]["id"]
+        target.write_text("newer hand edit", encoding="utf-8")
+        with pytest.raises(ValueError, match="newer"):
+            await srv._cmd_rollback_artifact(conn, {"version_id": create_version})
+
+        # Restore the file to the snapshotted state; undoing the create now
+        # removes the artifact again.
+        create_row = db.get_artifact_version(create_version)
+        target.write_text(create_row["after_text"], encoding="utf-8")
+        rolled = await srv._cmd_rollback_artifact(
+            conn, {"version_id": create_version}
+        )
+        assert rolled["rolled_back"] is True
+        assert not target.exists()
+        assert loader.find("Researcher") is None
+
+        with pytest.raises(ValueError):
+            await srv._cmd_rollback_artifact(conn, {"version_id": "missing-id"})
+    finally:
+        db.close()
+
+
+async def test_ipc_write_file_versions_suggest_apply_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The suggest-card apply path (_cmd_write_file) versions VISION/AGENTS."""
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path))
+    db = CollieDB(tmp_path / "collie.db")
+    srv = _make_server(tmp_path, db)
+    try:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        (workspace / "AGENTS.md").write_text("old about me", encoding="utf-8")
+        conn = _FakeConn()
+        result = await srv._cmd_write_file(
+            conn, {"path": "AGENTS.md", "content": "new about me"}
+        )
+        assert result["saved"] is True
+        assert result["version_id"] is not None
+        assert "-old about me" in (result["diff_text"] or "")
+        rows = db.list_artifact_versions(artifact_type="agents", artifact_key="AGENTS.md")
+        assert len(rows) == 1
+
+        # Writing the same content again creates no version.
+        result = await srv._cmd_write_file(
+            conn, {"path": "AGENTS.md", "content": "new about me"}
+        )
+        assert result["version_id"] is None
+        assert len(db.list_artifact_versions(artifact_type="agents")) == 1
+
+        # Non-artifact files are written but not versioned.
+        result = await srv._cmd_write_file(
+            conn, {"path": "notes.txt", "content": "hello"}
+        )
+        assert result["saved"] is True and result["version_id"] is None
+    finally:
+        db.close()

--- a/collie-ui/src/renderer/src/components/cards/CardRenderer.tsx
+++ b/collie-ui/src/renderer/src/components/cards/CardRenderer.tsx
@@ -12,6 +12,7 @@ import PlanCard from '../plans/PlanCard'
 import CapabilityListCard from './CapabilityListCard'
 import StatusCard from './StatusCard'
 import SuggestionCard from './SuggestionCard'
+import GardenerCard from './GardenerCard'
 import FilesChangedCard from './FilesChangedCard'
 
 interface Props {
@@ -49,6 +50,8 @@ export default function CardRenderer({ cardType, cardData }: Props): React.JSX.E
       return <StatusCard data={cardData} />
     case 'profile_suggestion':
       return <SuggestionCard data={cardData} />
+    case 'gardener_suggestion':
+      return <GardenerCard data={cardData} />
     case 'files_changed':
       return <FilesChangedCard data={cardData} />
     default:

--- a/collie-ui/src/renderer/src/components/cards/DiffView.tsx
+++ b/collie-ui/src/renderer/src/components/cards/DiffView.tsx
@@ -1,0 +1,55 @@
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+
+interface Props {
+  diff: string
+  /** Default collapsed state (only shows a summary line until opened). */
+  defaultCollapsed?: boolean
+  label?: string
+}
+
+/** Render a unified diff as friendly, color-coded lines. */
+export default function DiffView({ diff, defaultCollapsed = true, label }: Props): React.JSX.Element {
+  const [open, setOpen] = useState(!defaultCollapsed)
+
+  const { lines, added, removed } = useMemo(() => {
+    const raw = (diff || '').split('\n')
+    const lines = raw.filter((line) => !line.startsWith('+++') && !line.startsWith('---') && !line.startsWith('@@'))
+    const added = lines.filter((line) => line.startsWith('+')).length
+    const removed = lines.filter((line) => line.startsWith('-')).length
+    return { lines, added, removed }
+  }, [diff])
+
+  if (!diff) return <div />
+
+  const summary = label ?? `What changed: ${added} line${added === 1 ? '' : 's'} added, ${removed} removed`
+
+  return (
+    <div className="diff-view">
+      <button
+        type="button"
+        className="diff-toggle"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        <span>{summary}</span>
+      </button>
+      {open && (
+        <pre className="diff-text">
+          {lines.map((line, index) => {
+            const isAdded = line.startsWith('+')
+            const isRemoved = line.startsWith('-')
+            const cls = isAdded ? 'is-added' : isRemoved ? 'is-removed' : ''
+            return (
+              <span key={index} className={cls}>
+                {line === '' ? ' ' : line}
+                {'\n'}
+              </span>
+            )
+          })}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/collie-ui/src/renderer/src/components/cards/GardenerCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/GardenerCard.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { Check, Sparkles, Undo2, X } from 'lucide-react'
+import { collieClient, type GardenerSuggestion } from '../../lib/ipc'
+import DiffView from './DiffView'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+type Status = 'pending' | 'applying' | 'applied' | 'dismissed'
+
+const TYPE_LABELS: Record<string, string> = {
+  subagent: 'a subagent',
+  agents: 'Collie’s instructions (AGENTS.md)',
+  vision: 'Collie’s personality (VISION.md)',
+  memory_dream: 'long-term memory'
+}
+
+/** One Gardener suggestion: evidence + proposed change + Approve/Dismiss. */
+export default function GardenerCard({ data }: Props): React.JSX.Element {
+  const suggestions = (data.suggestions ?? []) as GardenerSuggestion[]
+  if (suggestions.length === 0) return <div />
+
+  return (
+    <div className="gardener-card">
+      <div className="suggestion-card-heading">
+        <Sparkles size={15} />
+        <span className="suggestion-card-label">Collie’s improvement ideas</span>
+      </div>
+      <p className="suggestion-card-text">
+        I looked at recent run records and found a few small things worth
+        reviewing. Approve any you like — everything stays undoable.
+      </p>
+      {suggestions.map((suggestion, index) => (
+        <GardenerRow
+          key={`${suggestion.artifact_type}:${suggestion.artifact_key}:${index}`}
+          suggestion={suggestion}
+        />
+      ))}
+    </div>
+  )
+}
+
+function GardenerRow({
+  suggestion
+}: {
+  suggestion: GardenerSuggestion
+}): React.JSX.Element {
+  const [status, setStatus] = useState<Status>('pending')
+  const [busy, setBusy] = useState(false)
+  const [versionId, setVersionId] = useState<string | null>(null)
+  const [diffText, setDiffText] = useState<string | null>(null)
+  const [notice, setNotice] = useState('')
+
+  const label = TYPE_LABELS[suggestion.artifact_type] ?? suggestion.artifact_key
+  const fileName =
+    suggestion.artifact_type === 'subagent'
+      ? `subagents/${suggestion.artifact_key}`
+      : suggestion.artifact_key
+
+  const handleApprove = async (): Promise<void> => {
+    setStatus('applying')
+    setBusy(true)
+    setNotice('')
+    try {
+      const result = await collieClient.applyGardenerSuggestion(suggestion)
+      setVersionId(result.version_id ?? null)
+      setDiffText(result.diff_text ?? null)
+      setStatus('applied')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not apply that change.')
+      setStatus('pending')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUndo = async (): Promise<void> => {
+    if (!versionId) return
+    setBusy(true)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      setVersionId(null)
+      setDiffText(null)
+      setNotice('Undone — the change was rolled back.')
+      setStatus('pending')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDismiss = (): void => {
+    setStatus('dismissed')
+  }
+
+  return (
+    <div className="gardener-row">
+      <div className="gardener-row-head">
+        <b>Improve {label}</b>
+        <span className="gardener-file">{fileName}</span>
+      </div>
+      {suggestion.rationale && (
+        <p className="suggestion-card-text">{suggestion.rationale}</p>
+      )}
+      {suggestion.evidence_ids.length > 0 && (
+        <p className="gardener-evidence">
+          Based on: {suggestion.evidence_ids.join(' · ')}
+        </p>
+      )}
+      {status === 'dismissed' ? (
+        <p className="suggestion-card-text">Dismissed — nothing changed.</p>
+      ) : status === 'applied' ? (
+        <>
+          <p className="suggestion-card-text">Applied. You can undo it any time.</p>
+          {diffText && <DiffView diff={diffText} label="See what changed" />}
+          {notice && <p className="suggestion-card-text">{notice}</p>}
+          {versionId && (
+            <div className="suggestion-card-actions">
+              <button
+                type="button"
+                className="suggestion-btn undo"
+                onClick={() => void handleUndo()}
+                disabled={busy}
+              >
+                <Undo2 size={14} /> {busy ? 'Undoing…' : 'Undo'}
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <pre className="gardener-proposed">{suggestion.proposed_text}</pre>
+          {notice && <p className="suggestion-card-text">{notice}</p>}
+          <div className="suggestion-card-actions">
+            <button
+              type="button"
+              className="suggestion-btn approve"
+              onClick={() => void handleApprove()}
+              disabled={busy || status === 'applying'}
+            >
+              <Check size={14} /> {status === 'applying' ? 'Applying…' : 'Approve'}
+            </button>
+            <button
+              type="button"
+              className="suggestion-btn dismiss"
+              onClick={handleDismiss}
+              disabled={busy}
+            >
+              <X size={14} /> Dismiss
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/collie-ui/src/renderer/src/components/cards/SuggestionCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/SuggestionCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Check, X, FileText, Sparkles } from 'lucide-react'
+import { Check, Undo2, X, FileText, Sparkles } from 'lucide-react'
 import { collieClient } from '../../lib/ipc'
+import DiffView from './DiffView'
 
 interface Props {
   data: Record<string, unknown>
@@ -15,6 +16,8 @@ export function mergeSuggestion(existing: string, suggestion: string): string {
   return `${current}\n\n${trimmed}\n`
 }
 
+type Status = 'pending' | 'checking' | 'saving' | 'saved' | 'dismissed'
+
 export default function SuggestionCard({ data }: Props): React.JSX.Element {
   const file = String(data.file || '')
   const label = String(data.label || '')
@@ -22,7 +25,11 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
   const reasoning = String(data.reasoning || '')
   const fileName = file || 'AGENTS.md'
 
-  const [status, setStatus] = useState<'pending' | 'checking' | 'saving' | 'saved' | 'dismissed'>('checking')
+  const [status, setStatus] = useState<Status>('checking')
+  const [busy, setBusy] = useState(false)
+  const [versionId, setVersionId] = useState<string | null>(null)
+  const [diffText, setDiffText] = useState<string | null>(null)
+  const [undoNotice, setUndoNotice] = useState('')
 
   const isPersonality = file === 'VISION.md'
   const Icon = isPersonality ? Sparkles : FileText
@@ -42,8 +49,10 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
     return () => { cancelled = true }
   }, [fileName, suggestion])
 
-  const handleApprove = async () => {
+  const handleApprove = async (): Promise<void> => {
     setStatus('saving')
+    setBusy(true)
+    setUndoNotice('')
     try {
       const { content } = await collieClient.readFile(fileName)
       if (content.trim() === suggestion.trim()) {
@@ -53,14 +62,35 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
       // Merge, never overwrite: the target file may hold user-authored
       // content the suggestion must not destroy.
       const applied = mergeSuggestion(content, suggestion)
-      await collieClient.writeFile(fileName, applied)
+      const result = await collieClient.writeFile(fileName, applied)
+      setVersionId(result.version_id ?? null)
+      setDiffText(result.diff_text ?? null)
       setStatus('saved')
     } catch {
       setStatus('pending')
+    } finally {
+      setBusy(false)
     }
   }
 
-  const handleDismiss = () => {
+  const handleUndo = async (): Promise<void> => {
+    if (!versionId) return
+    setBusy(true)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      setVersionId(null)
+      setDiffText(null)
+      setUndoNotice('Undone — the change was rolled back.')
+      setStatus('pending')
+    } catch (error) {
+      setUndoNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+      setStatus('saved')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDismiss = (): void => {
     setStatus('dismissed')
   }
 
@@ -76,6 +106,20 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
           <span className="suggestion-card-label">Applied to {label}</span>
         </div>
         <p className="suggestion-card-text">{reasoning}</p>
+        {diffText && <DiffView diff={diffText} label="See what changed" />}
+        {undoNotice && <p className="suggestion-card-text">{undoNotice}</p>}
+        {versionId && (
+          <div className="suggestion-card-actions">
+            <button
+              type="button"
+              className="suggestion-btn undo"
+              onClick={() => void handleUndo()}
+              disabled={busy}
+            >
+              <Undo2 size={14} /> {busy ? 'Undoing…' : 'Undo'}
+            </button>
+          </div>
+        )}
       </div>
     )
   }
@@ -108,10 +152,10 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
       <div className="suggestion-card-actions">
         <button
           className="suggestion-btn approve"
-          onClick={handleApprove}
+          onClick={() => void handleApprove()}
           disabled={status === 'saving'}
         >
-          {status === 'saving' ? 'Applying\u2026' : 'Approve edit'}
+          {status === 'saving' ? 'Applying…' : 'Approve edit'}
         </button>
         <button
           className="suggestion-btn dismiss"

--- a/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Check, Pencil, Plus, Trash2, X } from 'lucide-react'
-import { collieClient } from '../../lib/ipc'
+import { Check, History, Pencil, Plus, Sparkles, Trash2, Undo2, X } from 'lucide-react'
+import { collieClient, type ArtifactVersion } from '../../lib/ipc'
+import DiffView from '../cards/DiffView'
 
 interface Props {
   onNotice: (msg: string) => void
@@ -76,6 +77,26 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
     label: '',
     recurring: 0
   })
+  const [versions, setVersions] = useState<ArtifactVersion[]>([])
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [undoingId, setUndoingId] = useState<string | null>(null)
+  const [reviewBusy, setReviewBusy] = useState<'dream' | 'gardener' | null>(null)
+  const [reviewMsg, setReviewMsg] = useState('')
+
+  const refreshHistory = useCallback(async (): Promise<void> => {
+    try {
+      const [profile, dream] = await Promise.all([
+        collieClient.listVersions({ artifact_type: 'memory_profile', limit: 50 }),
+        collieClient.listVersions({ artifact_type: 'memory_dream', limit: 50 })
+      ])
+      const merged = [...profile.versions, ...dream.versions].sort((a, b) =>
+        b.created_at.localeCompare(a.created_at)
+      )
+      setVersions(merged)
+    } catch {
+      setVersions([])
+    }
+  }, [])
 
   const refresh = useCallback(async () => {
     const [pData, ppl, dateData] = await Promise.all([
@@ -86,7 +107,53 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
     setProfile(pData.profile || {})
     setPeople(ppl.people || [])
     setDates(dateData.dates || [])
-  }, [])
+    await refreshHistory()
+  }, [refreshHistory])
+
+  const undoVersion = async (versionId: string): Promise<void> => {
+    setUndoingId(versionId)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      await refreshHistory()
+      onNotice('Undone — the earlier version is back.')
+    } catch (error) {
+      onNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+    } finally {
+      setUndoingId(null)
+    }
+  }
+
+  const runSelfReview = async (kind: 'dream' | 'gardener'): Promise<void> => {
+    setReviewBusy(kind)
+    setReviewMsg('')
+    try {
+      const outcome =
+        kind === 'dream'
+          ? await collieClient.runDream()
+          : await collieClient.runGardener()
+      const message =
+        outcome.message ??
+        (kind === 'dream'
+          ? 'Memory review done.'
+          : 'Improvement suggestions are ready — check the chat for the review cards.')
+      setReviewMsg(message)
+      if (kind === 'dream') await refreshHistory()
+      onNotice(message)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'That review could not run right now.'
+      setReviewMsg(message)
+      onNotice(message)
+    } finally {
+      setReviewBusy(null)
+    }
+  }
+
+  const versionLabel = (version: ArtifactVersion): string => {
+    if (version.artifact_type === 'memory_dream') return "Collie's weekly memory review"
+    if (version.source === 'gardener') return "Collie's improvement suggestions"
+    return 'Your memory edit'
+  }
 
   useEffect(() => {
     void refresh().catch(() => undefined).finally(() => setLoading(false))
@@ -577,6 +644,89 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
           )}
         </>
       )}
+
+      <section className="memory-section">
+        <h3><Sparkles size={14} /> Collie's self-review</h3>
+        <p className="memory-note">
+          Run a memory review (tidies long-term memory, undoable) or ask for
+          improvement suggestions from recent run records. Suggestions appear
+          as review cards in the 🔔 conversation.
+        </p>
+        <div className="memory-toolbar">
+          <button
+            type="button"
+            className="settings-button"
+            disabled={reviewBusy !== null}
+            onClick={() => void runSelfReview('dream')}
+          >
+            <History size={13} />{' '}
+            {reviewBusy === 'dream' ? 'Reviewing…' : 'Review memory now'}
+          </button>
+          <button
+            type="button"
+            className="settings-button"
+            disabled={reviewBusy !== null}
+            onClick={() => void runSelfReview('gardener')}
+          >
+            <Sparkles size={13} />{' '}
+            {reviewBusy === 'gardener' ? 'Thinking…' : 'Suggest improvements'}
+          </button>
+        </div>
+        {reviewMsg && <p className="memory-note">{reviewMsg}</p>}
+      </section>
+
+      <section className="memory-section">
+        <h3><History size={14} /> History</h3>
+        <p className="memory-note">
+          Every memory change is snapshotted — edits, Collie's weekly memory reviews,
+          and improvement suggestions — so anything can be undone.
+        </p>
+        <div className="memory-toolbar">
+          <button
+            type="button"
+            className="settings-button"
+            onClick={() => setHistoryOpen((current) => !current)}
+            aria-expanded={historyOpen}
+          >
+            {historyOpen ? 'Hide history' : `Show history (${versions.length})`}
+          </button>
+        </div>
+        {historyOpen && (
+          versions.length === 0 ? (
+            <p className="memory-note">No changes recorded yet.</p>
+          ) : (
+            <div className="version-list">
+              {versions.map((version) => (
+                <div className="version-row" key={version.id}>
+                  <div className="version-row-main">
+                    <b>{versionLabel(version)}</b>
+                    <span>
+                      {version.status === 'rolled_back' ? 'Already undone · ' : ''}
+                      {new Date(version.created_at).toLocaleString()}
+                    </span>
+                    {version.diff_text && (
+                      <DiffView
+                        diff={version.diff_text}
+                        label={`Version ${version.version} — see what changed`}
+                      />
+                    )}
+                  </div>
+                  {version.status === 'applied' && (
+                    <button
+                      type="button"
+                      className="settings-button"
+                      disabled={undoingId === version.id}
+                      onClick={() => void undoVersion(version.id)}
+                    >
+                      <Undo2 size={13} /> {undoingId === version.id ? 'Undoing…' : 'Undo'}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )
+        )}
+      </section>
     </div>
   )
 }

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -315,6 +315,38 @@ export interface ToolEvent {
   finished_at?: string | null
 }
 
+/** One snapshotted artifact edit (PR 2 versioned rollback rail). */
+export interface ArtifactVersion {
+  id: string
+  artifact_type: string
+  artifact_key: string
+  version: number
+  before_text?: string | null
+  after_text?: string | null
+  diff_text?: string | null
+  evidence_json?: string | null
+  source: string
+  status: string
+  created_at: string
+}
+
+export interface RollbackArtifactResult {
+  rolled_back: boolean
+  version_id: string
+  artifact_type: string
+  artifact_key: string
+  version: number
+}
+
+/** One validated Gardener suggestion (proposed artifact change). */
+export interface GardenerSuggestion {
+  artifact_type: 'subagent' | 'agents' | 'vision' | 'memory_dream'
+  artifact_key: string
+  proposed_text: string
+  rationale: string
+  evidence_ids: string[]
+}
+
 /** A user-facing progress snapshot. It deliberately excludes tool traffic and model reasoning. */
 export interface TaskStep {
   key: string
@@ -635,6 +667,58 @@ export class CollieClient {
     return this.command('get_tool_events', opts ?? {})
   }
 
+  listVersions(opts?: {
+    artifact_type?: string
+    artifact_key?: string
+    limit?: number
+  }): Promise<{ versions: ArtifactVersion[] }> {
+    return this.command('list_versions', opts ?? {})
+  }
+
+  rollbackArtifact(versionId: string): Promise<RollbackArtifactResult> {
+    return this.command('rollback_artifact', { version_id: versionId })
+  }
+
+  /** Manual trigger: run one Dream consolidation pass (Settings -> Memory). */
+  runDream(): Promise<{
+    changed: boolean
+    reason?: string
+    version_id?: string | null
+    diff?: string
+    cursor?: string
+    message?: string
+  }> {
+    return this.command('run_dream', {})
+  }
+
+  /** Past Dream consolidations (memory_dream versions), newest first. */
+  getDreamHistory(): Promise<{ versions: ArtifactVersion[] }> {
+    return this.command('get_dream_history', {})
+  }
+
+  /** Manual trigger: run one Gardener pass (evidence -> suggestions). */
+  runGardener(): Promise<{
+    suggestions: GardenerSuggestion[]
+    rejected?: Array<{ reason: string; artifact_type: string; artifact_key: string }>
+    message?: string
+  }> {
+    return this.command('run_gardener', {})
+  }
+
+  /** Approve one suggestion: re-validated, applied, versioned (undoable). */
+  applyGardenerSuggestion(
+    suggestion: GardenerSuggestion
+  ): Promise<{
+    applied: boolean
+    no_change?: boolean
+    version_id?: string | null
+    diff_text?: string
+    artifact_type: string
+    artifact_key: string
+  }> {
+    return this.command('apply_gardener_suggestion', { suggestion })
+  }
+
   stopConversation(
     conversationId: string
   ): Promise<{
@@ -745,7 +829,10 @@ export class CollieClient {
     return this.command('read_file', { path })
   }
 
-  writeFile(path: string, content: string): Promise<{ saved: boolean }> {
+  writeFile(
+    path: string,
+    content: string
+  ): Promise<{ saved: boolean; version_id?: string | null; diff_text?: string | null }> {
     return this.command('write_file', { path, content })
   }
 

--- a/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { ArrowLeft, Bot, Eye, Plus, Shapes, Sparkles, Trash2, Zap, X } from 'lucide-react'
-import { collieClient, type CollieSkill, type Subagent, type SubagentStarter } from '../lib/ipc'
+import { ArrowLeft, Bot, Eye, History, Plus, Shapes, Sparkles, Trash2, Undo2, Zap, X } from 'lucide-react'
+import { collieClient, type ArtifactVersion, type CollieSkill, type Subagent, type SubagentStarter } from '../lib/ipc'
 import AgentAvatar from '../components/AgentAvatar'
 
 function summarizeDescription(description: string): string {
@@ -39,6 +39,8 @@ export default function AgentsScreen(): React.JSX.Element {
   const [notice, setNotice] = useState('')
   const [skills, setSkills] = useState<CollieSkill[]>([])
   const [category, setCategory] = useState<AgentCategory>('All')
+  const [versions, setVersions] = useState<ArtifactVersion[]>([])
+  const [undoingId, setUndoingId] = useState<string | null>(null)
 
   const selected = useMemo(
     () => agents.find((agent) => agent.id === selectedId) ?? null,
@@ -76,6 +78,41 @@ export default function AgentsScreen(): React.JSX.Element {
     setPrompt(selected?.system_prompt ?? '')
     setExecutionPosture(selected?.execution_posture ?? 'read_only')
   }, [selected])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!selected?.filename || new URLSearchParams(window.location.search).has('preview')) {
+      setVersions([])
+      return
+    }
+    collieClient
+      .listVersions({ artifact_type: 'subagent', artifact_key: selected.filename })
+      .then(({ versions }) => {
+        if (!cancelled) setVersions(versions)
+      })
+      .catch(() => {
+        if (!cancelled) setVersions([])
+      })
+    return () => { cancelled = true }
+  }, [selected?.filename])
+
+  const undoVersion = async (versionId: string): Promise<void> => {
+    setUndoingId(versionId)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      await refresh()
+      const { versions: fresh } = await collieClient.listVersions({
+        artifact_type: 'subagent',
+        artifact_key: selected?.filename
+      })
+      setVersions(fresh)
+      setNotice('Undone — the earlier version is back.')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+    } finally {
+      setUndoingId(null)
+    }
+  }
 
   const createAgent = async (
     nextName = name.trim(),
@@ -249,6 +286,49 @@ export default function AgentsScreen(): React.JSX.Element {
                   Save changes
                 </button>
               </div>
+            </section>
+            <section className="detail-card detail-card--wide">
+              <div className="detail-card-heading">
+                <div>
+                  <span className="detail-label">History</span>
+                  <h2>Past versions</h2>
+                </div>
+                <History size={18} />
+              </div>
+              <p className="detail-help">
+                Every edit to {selected.name}'s instructions is kept here, so a change
+                can always be undone.
+              </p>
+              {versions.length === 0 ? (
+                <p className="detail-help">No recorded changes yet.</p>
+              ) : (
+                <div className="version-list">
+                  {versions.map((version) => (
+                    <div className="version-row" key={version.id}>
+                      <div className="version-row-main">
+                        <b>Version {version.version}</b>
+                        <span>
+                          {version.status === 'rolled_back' ? 'Already undone · ' : ''}
+                          {new Date(version.created_at).toLocaleString()}
+                          {version.source === 'collie' || version.source === 'gardener'
+                            ? ` · by ${version.source === 'gardener' ? "Collie's gardener" : 'Collie'}`
+                            : ''}
+                        </span>
+                      </div>
+                      {version.status === 'applied' && (
+                        <button
+                          type="button"
+                          className="settings-button"
+                          disabled={undoingId === version.id}
+                          onClick={() => void undoVersion(version.id)}
+                        >
+                          <Undo2 size={13} /> {undoingId === version.id ? 'Undoing…' : 'Undo'}
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </section>
           </div>
           {notice && <p className="inline-notice" role="status">{notice}</p>}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1010,6 +1010,121 @@ button {
   color: var(--ink);
 }
 
+/* Gardener suggestion card (evidence -> propose -> approve/dismiss) */
+.gardener-card {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--card);
+  padding: 12px 14px;
+  margin: 4px 0 10px;
+}
+.gardener-row {
+  border-top: 1px dashed var(--line);
+  margin-top: 10px;
+  padding-top: 10px;
+}
+.gardener-row:first-of-type {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 0;
+}
+.gardener-row-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.gardener-row-head b {
+  font-size: 14px;
+  color: var(--ink);
+}
+.gardener-file {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: var(--font-mono, monospace);
+}
+.gardener-evidence {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.gardener-proposed {
+  max-height: 220px;
+  margin: 8px 0 12px;
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bone);
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ink);
+}
+
+/* Diff view (versioned rollback rail — added/removed lines) */
+.diff-view {
+  margin: 4px 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bone);
+  overflow: hidden;
+}
+.diff-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 7px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+.diff-toggle:hover { color: var(--ink); }
+.diff-text {
+  max-height: 220px;
+  margin: 0;
+  padding: 8px 10px;
+  overflow: auto;
+  border-top: 1px solid var(--line);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+.diff-text .is-added { color: #1a7f37; background: rgba(26, 127, 55, 0.08); }
+.diff-text .is-removed { color: #c0392b; background: rgba(192, 57, 43, 0.08); }
+
+/* Version history rows (Agents + Memory history) */
+.version-list { display: grid; gap: 6px; }
+.version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--card);
+}
+.version-row-main { display: grid; gap: 2px; min-width: 0; }
+.version-row-main b { font-size: 13px; color: var(--ink); }
+.version-row-main span { font-size: 11.5px; color: var(--muted); }
+.version-row .settings-button {
+  flex: none;
+  min-height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  border-radius: 8px;
+}
+
 .settings-lead { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
 .settings-card { margin-bottom: 14px; border: 1px solid var(--collie-border); border-radius: 14px; padding: 15px; }
 .settings-card h3 { display: flex; gap: 7px; align-items: center; margin: 0 0 12px; font-size: 14px; }

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -32,6 +32,32 @@ are not part of this public source tree.
   (run records), runtime composition, and the internal headless engine
   mode (`collie_core/headless.py` — one task, one JSON result document,
   exit; an engineering-only benchmark entry, not a user-facing CLI).
+- **Self-improvement stack** (Gardener Foundations, architecture:
+  `docs/engineering/architecture/gardener-foundations.md`):
+  - `collie_core/versions.py` — `VersionStore`: every user-visible artifact
+    edit (subagent files, `VISION.md`/`AGENTS.md`/`MEMORY.md`, dream
+    consolidations, Gardener applies) is snapshotted into the
+    `artifact_versions` table (schema V14) with a before/after text pair +
+    unified diff; one-action rollback that never clobbers newer owner
+    edits. Wired into `SubagentLoader`, `ProfileStore`, IPC `write_file`
+    (workspace artifacts), Dream, and Gardener applies.
+  - `collie_core/memory/dream.py` — `run_dream()`: bounded, read-only
+    consolidation of nanobot's long-term `memory/MEMORY.md` (vendored
+    Dream machinery: cursor, prompt builder, session pruning); versioned
+    as `memory_dream`, undoable in Settings → Memory.
+  - `collie_core/gardener/` — the self-improvement loop:
+    `evidence.py` (read-only telemetry queries: repeated tool failures,
+    repeated workflows, stopped turns, memory bloat), `propose.py`
+    (bounded subagent turn + deterministic validation: allowlisted
+    artifact types only, keyword gate against permissions/settings/
+    secrets/connectors, size budgets), `runner.py` (`run_gardener` +
+    `apply_suggestion` through the versioned rollback rail).
+  - Triggers: built-in automations (`memory_maintenance` Sun 09:00,
+    `gardener` Sun 10:00, seeded once, disabled by default) + manual IPC
+    (`run_dream`, `run_gardener`) from Settings → Memory → "Collie's
+    self-review". Review cards (`gardener_suggestion`) render in chat with
+    Approve/Dismiss/Undo.
+
 - `nanobot/` contains the adapted upstream engine. Changes should remain
   surgical and preserve third-party attribution.
 - `tests/` contains Python unit, integration, IPC, safety, and end-to-end

--- a/docs/engineering/architecture/gardener-foundations.md
+++ b/docs/engineering/architecture/gardener-foundations.md
@@ -1,0 +1,223 @@
+# Gardener Foundations — run records, versioned artifacts, Dream memory, and the Gardener MVP
+
+> **Status (2026-08-05):** fully landed. PR 1 (run records) merged on
+> `main`; PRs 2–4 (version store, Dream wiring, Gardener MVP) ship together
+> on `feat/gardener` as one branch. This document records the decisions and
+> the *shipped* shape — where it differs from the original plan, the
+> difference is deliberate and noted below.
+
+## Goal
+
+Give Collie a safe, evidence-driven self-improvement story:
+
+1. **Run records** — per-turn and per-tool telemetry (already merged, PR 1).
+2. **Version store** — every user-visible artifact edit is snapshotted with
+   a before/after text pair and a unified diff, and can be rolled back with
+   one action **without ever clobbering a newer owner edit**.
+3. **Episodic memory (Dream)** — wire nanobot's already-vendored Dream
+   machinery into Collie's automation scheduler with a review + undo surface.
+4. **Gardener MVP** — evidence queries → bounded proposal turn → review
+   cards with Approve/Dismiss → versioned, undoable applies.
+
+The four pieces are deliberately additive: three narrow packages in
+`collie_core/` (plus the telemetry package already on `main`), additive IPC
+commands, and no edits to the nanobot orchestration core.
+
+## Architecture
+
+### 1. Run records (`collie_core/telemetry/`, merged on main)
+
+- Schema V11: `turn_events` + `tool_events`; V12 adds prompt-hash columns
+  (`prompt_hash`, `tool_schema_hash`, `config_hash`) for the evaluation lab.
+- `RunRecorder` writes through a fire-and-forget writer thread (bounded
+  queue, drop counter, event-time timestamps) — telemetry never delays or
+  breaks a turn.
+- `TelemetryHook` observes every turn kind (chat, plan, routine, cron,
+  subagent, automation) through the existing `AgentHook` chain. Zero loop
+  edits.
+- All stored summaries pass through `redact_parameters` + truncation;
+  secrets never enter telemetry.
+
+The Gardener's evidence layer is the first real consumer of these tables.
+
+### 2. Version store (`collie_core/versions.py`, this branch)
+
+Schema V14 adds `artifact_versions`:
+
+| column | meaning |
+| --- | --- |
+| `artifact_type` | `subagent` \| `vision` \| `agents` \| `memory_profile` \| `memory_dream` \| `skill` |
+| `artifact_key` | plain filename (subagent file name, `VISION.md`, `AGENTS.md`, `MEMORY.md`, …) |
+| `version` | per-(type, key) monotonic counter |
+| `before_text` / `after_text` | full text pair |
+| `diff_text` | `difflib.unified_diff` |
+| `evidence_json` | Gardener trigger evidence (run ids, tool stats) |
+| `source` | `user` \| `collie` \| `gardener` |
+| `status` | `applied` \| `rolled_back` |
+
+`VersionStore.snapshot()` returns `None` when the texts are identical
+(nothing changed → no version row). `VersionStore.rollback()` restores the
+`before_text` of the target version **only when the artifact's current text
+still equals that version's `after_text`** — otherwise it raises
+`VersionConflictError` ("Undo the most recent change first"). The caller
+writes the restored text; each artifact type knows its own re-sync rules.
+
+**Wired write paths** (every one snapshots *before* writing):
+
+- `SubagentLoader.create/update/delete` → `subagent` versions; rollback
+  re-runs `loader.sync()` so the disk→DB mirror stays consistent.
+- `ProfileStore` mutation methods (`set`, `delete`, person/date CRUD) →
+  `memory_profile` versions of workspace `MEMORY.md`.
+- IPC `_cmd_write_file` classifies workspace files
+  (`VISION.md`, `AGENTS.md`, `MEMORY.md`, `memory/MEMORY.md`,
+  `subagents/*.md`) and snapshots automatically, returning
+  `version_id` + `diff_text` so the caller can offer Undo. This is the
+  suggest-card apply path: `SuggestionCard` reads, merges, writes, and
+  renders the returned diff with an **Undo** button.
+- Dream consolidations → `memory_dream` versions (`source="collie"`).
+- Gardener applies → `source="gardener"` with the evidence + rationale in
+  `evidence_json`.
+
+**UI (minimal but real):** `DiffView` (collapsible, color-coded unified
+diff), Undo on `SuggestionCard`, a History expansion in
+`AgentsScreen` and Settings → Memory (per-version diff + Undo), and a
+rollback rail in Settings → Memory → History.
+
+> **Schema note:** the original plan numbered the version store V12. By the
+> time it landed, V12 (prompt hashes) and V13 (`memory_journal`) were
+> already shipped on `main`, so `artifact_versions` is **V14**. Shipped
+> migrations are never edited.
+
+### 3. Dream memory (`collie_core/memory/dream.py`, this branch)
+
+Nanobot's Dream machinery (cursor, prompt builder, session keys, pruning)
+was vendored but dead; Collie had zero references. `run_dream()` wires it:
+
+1. `MemoryStore.build_dream_prompt()` — nothing new to review → early
+   return, cursor untouched.
+2. One **bounded, read-only** subagent turn under a `dream:<ts>` session
+   key: `max_iterations=1`, an **empty tool registry** (no tools, so
+   read-only by construction), `execution_posture="read_only"`. Collie has
+   no file-editing tools, so the output contract asks the model to return
+   the full proposed `memory/MEMORY.md` content (fence-tolerant parser).
+3. If the proposed content differs, write it atomically and snapshot via
+   `VersionStore` (`memory_dream` / `MEMORY.md`, `source="collie"`).
+4. Advance the dream cursor **only on success** (a completed turn — even a
+   no-change one — so history is never re-processed); failed/incomplete
+   turns leave the cursor put.
+5. `prune_dream_sessions(keep=10)` after each run.
+
+Dream never touches `ProfileStore` — it consolidates nanobot's long-term
+`memory/MEMORY.md` only.
+
+**Trigger:** two built-in automations seeded once under their own flag
+(`seed_gardener_automations`, never resurrects deletions), both disabled by
+default so nothing runs without the user enabling it:
+
+- **Memory maintenance** (`memory_maintenance` action type, `Sun 09:00`)
+- **Improvement suggestions** (`gardener` action type, `Sun 10:00`)
+
+The runtime's `_run_automation` dispatches these action types to their own
+bounded pipelines instead of a free-form prompt turn. Results land in the
+🔔 conversation and are broadcast like any automation.
+
+**Manual triggers:** IPC `run_dream` (Settings → Memory → "Review memory
+now") and `run_gardener` ("Suggest improvements") — both available from the
+Settings → Memory → "Collie's self-review" section.
+
+### 4. Gardener MVP (`collie_core/gardener/`, this branch)
+
+The loop: **evidence → propose → review → apply (versioned)**.
+
+**Evidence (`evidence.py`)** — read-only queries over the telemetry tables
+plus workspace files:
+
+- `recent_failures` — per-tool `error`/`denied`/`timeout` counts with
+  sample messages (default window: 14 days, min 2 failures).
+- `repeated_workflows` — per-turn ordered tool sequences appearing ≥ 3×.
+- `user_stops` — turns with status `stopped`/`cancelled`.
+- `memory_bloat` — size + duplicate-heading signals for `memory/MEMORY.md`
+  and `MEMORY.md`.
+
+**Propose (`propose.py`)** — one bounded subagent turn (same machinery as
+Dream: no tools, `read_only`, `max_iterations=1`) with a fixed prompt: the
+evidence summary (≤ ~2k tokens) + current agent/memory texts. Output is a
+JSON array of suggestions. **Nothing the model says is trusted** — every
+suggestion passes `validate_suggestion()`, a deterministic gate:
+
+- **Allowlist:** only `subagent`, `agents`, `vision`, `memory_dream`
+  artifact types may be proposed.
+- **Key safety:** plain filenames only (no path separators / traversal);
+  `agents` → `AGENTS.md`, `vision` → `VISION.md`,
+  `memory_dream` → `MEMORY.md`, `subagent` → `*.md`.
+- **Size budgets:** proposed text ≤ 4 000 chars, rationale ≤ 500 chars,
+  ≤ 3 suggestions per run.
+- **Keyword gate:** proposed text/rationale containing permissions,
+  approvals, settings, secrets, credentials, connectors, providers,
+  billing, or token-like language is rejected outright.
+
+Rejected suggestions are reported (reason + target) but never applied.
+
+**Runner (`runner.py`)** — `run_gardener()` collects evidence, proposes,
+and returns `{suggestions, rejected, evidence, message}`. `apply_suggestion()`
+**re-validates at apply time** (a forged or edited card cannot bypass the
+scope guard), snapshots through the version store (`source="gardener"`),
+writes the file, and re-syncs the subagent loader when needed.
+
+**Review surface:** suggestions render as `gardener_suggestion` chat cards
+(`GardenerCard`) in the 🔔 conversation with rationale, evidence labels,
+proposed text, **Approve / Dismiss**, and — after approval — the diff plus
+**Undo** (rollback through `apply_gardener_suggestion` /
+`rollback_artifact` IPC). Dismiss is a pure UI decision: no core write, no
+version row.
+
+**Scope guard (enforced in code, per the plan):** the Gardener only
+proposes agent instruction and memory consolidation changes. It never
+touches permissions, settings, secrets, or connectors — enforced by the
+allowlist + keyword gate, not by prompt wording.
+
+## Deferred (explicit, not forgotten)
+
+- **Sandbox replay.** The plan's ideal loop would run a proposed change in
+  a sandbox before applying it. The MVP deliberately ships without it: it
+  needs run-record history volume the product doesn't have yet, and the
+  deterministic scope guard + human approval stand in for it. Revisit when
+  telemetry has accumulated.
+- **Dream token-budget cap on injected memory** (`ContextBuilder` memory
+  section) — the vendored Dream machinery and the 3 000-token recent-history
+  cap bound the surface for now; a hard truncation of injected `MEMORY.md`
+  can follow with the memory hygiene work.
+- **Gardener "learn from approval" feedback loop** — the apply path records
+  evidence + rationale in `evidence_json` (so a later pass can learn which
+  suggestion classes get approved), but no learning model consumes it yet.
+
+## Files
+
+| path | role |
+| --- | --- |
+| `collie_core/telemetry/` | run records (PR 1, on `main`) |
+| `collie_core/versions.py` | `VersionStore` + `make_diff` |
+| `collie_core/memory/dream.py` | `run_dream()` consolidation runner |
+| `collie_core/gardener/evidence.py` | read-only evidence queries |
+| `collie_core/gardener/propose.py` | bounded proposal turn + strict validation |
+| `collie_core/gardener/runner.py` | `run_gardener` / `apply_suggestion` |
+| `collie_core/db.py` | schema V14 + `artifact_versions` methods |
+| `collie_core/ipc/server.py` | `list_versions`, `rollback_artifact`, `run_dream`, `get_dream_history`, `run_gardener`, `apply_gardener_suggestion` |
+| `collie_core/automations/scheduler.py` | `seed_gardener_automations` |
+| `collie_core/runtime.py` | version store wiring, Dream/Gardener pipelines, manual triggers |
+| `collie-ui/src/renderer/src/components/cards/DiffView.tsx` | unified-diff renderer |
+| `collie-ui/src/renderer/src/components/cards/GardenerCard.tsx` | review cards |
+| `collie-ui/src/renderer/src/components/settings/MemoryTab.tsx` | self-review buttons + History/Undo |
+| `collie-ui/src/renderer/src/screens/AgentsScreen.tsx` | subagent History/Undo |
+| `tests/collie/test_versions.py`, `test_dream_collie.py`, `test_gardener_mvp.py` | phase tests |
+
+## Verification
+
+- `pytest tests/collie -q --ignore=tests/collie/test_pet_status.py` — new
+  phase tests pass; only the documented Windows-only baseline failures
+  (DPAPI credentials, flaky IPC escape-path) remain.
+- `ruff check nanobot collie_core tests` — clean.
+- `npm run typecheck` + `npx vitest run` — clean.
+- e2e phase gates 1–4 stay green.
+- `tools/update_project_snapshot.py` + `--check` — regenerated for the new
+  packages.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,16 +11,16 @@
 
 ## Source inventory
 
-- Core Python files: **483**
-- Core Python test files: **220**
-- Desktop TypeScript/TSX files: **121**
+- Core Python files: **492**
+- Core Python test files: **223**
+- Desktop TypeScript/TSX files: **123**
 - Desktop test files: **36**
-- Active Markdown docs: **24**
+- Active Markdown docs: **25**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups
 
-`automations`, `connectors`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
+`automations`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
 
 ## Required orientation files
 


### PR DESCRIPTION
## Gardener Foundations, PRs 2–4 — versioned rollback, Dream memory, self-improvement MVP

Implements the remaining three phases of the Gardener Foundations plan (PR 1 — run-records telemetry — is already merged on `main`). The self-improvement story: every user-visible artifact edit is versioned and undoable, nanobot's Dream consolidator is wired into Collie, and a bounded Gardener MVP proposes evidence-based improvements as review cards.

### Phase 2 — Versioned artifact store + rollback rail

- Schema **V14**: `artifact_versions` (type, key, monotonic version, before/after text, unified diff, evidence, source, status).
- `collie_core/versions.py` — `VersionStore.snapshot()` (no-op on identical text) and `rollback()` with the **no-clobber guard** (refuses when current text ≠ the version's `after_text` — a newer owner edit is never overwritten).
- Wired write paths: `SubagentLoader` create/update/delete, `ProfileStore` mutations, IPC `write_file` (classifies `VISION.md` / `AGENTS.md` / `MEMORY.md` / `memory/MEMORY.md` / `subagents/*.md`, returns `version_id` + `diff_text`).
- IPC: `list_versions`, `rollback_artifact`. UI: `DiffView`, Undo + diff on `SuggestionCard`, History/Undo in `AgentsScreen`.

### Phase 3 — Dream memory wiring

- `collie_core/memory/dream.py` — `run_dream()`: bounded read-only subagent turn (no tools, `max_iterations=1`, `read_only`), proposed `memory/MEMORY.md` written atomically + snapshotted (`memory_dream`), cursor advances only on success, dream sessions pruned (keep 10). Never touches ProfileStore.
- Built-in automations seeded once (`Memory maintenance` Sun 09:00, `Improvement suggestions` Sun 10:00 — disabled by default, deletions never resurrected); runtime dispatches `memory_maintenance` / `gardener` action types to bounded pipelines.

### Phase 4 — Gardener MVP

- `gardener/evidence.py` — read-only queries: repeated tool failures (with samples), repeated workflows (≥3×), stopped turns, memory bloat.
- `gardener/propose.py` — one bounded proposal turn; **strict deterministic validation**: allowlisted types (`subagent`, `agents`, `vision`, `memory_dream`) only, safe keys, size budgets, keyword gate against permissions/settings/secrets/connectors.
- `gardener/runner.py` — `run_gardener()` + `apply_suggestion()` (re-validates at apply time; applies through the versioned rail, `source=gardener`, undoable).
- Review surface: `gardener_suggestion` chat cards (Approve/Dismiss/Undo), weekly automation + manual triggers (`run_gardener`, `apply_gardener_suggestion` IPC; Settings → Memory → "Collie's self-review").
- **Deferral (documented in the architecture doc):** sandbox replay before apply — needs run-record history volume; deterministic scope guard + human approval stand in for it.
- Docs: `docs/engineering/architecture/gardener-foundations.md` (keeps the telemetry docstring's "lands with PR 4" promise), PROJECT_MAP self-improvement stack, regenerated snapshot.

### Verification (all run on the VM, branch `feat/gardener`)

| gate | result |
| --- | --- |
| `pytest tests/collie -q --ignore=tests/collie/test_pet_status.py` | **592 passed**, 1 skipped, 5 failed = documented Windows-only baseline (4× DPAPI credentials in `test_services.py` + flaky `test_read_write_file_rejects_escape_paths`) |
| new phase tests | test_versions.py 23 ✓ · test_dream_collie.py 10 ✓ · test_gardener_mvp.py 36 ✓ |
| `ruff check nanobot collie_core tests` | clean |
| `npm run typecheck` (collie-ui) | clean |
| `npx vitest run` (collie-ui) | 179 passed / 36 files |
| `tools/update_project_snapshot.py --check` | current (492 py files, 223 test files, 123 TSX, 25 docs; `gardener` module group added) |
| e2e phase gates 1–4 | green (included in the 592) |
| secret scan | clean (no keys/tokens in diff) |
