### PR TITLE
feat(onboarding): paste-key connect, catalogue refresh, starter conversation

### DIFF
--- a/collie-core/collie_core/automations/scheduler.py
+++ b/collie-core/collie_core/automations/scheduler.py
@@ -20,7 +20,11 @@ from collie_core.db import CollieDB, utc_now
 from collie_core.routines.models import Schedule
 from collie_core.routines.schedule import next_occurrence
 
-__all__ = ["AutomationScheduler", "seed_builtin_automations"]
+__all__ = [
+    "AutomationScheduler",
+    "seed_builtin_automations",
+    "seed_gardener_automations",
+]
 
 BUILTIN_AUTOMATIONS = [
     {
@@ -136,6 +140,62 @@ def seed_builtin_automations(db: CollieDB) -> None:
     db.set_setting("automations.builtins_seeded", True)
 
 
+# Gardener-family built-ins (PR 3 + PR 4 of the Gardener Foundations plan).
+# Seeded under their own flag so installs that already ran
+# ``seed_builtin_automations`` still get them — and, like all built-ins,
+# a user deletion is never resurrected.
+GARDENER_AUTOMATIONS = [
+    {
+        "id": "collie-memory-maintenance",
+        "name": "Memory maintenance",
+        "description": "Weekly memory consolidation (Dream)",
+        "schedule": "Sun 09:00",
+        "action_type": "memory_maintenance",
+        "action_config": {
+            "kind": "dream",
+            "prompt": "",
+        },
+        "enabled": False,
+        "delivery_channels": ["in_app"],
+    },
+    {
+        "id": "collie-gardener-suggestions",
+        "name": "Improvement suggestions",
+        "description": "Weekly improvement suggestions from run records",
+        "schedule": "Sun 10:00",
+        "action_type": "gardener",
+        "action_config": {
+            "kind": "gardener",
+            "prompt": "",
+        },
+        "enabled": False,
+        "delivery_channels": ["in_app"],
+    },
+]
+
+
+def seed_gardener_automations(db: CollieDB) -> None:
+    """Seed the Gardener automations once (never resurrect deletions)."""
+    if db.get_setting("automations.gardener_seeded", False):
+        return
+    existing = {a["id"] for a in db.list_automations()}
+    for auto in GARDENER_AUTOMATIONS:
+        if auto["id"] in existing:
+            continue
+        db.add_automation(
+            auto["name"],
+            automation_id=auto["id"],
+            description=auto["description"],
+            schedule=auto["schedule"],
+            action_type=auto["action_type"],
+            action_config=auto["action_config"],
+            enabled=bool(auto.get("enabled", False)),
+            delivery_channels=auto["delivery_channels"],
+        )
+        logger.info("Seeded automation: {}", auto["name"])
+    db.set_setting("automations.gardener_seeded", True)
+
+
 def _match_schedule(schedule_str: str, now: datetime) -> bool:
     """Check if ``now`` matches a schedule string.
 
@@ -184,6 +244,7 @@ class AutomationScheduler:
 
     async def start(self) -> None:
         seed_builtin_automations(self.db)
+        seed_gardener_automations(self.db)
         stale_before = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(
             timespec="seconds"
         )

--- a/collie-core/collie_core/catalog/__init__.py
+++ b/collie-core/collie_core/catalog/__init__.py
@@ -1,0 +1,220 @@
+"""Bundled provider catalogue (models.dev snapshot + Collie curated layer).
+
+``CatalogueStore`` is the single access point for onboarding: it serves the
+provider list for the picker, the default model per provider, the base URL,
+key-prefix hints for paste-time auto-detection, and friendly model names for
+the "Connected — using …" confirmation. It also owns the optional weekly
+refresh (``refresh.py``) with version/hash retention and rollback to the
+last-good bundled snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from collie_core.catalog.curated import CURATED_ORDER, CURATED_PROVIDERS
+from collie_core.catalog.refresh import (
+    CATALOGUE_HASH_SETTING,
+    CATALOGUE_REFRESHED_AT_SETTING,
+    CATALOGUE_VERSION_SETTING,
+    fetch_and_trim_catalogue,
+)
+from collie_core.catalog.snapshot_util import (
+    SCHEMA_VERSION,
+    validate_catalogue_schema,
+)
+
+__all__ = ["CatalogueStore", "BUNDLED_SNAPSHOT_PATH", "SCHEMA_VERSION"]
+
+BUNDLED_SNAPSHOT_PATH = Path(__file__).resolve().parent / "snapshot.json"
+
+
+class CatalogueStore:
+    """Load, validate and query the provider catalogue snapshot."""
+
+    def __init__(self, settings: Any | None = None, snapshot_path: Path | None = None):
+        self._settings = settings
+        self._snapshot_path = snapshot_path or BUNDLED_SNAPSHOT_PATH
+        self._snapshot: dict[str, Any] | None = None
+        self._providers: dict[str, dict[str, Any]] = {}
+        self._model_names: dict[str, dict[str, str]] = {}
+        self._load()
+
+    # -- loading -----------------------------------------------------------
+
+    def _load(self) -> None:
+        """Load the bundled snapshot, then merge the live-refreshed overlay."""
+        # Reset first: when both the bundled file and the overlay are gone
+        # (rollback), a stale snapshot must not survive.
+        self._snapshot = None
+        if self._snapshot_path.is_file():
+            try:
+                self._snapshot = json.loads(self._snapshot_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                self._snapshot = None
+        if self._snapshot and not validate_catalogue_schema(self._snapshot):
+            self._snapshot = None
+        if self._settings is not None:
+            refreshed = str(self._settings.get_setting("catalogue.snapshot", "") or "")
+            if refreshed:
+                try:
+                    candidate = json.loads(refreshed)
+                except (TypeError, ValueError):
+                    candidate = None
+                if candidate is not None and validate_catalogue_schema(candidate):
+                    self._snapshot = candidate
+        self._index()
+
+    def _index(self) -> None:
+        providers: dict[str, dict[str, Any]] = {}
+        model_names: dict[str, dict[str, str]] = {}
+        for entry in (self._snapshot or {}).get("providers", []):
+            pid = str(entry.get("id") or "")
+            if not pid:
+                continue
+            models = entry.get("models") or {}
+            if isinstance(models, dict):
+                model_names[pid] = {
+                    str(mid): str(meta.get("name") or mid)
+                    for mid, meta in models.items()
+                    if isinstance(meta, dict)
+                }
+            providers[pid] = entry
+        self._providers = providers
+        self._model_names = model_names
+
+    # -- public queries ----------------------------------------------------
+
+    def snapshot_metadata(self) -> dict[str, Any]:
+        source = (self._snapshot or {}).get("source") or {}
+        return {
+            "schema_version": (self._snapshot or {}).get("schema_version"),
+            "generated_at": (self._snapshot or {}).get("generated_at"),
+            "source_url": source.get("url"),
+            "source_sha256": source.get("sha256"),
+            "source_providers_count": source.get("providers_count"),
+        }
+
+    def refresh_state(self) -> dict[str, Any]:
+        """Quiet Settings display: when the live catalogue was last accepted."""
+        if self._settings is None:
+            return {"available": False}
+        return {
+            "available": True,
+            "version": str(self._settings.get_setting(CATALOGUE_VERSION_SETTING, "") or ""),
+            "sha256": str(self._settings.get_setting(CATALOGUE_HASH_SETTING, "") or ""),
+            "refreshed_at": str(
+                self._settings.get_setting(CATALOGUE_REFRESHED_AT_SETTING, "") or ""
+            ),
+        }
+
+    def providers(self) -> list[dict[str, Any]]:
+        """Curated providers in picker order with merged snapshot data."""
+        out: list[dict[str, Any]] = []
+        ordered = list(CURATED_ORDER) + [
+            pid for pid in sorted(self._providers) if pid not in CURATED_ORDER
+        ]
+        for pid in ordered:
+            curated = dict(CURATED_PROVIDERS.get(pid) or {})
+            entry = self._providers.get(pid)
+            if entry is None:
+                continue
+            merged = {
+                "id": pid,
+                "name": curated.get("name") or entry.get("name") or pid,
+                "auth_type": curated.get("auth_type") or "api-key",
+                "protocol": curated.get("protocol") or "openai",
+                "api_base": curated.get("api_base") or entry.get("api_base"),
+                "default_model": curated.get("default_model") or entry.get("default_model"),
+                "key_prefixes": curated.get("key_prefixes") or [],
+                "tested": bool(curated.get("tested", False)),
+                "help_url": entry.get("help_url") or entry.get("doc_url"),
+                "models": [
+                    {"id": mid, "name": self._model_names.get(pid, {}).get(mid, mid)}
+                    for mid in (entry.get("models") or {}).keys()
+                ],
+            }
+            out.append(merged)
+        return out
+
+    def get_provider(self, provider_id: str) -> dict[str, Any] | None:
+        return next(
+            (p for p in self.providers() if p["id"] == provider_id),
+            None,
+        )
+
+    def default_model(self, provider_id: str) -> str | None:
+        provider = self.get_provider(provider_id)
+        if provider is None:
+            return None
+        return str(provider.get("default_model") or "") or None
+
+    def api_base(self, provider_id: str) -> str | None:
+        provider = self.get_provider(provider_id)
+        if provider is None:
+            return None
+        return str(provider.get("api_base") or "") or None
+
+    def model_label(self, provider_id: str, model_id: str | None) -> str | None:
+        """Friendly model name for the connect confirmation copy."""
+        if not model_id:
+            return None
+        names = self._model_names.get(provider_id, {})
+        return names.get(model_id) or model_id
+
+    # -- paste-time key detection -------------------------------------------
+
+    def detect_provider_for_key(self, api_key: str) -> list[str]:
+        """Ordered candidate provider ids for a pasted key (prefix hints only).
+
+        Ambiguous prefixes return every matching provider; the caller resolves
+        ambiguity with a live probe (the probe is the authority, not prefixes).
+        """
+        key = (api_key or "").strip()
+        if not key:
+            return []
+        matches: list[tuple[int, str]] = []
+        for provider in self.providers():
+            for prefix in provider.get("key_prefixes") or []:
+                prefix = str(prefix)
+                if prefix and key.startswith(prefix):
+                    matches.append((len(prefix), str(provider["id"])))
+                    break
+        if not matches:
+            return []
+        matches.sort(key=lambda item: item[0], reverse=True)
+        longest = matches[0][0]
+        # Only the longest matching prefix group counts: a key starting
+        # ``sk-ant-`` is an Anthropic key, not an ambiguous ``sk-`` key.
+        return [pid for length, pid in matches if length == longest]
+
+    # -- refresh / rollback --------------------------------------------------
+
+    async def refresh(self, url: str | None = None) -> dict[str, Any]:
+        """Fetch the live models.dev feed, validate, trim, and persist.
+
+        The previous snapshot stays available: the accepted snapshot (with its
+        version + sha256) is retained in settings, and ``rollback()`` restores
+        the bundled file as the last-good source.
+        """
+        if self._settings is None:
+            return {"refreshed": False, "error": "Catalogue refresh needs a settings store."}
+        result = await fetch_and_trim_catalogue(
+            settings=self._settings, url=url
+        )
+        if result.get("refreshed"):
+            self._load()
+        return result
+
+    def rollback(self) -> dict[str, Any]:
+        """Drop the live-refreshed overlay and return to the bundled snapshot."""
+        if self._settings is None:
+            return {"rolled_back": False, "error": "Catalogue refresh needs a settings store."}
+        self._settings.delete_setting("catalogue.snapshot")
+        self._settings.delete_setting(CATALOGUE_VERSION_SETTING)
+        self._settings.delete_setting(CATALOGUE_HASH_SETTING)
+        self._settings.delete_setting(CATALOGUE_REFRESHED_AT_SETTING)
+        self._load()
+        return {"rolled_back": True}

--- a/collie-core/collie_core/catalog/curated.py
+++ b/collie-core/collie_core/catalog/curated.py
@@ -1,0 +1,135 @@
+"""Collie-owned curated layer over the models.dev catalogue.
+
+This is the small, hand-maintained overlay the strategy doc requires: it
+defines which providers Collie shows, the friendly display name, the auth
+type, the protocol/adapter, the implied base URL when models.dev has none,
+a sensible default model, the help link, key prefixes used for paste-time
+auto-detection, and whether Collie has actually tested the provider.
+
+The bundled snapshot (``snapshot.json``) is generated from the live
+models.dev feed by ``tools/update_catalogue_snapshot.py``; this curated layer
+is merged over it at generation time (and at refresh time, so a refresh never
+loses the Collie-owned overrides).
+"""
+
+from __future__ import annotations
+
+# id -> curated metadata. ``models`` is intentionally NOT here — it comes
+# from the models.dev snapshot. Everything else is Collie-owned truth.
+CURATED_PROVIDERS: dict[str, dict[str, object]] = {
+    "openai": {
+        "name": "OpenAI",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.openai.com/v1",
+        "default_model": "gpt-5.5",
+        "key_prefixes": ["sk-proj-", "sk-"],
+        "tested": True,
+    },
+    "anthropic": {
+        "name": "Anthropic",
+        "auth_type": "api-key",
+        "protocol": "anthropic",
+        "api_base": "https://api.anthropic.com",
+        "default_model": "claude-sonnet-4-6",
+        "key_prefixes": ["sk-ant-"],
+        "tested": True,
+    },
+    "deepseek": {
+        "name": "DeepSeek",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.deepseek.com",
+        "default_model": "deepseek-v4-flash",
+        "key_prefixes": ["sk-"],
+        "tested": True,
+    },
+    "openrouter": {
+        "name": "OpenRouter",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://openrouter.ai/api/v1",
+        "default_model": "~openai/gpt-mini-latest",
+        "key_prefixes": ["sk-or-"],
+        "tested": True,
+    },
+    "groq": {
+        "name": "Groq",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.groq.com/openai/v1",
+        "default_model": "llama-3.3-70b-versatile",
+        "key_prefixes": ["gsk_"],
+        "tested": True,
+    },
+    "google": {
+        "name": "Google Gemini",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        # OpenAI-compatible endpoint Google exposes for Gemini API keys.
+        "api_base": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "default_model": "gemini-flash-latest",
+        "key_prefixes": ["AIza"],
+        "tested": False,
+    },
+    "xai": {
+        "name": "xAI",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.x.ai/v1",
+        "default_model": "grok-4.3",
+        "key_prefixes": ["xai-"],
+        "tested": False,
+    },
+    "perplexity": {
+        "name": "Perplexity",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.perplexity.ai",
+        "default_model": "sonar",
+        "key_prefixes": ["pplx-"],
+        "tested": False,
+    },
+    "mistral": {
+        "name": "Mistral",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.mistral.ai/v1",
+        "default_model": "mistral-small-2506",
+        "key_prefixes": [],
+        "tested": False,
+    },
+    "fireworks-ai": {
+        "name": "Fireworks AI",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://api.fireworks.ai/inference/v1",
+        "default_model": "accounts/fireworks/models/deepseek-v4-flash",
+        "key_prefixes": [],
+        "tested": False,
+    },
+    "zhipuai": {
+        "name": "Zhipu AI",
+        "auth_type": "api-key",
+        "protocol": "openai",
+        "api_base": "https://open.bigmodel.cn/api/paas/v4",
+        "default_model": "glm-4.7-flash",
+        "key_prefixes": [],
+        "tested": False,
+    },
+}
+
+# Order shown in the picker (a stable, curated order beats dict order).
+CURATED_ORDER: tuple[str, ...] = (
+    "openai",
+    "anthropic",
+    "deepseek",
+    "openrouter",
+    "groq",
+    "google",
+    "xai",
+    "perplexity",
+    "mistral",
+    "fireworks-ai",
+    "zhipuai",
+)

--- a/collie-core/collie_core/catalog/refresh.py
+++ b/collie-core/collie_core/catalog/refresh.py
@@ -1,0 +1,96 @@
+"""Optional weekly models.dev catalogue refresh.
+
+The bundled snapshot (``collie_core/catalog/snapshot.json``) is the runtime
+fallback and always works offline. This module implements the optional,
+HTTPS-fetched, schema-validated refresh: it re-fetches models.dev api.json,
+re-trims it with the curated layer, and only then persists it as a settings
+overlay, retaining the accepted snapshot's version + sha256 so Settings can
+show "catalogue updated X ago" and rollback can return to the last-good
+bundled snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+from collie_core.catalog.snapshot_util import trim_live_catalogue
+
+CATALOGUE_VERSION_SETTING = "catalogue.refresh.version"
+CATALOGUE_HASH_SETTING = "catalogue.refresh.sha256"
+CATALOGUE_REFRESHED_AT_SETTING = "catalogue.refresh.updated_at"
+CATALOGUE_SNAPSHOT_SETTING = "catalogue.snapshot"
+
+MODELS_DEV_URL = "https://models.dev/api.json"
+_FETCH_TIMEOUT_SECONDS = 20
+_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fetch(url: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Collie/alpha (catalogue refresh)"},
+    )
+    with urllib.request.urlopen(request, timeout=_FETCH_TIMEOUT_SECONDS) as response:
+        data = response.read(_MAX_PAYLOAD_BYTES + 1)
+    if len(data) > _MAX_PAYLOAD_BYTES:
+        raise ValueError("models.dev payload exceeded the size limit")
+    return data
+
+
+async def fetch_and_trim_catalogue(
+    settings: Any,
+    url: str | None = None,
+) -> dict[str, Any]:
+    """Fetch, validate and persist a refreshed catalogue snapshot.
+
+    On any failure the previous snapshot (bundled or last accepted) is left
+    untouched and a human error is returned.
+    """
+    try:
+        data = await _fetch_async(url or MODELS_DEV_URL)
+        raw = json.loads(data.decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as error:
+        return {
+            "refreshed": False,
+            "error": "I couldn't reach the provider catalogue right now. "
+            "Collie keeps using the bundled one — try again later.",
+            "detail": str(error),
+        }
+
+    trimmed = trim_live_catalogue(raw, generated_at=_now_iso())
+    if trimmed is None:
+        return {
+            "refreshed": False,
+            "error": "The provider catalogue came back in a shape I don't trust, "
+            "so I kept the bundled one.",
+            "detail": "schema validation failed",
+        }
+
+    serialized = json.dumps(trimmed, ensure_ascii=False, separators=(",", ":"))
+    source = trimmed.get("source") or {}
+    settings.set_setting(CATALOGUE_VERSION_SETTING, str(source.get("sha256") or "")[:16])
+    settings.set_setting(CATALOGUE_HASH_SETTING, str(source.get("sha256") or ""))
+    settings.set_setting(CATALOGUE_REFRESHED_AT_SETTING, str(trimmed.get("generated_at") or ""))
+    settings.set_setting(CATALOGUE_SNAPSHOT_SETTING, serialized)
+    return {
+        "refreshed": True,
+        "version": str(source.get("sha256") or "")[:16],
+        "sha256": str(source.get("sha256") or ""),
+        "refreshed_at": trimmed.get("generated_at"),
+        "providers_count": len(trimmed.get("providers") or []),
+    }
+
+
+async def _fetch_async(url: str) -> bytes:
+    """Run the blocking fetch off the event loop."""
+    import asyncio
+
+    return await asyncio.to_thread(_fetch, url)

--- a/collie-core/collie_core/catalog/snapshot.json
+++ b/collie-core/collie_core/catalog/snapshot.json
@@ -1,0 +1,1790 @@
+{
+ "schema_version": 1,
+ "generated_at": "2026-08-05T04:56:59.063557+00:00",
+ "source": {
+  "url": "https://models.dev/api.json",
+  "sha256": "e9b7b29b1195ad32f464bd47caea832d9c7c61e3159618fbb4a2507b4d82e5fe",
+  "providers_count": 180
+ },
+ "providers": [
+  {
+   "id": "openai",
+   "name": "OpenAI",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.openai.com/v1",
+   "default_model": "gpt-5.5",
+   "key_prefixes": [
+    "sk-proj-",
+    "sk-"
+   ],
+   "tested": true,
+   "doc_url": "https://platform.openai.com/docs/models",
+   "help_url": null,
+   "models": {
+    "gpt-image-2": {
+     "name": "gpt-image-2"
+    },
+    "gpt-5.2-pro": {
+     "name": "GPT-5.2 Pro"
+    },
+    "gpt-5.5-pro": {
+     "name": "GPT-5.5 Pro"
+    },
+    "gpt-4.1-mini": {
+     "name": "GPT-4.1 mini"
+    },
+    "gpt-4o": {
+     "name": "GPT-4o"
+    },
+    "gpt-5.3-codex-spark": {
+     "name": "GPT-5.3 Codex Spark"
+    },
+    "gpt-5.4-pro": {
+     "name": "GPT-5.4 Pro"
+    },
+    "gpt-5.6-sol": {
+     "name": "GPT-5.6 Sol"
+    },
+    "text-embedding-ada-002": {
+     "name": "text-embedding-ada-002"
+    },
+    "gpt-4.1-nano": {
+     "name": "GPT-4.1 nano"
+    },
+    "gpt-5.2-chat-latest": {
+     "name": "GPT-5.2 Chat"
+    },
+    "o3-mini": {
+     "name": "o3-mini"
+    },
+    "gpt-image-1-mini": {
+     "name": "gpt-image-1-mini"
+    },
+    "gpt-5.5": {
+     "name": "GPT-5.5"
+    },
+    "o3-pro": {
+     "name": "o3-pro"
+    },
+    "gpt-4o-mini": {
+     "name": "GPT-4o mini"
+    },
+    "chatgpt-image-latest": {
+     "name": "chatgpt-image-latest"
+    },
+    "gpt-5": {
+     "name": "GPT-5"
+    },
+    "gpt-realtime-2.1": {
+     "name": "GPT-Realtime-2.1"
+    },
+    "gpt-3.5-turbo": {
+     "name": "GPT-3.5-turbo"
+    },
+    "gpt-4o-2024-05-13": {
+     "name": "GPT-4o (2024-05-13)"
+    },
+    "gpt-4o-2024-11-20": {
+     "name": "GPT-4o (2024-11-20)"
+    },
+    "gpt-5.4": {
+     "name": "GPT-5.4"
+    },
+    "gpt-5.3-chat-latest": {
+     "name": "GPT-5.3 Chat (latest)"
+    },
+    "gpt-image-1.5": {
+     "name": "gpt-image-1.5"
+    },
+    "gpt-5.4-nano": {
+     "name": "GPT-5.4 nano"
+    },
+    "gpt-5-pro": {
+     "name": "GPT-5 Pro"
+    },
+    "gpt-5.4-mini": {
+     "name": "GPT-5.4 mini"
+    },
+    "o1": {
+     "name": "o1"
+    },
+    "gpt-5.6-luna": {
+     "name": "GPT-5.6 Luna"
+    },
+    "gpt-5.2": {
+     "name": "GPT-5.2"
+    },
+    "gpt-5.3-codex": {
+     "name": "GPT-5.3 Codex"
+    },
+    "gpt-5-mini": {
+     "name": "GPT-5 Mini"
+    },
+    "o1-pro": {
+     "name": "o1-pro"
+    },
+    "gpt-5.6": {
+     "name": "GPT-5.6"
+    },
+    "gpt-5.1": {
+     "name": "GPT-5.1"
+    },
+    "gpt-4-turbo": {
+     "name": "GPT-4 Turbo"
+    },
+    "gpt-4o-2024-08-06": {
+     "name": "GPT-4o (2024-08-06)"
+    },
+    "gpt-5-nano": {
+     "name": "GPT-5 Nano"
+    },
+    "o3": {
+     "name": "o3"
+    },
+    "gpt-5.6-terra": {
+     "name": "GPT-5.6 Terra"
+    },
+    "gpt-image-1": {
+     "name": "gpt-image-1"
+    },
+    "gpt-4.1": {
+     "name": "GPT-4.1"
+    },
+    "o4-mini": {
+     "name": "o4-mini"
+    },
+    "gpt-4": {
+     "name": "GPT-4"
+    },
+    "text-embedding-3-large": {
+     "name": "text-embedding-3-large"
+    },
+    "text-embedding-3-small": {
+     "name": "text-embedding-3-small"
+    }
+   }
+  },
+  {
+   "id": "anthropic",
+   "name": "Anthropic",
+   "auth_type": "api-key",
+   "protocol": "anthropic",
+   "api_base": "https://api.anthropic.com",
+   "default_model": "claude-sonnet-4-6",
+   "key_prefixes": [
+    "sk-ant-"
+   ],
+   "tested": true,
+   "doc_url": "https://docs.anthropic.com/en/docs/about-claude/models",
+   "help_url": null,
+   "models": {
+    "claude-sonnet-4-6": {
+     "name": "Claude Sonnet 4.6"
+    },
+    "claude-haiku-4-5": {
+     "name": "Claude Haiku 4.5 (latest)"
+    },
+    "claude-opus-4-6": {
+     "name": "Claude Opus 4.6"
+    },
+    "claude-fable-5": {
+     "name": "Claude Fable 5"
+    },
+    "claude-opus-4-8": {
+     "name": "Claude Opus 4.8"
+    },
+    "claude-opus-4-1": {
+     "name": "Claude Opus 4.1 (latest)"
+    },
+    "claude-sonnet-4-5": {
+     "name": "Claude Sonnet 4.5 (latest)"
+    },
+    "claude-sonnet-4-5-20250929": {
+     "name": "Claude Sonnet 4.5"
+    },
+    "claude-opus-4-5-20251101": {
+     "name": "Claude Opus 4.5"
+    },
+    "claude-haiku-4-5-20251001": {
+     "name": "Claude Haiku 4.5"
+    },
+    "claude-opus-4-7": {
+     "name": "Claude Opus 4.7"
+    },
+    "claude-opus-4-5": {
+     "name": "Claude Opus 4.5 (latest)"
+    },
+    "claude-sonnet-5": {
+     "name": "Claude Sonnet 5"
+    },
+    "claude-opus-5": {
+     "name": "Claude Opus 5"
+    },
+    "claude-opus-4-1-20250805": {
+     "name": "Claude Opus 4.1"
+    }
+   }
+  },
+  {
+   "id": "deepseek",
+   "name": "DeepSeek",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.deepseek.com",
+   "default_model": "deepseek-v4-flash",
+   "key_prefixes": [
+    "sk-"
+   ],
+   "tested": true,
+   "doc_url": "https://api-docs.deepseek.com/quick_start/pricing",
+   "help_url": null,
+   "models": {
+    "deepseek-v4-flash": {
+     "name": "DeepSeek V4 Flash"
+    },
+    "deepseek-v4-pro": {
+     "name": "DeepSeek V4 Pro"
+    },
+    "deepseek-chat": {
+     "name": "DeepSeek Chat"
+    },
+    "deepseek-reasoner": {
+     "name": "DeepSeek Reasoner"
+    }
+   }
+  },
+  {
+   "id": "openrouter",
+   "name": "OpenRouter",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://openrouter.ai/api/v1",
+   "default_model": "~openai/gpt-mini-latest",
+   "key_prefixes": [
+    "sk-or-"
+   ],
+   "tested": true,
+   "doc_url": "https://openrouter.ai/models",
+   "help_url": null,
+   "models": {
+    "~openai/gpt-latest": {
+     "name": "OpenAI GPT Latest"
+    },
+    "~openai/gpt-mini-latest": {
+     "name": "OpenAI GPT Mini Latest"
+    },
+    "microsoft/phi-4": {
+     "name": "Phi 4"
+    },
+    "microsoft/wizardlm-2-8x22b": {
+     "name": "WizardLM-2 8x22B"
+    },
+    "cohere/command-r-08-2024": {
+     "name": "Command R"
+    },
+    "cohere/command-a": {
+     "name": "Command A"
+    },
+    "cohere/command-r-plus-08-2024": {
+     "name": "Command R+"
+    },
+    "cohere/command-r7b-12-2024": {
+     "name": "Command R7B"
+    },
+    "cohere/north-mini-code:free": {
+     "name": "North Mini Code (free)"
+    },
+    "nvidia/nemotron-3-ultra-550b-a55b:free": {
+     "name": "Nemotron 3 Ultra (free)"
+    },
+    "nvidia/nemotron-3-nano-30b-a3b": {
+     "name": "Nemotron 3 Nano 30B A3B"
+    },
+    "nvidia/nemotron-nano-9b-v2:free": {
+     "name": "Nemotron Nano 9B V2 (free)"
+    },
+    "nvidia/nemotron-3-super-120b-a12b": {
+     "name": "Nemotron 3 Super 120B A12B"
+    },
+    "nvidia/nemotron-3-nano-30b-a3b:free": {
+     "name": "Nemotron 3 Nano 30B A3B (free)"
+    },
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+     "name": "Nemotron 3 Nano Omni (free)"
+    },
+    "nvidia/nemotron-3.5-content-safety:free": {
+     "name": "Nemotron 3.5 Content Safety (free)"
+    },
+    "nvidia/nemotron-3-ultra-550b-a55b": {
+     "name": "Nemotron 3 Ultra 550B A55B"
+    },
+    "nvidia/nemotron-nano-12b-v2-vl:free": {
+     "name": "Nemotron Nano 12B 2 VL (free)"
+    },
+    "nvidia/nemotron-3-super-120b-a12b:free": {
+     "name": "Nemotron 3 Super (free)"
+    },
+    "deepcogito/cogito-v2.1-671b": {
+     "name": "Cogito v2.1 671B"
+    },
+    "google/lyria-3-pro-preview": {
+     "name": "Lyria 3 Pro Preview"
+    },
+    "google/gemini-3.5-flash": {
+     "name": "Gemini 3.5 Flash"
+    },
+    "google/gemini-2.5-flash": {
+     "name": "Gemini 2.5 Flash"
+    },
+    "google/gemma-3-4b-it": {
+     "name": "Gemma 3 4B"
+    },
+    "google/gemini-3.5-flash-lite": {
+     "name": "Gemini 3.5 Flash Lite"
+    },
+    "google/gemini-2.5-pro-preview": {
+     "name": "Gemini 2.5 Pro Preview 06-05"
+    },
+    "google/lyria-3-clip-preview": {
+     "name": "Lyria 3 Clip Preview"
+    },
+    "google/gemini-3-pro-image-preview": {
+     "name": "Nano Banana Pro"
+    },
+    "google/gemini-3.1-flash-lite-preview": {
+     "name": "Gemini 3.1 Flash Lite Preview"
+    },
+    "google/gemini-3-flash-preview": {
+     "name": "Gemini 3 Flash Preview"
+    },
+    "google/gemini-3.1-pro-preview-customtools": {
+     "name": "Gemini 3.1 Pro Preview Custom Tools"
+    },
+    "google/gemini-3.1-flash-lite-image": {
+     "name": "Nano Banana 2 Lite"
+    },
+    "google/gemini-3.1-flash-image-preview": {
+     "name": "Nano Banana 2"
+    },
+    "google/gemma-4-26b-a4b-it": {
+     "name": "Gemma 4 26B A4B IT"
+    },
+    "google/gemma-2-27b-it": {
+     "name": "Gemma 2 27B"
+    },
+    "google/gemma-3-27b-it": {
+     "name": "Gemma 3 27B"
+    },
+    "google/gemma-4-26b-a4b-it:free": {
+     "name": "Gemma 4 26B A4B  (free)"
+    },
+    "google/gemini-3.6-flash": {
+     "name": "Gemini 3.6 Flash"
+    },
+    "google/gemini-3.1-flash-lite": {
+     "name": "Gemini 3.1 Flash Lite"
+    },
+    "google/gemini-2.5-pro-preview-05-06": {
+     "name": "Gemini 2.5 Pro Preview 05-06"
+    },
+    "google/gemma-3-12b-it": {
+     "name": "Gemma 3 12B"
+    },
+    "google/gemma-4-31b-it": {
+     "name": "Gemma 4 31B IT"
+    },
+    "google/gemini-3.1-flash-image": {
+     "name": "Nano Banana 2"
+    },
+    "google/gemini-2.5-flash-image": {
+     "name": "Nano Banana"
+    },
+    "google/gemma-3n-e4b-it": {
+     "name": "Gemma 3n 4B"
+    },
+    "google/gemini-3-pro-image": {
+     "name": "Nano Banana Pro"
+    },
+    "google/gemini-3.1-pro-preview": {
+     "name": "Gemini 3.1 Pro Preview"
+    },
+    "google/gemini-2.5-pro": {
+     "name": "Gemini 2.5 Pro"
+    },
+    "google/gemini-2.5-flash-lite": {
+     "name": "Gemini 2.5 Flash-Lite"
+    },
+    "google/gemma-4-31b-it:free": {
+     "name": "Gemma 4 31B (free)"
+    },
+    "thinkingmachines/inkling-small": {
+     "name": "Inkling Small"
+    },
+    "thinkingmachines/inkling": {
+     "name": "Inkling"
+    },
+    "relace/relace-apply-3": {
+     "name": "Relace Apply 3"
+    },
+    "relace/relace-search": {
+     "name": "Relace Search"
+    },
+    "~deepseek/deepseek-v4-flash-latest": {
+     "name": "DeepSeek V4 Flash Latest"
+    },
+    "perceptron/perceptron-mk1": {
+     "name": "Perceptron Mk1"
+    },
+    "sakana/fugu-ultra": {
+     "name": "Fugu Ultra"
+    },
+    "~google/gemini-flash-latest": {
+     "name": "Google Gemini Flash Latest"
+    },
+    "~google/gemini-pro-latest": {
+     "name": "Google Gemini Pro Latest"
+    },
+    "qwen/qwen3.5-flash-02-23": {
+     "name": "Qwen3.5-Flash"
+    },
+    "qwen/qwen3.7-flash": {
+     "name": "Qwen3.7 Flash"
+    },
+    "qwen/qwen3.7-plus": {
+     "name": "Qwen3.7 Plus"
+    },
+    "qwen/qwen3-32b": {
+     "name": "Qwen3 32B"
+    },
+    "qwen/qwen3.6-35b-a3b": {
+     "name": "Qwen3.6 35B-A3B"
+    },
+    "qwen/qwen3-30b-a3b": {
+     "name": "Qwen3 30B A3B"
+    },
+    "qwen/qwen3-235b-a22b-thinking-2507": {
+     "name": "Qwen3 235B A22B Thinking 2507"
+    },
+    "qwen/qwen3-vl-30b-a3b-thinking": {
+     "name": "Qwen3 VL 30B A3B Thinking"
+    },
+    "qwen/qwen3-coder-30b-a3b-instruct": {
+     "name": "Qwen3-Coder 30B-A3B Instruct"
+    },
+    "qwen/qwen3.5-plus-02-15": {
+     "name": "Qwen3.5 Plus 2026-02-15"
+    },
+    "qwen/qwen3.5-27b": {
+     "name": "Qwen3.5 27B"
+    },
+    "qwen/qwen3.7-max": {
+     "name": "Qwen3.7 Max"
+    },
+    "qwen/qwen3-next-80b-a3b-thinking": {
+     "name": "Qwen3-Next 80B-A3B (Thinking)"
+    },
+    "qwen/qwen3.5-9b": {
+     "name": "Qwen3.5 9B"
+    },
+    "qwen/qwen3.6-27b": {
+     "name": "Qwen3.6 27B"
+    },
+    "qwen/qwen3.5-35b-a3b": {
+     "name": "Qwen3.5 35B-A3B"
+    },
+    "qwen/qwen-2.5-7b-instruct": {
+     "name": "Qwen2.5 7B Instruct"
+    },
+    "qwen/qwen3-14b": {
+     "name": "Qwen3 14B"
+    },
+    "qwen/qwen3-235b-a22b": {
+     "name": "Qwen3 235B-A22B"
+    },
+    "qwen/qwen3-max": {
+     "name": "Qwen3 Max"
+    },
+    "qwen/qwen3-vl-8b-instruct": {
+     "name": "Qwen3 VL 8B Instruct"
+    },
+    "qwen/qwen3-8b": {
+     "name": "Qwen3 8B"
+    },
+    "qwen/qwen3-coder-plus": {
+     "name": "Qwen3 Coder Plus"
+    },
+    "qwen/qwen3.8-max": {
+     "name": "Qwen3.8 Max"
+    },
+    "qwen/qwen3-coder-flash": {
+     "name": "Qwen3 Coder Flash"
+    },
+    "qwen/qwen3-vl-235b-a22b-instruct": {
+     "name": "Qwen3 VL 235B A22B Instruct"
+    },
+    "qwen/qwen3-vl-32b-instruct": {
+     "name": "Qwen3 VL 32B Instruct"
+    },
+    "qwen/qwen-2.5-72b-instruct": {
+     "name": "Qwen2.5 72B Instruct"
+    },
+    "qwen/qwen-plus-2025-07-28:thinking": {
+     "name": "Qwen Plus 0728 (thinking)"
+    },
+    "qwen/qwen-plus": {
+     "name": "Qwen Plus"
+    },
+    "qwen/qwen3-30b-a3b-thinking-2507": {
+     "name": "Qwen3 30B A3B Thinking 2507"
+    },
+    "qwen/qwen3-vl-8b-thinking": {
+     "name": "Qwen3 VL 8B Thinking"
+    },
+    "qwen/qwen3-235b-a22b-2507": {
+     "name": "Qwen3 235B A22B Instruct 2507"
+    },
+    "qwen/qwen3.6-flash": {
+     "name": "Qwen3.6 Flash"
+    },
+    "qwen/qwen3-30b-a3b-instruct-2507": {
+     "name": "Qwen3 30B A3B Instruct 2507"
+    },
+    "qwen/qwen3-vl-30b-a3b-instruct": {
+     "name": "Qwen3 VL 30B A3B Instruct"
+    },
+    "qwen/qwen3.5-397b-a17b": {
+     "name": "Qwen3.5 397B-A17B"
+    },
+    "qwen/qwen-2.5-coder-32b-instruct": {
+     "name": "Qwen2.5 Coder 32B Instruct"
+    },
+    "qwen/qwen3-vl-235b-a22b-thinking": {
+     "name": "Qwen3 VL 235B A22B Thinking"
+    },
+    "qwen/qwen3.6-max-preview": {
+     "name": "Qwen3.6 Max Preview"
+    },
+    "qwen/qwen3-max-thinking": {
+     "name": "Qwen3 Max Thinking"
+    },
+    "qwen/qwen3-coder": {
+     "name": "Qwen3 Coder 480B A35B"
+    },
+    "qwen/qwen3-coder-next": {
+     "name": "Qwen3 Coder Next"
+    },
+    "qwen/qwen3.6-plus": {
+     "name": "Qwen3.6 Plus"
+    },
+    "qwen/qwen3.5-122b-a10b": {
+     "name": "Qwen3.5 122B-A10B"
+    },
+    "qwen/qwen3.5-plus-20260420": {
+     "name": "Qwen3.5 Plus 2026-04-20"
+    },
+    "qwen/qwen-plus-2025-07-28": {
+     "name": "Qwen Plus 0728"
+    },
+    "qwen/qwen3-next-80b-a3b-instruct": {
+     "name": "Qwen3-Next 80B-A3B Instruct"
+    },
+    "qwen/qwen2.5-vl-72b-instruct": {
+     "name": "Qwen2.5 VL 72B Instruct"
+    },
+    "inception/mercury-2": {
+     "name": "Mercury 2"
+    },
+    "rekaai/reka-edge": {
+     "name": "Reka Edge"
+    },
+    "rekaai/reka-flash-3": {
+     "name": "Reka Flash 3"
+    },
+    "tencent/hunyuan-a13b-instruct": {
+     "name": "Hunyuan A13B Instruct"
+    },
+    "tencent/hy3": {
+     "name": "Hy3"
+    },
+    "tencent/hy3-preview": {
+     "name": "Hy3 preview"
+    },
+    "upstage/solar-pro-3": {
+     "name": "Solar Pro 3"
+    },
+    "~x-ai/grok-latest": {
+     "name": "Grok Latest"
+    },
+    "mistralai/mistral-large": {
+     "name": "Mistral Large"
+    },
+    "mistralai/ministral-8b-2512": {
+     "name": "Ministral 3 8B 2512"
+    },
+    "mistralai/ministral-14b-2512": {
+     "name": "Ministral 3 14B 2512"
+    },
+    "mistralai/ministral-3b-2512": {
+     "name": "Ministral 3 3B 2512"
+    },
+    "mistralai/mistral-small-24b-instruct-2501": {
+     "name": "Mistral Small 3"
+    },
+    "mistralai/mistral-large-2407": {
+     "name": "Mistral Large 2407"
+    },
+    "mistralai/mistral-medium-3.1": {
+     "name": "Mistral Medium 3.1"
+    },
+    "mistralai/mistral-nemo": {
+     "name": "Mistral Nemo"
+    },
+    "mistralai/mistral-saba": {
+     "name": "Saba"
+    },
+    "mistralai/mistral-small-2603": {
+     "name": "Mistral Small 4"
+    },
+    "mistralai/codestral-2508": {
+     "name": "Codestral 2508"
+    },
+    "mistralai/mixtral-8x22b-instruct": {
+     "name": "Mixtral 8x22B Instruct"
+    },
+    "mistralai/voxtral-small-24b-2507": {
+     "name": "Voxtral Small 24B 2507"
+    },
+    "mistralai/mistral-small-3.2-24b-instruct": {
+     "name": "Mistral Small 3.2 24B"
+    },
+    "mistralai/mistral-medium-3-5": {
+     "name": "Mistral Medium 3.5"
+    },
+    "mistralai/mistral-small-3.1-24b-instruct": {
+     "name": "Mistral Small 3.1 24B"
+    },
+    "mistralai/mistral-medium-3": {
+     "name": "Mistral Medium 3"
+    },
+    "mistralai/mistral-large-2512": {
+     "name": "Mistral Large 3"
+    },
+    "bytedance/ui-tars-1.5-7b": {
+     "name": "UI-TARS 7B "
+    },
+    "nex-agi/nex-n2-mini": {
+     "name": "Nex-N2-Mini"
+    },
+    "nex-agi/nex-n2-pro": {
+     "name": "Nex-N2-Pro"
+    },
+    "thedrummer/rocinante-12b": {
+     "name": "Rocinante 12B"
+    },
+    "thedrummer/unslopnemo-12b": {
+     "name": "UnslopNemo 12B"
+    },
+    "thedrummer/cydonia-24b-v4.1": {
+     "name": "Cydonia 24B V4.1"
+    },
+    "thedrummer/skyfall-36b-v2": {
+     "name": "Skyfall 36B V2"
+    },
+    "undi95/remm-slerp-l2-13b": {
+     "name": "ReMM SLERP 13B"
+    },
+    "meta/muse-spark-1.1": {
+     "name": "Muse Spark 1.1"
+    },
+    "gryphe/mythomax-l2-13b": {
+     "name": "MythoMax 13B"
+    },
+    "inclusionai/ring-2.6-1t": {
+     "name": "Ring-2.6-1T"
+    },
+    "inclusionai/ling-2.6-1t": {
+     "name": "Ling-2.6-1T"
+    },
+    "inclusionai/ling-2.6-flash": {
+     "name": "Ling-2.6-flash"
+    },
+    "inclusionai/ling-3.0-flash:free": {
+     "name": "Ling-3.0-flash (free)"
+    },
+    "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+     "name": "Uncensored"
+    },
+    "allenai/olmo-3-32b-think": {
+     "name": "Olmo 3 32B Think"
+    },
+    "meituan/longcat-2.0": {
+     "name": "LongCat 2.0"
+    },
+    "ai21/jamba-large-1.7": {
+     "name": "Jamba Large 1.7"
+    },
+    "mancer/weaver": {
+     "name": "Weaver (alpha)"
+    },
+    "morph/morph-v3-large": {
+     "name": "Morph V3 Large"
+    },
+    "morph/morph-v3-fast": {
+     "name": "Morph V3 Fast"
+    },
+    "nousresearch/hermes-3-llama-3.1-70b": {
+     "name": "Hermes 3 70B Instruct"
+    },
+    "nousresearch/hermes-3-llama-3.1-405b": {
+     "name": "Hermes 3 405B Instruct"
+    },
+    "nousresearch/hermes-4-405b": {
+     "name": "Hermes 4 405B"
+    },
+    "nousresearch/hermes-4-70b": {
+     "name": "Hermes 4 70B"
+    },
+    "poolside/laguna-xs-2.1": {
+     "name": "Laguna XS 2.1"
+    },
+    "poolside/laguna-s-2.1": {
+     "name": "Laguna S 2.1"
+    },
+    "poolside/laguna-s-2.1:free": {
+     "name": "Laguna S 2.1 (free)"
+    },
+    "poolside/laguna-xs-2.1:free": {
+     "name": "Laguna XS 2.1 (free)"
+    },
+    "minimax/minimax-m2-her": {
+     "name": "MiniMax M2-her"
+    },
+    "minimax/minimax-m2.7": {
+     "name": "MiniMax-M2.7"
+    },
+    "minimax/minimax-m3": {
+     "name": "MiniMax-M3"
+    },
+    "minimax/minimax-m1": {
+     "name": "MiniMax M1"
+    },
+    "minimax/minimax-m2.5": {
+     "name": "MiniMax-M2.5"
+    },
+    "minimax/minimax-m2": {
+     "name": "MiniMax-M2"
+    },
+    "minimax/minimax-01": {
+     "name": "MiniMax-01"
+    },
+    "minimax/minimax-m2.1": {
+     "name": "MiniMax-M2.1"
+    },
+    "deepseek/deepseek-v3.2-exp": {
+     "name": "DeepSeek V3.2 Exp"
+    },
+    "deepseek/deepseek-v4-flash": {
+     "name": "DeepSeek V4 Flash"
+    },
+    "deepseek/deepseek-chat-v3-0324": {
+     "name": "DeepSeek V3 0324"
+    },
+    "deepseek/deepseek-r1-distill-llama-70b": {
+     "name": "R1 Distill Llama 70B"
+    },
+    "deepseek/deepseek-v4-pro": {
+     "name": "DeepSeek V4 Pro"
+    },
+    "deepseek/deepseek-r1-0528": {
+     "name": "R1 0528"
+    },
+    "deepseek/deepseek-v4-flash-0731": {
+     "name": "DeepSeek V4 Flash 0731"
+    },
+    "deepseek/deepseek-v3.2": {
+     "name": "DeepSeek V3.2"
+    },
+    "deepseek/deepseek-r1": {
+     "name": "DeepSeek-R1"
+    },
+    "deepseek/deepseek-chat": {
+     "name": "DeepSeek Chat"
+    },
+    "deepseek/deepseek-v3.1-terminus": {
+     "name": "DeepSeek V3.1 Terminus"
+    },
+    "deepseek/deepseek-chat-v3.1": {
+     "name": "DeepSeek V3.1"
+    },
+    "amazon/nova-premier-v1": {
+     "name": "Nova Premier 1.0"
+    },
+    "amazon/nova-2-lite-v1": {
+     "name": "Nova 2 Lite"
+    },
+    "amazon/nova-pro-v1": {
+     "name": "Nova Pro 1.0"
+    },
+    "amazon/nova-micro-v1": {
+     "name": "Nova Micro 1.0"
+    },
+    "amazon/nova-lite-v1": {
+     "name": "Nova Lite 1.0"
+    },
+    "~moonshotai/kimi-latest": {
+     "name": "MoonshotAI Kimi Latest"
+    },
+    "ibm-granite/granite-4.0-h-micro": {
+     "name": "Granite 4.0 Micro"
+    },
+    "ibm-granite/granite-4.1-8b": {
+     "name": "Granite 4.1 8B"
+    },
+    "x-ai/grok-4.20-multi-agent": {
+     "name": "Grok 4.20 Multi-Agent"
+    },
+    "x-ai/grok-4.3": {
+     "name": "Grok 4.3"
+    },
+    "x-ai/grok-4.5": {
+     "name": "Grok 4.5"
+    },
+    "x-ai/grok-build-0.1": {
+     "name": "Grok Build 0.1"
+    },
+    "x-ai/grok-4.20": {
+     "name": "Grok 4.20"
+    },
+    "kwaipilot/kat-coder-pro-v2": {
+     "name": "KAT-Coder-Pro V2"
+    },
+    "kwaipilot/kat-coder-pro-v2.5": {
+     "name": "KAT-Coder-Pro V2.5"
+    },
+    "kwaipilot/kat-coder-air-v2.5": {
+     "name": "KAT-Coder-Air V2.5"
+    },
+    "sao10k/l3.1-euryale-70b": {
+     "name": "Llama 3.1 Euryale 70B v2.2"
+    },
+    "sao10k/l3.3-euryale-70b": {
+     "name": "Llama 3.3 Euryale 70B"
+    },
+    "sao10k/l3-lunaris-8b": {
+     "name": "Llama 3 8B Lunaris"
+    },
+    "openrouter/pareto-code": {
+     "name": "Pareto Code Router"
+    },
+    "openrouter/bodybuilder": {
+     "name": "Body Builder (beta)"
+    },
+    "openrouter/free": {
+     "name": "Free Models Router"
+    },
+    "openrouter/auto": {
+     "name": "Auto Router"
+    },
+    "openrouter/fusion": {
+     "name": "Fusion"
+    },
+    "aion-labs/aion-2.0": {
+     "name": "Aion-2.0"
+    },
+    "aion-labs/aion-3.0-mini": {
+     "name": "Aion-3.0-Mini"
+    },
+    "aion-labs/aion-rp-llama-3.1-8b": {
+     "name": "Aion-RP 1.0 (8B)"
+    },
+    "aion-labs/aion-3.0": {
+     "name": "Aion-3.0"
+    },
+    "xiaomi/mimo-v2.5": {
+     "name": "MiMo-V2.5"
+    },
+    "xiaomi/mimo-v2.5-pro": {
+     "name": "MiMo-V2.5-Pro"
+    },
+    "writer/palmyra-x5": {
+     "name": "Palmyra X5"
+    },
+    "anthropic/claude-sonnet-4.6": {
+     "name": "Claude Sonnet 4.6"
+    },
+    "anthropic/claude-fable-5": {
+     "name": "Claude Fable 5"
+    },
+    "anthropic/claude-opus-4.8-fast": {
+     "name": "Claude Opus 4.8 (Fast)"
+    },
+    "anthropic/claude-opus-4.1": {
+     "name": "Claude Opus 4.1 (latest)"
+    },
+    "anthropic/claude-opus-4.5": {
+     "name": "Claude Opus 4.5 (latest)"
+    },
+    "anthropic/claude-opus-4.7": {
+     "name": "Claude Opus 4.7"
+    },
+    "anthropic/claude-sonnet-4.5": {
+     "name": "Claude Sonnet 4.5 (latest)"
+    },
+    "anthropic/claude-3-haiku": {
+     "name": "Claude 3 Haiku"
+    },
+    "anthropic/claude-opus-5-fast": {
+     "name": "Claude Opus 5 (Fast)"
+    },
+    "anthropic/claude-sonnet-4": {
+     "name": "Claude Sonnet 4"
+    },
+    "anthropic/claude-haiku-4.5": {
+     "name": "Claude Haiku 4.5 (latest)"
+    },
+    "anthropic/claude-opus-4": {
+     "name": "Claude Opus 4"
+    },
+    "anthropic/claude-opus-4.8": {
+     "name": "Claude Opus 4.8"
+    },
+    "anthropic/claude-sonnet-5": {
+     "name": "Claude Sonnet 5"
+    },
+    "anthropic/claude-opus-5": {
+     "name": "Claude Opus 5"
+    },
+    "anthropic/claude-opus-4.6": {
+     "name": "Claude Opus 4.6"
+    },
+    "anthropic/claude-opus-4.7-fast": {
+     "name": "Claude Opus 4.7 (Fast)"
+    },
+    "~anthropic/claude-sonnet-latest": {
+     "name": "Anthropic Claude Sonnet Latest"
+    },
+    "~anthropic/claude-opus-latest": {
+     "name": "Claude Opus Latest"
+    },
+    "~anthropic/claude-haiku-latest": {
+     "name": "Anthropic Claude Haiku Latest"
+    },
+    "~anthropic/claude-fable-latest": {
+     "name": "Claude Fable Latest"
+    },
+    "z-ai/glm-4.6v": {
+     "name": "GLM-4.6V"
+    },
+    "z-ai/glm-5": {
+     "name": "GLM-5"
+    },
+    "z-ai/glm-4.5-air": {
+     "name": "GLM-4.5-Air"
+    },
+    "z-ai/glm-5.1": {
+     "name": "GLM-5.1"
+    },
+    "z-ai/glm-4.7-flash": {
+     "name": "GLM-4.7-Flash"
+    },
+    "z-ai/glm-5.2": {
+     "name": "GLM-5.2"
+    },
+    "z-ai/glm-4.6": {
+     "name": "GLM-4.6"
+    },
+    "z-ai/glm-4.5": {
+     "name": "GLM-4.5"
+    },
+    "z-ai/glm-4.5v": {
+     "name": "GLM-4.5V"
+    },
+    "z-ai/glm-4.7": {
+     "name": "GLM-4.7"
+    },
+    "z-ai/glm-5-turbo": {
+     "name": "GLM-5-Turbo"
+    },
+    "z-ai/glm-5v-turbo": {
+     "name": "GLM-5V-Turbo"
+    },
+    "perplexity/sonar-pro-search": {
+     "name": "Sonar Pro Search"
+    },
+    "perplexity/sonar-deep-research": {
+     "name": "Sonar Deep Research"
+    },
+    "perplexity/sonar": {
+     "name": "Sonar"
+    },
+    "perplexity/sonar-pro": {
+     "name": "Sonar Pro"
+    },
+    "perplexity/sonar-reasoning-pro": {
+     "name": "Sonar Reasoning Pro"
+    },
+    "moonshotai/kimi-k2.5": {
+     "name": "Kimi K2.5"
+    },
+    "moonshotai/kimi-k2.6": {
+     "name": "Kimi K2.6"
+    },
+    "moonshotai/kimi-k2.7-code": {
+     "name": "Kimi K2.7 Code"
+    },
+    "moonshotai/kimi-k2": {
+     "name": "Kimi K2 0711"
+    },
+    "moonshotai/kimi-k2-thinking": {
+     "name": "Kimi K2 Thinking"
+    },
+    "moonshotai/kimi-k3": {
+     "name": "Kimi K3"
+    },
+    "moonshotai/kimi-k2-0905": {
+     "name": "Kimi K2 0905"
+    },
+    "openai/gpt-5.1-codex-mini": {
+     "name": "GPT-5.1 Codex mini"
+    },
+    "openai/gpt-chat-latest": {
+     "name": "GPT Chat Latest"
+    },
+    "openai/gpt-5.2-pro": {
+     "name": "GPT-5.2 Pro"
+    },
+    "openai/gpt-5.5-pro": {
+     "name": "GPT-5.5 Pro"
+    },
+    "openai/gpt-4.1-mini": {
+     "name": "GPT-4.1 mini"
+    },
+    "openai/gpt-4o": {
+     "name": "GPT-4o"
+    },
+    "openai/gpt-5.4-pro": {
+     "name": "GPT-5.4 Pro"
+    },
+    "openai/gpt-audio-mini": {
+     "name": "GPT Audio Mini"
+    },
+    "openai/gpt-5.6-sol": {
+     "name": "GPT-5.6 Sol"
+    },
+    "openai/o3-mini-high": {
+     "name": "o3 Mini High"
+    },
+    "openai/gpt-4o-mini-2024-07-18": {
+     "name": "GPT-4o-mini (2024-07-18)"
+    },
+    "openai/gpt-4.1-nano": {
+     "name": "GPT-4.1 nano"
+    },
+    "openai/gpt-oss-20b": {
+     "name": "GPT OSS 20B"
+    },
+    "openai/gpt-oss-safeguard-20b": {
+     "name": "gpt-oss-safeguard-20b"
+    },
+    "openai/o3-mini": {
+     "name": "o3-mini"
+    },
+    "openai/gpt-5.6-sol-pro": {
+     "name": "GPT-5.6 Sol Pro"
+    },
+    "openai/gpt-5.5": {
+     "name": "GPT-5.5"
+    },
+    "openai/gpt-3.5-turbo-0613": {
+     "name": "GPT-3.5 Turbo (older v0613)"
+    },
+    "openai/o3-pro": {
+     "name": "o3-pro"
+    },
+    "openai/gpt-4o-mini": {
+     "name": "GPT-4o mini"
+    },
+    "openai/gpt-5": {
+     "name": "GPT-5"
+    },
+    "openai/gpt-audio": {
+     "name": "GPT Audio"
+    },
+    "openai/o4-mini-high": {
+     "name": "o4 Mini High"
+    },
+    "openai/gpt-3.5-turbo": {
+     "name": "GPT-3.5-turbo"
+    },
+    "openai/gpt-4o-2024-05-13": {
+     "name": "GPT-4o (2024-05-13)"
+    },
+    "openai/gpt-4o-2024-11-20": {
+     "name": "GPT-4o (2024-11-20)"
+    },
+    "openai/gpt-5.4": {
+     "name": "GPT-5.4"
+    },
+    "openai/gpt-5.6-luna-pro": {
+     "name": "GPT-5.6 Luna Pro"
+    },
+    "openai/gpt-5.2-chat": {
+     "name": "GPT-5.2 Chat"
+    },
+    "openai/gpt-5.2-codex": {
+     "name": "GPT-5.2 Codex"
+    },
+    "openai/gpt-5.4-nano": {
+     "name": "GPT-5.4 nano"
+    },
+    "openai/gpt-5-pro": {
+     "name": "GPT-5 Pro"
+    },
+    "openai/gpt-5.4-mini": {
+     "name": "GPT-5.4 mini"
+    },
+    "openai/gpt-oss-120b": {
+     "name": "GPT OSS 120B"
+    },
+    "openai/gpt-3.5-turbo-16k": {
+     "name": "GPT-3.5 Turbo 16k"
+    },
+    "openai/o1": {
+     "name": "o1"
+    },
+    "openai/gpt-5.6-luna": {
+     "name": "GPT-5.6 Luna"
+    },
+    "openai/gpt-5.2": {
+     "name": "GPT-5.2"
+    },
+    "openai/gpt-5.3-codex": {
+     "name": "GPT-5.3 Codex"
+    },
+    "openai/gpt-5-mini": {
+     "name": "GPT-5 Mini"
+    },
+    "openai/gpt-5.3-chat": {
+     "name": "GPT-5.3 Chat"
+    },
+    "openai/o1-pro": {
+     "name": "o1-pro"
+    },
+    "openai/gpt-5-image": {
+     "name": "GPT-5 Image"
+    },
+    "openai/gpt-5.1": {
+     "name": "GPT-5.1"
+    },
+    "openai/gpt-4-turbo-preview": {
+     "name": "GPT-4 Turbo Preview"
+    },
+    "openai/gpt-4-turbo": {
+     "name": "GPT-4 Turbo"
+    },
+    "openai/gpt-4o-2024-08-06": {
+     "name": "GPT-4o (2024-08-06)"
+    },
+    "openai/gpt-5.4-image-2": {
+     "name": "GPT-5.4 Image 2"
+    },
+    "openai/gpt-5.1-codex": {
+     "name": "GPT-5.1 Codex"
+    },
+    "openai/gpt-5-nano": {
+     "name": "GPT-5 Nano"
+    },
+    "openai/o3": {
+     "name": "o3"
+    },
+    "openai/gpt-3.5-turbo-instruct": {
+     "name": "GPT-3.5 Turbo Instruct"
+    },
+    "openai/gpt-5.6-terra": {
+     "name": "GPT-5.6 Terra"
+    },
+    "openai/gpt-5-image-mini": {
+     "name": "GPT-5 Image Mini"
+    },
+    "openai/gpt-5.6-terra-pro": {
+     "name": "GPT-5.6 Terra Pro"
+    },
+    "openai/gpt-4.1": {
+     "name": "GPT-4.1"
+    },
+    "openai/o4-mini": {
+     "name": "o4-mini"
+    },
+    "openai/gpt-oss-20b:free": {
+     "name": "gpt-oss-20b (free)"
+    },
+    "openai/gpt-5.1-codex-max": {
+     "name": "GPT-5.1 Codex Max"
+    },
+    "openai/gpt-4": {
+     "name": "GPT-4"
+    },
+    "baidu/ernie-4.5-vl-424b-a47b": {
+     "name": "ERNIE 4.5 VL 424B A47B "
+    },
+    "meta-llama/llama-3.1-70b-instruct": {
+     "name": "Llama 3.1 70B Instruct"
+    },
+    "meta-llama/llama-guard-4-12b": {
+     "name": "Llama Guard 4 12B"
+    },
+    "meta-llama/llama-3.2-1b-instruct": {
+     "name": "Llama 3.2 1B Instruct"
+    },
+    "meta-llama/llama-3.3-70b-instruct": {
+     "name": "Llama-3.3-70B-Instruct"
+    },
+    "meta-llama/llama-4-maverick": {
+     "name": "Llama 4 Maverick"
+    },
+    "meta-llama/llama-4-scout": {
+     "name": "Llama 4 Scout"
+    },
+    "meta-llama/llama-3.2-3b-instruct": {
+     "name": "Llama 3.2 3B Instruct"
+    },
+    "meta-llama/llama-3.1-8b-instruct": {
+     "name": "Llama 3.1 8B Instruct"
+    },
+    "arcee-ai/virtuoso-large": {
+     "name": "Virtuoso Large"
+    },
+    "arcee-ai/trinity-large-thinking": {
+     "name": "Trinity Large Thinking"
+    },
+    "bytedance-seed/seed-1.6": {
+     "name": "Seed 1.6"
+    },
+    "bytedance-seed/seed-2.0-mini": {
+     "name": "Seed-2.0-Mini"
+    },
+    "bytedance-seed/seed-1.6-flash": {
+     "name": "Seed 1.6 Flash"
+    },
+    "bytedance-seed/seed-2.0-lite": {
+     "name": "Seed-2.0-Lite"
+    },
+    "stepfun/step-3.5-flash": {
+     "name": "Step 3.5 Flash"
+    },
+    "stepfun/step-3.7-flash": {
+     "name": "Step 3.7 Flash"
+    },
+    "anthracite-org/magnum-v4-72b": {
+     "name": "Magnum v4 72B"
+    }
+   }
+  },
+  {
+   "id": "groq",
+   "name": "Groq",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.groq.com/openai/v1",
+   "default_model": "llama-3.3-70b-versatile",
+   "key_prefixes": [
+    "gsk_"
+   ],
+   "tested": true,
+   "doc_url": "https://console.groq.com/docs/models",
+   "help_url": null,
+   "models": {
+    "llama-3.3-70b-versatile": {
+     "name": "Llama 3.3 70B"
+    },
+    "llama-3.1-8b-instant": {
+     "name": "Llama 3.1 8B"
+    },
+    "whisper-large-v3": {
+     "name": "Whisper"
+    },
+    "allam-2-7b": {
+     "name": "ALLaM-2-7b"
+    },
+    "whisper-large-v3-turbo": {
+     "name": "Whisper Large V3 Turbo"
+    },
+    "qwen/qwen3.6-27b": {
+     "name": "Qwen3.6 27B"
+    },
+    "canopylabs/orpheus-arabic-saudi": {
+     "name": "Canopy Labs Orpheus Arabic Saudi"
+    },
+    "canopylabs/orpheus-v1-english": {
+     "name": "Canopy Labs Orpheus V1 English"
+    },
+    "groq/compound-mini": {
+     "name": "Compound Mini"
+    },
+    "groq/compound": {
+     "name": "Compound"
+    },
+    "openai/gpt-oss-20b": {
+     "name": "GPT OSS 20B"
+    },
+    "openai/gpt-oss-safeguard-20b": {
+     "name": "Safety GPT OSS 20B"
+    },
+    "openai/gpt-oss-120b": {
+     "name": "GPT OSS 120B"
+    },
+    "meta-llama/llama-prompt-guard-2-22m": {
+     "name": "Llama Prompt Guard 2 22M"
+    },
+    "meta-llama/llama-prompt-guard-2-86m": {
+     "name": "Prompt Guard 2 86M"
+    }
+   }
+  },
+  {
+   "id": "google",
+   "name": "Google Gemini",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://generativelanguage.googleapis.com/v1beta/openai",
+   "default_model": "gemini-flash-latest",
+   "key_prefixes": [
+    "AIza"
+   ],
+   "tested": false,
+   "doc_url": "https://ai.google.dev/gemini-api/docs/models",
+   "help_url": null,
+   "models": {
+    "gemini-2.5-computer-use-preview-10-2025": {
+     "name": "Gemini 2.5 Computer Use Preview 10-2025"
+    },
+    "deep-research-preview-04-2026": {
+     "name": "Deep Research Preview (Apr-21-2026)"
+    },
+    "gemini-3.1-flash-tts-preview": {
+     "name": "Gemini 3.1 Flash TTS Preview"
+    },
+    "gemini-flash-latest": {
+     "name": "Gemini Flash Latest"
+    },
+    "gemini-embedding-2": {
+     "name": "Gemini Embedding 2"
+    },
+    "lyria-3-pro-preview": {
+     "name": "Lyria 3 Pro Preview"
+    },
+    "gemini-3.5-flash": {
+     "name": "Gemini 3.5 Flash"
+    },
+    "gemini-2.5-flash": {
+     "name": "Gemini 2.5 Flash"
+    },
+    "gemini-3.5-flash-lite": {
+     "name": "Gemini 3.5 Flash Lite"
+    },
+    "lyria-3-clip-preview": {
+     "name": "Lyria 3 Clip Preview"
+    },
+    "gemini-omni-flash-preview": {
+     "name": "Gemini Omni Flash Preview"
+    },
+    "veo-3.1-generate-preview": {
+     "name": "Veo 3.1"
+    },
+    "deep-research-max-preview-04-2026": {
+     "name": "Deep Research Max Preview (Apr-21-2026)"
+    },
+    "gemini-3-pro-image-preview": {
+     "name": "Nano Banana Pro"
+    },
+    "gemini-3.1-flash-lite-preview": {
+     "name": "Gemini 3.1 Flash Lite Preview"
+    },
+    "gemini-3.5-live-translate-preview": {
+     "name": "Gemini 3.5 Live Translate Preview"
+    },
+    "gemini-3-flash-preview": {
+     "name": "Gemini 3 Flash Preview"
+    },
+    "gemini-3.1-pro-preview-customtools": {
+     "name": "Gemini 3.1 Pro Preview Custom Tools"
+    },
+    "gemini-3.1-flash-lite-image": {
+     "name": "Nano Banana 2 Lite"
+    },
+    "gemini-3.1-flash-image-preview": {
+     "name": "Nano Banana 2"
+    },
+    "gemini-robotics-er-1.6-preview": {
+     "name": "Gemini Robotics-ER 1.6 Preview"
+    },
+    "gemma-4-26b-a4b-it": {
+     "name": "Gemma 4 26B A4B IT"
+    },
+    "gemini-embedding-001": {
+     "name": "Gemini Embedding 001"
+    },
+    "veo-3.1-lite-generate-preview": {
+     "name": "Veo 3.1 lite"
+    },
+    "gemini-2.0-flash": {
+     "name": "Gemini 2.0 Flash"
+    },
+    "gemini-3.6-flash": {
+     "name": "Gemini 3.6 Flash"
+    },
+    "veo-3.1-fast-generate-preview": {
+     "name": "Veo 3.1 fast"
+    },
+    "gemini-3.1-flash-lite": {
+     "name": "Gemini 3.1 Flash Lite"
+    },
+    "gemma-4-31b-it": {
+     "name": "Gemma 4 31B IT"
+    },
+    "gemini-3.1-flash-image": {
+     "name": "Nano Banana 2"
+    },
+    "gemini-2.5-flash-image": {
+     "name": "Nano Banana"
+    },
+    "gemini-2.5-flash-preview-tts": {
+     "name": "Gemini 2.5 Flash Preview TTS"
+    },
+    "gemini-3-pro-image": {
+     "name": "Nano Banana Pro"
+    },
+    "gemini-3.1-pro-preview": {
+     "name": "Gemini 3.1 Pro Preview"
+    },
+    "gemini-flash-lite-latest": {
+     "name": "Gemini Flash-Lite Latest"
+    },
+    "gemini-2.5-pro": {
+     "name": "Gemini 2.5 Pro"
+    },
+    "gemini-3-pro-preview": {
+     "name": "Gemini 3 Pro Preview"
+    },
+    "gemini-2.5-flash-lite": {
+     "name": "Gemini 2.5 Flash-Lite"
+    },
+    "gemini-2.5-pro-preview-tts": {
+     "name": "Gemini 2.5 Pro Preview TTS"
+    },
+    "gemini-2.0-flash-lite": {
+     "name": "Gemini 2.0 Flash-Lite"
+    },
+    "gemini-3.1-flash-live-preview": {
+     "name": "Gemini 3.1 Flash Live Preview"
+    }
+   }
+  },
+  {
+   "id": "xai",
+   "name": "xAI",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.x.ai/v1",
+   "default_model": "grok-4.3",
+   "key_prefixes": [
+    "xai-"
+   ],
+   "tested": false,
+   "doc_url": "https://docs.x.ai/docs/models",
+   "help_url": null,
+   "models": {
+    "grok-imagine-video": {
+     "name": "Grok Imagine Video"
+    },
+    "grok-4.3": {
+     "name": "Grok 4.3"
+    },
+    "grok-4.20-0309-non-reasoning": {
+     "name": "Grok 4.20 (Non-Reasoning)"
+    },
+    "grok-imagine-video-1.5": {
+     "name": "Grok Imagine Video 1.5"
+    },
+    "grok-4.20-multi-agent-0309": {
+     "name": "Grok 4.20 Multi-Agent"
+    },
+    "grok-imagine-image-quality": {
+     "name": "Grok Imagine Image Quality"
+    },
+    "grok-4.5": {
+     "name": "Grok 4.5"
+    },
+    "grok-build-0.1": {
+     "name": "Grok Build 0.1"
+    },
+    "grok-4.20-0309-reasoning": {
+     "name": "Grok 4.20 (Reasoning)"
+    },
+    "grok-imagine-image": {
+     "name": "Grok Imagine Image"
+    }
+   }
+  },
+  {
+   "id": "perplexity",
+   "name": "Perplexity",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.perplexity.ai",
+   "default_model": "sonar",
+   "key_prefixes": [
+    "pplx-"
+   ],
+   "tested": false,
+   "doc_url": "https://docs.perplexity.ai",
+   "help_url": null,
+   "models": {
+    "sonar-deep-research": {
+     "name": "Perplexity Sonar Deep Research"
+    },
+    "sonar": {
+     "name": "Sonar"
+    },
+    "sonar-pro": {
+     "name": "Sonar Pro"
+    },
+    "sonar-reasoning-pro": {
+     "name": "Sonar Reasoning Pro"
+    }
+   }
+  },
+  {
+   "id": "mistral",
+   "name": "Mistral",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.mistral.ai/v1",
+   "default_model": "mistral-small-2506",
+   "key_prefixes": [],
+   "tested": false,
+   "doc_url": "https://docs.mistral.ai/getting-started/models/",
+   "help_url": null,
+   "models": {
+    "mistral-small-2506": {
+     "name": "Mistral Small 3.2"
+    },
+    "pixtral-large-latest": {
+     "name": "Pixtral Large (latest)"
+    },
+    "pixtral-12b": {
+     "name": "Pixtral 12B"
+    },
+    "open-mixtral-8x7b": {
+     "name": "Mixtral 8x7B"
+    },
+    "labs-devstral-small-2512": {
+     "name": "Devstral Small 2"
+    },
+    "magistral-medium-latest": {
+     "name": "Magistral Medium (latest)"
+    },
+    "mistral-medium-2508": {
+     "name": "Mistral Medium 3.1"
+    },
+    "mistral-large-2411": {
+     "name": "Mistral Large 2.1"
+    },
+    "voxtral-mini-tts-latest": {
+     "name": "Voxtral Mini TTS (latest)"
+    },
+    "mistral-medium-latest": {
+     "name": "Mistral Medium (latest)"
+    },
+    "devstral-small-2507": {
+     "name": "Devstral Small"
+    },
+    "open-mistral-7b": {
+     "name": "Mistral 7B"
+    },
+    "mistral-medium-2505": {
+     "name": "Mistral Medium 3"
+    },
+    "ministral-3b-latest": {
+     "name": "Ministral 3B (latest)"
+    },
+    "mistral-small-latest": {
+     "name": "Mistral Small (latest)"
+    },
+    "open-mixtral-8x22b": {
+     "name": "Mixtral 8x22B"
+    },
+    "mistral-nemo": {
+     "name": "Mistral Nemo"
+    },
+    "mistral-small-2603": {
+     "name": "Mistral Small 4"
+    },
+    "mistral-medium-2604": {
+     "name": "Mistral Medium 3.5"
+    },
+    "voxtral-mini-latest": {
+     "name": "Voxtral Mini (latest)"
+    },
+    "voxtral-small-latest": {
+     "name": "Voxtral Small (latest)"
+    },
+    "devstral-latest": {
+     "name": "Devstral 2"
+    },
+    "ministral-8b-latest": {
+     "name": "Ministral 8B (latest)"
+    },
+    "mistral-embed": {
+     "name": "Mistral Embed"
+    },
+    "codestral-latest": {
+     "name": "Codestral (latest)"
+    },
+    "devstral-medium-latest": {
+     "name": "Devstral 2 (latest)"
+    },
+    "devstral-2512": {
+     "name": "Devstral 2"
+    },
+    "mistral-large-latest": {
+     "name": "Mistral Large (latest)"
+    },
+    "devstral-medium-2507": {
+     "name": "Devstral Medium"
+    },
+    "devstral-small-2505": {
+     "name": "Devstral Small 2505"
+    },
+    "magistral-small": {
+     "name": "Magistral Small"
+    },
+    "open-mistral-nemo": {
+     "name": "Open Mistral Nemo"
+    },
+    "mistral-large-2512": {
+     "name": "Mistral Large 3"
+    }
+   }
+  },
+  {
+   "id": "fireworks-ai",
+   "name": "Fireworks AI",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://api.fireworks.ai/inference/v1",
+   "default_model": "accounts/fireworks/models/deepseek-v4-flash",
+   "key_prefixes": [],
+   "tested": false,
+   "doc_url": "https://fireworks.ai/docs/",
+   "help_url": null,
+   "models": {
+    "accounts/fireworks/routers/glm-5p2-fast": {
+     "name": "GLM 5.2 Fast"
+    },
+    "accounts/fireworks/routers/kimi-k2p6-fast": {
+     "name": "Kimi K2.6 Fast"
+    },
+    "accounts/fireworks/routers/kimi-k2p6-turbo": {
+     "name": "Kimi K2.6 Turbo"
+    },
+    "accounts/fireworks/routers/kimi-k2p7-code-fast": {
+     "name": "Kimi K2.7 Code Fast"
+    },
+    "accounts/fireworks/routers/kimi-k3-fast": {
+     "name": "Kimi K3 Fast"
+    },
+    "accounts/fireworks/models/qwen3p7-plus": {
+     "name": "Qwen 3.7 Plus"
+    },
+    "accounts/fireworks/models/deepseek-v4-flash": {
+     "name": "DeepSeek V4 Flash"
+    },
+    "accounts/fireworks/models/gpt-oss-20b": {
+     "name": "GPT OSS 20B"
+    },
+    "accounts/fireworks/models/minimax-m2p7": {
+     "name": "MiniMax-M2.7"
+    },
+    "accounts/fireworks/models/kimi-k2p6": {
+     "name": "Kimi K2.6"
+    },
+    "accounts/fireworks/models/minimax-m3": {
+     "name": "MiniMax-M3"
+    },
+    "accounts/fireworks/models/deepseek-v4-pro": {
+     "name": "DeepSeek V4 Pro"
+    },
+    "accounts/fireworks/models/deepseek-v4-flash-0731": {
+     "name": "DeepSeek V4 Flash 0731"
+    },
+    "accounts/fireworks/models/kimi-k2p7-code": {
+     "name": "Kimi K2.7 Code"
+    },
+    "accounts/fireworks/models/gpt-oss-120b": {
+     "name": "GPT OSS 120B"
+    },
+    "accounts/fireworks/models/glm-5p2": {
+     "name": "GLM 5.2"
+    },
+    "accounts/fireworks/models/kimi-k3": {
+     "name": "Kimi K3"
+    }
+   }
+  },
+  {
+   "id": "zhipuai",
+   "name": "Zhipu AI",
+   "auth_type": "api-key",
+   "protocol": "openai",
+   "api_base": "https://open.bigmodel.cn/api/paas/v4",
+   "default_model": "glm-4.7-flash",
+   "key_prefixes": [],
+   "tested": false,
+   "doc_url": "https://docs.z.ai/guides/overview/pricing",
+   "help_url": null,
+   "models": {
+    "glm-5": {
+     "name": "GLM-5"
+    },
+    "glm-5.1": {
+     "name": "GLM-5.1"
+    },
+    "glm-5.2": {
+     "name": "GLM-5.2"
+    },
+    "glm-5v-turbo": {
+     "name": "GLM-5V-Turbo"
+    },
+    "glm-4.5-flash": {
+     "name": "GLM-4.5-Flash"
+    },
+    "glm-4.7": {
+     "name": "GLM-4.7"
+    },
+    "glm-4.5v": {
+     "name": "GLM-4.5V"
+    },
+    "glm-4.5": {
+     "name": "GLM-4.5"
+    },
+    "glm-4.6": {
+     "name": "GLM-4.6"
+    },
+    "glm-4.7-flashx": {
+     "name": "GLM-4.7-FlashX"
+    },
+    "glm-4.7-flash": {
+     "name": "GLM-4.7-Flash"
+    },
+    "glm-4.5-air": {
+     "name": "GLM-4.5-Air"
+    },
+    "glm-4.6v": {
+     "name": "GLM-4.6V"
+    }
+   }
+  }
+ ]
+}

--- a/collie-core/collie_core/catalog/snapshot_util.py
+++ b/collie-core/collie_core/catalog/snapshot_util.py
@@ -1,0 +1,103 @@
+"""Snapshot trimming + schema validation shared by the builder, loader and refresh.
+
+Kept out of ``catalog/__init__.py`` so ``refresh`` can import it without a
+circular import (``__init__`` imports ``refresh`` for the store API).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from collie_core.catalog.curated import CURATED_ORDER, CURATED_PROVIDERS
+
+SCHEMA_VERSION = 1
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def validate_catalogue_schema(snapshot: Any) -> bool:
+    """Schema-validate a catalogue snapshot before it is trusted.
+
+    Catches truncated fetches, HTML error pages, and wrong-shaped payloads
+    before they can replace the good snapshot.
+    """
+    if not isinstance(snapshot, dict):
+        return False
+    if snapshot.get("schema_version") != SCHEMA_VERSION:
+        return False
+    if not isinstance(snapshot.get("providers"), list) or not snapshot["providers"]:
+        return False
+    if not isinstance(snapshot.get("source"), dict):
+        return False
+    for entry in snapshot["providers"]:
+        if not isinstance(entry, dict):
+            return False
+        if not isinstance(entry.get("id"), str) or not entry["id"]:
+            return False
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            return False
+    return True
+
+
+def trim_live_catalogue(raw: dict[str, Any], generated_at: str) -> dict[str, Any] | None:
+    """Trim a raw models.dev api.json payload into a Collie snapshot.
+
+    Keeps only curated providers and the fields Collie needs. Returns None
+    when the payload is not a usable models.dev document.
+    """
+    if not isinstance(raw, dict):
+        return None
+    raw_providers = raw.get("providers")
+    if not isinstance(raw_providers, dict):
+        # models.dev api.json keys ARE the provider slugs (no wrapper key).
+        raw_providers = raw
+    if not raw_providers:
+        return None
+    providers_out: list[dict[str, Any]] = []
+    for pid in CURATED_ORDER:
+        raw_entry = raw_providers.get(pid)
+        if not isinstance(raw_entry, dict):
+            continue
+        raw_models = raw_entry.get("models")
+        if not isinstance(raw_models, dict):
+            continue
+        curated = CURATED_PROVIDERS.get(pid) or {}
+        models_out: dict[str, dict[str, str]] = {}
+        for mid, meta in raw_models.items():
+            if not isinstance(meta, dict):
+                continue
+            name = str(meta.get("name") or mid)
+            models_out[str(mid)] = {"name": name}
+        if not models_out:
+            continue
+        entry: dict[str, Any] = {
+            "id": pid,
+            "name": str(curated.get("name") or raw_entry.get("name") or pid),
+            "auth_type": curated.get("auth_type") or "api-key",
+            "protocol": curated.get("protocol") or "openai",
+            "api_base": curated.get("api_base") or raw_entry.get("api"),
+            "default_model": curated.get("default_model") or next(iter(models_out)),
+            "key_prefixes": curated.get("key_prefixes") or [],
+            "tested": bool(curated.get("tested", False)),
+            "doc_url": raw_entry.get("doc"),
+            "help_url": curated.get("help_url"),
+            "models": models_out,
+        }
+        providers_out.append(entry)
+    if not providers_out:
+        return None
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "source": {
+            "url": "https://models.dev/api.json",
+            "sha256": sha256_hex(json.dumps(raw, sort_keys=True).encode("utf-8")),
+            "providers_count": len(raw_providers),
+        },
+        "providers": providers_out,
+    }

--- a/collie-core/collie_core/commands.py
+++ b/collie-core/collie_core/commands.py
@@ -34,7 +34,18 @@ class CommandSpec:
 
 
 CORE_COMMANDS: tuple[CommandSpec, ...] = (
-    CommandSpec("start", "Show the Collie command menu", "/start", "Help"),
+    CommandSpec(
+        "start",
+        "Open the getting-started chat (desktop) / show commands",
+        "/start",
+        "Help",
+    ),
+    CommandSpec(
+        "get-started",
+        "Open the getting-started chat",
+        "/get-started",
+        "Help",
+    ),
     CommandSpec("new", "Start a fresh conversation", "/new", "Session"),
     CommandSpec("compact", "Summarize older context and keep recent turns", "/compact", "Session"),
     CommandSpec("status", "Show model, context, and active helpers", "/status", "Session"),
@@ -175,7 +186,22 @@ class CommandController:
                 "content": f"I don't know /{command} yet. Try /help to see what I can do.",
             }
 
-        if command in {"help", "commands", "start"}:
+        if command == "start" and origin == "desktop":
+            # Desktop /start reopens the starter conversation (idempotent).
+            return {"handled": True, "starter_conversation": True, "content": ""}
+
+        if command == "get-started":
+            if origin != "desktop":
+                lines = ["Getting started lives in the Collie desktop app. "
+                         "Here are my commands instead:"]
+                for item in CORE_COMMANDS:
+                    if item.name == "help":
+                        continue
+                    lines.append(f"- `{item.usage}` — {item.description}")
+                return {"handled": True, "content": "\n".join(lines)}
+            return {"handled": True, "starter_conversation": True, "content": ""}
+
+        if command in {"help", "commands"} or (command == "start" and origin != "desktop"):
             lines = ["Here are my commands:"]
             for item in CORE_COMMANDS:
                 if item.name == "help":

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -537,6 +537,31 @@ CREATE INDEX IF NOT EXISTS idx_memory_journal_created
     ON memory_journal(created_at DESC);
 """
 
+# Versioned artifact store (PR 2 of the Gardener Foundations plan): every
+# user-visible artifact edit (subagent files, VISION.md / AGENTS.md /
+# MEMORY.md, dream consolidations, Gardener applies) is snapshotted with a
+# before/after text pair + unified diff so any change can be rolled back
+# without clobbering newer owner edits. Complementary to the memory_journal
+# (which records per-key memory mutations) — this records full-file states.
+_SCHEMA_V14 = """
+CREATE TABLE IF NOT EXISTS artifact_versions (
+  id TEXT PRIMARY KEY,
+  artifact_type TEXT NOT NULL,      -- subagent|vision|agents|memory_profile|memory_dream|skill
+  artifact_key TEXT NOT NULL,       -- subagent filename | "VISION.md" | "AGENTS.md" | "MEMORY.md" | "memory/MEMORY.md"
+  version INTEGER NOT NULL,
+  before_text TEXT,
+  after_text TEXT,
+  diff_text TEXT,                   -- difflib.unified_diff
+  evidence_json TEXT,               -- Gardener trigger evidence (run ids, tool stats)
+  source TEXT NOT NULL DEFAULT 'user',  -- user|collie|gardener
+  status TEXT NOT NULL DEFAULT 'applied', -- applied|rolled_back
+  created_at TEXT NOT NULL,
+  UNIQUE(artifact_type, artifact_key, version)
+);
+CREATE INDEX IF NOT EXISTS idx_artifact_versions_type
+  ON artifact_versions(artifact_type, artifact_key, version DESC);
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -552,6 +577,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V11,
     _SCHEMA_V12,
     _SCHEMA_V13,
+    _SCHEMA_V14,
 ]
 
 
@@ -3480,6 +3506,99 @@ class CollieDB:
             for row in rows
         ]
 
+    # -- artifact versions (Gardener rollback rail) ---------------------------------------------
+
+    def snapshot_artifact(
+        self,
+        artifact_type: str,
+        artifact_key: str,
+        before_text: str,
+        after_text: str,
+        diff_text: str,
+        evidence: Any = None,
+        source: str = "user",
+    ) -> dict[str, Any]:
+        """Append a version row for an artifact edit; returns the new row."""
+        with self._write_immediate() as conn:
+            row = conn.execute(
+                "SELECT MAX(version) AS v FROM artifact_versions "
+                "WHERE artifact_type = ? AND artifact_key = ?",
+                (artifact_type, artifact_key),
+            ).fetchone()
+            version = int(row["v"] or 0) + 1
+            version_id = new_id()
+            conn.execute(
+                "INSERT INTO artifact_versions (id, artifact_type, artifact_key, "
+                "version, before_text, after_text, diff_text, evidence_json, "
+                "source, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, "
+                "'applied', ?)",
+                (
+                    version_id,
+                    artifact_type,
+                    artifact_key,
+                    version,
+                    before_text,
+                    after_text,
+                    diff_text,
+                    json.dumps(evidence, ensure_ascii=False) if evidence is not None else None,
+                    source,
+                    utc_now(),
+                ),
+            )
+            return {
+                "id": version_id,
+                "artifact_type": artifact_type,
+                "artifact_key": artifact_key,
+                "version": version,
+                "status": "applied",
+            }
+
+    def latest_artifact_version(
+        self, artifact_type: str, artifact_key: str
+    ) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT MAX(version) AS v FROM artifact_versions "
+                "WHERE artifact_type = ? AND artifact_key = ?",
+                (artifact_type, artifact_key),
+            ).fetchone()
+            return int(row["v"] or 0) if row else 0
+
+    def list_artifact_versions(
+        self,
+        artifact_type: str | None = None,
+        artifact_key: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List artifact versions, most recent first, with optional filters."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if artifact_type:
+            clauses.append("artifact_type = ?")
+            params.append(artifact_type)
+        if artifact_key:
+            clauses.append("artifact_key = ?")
+            params.append(artifact_key)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+        return self._rows(
+            f"SELECT * FROM artifact_versions {where} "
+            "ORDER BY created_at DESC, version DESC LIMIT ?",
+            tuple(params),
+        )
+
+    def get_artifact_version(self, version_id: str) -> dict[str, Any] | None:
+        return self._row(
+            "SELECT * FROM artifact_versions WHERE id = ?", (version_id,)
+        )
+
+    def mark_artifact_rolled_back(self, version_id: str) -> None:
+        with self._write() as conn:
+            conn.execute(
+                "UPDATE artifact_versions SET status = 'rolled_back' WHERE id = ?",
+                (version_id,),
+            )
+
     # -- data management ----------------------------------------------------------------------------
 
     def export_all(self) -> dict[str, Any]:
@@ -3525,6 +3644,12 @@ class CollieDB:
             "tool_events": self._rows(
                 "SELECT * FROM tool_events ORDER BY started_at"
             ),
+            "memory_journal": self._rows(
+                "SELECT * FROM memory_journal ORDER BY created_at"
+            ),
+            "artifact_versions": self._rows(
+                "SELECT * FROM artifact_versions ORDER BY created_at, version"
+            ),
             "approval_rules": self.list_approval_rules(),
             "approval_requests": self._rows(
                 "SELECT * FROM approval_requests ORDER BY requested_at"
@@ -3563,6 +3688,7 @@ class CollieDB:
                 "task_checklist_steps", "task_checklists", "conversation_review_gates",
                 "plan_change_requests", "run_task_state_revisions",
                 "tool_events", "turn_events",
+                "artifact_versions",
                 "run_steps",
                 "approval_requests", "approval_rules", "runs", "plans",
                 "messages", "conversations", "profile", "people", "important_dates",

--- a/collie-core/collie_core/gardener/__init__.py
+++ b/collie-core/collie_core/gardener/__init__.py
@@ -1,0 +1,28 @@
+"""Gardener — Collie's self-improvement loop (evidence → propose → review).
+
+The Gardener reads run-record telemetry, proposes conservative
+improvements to agent instruction files and long-term memory, and applies
+them only through the versioned rollback rail after human approval.
+
+MVP scope: no sandbox replay (documented deferral) — deterministic scope
+validation + human approval stand in for it.
+"""
+
+from collie_core.gardener.evidence import collect_evidence
+from collie_core.gardener.propose import (
+    ALLOWED_ARTIFACT_TYPES,
+    ProposalValidationError,
+    propose,
+    validate_suggestion,
+)
+from collie_core.gardener.runner import apply_suggestion, run_gardener
+
+__all__ = [
+    "ALLOWED_ARTIFACT_TYPES",
+    "ProposalValidationError",
+    "apply_suggestion",
+    "collect_evidence",
+    "propose",
+    "run_gardener",
+    "validate_suggestion",
+]

--- a/collie-core/collie_core/gardener/evidence.py
+++ b/collie-core/collie_core/gardener/evidence.py
@@ -1,0 +1,202 @@
+"""Gardener evidence queries — read-only signals over run-record telemetry.
+
+The Gardener's evidence layer answers four questions from the telemetry
+tables (``turn_events`` / ``tool_events``) plus the workspace files:
+
+1. **Repeated tool failures** — tools that error or are denied often enough
+   to be worth a fix (e.g. a tool description tweak).
+2. **Repeated workflows** — tool sequences that appear again and again, a
+   sign the user repeats a multi-step task that could become a routine.
+3. **Denied / stopped turns** — turns the user stopped or that the model
+   ended early, a signal of friction.
+4. **Memory bloat** — ``memory/MEMORY.md`` (long-term) and ``MEMORY.md``
+   (profile mirror) growing past sensible sizes or accumulating duplicate
+   headings.
+
+Everything here is **read-only**: no writes to the DB and no writes to the
+workspace. The Gardener's proposal step consumes the summary and the
+apply step goes through the versioned rollback rail.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "collect_evidence",
+    "memory_bloat",
+    "recent_failures",
+    "repeated_workflows",
+    "user_stops",
+]
+
+# A tool is "failing" when it errors or is denied by the permission layer.
+_FAILING_STATUSES = ("error", "denied", "timeout")
+
+# Tool sequences shorter than this are too trivial to be a workflow.
+_MIN_WORKFLOW_LEN = 2
+# A workflow must appear at least this often to be "repeated".
+_MIN_WORKFLOW_REPEATS = 3
+# A failing tool must trip at least this often before the Gardener bothers.
+_MIN_FAILURE_COUNT = 2
+
+# Memory files the Gardener watches for bloat.
+_MEMORY_FILES = (
+    ("memory", "memory/MEMORY.md"),  # nanobot long-term memory (Dream target)
+    ("profile", "MEMORY.md"),  # ProfileStore mirror
+)
+
+# Soft caps (characters) — above these the Gardener may suggest tidying.
+_SOFT_CAPS: dict[str, int] = {"memory": 12_000, "profile": 12_000}
+
+
+def _since(days: int = 14) -> str:
+    """ISO timestamp ``days`` ago (UTC), the default evidence window."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(
+        timespec="seconds"
+    )
+
+
+def recent_failures(
+    db: Any, since: str | None = None, min_count: int = _MIN_FAILURE_COUNT
+) -> list[dict[str, Any]]:
+    """Per-tool failure counts with sample messages, most failing first."""
+    events = db.list_tool_events(limit=500)
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for event in events:
+        started = str(event.get("started_at") or "")
+        if since and started and started < since:
+            continue
+        if str(event.get("status") or "") not in _FAILING_STATUSES:
+            continue
+        name = str(event.get("tool_name") or "unknown")
+        buckets.setdefault(name, []).append(event)
+
+    rows: list[dict[str, Any]] = []
+    for name, items in buckets.items():
+        if len(items) < min_count:
+            continue
+        samples = [
+            (str(item.get("error_message") or "") or None)
+            for item in items[:3]
+            if item.get("error_message")
+        ]
+        rows.append(
+            {
+                "tool_name": name,
+                "failures": len(items),
+                "statuses": sorted({str(i.get("status") or "") for i in items}),
+                "sample_errors": [s for s in samples if s][:3],
+                "last_seen": max(str(i.get("started_at") or "") for i in items),
+            }
+        )
+    rows.sort(key=lambda r: r["failures"], reverse=True)
+    return rows
+
+
+def repeated_workflows(
+    db: Any,
+    since: str | None = None,
+    min_repeats: int = _MIN_WORKFLOW_REPEATS,
+) -> list[dict[str, Any]]:
+    """Tool sequences (by turn) that recur often enough to suggest a routine.
+
+    A workflow is the ordered list of tool names in one turn (collapsed
+    repeats). Sequences shorter than ``_MIN_WORKFLOW_LEN`` are ignored.
+    """
+    turns = db.list_turn_events(limit=200)
+    sequences: dict[tuple[str, ...], int] = {}
+    for turn in turns:
+        started = str(turn.get("started_at") or "")
+        if since and started and started < since:
+            continue
+        tool_events = db.list_tool_events(turn_id=turn["id"], limit=100)
+        names: list[str] = []
+        for event in tool_events:
+            name = str(event.get("tool_name") or "")
+            if name and (not names or names[-1] != name):
+                names.append(name)
+        if len(names) >= _MIN_WORKFLOW_LEN:
+            key = tuple(names)
+            sequences[key] = sequences.get(key, 0) + 1
+
+    return [
+        {
+            "workflow": list(key),
+            "repeats": count,
+        }
+        for key, count in sorted(
+            sequences.items(), key=lambda item: item[1], reverse=True
+        )
+        if count >= min_repeats
+    ]
+
+
+def user_stops(db: Any, since: str | None = None) -> list[dict[str, Any]]:
+    """Turns the user stopped or that never completed (friction signals)."""
+    turns = db.list_turn_events(limit=200)
+    stopped: list[dict[str, Any]] = []
+    for turn in turns:
+        started = str(turn.get("started_at") or "")
+        if since and started and started < since:
+            continue
+        if str(turn.get("status") or "") in ("stopped", "cancelled"):
+            stopped.append(
+                {
+                    "turn_id": turn["id"],
+                    "status": turn["status"],
+                    "started_at": started,
+                    "conversation_id": str(turn.get("conversation_id") or ""),
+                }
+            )
+    stopped.sort(key=lambda r: r["started_at"], reverse=True)
+    return stopped
+
+
+def memory_bloat(workspace: Path) -> list[dict[str, Any]]:
+    """Size + duplicate-heading signals for the memory files.
+
+    Returns one entry per watched file that exists, with ``bloated`` set
+    when the file exceeds its soft cap or contains repeated ``#``-headings.
+    """
+    workspace = Path(workspace)
+    findings: list[dict[str, Any]] = []
+    for kind, rel in _MEMORY_FILES:
+        path = workspace / rel
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        headings = [
+            line.strip().lstrip("#").strip().lower()
+            for line in text.splitlines()
+            if line.strip().startswith("#") and line.strip().lstrip("#").strip()
+        ]
+        dupes = {
+            heading for heading in headings if headings.count(heading) > 1
+        }
+        bloated = len(text) > _SOFT_CAPS.get(kind, 12_000) or bool(dupes)
+        findings.append(
+            {
+                "kind": kind,
+                "path": rel,
+                "chars": len(text),
+                "lines": len(text.splitlines()),
+                "duplicate_headings": sorted(dupes)[:10],
+                "bloated": bloated,
+            }
+        )
+    return findings
+
+
+def collect_evidence(db: Any, workspace: Path, since: str | None = None) -> dict[str, Any]:
+    """Aggregate the Gardener's evidence into one bounded summary dict."""
+    since = since or _since()
+    return {
+        "since": since,
+        "failures": recent_failures(db, since=since),
+        "workflows": repeated_workflows(db, since=since),
+        "user_stops": user_stops(db, since=since),
+        "memory": memory_bloat(workspace),
+    }

--- a/collie-core/collie_core/gardener/propose.py
+++ b/collie-core/collie_core/gardener/propose.py
@@ -1,0 +1,365 @@
+"""Gardener proposal step — bounded subagent call + strict validation.
+
+The Gardener runs one **bounded, read-only** subagent turn (a single model
+call, no tools, ``read_only`` posture — the same machinery the Dream runner
+uses) with a fixed prompt: the evidence summary and the current agent /
+memory texts go in, a structured JSON list of suggestions comes out.
+
+Nothing the model says is trusted: every suggestion passes through
+:func:`validate_suggestion`, a deterministic gate that enforces
+
+* **artifact allowlist** — only ``subagent``, ``agents``, ``vision`` and
+  ``memory_dream`` targets may be proposed;
+* **key safety** — artifact keys must be plain filenames (no path
+  traversal) and must match the artifact type;
+* **size budgets** — proposed text and rationale are length-capped;
+* **keyword gate** — proposed text mentioning permissions, settings,
+  secrets, connectors, credentials or anything out of the Gardener's
+  scope is rejected outright.
+
+Suggestions that fail validation are dropped with a reason; the runner
+reports how many were rejected.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.runner import AgentRunSpec
+from nanobot.agent.tools.registry import ToolRegistry
+
+__all__ = [
+    "ALLOWED_ARTIFACT_TYPES",
+    "FORBIDDEN_TERMS",
+    "MAX_PROPOSED_CHARS",
+    "MAX_RATIONALE_CHARS",
+    "MAX_SUGGESTIONS",
+    "ProposalValidationError",
+    "propose",
+    "validate_suggestion",
+]
+
+# The only artifact types the Gardener may touch (scope guard from the
+# plan: agent instructions + memory consolidation, nothing else).
+ALLOWED_ARTIFACT_TYPES: tuple[str, ...] = (
+    "subagent",
+    "agents",
+    "vision",
+    "memory_dream",
+)
+
+# Deterministic keyword gate: any of these in a proposed text (or
+# rationale) is out of scope and the suggestion is rejected. Deliberately
+# conservative and plain-worded — the Gardener never proposes changes to
+# permissions, settings, secrets, or connectors.
+FORBIDDEN_TERMS: tuple[str, ...] = (
+    "permission",
+    "approval",
+    "approve",
+    "auto-approv",
+    "settings",
+    "setting",
+    "secret",
+    "password",
+    "credential",
+    "api key",
+    "apikey",
+    "token",
+    "connector",
+    "oauth",
+    "billing",
+    "payment",
+    "credit card",
+    "model provider",
+    "provider key",
+)
+
+# Size budgets (characters).
+MAX_PROPOSED_CHARS = 4_000
+MAX_RATIONALE_CHARS = 500
+MAX_SUGGESTIONS = 3
+
+# Evidence summary length budget for the prompt (≈2k tokens of text).
+MAX_EVIDENCE_CHARS = 8_000
+# Per-artifact current-text budget fed to the model.
+MAX_ARTIFACT_TEXT_CHARS = 6_000
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
+
+_GARDENER_SYSTEM_PROMPT = (
+    "You are Collie's improvement Gardener. Follow the instructions in the "
+    "user message exactly, and output only the requested JSON."
+)
+
+_GARDENER_PROMPT_TEMPLATE = """You help Collie (a local-first AI assistant for non-coders) improve itself.
+
+Below is evidence from Collie's recent run records (tool failures, repeated
+workflows, stopped turns, memory size) and the current text of a few agent
+instruction / memory files.
+
+## Evidence
+{evidence}
+
+## Current files
+{artifacts}
+
+## Your task
+Propose up to {max_suggestions} concrete, conservative improvements. Each
+suggestion must do exactly ONE of:
+
+- rewrite one agent instruction file (AGENTS.md, VISION.md) so Collie's
+  instructions match observed friction (e.g. a tool that keeps failing,
+  a workflow the user repeats),
+- tighten one subagent prompt (subagents/<name>.md),
+- tidy the long-term memory file (memory/MEMORY.md): merge duplicates,
+  prune stale entries, keep facts atomic.
+
+Output ONLY a JSON array (no markdown, no commentary):
+[{{"artifact_type": "subagent|agents|vision|memory_dream",
+   "artifact_key": "<plain filename>",
+   "proposed_text": "<full new file content>",
+   "rationale": "<1-2 sentences, referencing the evidence>",
+   "evidence_ids": ["<short labels from the evidence, e.g. 'failures:web_fetch'>"]}}]
+
+Rules:
+- Never propose changes to permissions, settings, secrets, credentials,
+  connectors, billing, or providers. Those are out of scope.
+- Never invent facts. Base every change on the evidence above.
+- Keep proposed_text complete (the whole file), not a patch.
+- If nothing is worth changing, output an empty array: []
+"""
+
+
+class ProposalValidationError(Exception):
+    """Raised when a Gardener suggestion violates the scope guard."""
+
+
+def _normalise_key(key: str) -> str:
+    return (key or "").strip().lstrip("/")
+
+
+def validate_suggestion(suggestion: dict[str, Any]) -> dict[str, Any]:
+    """Strictly validate one model-proposed suggestion (deterministic).
+
+    Returns the cleaned suggestion, or raises
+    :class:`ProposalValidationError` with a human reason. This is the
+    Gardener's security boundary: nothing a model says is ever applied
+    without passing through here (the apply path re-validates too).
+    """
+    artifact_type = str(suggestion.get("artifact_type") or "").strip()
+    if artifact_type not in ALLOWED_ARTIFACT_TYPES:
+        raise ProposalValidationError(
+            f"'{artifact_type or '(missing)'}' is not a target the Gardener "
+            "may change."
+        )
+
+    key = _normalise_key(str(suggestion.get("artifact_key") or ""))
+    if not key or "/" in key or "\\" in key or key in (".", ".."):
+        raise ProposalValidationError(
+            f"'{key}' is not a safe artifact key (plain filenames only)."
+        )
+
+    if artifact_type == "subagent":
+        if not key.endswith(".md"):
+            raise ProposalValidationError(
+                "Subagent suggestions must target a '.md' file."
+            )
+    elif artifact_type in ("agents", "vision"):
+        expected = "AGENTS.md" if artifact_type == "agents" else "VISION.md"
+        if key != expected:
+            raise ProposalValidationError(
+                f"{artifact_type} suggestions must target '{expected}'."
+            )
+    elif artifact_type == "memory_dream":
+        if key != "MEMORY.md":
+            raise ProposalValidationError(
+                "Memory suggestions must target 'MEMORY.md'."
+            )
+
+    proposed = str(suggestion.get("proposed_text") or "")
+    if not proposed.strip():
+        raise ProposalValidationError(
+            "The proposed text is empty — there's nothing to apply."
+        )
+    if len(proposed) > MAX_PROPOSED_CHARS:
+        raise ProposalValidationError(
+            f"The proposed text is {len(proposed)} characters — over the "
+            f"{MAX_PROPOSED_CHARS}-character budget."
+        )
+    rationale = str(suggestion.get("rationale") or "")
+    if len(rationale) > MAX_RATIONALE_CHARS:
+        raise ProposalValidationError(
+            f"The rationale is {len(rationale)} characters — over the "
+            f"{MAX_RATIONALE_CHARS}-character budget."
+        )
+
+    evidence_ids = suggestion.get("evidence_ids") or []
+    if not isinstance(evidence_ids, list):
+        evidence_ids = []
+    evidence_ids = [str(item) for item in evidence_ids][:10]
+
+    # Keyword gate on the actual content (case-insensitive, word-bounded
+    # where it matters). This is the deterministic scope guard.
+    haystack = f"{proposed}\n{rationale}".lower()
+    for term in FORBIDDEN_TERMS:
+        if term in haystack:
+            raise ProposalValidationError(
+                f"The proposal mentions '{term}', which is out of scope for "
+                "the Gardener (permissions, settings, secrets, and "
+                "connectors are never auto-suggested)."
+            )
+
+    return {
+        "artifact_type": artifact_type,
+        "artifact_key": key,
+        "proposed_text": proposed,
+        "rationale": rationale,
+        "evidence_ids": evidence_ids,
+    }
+
+
+def _extract_json(response: str) -> list[dict[str, Any]]:
+    """Pull the suggestion array out of a model response, best-effort."""
+    text = (response or "").strip()
+    match = _FENCE_RE.search(text)
+    if match:
+        text = match.group(1).strip()
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError):
+        start, end = text.find("["), text.rfind("]")
+        if start == -1 or end <= start:
+            return []
+        try:
+            parsed = json.loads(text[start : end + 1])
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def _artifact_text(workspace: Path, artifact_type: str, key: str) -> str:
+    """Read a (validated) artifact's current text for the prompt."""
+    base = Path(workspace)
+    if artifact_type == "subagent":
+        path = base / "subagents" / key
+    elif artifact_type == "memory_dream":
+        path = base / "memory" / key
+    else:
+        path = base / key
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def build_prompt(evidence: dict[str, Any], workspace: Path) -> str:
+    """Render the Gardener prompt (bounded: evidence + current texts)."""
+    evidence_text = json.dumps(evidence, ensure_ascii=False, indent=1)
+    if len(evidence_text) > MAX_EVIDENCE_CHARS:
+        evidence_text = evidence_text[:MAX_EVIDENCE_CHARS] + "\n…(truncated)"
+
+    sections: list[str] = []
+    for artifact_type in ALLOWED_ARTIFACT_TYPES:
+        if artifact_type == "subagent":
+            sub_dir = Path(workspace) / "subagents"
+            if not sub_dir.exists():
+                continue
+            for path in sorted(sub_dir.glob("*.md")):
+                text = path.read_text(encoding="utf-8")
+                sections.append(
+                    f"### subagents/{path.name}\n{text[:MAX_ARTIFACT_TEXT_CHARS]}"
+                )
+        elif artifact_type == "memory_dream":
+            path = Path(workspace) / "memory" / "MEMORY.md"
+            if path.exists():
+                text = path.read_text(encoding="utf-8")
+                sections.append(
+                    f"### memory/MEMORY.md\n{text[:MAX_ARTIFACT_TEXT_CHARS]}"
+                )
+        else:
+            key = "AGENTS.md" if artifact_type == "agents" else "VISION.md"
+            path = Path(workspace) / key
+            if path.exists():
+                text = path.read_text(encoding="utf-8")
+                sections.append(f"### {key}\n{text[:MAX_ARTIFACT_TEXT_CHARS]}")
+
+    return _GARDENER_PROMPT_TEMPLATE.format(
+        evidence=evidence_text,
+        artifacts="\n\n".join(sections) if sections else "(no files yet)",
+        max_suggestions=MAX_SUGGESTIONS,
+    )
+
+
+async def propose(
+    loop: Any,
+    workspace: Path,
+    evidence: dict[str, Any],
+    session_key: str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run the bounded Gardener turn; return (valid, rejected) suggestions.
+
+    ``valid`` is the validated, cleaned suggestion list; ``rejected`` is a
+    list of ``{"reason": str, "artifact_type": str, "artifact_key": str}``
+    for the suggestions the deterministic gate refused. Both are safe to
+    render.
+    """
+    workspace = Path(workspace)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    gardener_key = session_key or f"gardener:{stamp}"
+
+    spec = AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": _GARDENER_SYSTEM_PROMPT},
+            {"role": "user", "content": build_prompt(evidence, workspace)},
+        ],
+        tools=ToolRegistry(),  # no tools: bounded, read-only by construction
+        runtime=loop.llm_runtime(),
+        max_iterations=1,
+        max_tool_result_chars=4000,
+        hook=None,
+        session_key=gardener_key,
+        workspace=workspace,
+        execution_posture="read_only",
+    )
+
+    try:
+        result = await loop.subagents.runner.run(spec)
+    except Exception:
+        logger.exception("Gardener proposal turn failed")
+        return [], [{"reason": "turn_error", "artifact_type": "", "artifact_key": ""}]
+
+    if getattr(result, "stop_reason", None) != "completed":
+        logger.warning(
+            "Gardener proposal turn did not complete (stop_reason={})",
+            getattr(result, "stop_reason", None),
+        )
+        return [], [
+            {
+                "reason": f"stop_reason:{getattr(result, 'stop_reason', 'unknown')}",
+                "artifact_type": "",
+                "artifact_key": "",
+            }
+        ]
+
+    raw = _extract_json(getattr(result, "final_content", None) or "")
+    valid: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for suggestion in raw[: MAX_SUGGESTIONS + 2]:
+        try:
+            valid.append(validate_suggestion(suggestion))
+        except ProposalValidationError as exc:
+            rejected.append(
+                {
+                    "reason": str(exc),
+                    "artifact_type": str(suggestion.get("artifact_type") or ""),
+                    "artifact_key": str(suggestion.get("artifact_key") or ""),
+                }
+            )
+    return valid[:MAX_SUGGESTIONS], rejected

--- a/collie-core/collie_core/gardener/runner.py
+++ b/collie-core/collie_core/gardener/runner.py
@@ -1,0 +1,164 @@
+"""Gardener runner — evidence → proposals → review cards → versioned apply.
+
+The runner ties the Gardener story together:
+
+1. :func:`run_gardener` collects evidence (read-only telemetry queries),
+   runs the bounded proposal turn, validates every suggestion, and returns
+   the suggestion list for the review surface (chat cards with
+   Approve/Dismiss).
+2. :func:`apply_suggestion` applies ONE approved suggestion through the
+   versioned rollback rail: the current artifact text is snapshotted with
+   the proposed text (``source="gardener"``), the new text is written, and
+   dependent state (the subagent loader's disk→DB mirror) is re-synced.
+   Rejected-while-applying is impossible: the suggestion is re-validated
+   here, so even a hand-crafted IPC frame cannot bypass the scope guard.
+
+The MVP deliberately has **no sandbox replay** (running a proposed change
+in a sandbox before applying it) — that needs run-record history volume the
+product doesn't have yet, and the deterministic scope guard + human
+approval stand in for it. This is a documented deferral, not a gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from collie_core.gardener.evidence import collect_evidence
+from collie_core.gardener.propose import propose, validate_suggestion
+from collie_core.versions import make_diff
+
+__all__ = ["apply_suggestion", "run_gardener"]
+
+_MAX_SUGGESTIONS_IN_CARD = 3
+
+
+def _target_path(workspace: Path, artifact_type: str, key: str) -> Path:
+    """Resolve a validated artifact type+key to its workspace path."""
+    base = Path(workspace)
+    if artifact_type == "subagent":
+        return base / "subagents" / key
+    if artifact_type == "memory_dream":
+        return base / "memory" / key
+    return base / key
+
+
+def apply_suggestion(
+    *,
+    workspace: Path,
+    suggestion: dict[str, Any],
+    version_store: Any = None,
+    subagent_loader: Any = None,
+) -> dict[str, Any]:
+    """Apply one approved (re-validated) suggestion, versioned + undoable.
+
+    Returns ``{"applied": True, "version_id": ..., "diff_text": ...}``.
+    Raises :class:`ProposalValidationError` when the suggestion is out of
+    scope, and :class:`ValueError` when the target cannot be written.
+    """
+    # Re-validate at apply time: the review card data could have been
+    # forged or edited between propose and approve.
+    cleaned = validate_suggestion(suggestion)
+
+    workspace = Path(workspace)
+    target = _target_path(workspace, cleaned["artifact_type"], cleaned["artifact_key"])
+    before = target.read_text(encoding="utf-8") if target.exists() else ""
+
+    proposed = cleaned["proposed_text"]
+    new_text = proposed if proposed.endswith("\n") else proposed + "\n"
+    if before == new_text:
+        return {
+            "applied": True,
+            "no_change": True,
+            "version_id": None,
+            "diff_text": "",
+            "artifact_type": cleaned["artifact_type"],
+            "artifact_key": cleaned["artifact_key"],
+        }
+
+    version_id: str | None = None
+    if version_store is not None:
+        try:
+            version_id = version_store.snapshot(
+                cleaned["artifact_type"],
+                cleaned["artifact_key"],
+                before,
+                new_text,
+                evidence={
+                    "evidence_ids": cleaned.get("evidence_ids") or [],
+                    "rationale": cleaned.get("rationale") or "",
+                },
+                source="gardener",
+            )
+        except Exception:
+            # Versioning is a rollback rail — never block the apply.
+            logger.exception("gardener apply version snapshot failed (swallowed)")
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(new_text, encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"I couldn't write the change: {exc}") from exc
+
+    # Subagent edits live in both the file and the loader's DB mirror;
+    # reconcile disk -> DB so the two never disagree.
+    if cleaned["artifact_type"] == "subagent" and subagent_loader is not None:
+        try:
+            subagent_loader.sync()
+        except Exception:
+            logger.exception("subagent re-sync after gardener apply failed (swallowed)")
+
+    return {
+        "applied": True,
+        "no_change": False,
+        "version_id": version_id,
+        "diff_text": make_diff(before, new_text, cleaned["artifact_key"]),
+        "artifact_type": cleaned["artifact_type"],
+        "artifact_key": cleaned["artifact_key"],
+    }
+
+
+async def run_gardener(
+    *,
+    workspace: Path,
+    db: Any,
+    loop: Any,
+    version_store: Any = None,
+    since: str | None = None,
+) -> dict[str, Any]:
+    """Run one Gardener pass: evidence → proposals → validated suggestions.
+
+    Returns ``{"suggestions": [...], "rejected": [...], "message": str,
+    "evidence": {...}}``. ``suggestions`` is the validated list for the
+    review cards; ``rejected`` reports what the scope guard refused.
+    """
+    workspace = Path(workspace)
+    evidence = collect_evidence(db, workspace, since=since)
+
+    if not (evidence["failures"] or evidence["workflows"] or
+            evidence["user_stops"] or any(m.get("bloated") for m in evidence["memory"])):
+        return {
+            "suggestions": [],
+            "rejected": [],
+            "evidence": evidence,
+            "message": "No improvement signals this week — run records look healthy.",
+        }
+
+    valid, rejected = await propose(loop, workspace, evidence)
+    suggestions = valid[:_MAX_SUGGESTIONS_IN_CARD]
+    if not suggestions:
+        message = "I looked at the run records but nothing rose to a suggestion worth your time."
+    else:
+        message = (
+            f"I found {len(suggestions)} suggestion"
+            f"{'' if len(suggestions) == 1 else 's'} from the last two weeks "
+            "of run records. Review each one — you can approve or dismiss."
+        )
+    return {
+        "suggestions": suggestions,
+        "rejected": rejected,
+        "evidence": evidence,
+        "message": message,
+    }

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -201,6 +201,8 @@ class CollieIPCServer:
         on_set_approval_preset: Callable[[str], None] | None = None,
         legacy_oauth_root: Path | None = None,
         token: str | None = None,
+        dream_runner: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+        gardener_runner: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     ) -> None:
         self.db = db
         self.host = host
@@ -232,6 +234,8 @@ class CollieIPCServer:
         self._on_set_approval_preset = on_set_approval_preset
         self._legacy_oauth_root = Path(legacy_oauth_root or legacy_oauth_data_root())
         self._token = token
+        self._dream_runner = dream_runner
+        self._gardener_runner = gardener_runner
         self._clients: set[ServerConnection] = set()
         self._server: Any = None
         self._chat_tasks: dict[str, asyncio.Task] = {}
@@ -1185,6 +1189,52 @@ class CollieIPCServer:
             limit = 50
         return {"entries": self.db.list_memory_journal(limit=max(1, min(limit, 500)))}
 
+    async def _cmd_run_dream(self, connection: ServerConnection, frame: dict) -> dict:
+        """Manual trigger: run one Dream consolidation pass now."""
+        if self._dream_runner is None:
+            raise ValueError("The memory review isn't available right now.")
+        outcome = await self._dream_runner()
+        return dict(outcome or {})
+
+    async def _cmd_get_dream_history(self, connection: ServerConnection, frame: dict) -> dict:
+        """Past Dream consolidations (memory_dream versions), newest first."""
+        versions = await asyncio.to_thread(
+            self.db.list_artifact_versions,
+            artifact_type="memory_dream",
+            limit=50,
+        )
+        return {"versions": versions}
+
+    async def _cmd_run_gardener(self, connection: ServerConnection, frame: dict) -> dict:
+        """Manual trigger: run one Gardener pass (evidence → suggestions)."""
+        if self._gardener_runner is None:
+            raise ValueError("The improvement suggestions aren't available right now.")
+        outcome = await self._gardener_runner()
+        return dict(outcome or {})
+
+    async def _cmd_apply_gardener_suggestion(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        """Approve one suggestion: re-validate, apply, version (undoable)."""
+        from collie_core.gardener.propose import ProposalValidationError
+        from collie_core.gardener.runner import apply_suggestion
+        from collie_core.versions import VersionStore
+
+        suggestion = frame.get("suggestion")
+        if not isinstance(suggestion, dict):
+            raise ValueError("A suggestion is required to approve.")
+        try:
+            result = await asyncio.to_thread(
+                apply_suggestion,
+                workspace=collie_home() / "workspace",
+                suggestion=suggestion,
+                version_store=VersionStore(self.db),
+                subagent_loader=self._subagent_loader,
+            )
+        except ProposalValidationError as exc:
+            raise ValueError(str(exc)) from exc
+        return result
+
     def _memory(self) -> Any:
         if self._profile_store is None:
             raise ValueError("memory is not available")
@@ -1440,8 +1490,117 @@ class CollieIPCServer:
         file_path = self._resolve_workspace_path(str(frame.get("path") or ""))
         content = str(frame.get("content") or "")
         file_path.parent.mkdir(parents=True, exist_ok=True)
+        before = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
+        artifact = self._classify_workspace_artifact(file_path)
+        version_id: str | None = None
+        diff_text: str | None = None
+        if artifact is not None and before != content:
+            from collie_core.versions import VersionStore, make_diff
+
+            version_id = VersionStore(self.db).snapshot(
+                artifact[0], artifact[1], before, content, source="user"
+            )
+            if version_id is not None:
+                diff_text = make_diff(before, content, artifact[1])
         file_path.write_text(content, encoding="utf-8")
-        return {"saved": True}
+        return {
+            "saved": True,
+            "version_id": version_id,
+            "diff_text": diff_text,
+        }
+
+    def _classify_workspace_artifact(self, file_path: Path) -> tuple[str, str] | None:
+        """Map a workspace file to a versioned artifact type, if it is one."""
+        workspace = Path(os.path.normpath(collie_home() / "workspace"))
+        try:
+            rel = file_path.relative_to(workspace)
+        except ValueError:
+            return None
+        parts = rel.parts
+        if parts == ("VISION.md",):
+            return ("vision", "VISION.md")
+        if parts == ("AGENTS.md",):
+            return ("agents", "AGENTS.md")
+        if parts == ("MEMORY.md",):
+            return ("memory_profile", "MEMORY.md")
+        if parts == ("memory", "MEMORY.md"):
+            return ("memory_dream", "MEMORY.md")
+        if len(parts) == 2 and parts[0] == "subagents" and parts[1].endswith(".md"):
+            return ("subagent", parts[1])
+        return None
+
+    def _artifact_target(self, artifact_type: str, key: str) -> Path:
+        """Resolve an artifact type+key to its workspace path (strict)."""
+        if not key or "/" in key or "\\" in key or key in (".", ".."):
+            raise ValueError("Invalid artifact key")
+        workspace = Path(os.path.normpath(collie_home() / "workspace"))
+        if artifact_type == "subagent":
+            target = workspace / "subagents" / key
+        elif artifact_type == "memory_dream":
+            target = workspace / "memory" / key
+        elif artifact_type in ("vision", "agents", "memory_profile", "skill"):
+            target = workspace / key
+        else:
+            raise ValueError(f"Unknown artifact type: {artifact_type}")
+        if not target.is_relative_to(workspace):
+            raise ValueError("Invalid artifact path")
+        return target
+
+    async def _cmd_list_versions(self, connection: ServerConnection, frame: dict) -> dict:
+        """List artifact versions (most recent first) — read-only rollback rail."""
+        artifact_type = str(frame.get("artifact_type") or "") or None
+        artifact_key = str(frame.get("artifact_key") or "") or None
+        limit = frame.get("limit")
+        try:
+            limit = int(limit) if limit is not None else 100
+        except (TypeError, ValueError):
+            limit = 100
+        versions = await asyncio.to_thread(
+            self.db.list_artifact_versions,
+            artifact_type=artifact_type,
+            artifact_key=artifact_key,
+            limit=max(1, min(limit, 500)),
+        )
+        return {"versions": versions}
+
+    async def _cmd_rollback_artifact(self, connection: ServerConnection, frame: dict) -> dict:
+        """Undo one artifact version (no-clobber guarded) and re-sync state."""
+        from collie_core.versions import VersionConflictError, VersionStore
+
+        version_id = str(frame.get("version_id") or "")
+        row = self.db.get_artifact_version(version_id)
+        if row is None:
+            raise ValueError("I can't find that change — it may have been cleaned up.")
+        artifact_type = str(row["artifact_type"])
+        key = str(row["artifact_key"])
+        target = self._artifact_target(artifact_type, key)
+        current = target.read_text(encoding="utf-8") if target.exists() else ""
+        try:
+            result = VersionStore(self.db).rollback(
+                artifact_type,
+                key,
+                to_version=int(row["version"]),
+                current_text=current,
+            )
+        except VersionConflictError as exc:
+            raise ValueError(str(exc)) from exc
+        restored = result["restored_text"]
+        if restored:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(restored, encoding="utf-8")
+        elif target.exists():
+            target.unlink()
+        # A subagent rollback also restores the database row (or renames it
+        # back): the loader reconciles disk -> DB.
+        if artifact_type == "subagent" and self._subagent_loader is not None:
+            await asyncio.to_thread(self._subagent_loader.sync)
+        return {
+            "rolled_back": True,
+            "version_id": result["version_id"],
+            "artifact_type": artifact_type,
+            "artifact_key": key,
+            "version": result["version"],
+        }
 
     async def _cmd_list_automations(self, connection: ServerConnection, frame: dict) -> dict:
         return {"automations": self.db.list_automations()}

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -59,6 +59,10 @@ from websockets.asyncio.server import ServerConnection, serve
 
 from collie_core.db import CollieDB, collie_home
 from collie_core.ipc.thinking import phrase_for_state, thinking_state_for_tool
+from collie_core.onboarding import (
+    capture_starter_name,
+    ensure_starter_conversation,
+)
 from collie_core.permissions.classifier import classify_tool
 from collie_core.permissions.models import Risk
 from collie_core.providers.storage import legacy_oauth_data_root
@@ -475,6 +479,80 @@ class CollieIPCServer:
         if self._command_catalog is None:
             return {"commands": [], "agents": [], "skills": []}
         return self._command_catalog()
+
+    # -- provider catalogue (models.dev snapshot) --------------------------------------
+
+    def _catalogue(self) -> Any:
+        from collie_core.catalog import CatalogueStore
+
+        return CatalogueStore(settings=self.db)
+
+    async def _cmd_get_provider_catalogue(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        catalogue = self._catalogue()
+        return {
+            "providers": catalogue.providers(),
+            "snapshot": catalogue.snapshot_metadata(),
+            "refresh": catalogue.refresh_state(),
+        }
+
+    async def _cmd_refresh_provider_catalogue(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        catalogue = self._catalogue()
+        return await catalogue.refresh(url=frame.get("url") or None)
+
+    async def _cmd_rollback_provider_catalogue(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        catalogue = self._catalogue()
+        return catalogue.rollback()
+
+    # -- connect-time validation helpers ------------------------------------------------
+
+    async def _cmd_detect_provider_for_key(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        from collie_core.providers.validation import detect_provider_for_key
+
+        api_key = str(frame.get("api_key") or "")
+        if not api_key:
+            return {"detected": False, "provider_id": None, "reason": "empty_key"}
+        return await detect_provider_for_key(api_key, catalogue=self._catalogue())
+
+    async def _cmd_detect_models(self, connection: ServerConnection, frame: dict) -> dict:
+        from collie_core.providers.validation import detect_models_for_base_url
+
+        return await detect_models_for_base_url(
+            str(frame.get("api_base") or ""),
+            protocol=str(frame.get("protocol") or "openai"),
+            api_key=str(frame.get("api_key") or "") or None,
+        )
+
+    async def _cmd_detect_local_models(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        from collie_core.providers.validation import detect_local_ollama
+
+        return await detect_local_ollama()
+
+    # -- starter conversation -------------------------------------------------------------
+
+    async def _cmd_get_starter_conversation(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        result = ensure_starter_conversation(
+            self.db,
+            reuse_conversation_id=str(frame.get("conversation_id") or "") or None,
+        )
+        if result.get("greeting") is not None:
+            await self.broadcast({
+                "type": "message",
+                "conversation_id": result["conversation"]["id"],
+                "message": result["greeting"],
+            })
+        return {"conversation": result["conversation"], "greeted": result["greeted"]}
 
     async def _cmd_transcribe(self, connection: ServerConnection, frame: dict) -> dict:
         """Turn a renderer-captured WAV into English text without a cloud service."""
@@ -2391,11 +2469,43 @@ class CollieIPCServer:
                     "message": assistant_msg,
                 })
                 return
+            if command_result and command_result.get("starter_conversation"):
+                # /get-started (and desktop /start): open/seed the starter
+                # conversation. An empty conversation created for this frame
+                # becomes the starter; the command text is a control
+                # instruction and is never persisted as a chat bubble.
+                starter = ensure_starter_conversation(
+                    self.db,
+                    reuse_conversation_id=conv_id if created_conversation else None,
+                )
+                starter_conv_id = str(starter["conversation"]["id"])
+                if starter.get("greeting") is not None:
+                    await self.broadcast({
+                        "type": "message",
+                        "conversation_id": starter_conv_id,
+                        "message": starter["greeting"],
+                    })
+                await self._send(connection, {
+                    "type": "ok",
+                    "id": frame.get("id"),
+                    "data": {
+                        "conversation_id": starter_conv_id,
+                        "command_handled": True,
+                        "starter_conversation": True,
+                    },
+                })
+                return
             if command_result and not command_result.get("handled"):
                 agent_content = str(command_result.get("forward_prompt") or content)
                 raw_message_metadata = command_result.get("message_metadata")
                 if isinstance(raw_message_metadata, dict):
                     message_metadata = dict(raw_message_metadata)
+
+        # First real reply in the starter thread: remember the user's name
+        # (approval-free ProfileStore write; whatever they said, or nothing).
+        # Commands never count as a name.
+        if command_result is None:
+            capture_starter_name(self.db, self._profile_store, conv_id, content)
 
         user_msg = self.db.add_message(
             conv_id,

--- a/collie-core/collie_core/memory/dream.py
+++ b/collie-core/collie_core/memory/dream.py
@@ -1,0 +1,226 @@
+"""Collie's Dream runner — episodic memory consolidation (Gardener PR 3).
+
+Wires nanobot's already-vendored Dream machinery (cursor, prompt builder,
+session keys, pruning) into Collie:
+
+1. Build the Dream prompt from unprocessed conversation history via
+   ``MemoryStore.build_dream_prompt()``.
+2. Run a **bounded, read-only** loop turn under a ``dream:<ts>`` session key
+   using the subagent runner machinery (one model call, no tools, no
+   approvals, read-only posture). Collie has no file-editing tools, so the
+   model outputs the full proposed new ``memory/MEMORY.md`` as its final
+   response.
+3. If the proposed content differs from the current file, write it and
+   snapshot it via the version store (``artifact_type="memory_dream"``) so
+   the change is reviewable and undoable in Settings → Memory.
+4. Advance the dream cursor **only on success** (a completed turn — even
+   one that produced no change — so history is never re-processed).
+5. Prune old Dream sessions (keep 10) after each run.
+
+Never touches ProfileStore (the structured profile memory) — Dream
+consolidates nanobot's long-term ``memory/MEMORY.md`` only.
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.runner import AgentRunSpec
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.agent.turn_hooks import AgentTurnHookContext
+
+__all__ = ["run_dream"]
+
+# Collie has no file-editing tools; the Dream model must return the file
+# content directly instead of editing on disk.
+_DREAM_OUTPUT_CONTRACT = """
+
+## Collie output contract
+Collie has no file-editing tools, so you cannot edit files directly. Do not
+try to call any tool. Analyze the Conversation History and the current
+memory files above, then output ONLY the full new content of
+``memory/MEMORY.md`` — the complete file, nothing else. No commentary, no
+preamble, no markdown code fences. Preserve every fact that is still true,
+prune stale entries, and keep facts atomic and non-duplicated.
+"""
+
+_DREAM_SYSTEM_PROMPT = (
+    "You are Collie's memory consolidation engine. Follow the instructions "
+    "in the user message exactly, and output only the requested file content."
+)
+
+_FENCE_RE = re.compile(r"```[a-zA-Z0-9_-]*\s*\n(.*?)```", re.DOTALL)
+
+
+def _extract_file_content(response: str) -> str:
+    """Pull the proposed file content out of a model response."""
+    text = (response or "").strip()
+    match = _FENCE_RE.search(text)
+    if match:
+        return match.group(1).strip()
+    return text
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix="MEMORY.md.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with open(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        Path(tmp_name).replace(path)
+    finally:
+        with suppress(FileNotFoundError):
+            Path(tmp_name).unlink()
+
+
+def _build_turn_hook(loop: Any, session_key: str) -> Any | None:
+    """Compose the loop's telemetry hook factories (best-effort, like
+    ``SubagentManager._run_subagent``) so Dream turns are recorded."""
+    try:
+        factories = getattr(loop.subagents, "hook_factories", None) or []
+        if not factories:
+            return None
+        from nanobot.agent.hook import CompositeHook
+
+        turn_context = AgentTurnHookContext(
+            on_progress=None,
+            workspace=Path(loop.workspace or "."),
+            channel="collie",
+            chat_id="dream",
+            message_id=None,
+            session_key=session_key,
+            metadata={"turn_kind": "automation"},
+        )
+        extra = [factory(turn_context) for factory in factories]
+        extra = [hook for hook in extra if hook is not None]
+        return CompositeHook(extra) if extra else None
+    except Exception:
+        logger.exception("dream telemetry hook build failed (swallowed)")
+        return None
+
+
+async def run_dream(
+    *,
+    workspace: Path,
+    db: Any,
+    loop: Any,
+    version_store: Any = None,
+    session_key: str | None = None,
+) -> dict[str, Any]:
+    """Run one Dream consolidation pass; returns a result summary dict."""
+    from collie_core.versions import make_diff
+
+    store: MemoryStore = loop.context.memory
+    built = store.build_dream_prompt()
+    if built is None:
+        return {
+            "changed": False,
+            "reason": "no_new_history",
+            "message": "Nothing new to review — memory is already up to date.",
+        }
+
+    prompt, cursor = built
+    dream_key = session_key or MemoryStore.dream_session_key()
+
+    spec = AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": _DREAM_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt + _DREAM_OUTPUT_CONTRACT},
+        ],
+        tools=ToolRegistry(),  # no tools: bounded, read-only by construction
+        runtime=loop.llm_runtime(),
+        max_iterations=1,
+        max_tool_result_chars=4000,
+        hook=_build_turn_hook(loop, dream_key),
+        session_key=dream_key,
+        workspace=workspace,
+        execution_posture="read_only",
+    )
+    try:
+        result = await loop.subagents.runner.run(spec)
+    except Exception:
+        logger.exception("Dream turn failed")
+        return {
+            "changed": False,
+            "reason": "turn_error",
+            "message": "The memory review hit a snag — I'll try again later.",
+        }
+
+    if result.stop_reason != "completed":
+        logger.warning(
+            "Dream turn did not complete (stop_reason={}); cursor not advanced",
+            result.stop_reason,
+        )
+        return {
+            "changed": False,
+            "reason": f"stop_reason:{result.stop_reason}",
+            "message": "The memory review didn't finish — I'll try again later.",
+        }
+
+    proposed = _extract_file_content(result.final_content or "")
+    if not proposed:
+        return {
+            "changed": False,
+            "reason": "empty_response",
+            "message": "The memory review came back empty — I'll try again later.",
+        }
+
+    memory_file = Path(workspace) / "memory" / "MEMORY.md"
+    before = memory_file.read_text(encoding="utf-8") if memory_file.exists() else ""
+    new_text = proposed.rstrip() + "\n"
+
+    if before.strip() == new_text.strip():
+        # The run succeeded; history is processed even when nothing changed.
+        store.set_last_dream_cursor(cursor)
+        _prune(workspace)
+        return {
+            "changed": False,
+            "reason": "no_content_change",
+            "cursor": cursor,
+            "message": "Memory review done — everything was already tidy.",
+        }
+
+    _atomic_write(memory_file, new_text)
+    version_id = None
+    if version_store is not None:
+        try:
+            version_id = version_store.snapshot(
+                "memory_dream",
+                "MEMORY.md",
+                before,
+                new_text,
+                evidence={"cursor": cursor, "session_key": dream_key},
+                source="collie",
+            )
+        except Exception:
+            logger.exception("dream version snapshot failed (swallowed)")
+
+    # Success path only: the content is durable and versioned, so the
+    # processed history is marked done.
+    store.set_last_dream_cursor(cursor)
+    _prune(workspace)
+
+    return {
+        "changed": True,
+        "version_id": version_id,
+        "cursor": cursor,
+        "diff": make_diff(before, proposed, "memory/MEMORY.md"),
+        "message": "Memory review done — I tidied up my long-term memory.",
+    }
+
+
+def _prune(workspace: Path) -> None:
+    """Keep only the 10 most recent Dream sessions (best-effort)."""
+    try:
+        MemoryStore.prune_dream_sessions(Path(workspace) / "sessions", keep=10)
+    except Exception:
+        logger.exception("dream session prune failed (swallowed)")

--- a/collie-core/collie_core/memory/profile.py
+++ b/collie-core/collie_core/memory/profile.py
@@ -19,6 +19,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from collie_core.db import CollieDB
 
 __all__ = ["ProfileStore", "PROFILE_KEYS"]
@@ -55,10 +57,33 @@ PROFILE_KEYS: dict[str, str] = {
 class ProfileStore:
     """Structured profile memory backed by SQLite, mirrored to MEMORY.md."""
 
-    def __init__(self, db: CollieDB, workspace: Path):
+    def __init__(
+        self, db: CollieDB, workspace: Path, version_store: Any = None
+    ) -> None:
         self.db = db
         self.workspace = workspace
         self.memory_file = workspace / "MEMORY.md"
+        self._version_store = version_store
+
+    # -- versioning (Gardener rollback rail) --------------------------------
+
+    def _snapshot_memory(self) -> None:
+        """Snapshot MEMORY.md before a regeneration; never breaks the write."""
+        if self._version_store is None:
+            return
+        try:
+            before = ""
+            if self.memory_file.exists():
+                before = self.memory_file.read_text(encoding="utf-8")
+            after = self.memory_markdown()
+            if before != after:
+                self._version_store.snapshot(
+                    "memory_profile", "MEMORY.md", before, after, source="user"
+                )
+        except Exception:
+            # Versioning is a rollback rail — a failure must never block a
+            # memory write the user asked for.
+            logger.exception("memory version snapshot failed (swallowed)")
 
     # -- profile facts -------------------------------------------------------
 
@@ -77,12 +102,14 @@ class ProfileStore:
             "add" if existing is None or existing == "" else "update",
             value,
         )
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def delete(self, key: str) -> None:
         existing = self.db.get_profile(key, None)
         self.db.delete_profile(key)
         self._journal("fact", key, "delete", existing)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def all(self) -> dict[str, Any]:
@@ -99,6 +126,7 @@ class ProfileStore:
         else:
             person = self.db.add_person(name, **fields)
             self._journal("person", name, "add", fields)
+        self._snapshot_memory()
         self.regenerate_memory_md()
         return person  # type: ignore[return-value]
 
@@ -112,12 +140,14 @@ class ProfileStore:
         person = self.db.get_person(person_id) or {}
         self.db.update_person(person_id, **fields)
         self._journal("person", person.get("name") or person_id, "update", fields)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def delete_person(self, person_id: str) -> None:
         person = self.db.get_person(person_id) or {}
         self.db.delete_person(person_id)
         self._journal("person", person.get("name") or person_id, "delete", person)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def list_people(self) -> list[dict[str, Any]]:
@@ -128,6 +158,7 @@ class ProfileStore:
     def add_date(self, date: str, label: str, **kwargs: Any) -> dict[str, Any]:
         row = self.db.add_date(date, label, **kwargs)
         self._journal("date", label, "add", {"date": date, **kwargs})
+        self._snapshot_memory()
         self.regenerate_memory_md()
         return row
 
@@ -138,12 +169,14 @@ class ProfileStore:
         row = self.db.get_date(date_id) or {}
         self.db.update_date(date_id, **fields)
         self._journal("date", row.get("label") or date_id, "update", fields)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     def delete_date(self, date_id: str) -> None:
         row = self.db.get_date(date_id) or {}
         self.db.delete_date(date_id)
         self._journal("date", row.get("label") or date_id, "delete", row)
+        self._snapshot_memory()
         self.regenerate_memory_md()
 
     # -- MEMORY.md generation --------------------------------------------------------

--- a/collie-core/collie_core/memory/profile.py
+++ b/collie-core/collie_core/memory/profile.py
@@ -39,6 +39,7 @@ def _md_value(value: Any) -> str:
 
 # Known profile keys shown in Settings → Memory with friendly labels.
 PROFILE_KEYS: dict[str, str] = {
+    "name": "Name",
     "dietary": "Food & allergies",
     "wake_time": "Wakes up",
     "sleep_time": "Goes to sleep",

--- a/collie-core/collie_core/onboarding.py
+++ b/collie-core/collie_core/onboarding.py
@@ -1,0 +1,112 @@
+"""Starter conversation: the scripted, local first message after connect.
+
+After a provider is connected the app goes straight to chat — no empty
+state. The conversation opens with a scripted greeting from Collie (instant,
+local, can never fail — it is NOT model-generated). The greeting appears
+only once per conversation; ``/get-started`` and the Settings button reopen
+the same conversation idempotently.
+
+The user's first reply ("Rick") still goes through the normal agent loop;
+the name is captured into profile memory beforehand so the model greets
+them by name (MEMORY.md is injected into the loop's bootstrap context).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+STARTER_CONVERSATION_SETTING = "onboarding.starter_conversation_id"
+
+STARTER_GREETING = (
+    "Hey, welcome! I'm Collie — your personal AI. What's your name?\n\n"
+    "(P.S. That's me — the little dog on your desktop. Click me to say hi anytime.)"
+)
+
+# A name worth remembering: a single short line. Longer answers, questions,
+# or empty replies are not names — we never force it.
+_MAX_NAME_LENGTH = 64
+
+
+def _is_reasonable_name(reply: str) -> bool:
+    text = (reply or "").strip()
+    if not text:
+        return False
+    if len(text) > _MAX_NAME_LENGTH:
+        return False
+    if "\n" in text or "\r" in text:
+        return False
+    return True
+
+
+def ensure_starter_conversation(
+    db: Any,
+    *,
+    reuse_conversation_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the starter conversation, seeding the greeting on first use.
+
+    Idempotent: once the starter conversation exists (tracked in settings),
+    later calls return it without re-greeting. If the recorded conversation
+    was deleted, a fresh one is created. The seeded greeting is returned in
+    ``greeting`` (``None`` when the thread already existed) so the async IPC
+    caller can broadcast it — seeding itself never awaits or fails.
+    """
+    starter_id = str(db.get_setting(STARTER_CONVERSATION_SETTING, "") or "")
+    if starter_id:
+        existing = db.get_conversation(starter_id)
+        if existing is not None:
+            return {"conversation": existing, "greeted": False, "greeting": None}
+
+    conversation = _candidate_starter_conversation(db, reuse_conversation_id)
+    db.set_conversation_mode(str(conversation["id"]), "execute")
+    conversation["execution_mode"] = "execute"
+
+    greeting = db.add_message(str(conversation["id"]), "assistant", STARTER_GREETING)
+    db.set_setting(STARTER_CONVERSATION_SETTING, str(conversation["id"]))
+    return {"conversation": conversation, "greeted": True, "greeting": greeting}
+
+
+def _candidate_starter_conversation(
+    db: Any, reuse_conversation_id: str | None
+) -> dict[str, Any]:
+    """Reuse a just-created empty conversation, or make a fresh starter one."""
+    if reuse_conversation_id:
+        candidate = db.get_conversation(reuse_conversation_id)
+        if candidate is not None and not db.get_messages(reuse_conversation_id):
+            return candidate
+    return db.create_conversation(title="Getting started")
+
+
+def is_starter_conversation(db: Any, conversation_id: str) -> bool:
+    return (
+        str(db.get_setting(STARTER_CONVERSATION_SETTING, "") or "")
+        == str(conversation_id)
+    )
+
+
+def capture_starter_name(
+    db: Any,
+    profile_store: Any,
+    conversation_id: str,
+    reply: str,
+) -> bool:
+    """Save the first reply in the starter thread as the user's name.
+
+    Only fires once (the profile has no name yet and the conversation holds
+    only the greeting). Whatever they said is stored verbatim — or nothing;
+    the name is never forced.
+    """
+    if profile_store is None:
+        return False
+    if not is_starter_conversation(db, conversation_id):
+        return False
+    if profile_store.get("name"):
+        return False
+    messages = db.get_messages(conversation_id)
+    if len(messages) != 1:
+        # The greeting is the only message before the first real reply.
+        return False
+    if not _is_reasonable_name(reply):
+        return False
+    profile_store.set("name", reply.strip())
+    return True

--- a/collie-core/collie_core/providers/validation.py
+++ b/collie-core/collie_core/providers/validation.py
@@ -1,0 +1,314 @@
+"""Read-only API-key validation probes used at Connect time.
+
+Design rules (provider-onboarding.md):
+- Prefer the provider's model-list endpoint with the user's key; fall back to
+  a 1-token completion to the recommended model.
+- The probe is the authority on whether a key works — prefixes are only hints.
+- Never log the key. Never include it in errors, results, or telemetry.
+
+Every probe is a plain HTTP request with a short timeout, run off the event
+loop. A 401/403 is a definitive "key didn't work"; 429/5xx and network errors
+are not treated as key failures (rate limits and outages are not bad keys).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from collie_core.catalog import CatalogueStore
+
+_PROBE_TIMEOUT_SECONDS = 8
+_MAX_RESPONSE_BYTES = 512 * 1024
+_USER_AGENT = "Collie/alpha (connect validation)"
+
+
+def _request(
+    url: str,
+    *,
+    headers: dict[str, str],
+    payload: dict[str, Any] | None = None,
+    timeout: float = _PROBE_TIMEOUT_SECONDS,
+) -> tuple[int, Any]:
+    """Return (status, parsed_json_or_none). Raises on network errors.
+
+    HTTPError (4xx/5xx) is a subclass of URLError but is a *response*, not a
+    network failure: it is caught here and returned as a status so callers can
+    classify a 401/403 as a bad key rather than an outage.
+    """
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, headers=headers, method="POST" if payload else "GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read(_MAX_RESPONSE_BYTES + 1)
+            if len(body) > _MAX_RESPONSE_BYTES:
+                raise ValueError("response exceeded the size limit")
+            return int(response.status), _parse_json(body)
+    except urllib.error.HTTPError as error:
+        body = error.read(_MAX_RESPONSE_BYTES + 1)
+        return int(error.code), _parse_json(body)
+
+
+def _parse_json(body: bytes) -> Any:
+    if not body:
+        return None
+    try:
+        return json.loads(body.decode("utf-8"))
+    except ValueError:
+        return None
+
+
+def _openai_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+
+
+def _anthropic_headers(api_key: str) -> dict[str, str]:
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+
+
+def _models_url(api_base: str, protocol: str) -> str:
+    base = api_base.rstrip("/")
+    if protocol == "anthropic":
+        return f"{base}/v1/models" if not base.endswith("/v1") else f"{base}/models"
+    return f"{base}/models"
+
+
+def _chat_url(api_base: str, protocol: str) -> str:
+    base = api_base.rstrip("/")
+    if protocol == "anthropic":
+        return f"{base}/v1/messages" if not base.endswith("/v1") else f"{base}/messages"
+    return f"{base}/chat/completions"
+
+
+def _one_token_payload(protocol: str, model: str) -> dict[str, Any]:
+    if protocol == "anthropic":
+        return {
+            "model": model,
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "ping"}],
+        }
+    return {
+        "model": model,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
+
+
+def _probe_models_endpoint(
+    api_base: str,
+    protocol: str,
+    api_key: str,
+) -> tuple[int, Any]:
+    """Hit the model-list endpoint; returns (status, body)."""
+    headers = (
+        _anthropic_headers(api_key)
+        if protocol == "anthropic"
+        else _openai_headers(api_key)
+    )
+    return _request(_models_url(api_base, protocol), headers=headers)
+
+
+def _probe_one_token(
+    api_base: str,
+    protocol: str,
+    api_key: str,
+    model: str,
+) -> tuple[int, Any]:
+    """Hit the chat endpoint with max_tokens=1; returns (status, body)."""
+    headers = (
+        _anthropic_headers(api_key)
+        if protocol == "anthropic"
+        else _openai_headers(api_key)
+    )
+    return _request(
+        _chat_url(api_base, protocol),
+        headers=headers,
+        payload=_one_token_payload(protocol, model),
+    )
+
+
+def _is_auth_failure(status: int) -> bool:
+    return status in (401, 403)
+
+
+def _is_unsupported(status: int) -> bool:
+    return status in (404, 405, 400)
+
+
+def _parse_model_ids(protocol: str, body: Any) -> list[str]:
+    if not isinstance(body, dict):
+        return []
+    raw = body.get("data")
+    if isinstance(raw, list):
+        ids: list[str] = []
+        for item in raw:
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                ids.append(item["id"])
+        return ids
+    return []
+
+
+async def probe_api_key(
+    *,
+    provider_id: str,
+    api_key: str,
+    api_base: str | None = None,
+    protocol: str = "openai",
+    model: str | None = None,
+    catalogue: CatalogueStore | None = None,
+) -> dict[str, Any]:
+    """Validate a key with a read-only request. Never logs the key.
+
+    Returns::
+        {"ok": True, "model": <id|None>, "model_label": <friendly|None>,
+         "models": [...]}
+        {"ok": False, "error": "auth"|"network"|"invalid", "detail": "..."}
+    """
+    catalogue = catalogue or CatalogueStore()
+    if not api_base:
+        api_base = catalogue.api_base(provider_id)
+    if not api_base:
+        return {"ok": False, "error": "invalid", "detail": "no api_base known for provider"}
+    if not model:
+        model = catalogue.default_model(provider_id)
+    if not model:
+        return {"ok": False, "error": "invalid", "detail": "no default model known for provider"}
+
+    try:
+        status, body = await asyncio.to_thread(
+            _probe_models_endpoint, api_base, protocol, api_key
+        )
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as error:
+        return {"ok": False, "error": "network", "detail": str(error)}
+
+    if _is_auth_failure(status):
+        return {"ok": False, "error": "auth", "detail": f"models endpoint {status}"}
+    if status == 200:
+        ids = _parse_model_ids(protocol, body)
+        chosen = model if model in ids else (ids[0] if ids else model)
+        label = catalogue.model_label(provider_id, chosen) or chosen
+        return {
+            "ok": True,
+            "model": chosen,
+            "model_label": label,
+            "models": ids,
+        }
+
+    # Model list unsupported (404/405/400) — fall back to a 1-token completion.
+    try:
+        status, _body = await asyncio.to_thread(
+            _probe_one_token, api_base, protocol, api_key, model
+        )
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as error:
+        return {"ok": False, "error": "network", "detail": str(error)}
+    if _is_auth_failure(status):
+        return {"ok": False, "error": "auth", "detail": f"completion endpoint {status}"}
+    if status in (200, 201):
+        label = catalogue.model_label(provider_id, model) or model
+        return {"ok": True, "model": model, "model_label": label, "models": []}
+    return {
+        "ok": False,
+        "error": "invalid",
+        "detail": f"completion endpoint {status}",
+    }
+
+
+async def detect_provider_for_key(
+    api_key: str,
+    catalogue: CatalogueStore | None = None,
+) -> dict[str, Any]:
+    """Resolve a pasted key to a provider, probing ambiguous prefixes.
+
+    Unambiguous prefixes (``gsk_``, ``sk-ant-``, …) resolve instantly;
+    ``sk-`` (OpenAI vs DeepSeek) is resolved by probing each candidate's
+    model-list endpoint — the first one that accepts the key wins.
+    """
+    catalogue = catalogue or CatalogueStore()
+    candidates = catalogue.detect_provider_for_key(api_key)
+    if not candidates:
+        return {"detected": False, "provider_id": None, "reason": "no_prefix_match"}
+    if len(candidates) == 1:
+        return {"detected": True, "provider_id": candidates[0], "reason": "prefix"}
+    for provider_id in candidates:
+        result = await probe_api_key(
+            provider_id=provider_id, api_key=api_key, catalogue=catalogue
+        )
+        if result.get("ok"):
+            return {"detected": True, "provider_id": provider_id, "reason": "probe"}
+    return {
+        "detected": False,
+        "provider_id": None,
+        "reason": "probe_failed",
+        "candidates": candidates,
+    }
+
+
+async def detect_models_for_base_url(
+    api_base: str,
+    protocol: str = "openai",
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """List models served by a custom base URL (the Advanced 'Detect models')."""
+    base = (api_base or "").strip().rstrip("/")
+    if not base:
+        return {"detected": False, "error": "missing_base_url", "models": []}
+    if api_key:
+        headers = (
+            _anthropic_headers(api_key)
+            if protocol == "anthropic"
+            else _openai_headers(api_key)
+        )
+    else:
+        headers = {"Content-Type": "application/json", "User-Agent": _USER_AGENT}
+    try:
+        status, body = await asyncio.to_thread(
+            _request, _models_url(base, protocol), headers=headers
+        )
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as error:
+        return {"detected": False, "error": "network", "detail": str(error), "models": []}
+    if status != 200:
+        return {"detected": False, "error": f"http_{status}", "models": []}
+    ids = _parse_model_ids(protocol, body)
+    return {"detected": bool(ids), "error": None, "models": ids}
+
+
+async def detect_local_ollama() -> dict[str, Any]:
+    """Check for a local Ollama install and list its models.
+
+    The HTTP probe (default http://localhost:11434) is the authority — a
+    bundled desktop app cannot rely on PATH. Honors OLLAMA_HOST like Ollama
+    itself does.
+    """
+    host = os.environ.get("OLLAMA_HOST", "").strip()
+    base = host.rstrip("/") if host else "http://localhost:11434"
+    try:
+        status, body = await asyncio.to_thread(
+            _request, f"{base}/api/tags", headers={"User-Agent": _USER_AGENT}
+        )
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return {"available": False, "models": []}
+    if status != 200 or not isinstance(body, dict):
+        return {"available": False, "models": []}
+    models: list[str] = []
+    for item in body.get("models") or []:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            name = item["name"]
+            if name.endswith(":latest"):
+                name = name[: -len(":latest")]
+            models.append(name)
+    return {"available": bool(models), "models": sorted(models)}

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import json
 import os
 import sys
 import urllib.parse
@@ -63,7 +64,12 @@ class CollieRuntime:
         set_config_path(collie_home() / "config.json")
         self.workspace = collie_settings.ensure_workspace()
         bind_suggest_workspace(self.workspace)
-        self.profile = ProfileStore(self.db, self.workspace)
+        from collie_core.versions import VersionStore
+
+        self.versions = VersionStore(self.db)
+        self.profile = ProfileStore(
+            self.db, self.workspace, version_store=self.versions
+        )
         self.profile.regenerate_memory_md()
         bind_profile_store(self.profile)
         bind_reminders_db(self.db)
@@ -142,6 +148,8 @@ class CollieRuntime:
             conversation_deleter=self.delete_conversation_sessions,
             on_set_approval_preset=self.permission_evaluator.set_local_write_preset,
             token=ipc_token,
+            dream_runner=self._run_dream_manual,
+            gardener_runner=self._run_gardener_manual,
         )
         self.approvals = ApprovalBroker(
             self.db, self.permission_evaluator, self.ipc.broadcast
@@ -729,18 +737,24 @@ class CollieRuntime:
                 action_config = _json.loads(action_config)
             except (TypeError, ValueError):
                 action_config = {}
+        action_type = str(auto.get("action_type") or "")
+
+        # Gardener-family automations run their own bounded pipelines
+        # instead of a free-form prompt turn.
+        if action_type == "memory_maintenance":
+            await self._run_memory_maintenance(auto)
+            return
+        if action_type == "gardener":
+            await self._run_gardener(auto)
+            return
+
         prompt = ""
         if isinstance(action_config, dict):
             prompt = str(action_config.get("prompt") or "")
         if not prompt:
             return
 
-        conv_key = f"automations.{auto_id}.conversation_id"
-        conv_id = str(self.db.get_setting(conv_key, "") or "")
-        if not conv_id or self.db.get_conversation(conv_id) is None:
-            conv = self.db.create_conversation(title=f"🔔 {name}")
-            conv_id = conv["id"]
-            self.db.set_setting(conv_key, conv_id)
+        conv_id = self._automation_conversation_id(auto)
 
         outbound = await self.loop.process_direct(
             prompt,
@@ -784,6 +798,150 @@ class CollieRuntime:
         targets.update(self.messengers.automation_targets())
         for target in sorted(targets):
             await self.messengers.deliver(target, f"🔔 {name}\n\n{content}")
+
+    # -- Gardener-family automation pipelines ------------------------------------
+
+    def _automation_conversation_id(self, auto: dict[str, Any]) -> str:
+        """Resolve (or create) the per-automation 🔔 conversation."""
+        auto_id = str(auto.get("id") or "")
+        name = str(auto.get("name") or "Automation")
+        conv_key = f"automations.{auto_id}.conversation_id"
+        conv_id = str(self.db.get_setting(conv_key, "") or "")
+        if not conv_id or self.db.get_conversation(conv_id) is None:
+            conv = self.db.create_conversation(title=f"🔔 {name}")
+            conv_id = conv["id"]
+            self.db.set_setting(conv_key, conv_id)
+        return conv_id
+
+    async def _announce_automation_result(
+        self, auto: dict[str, Any], conv_id: str, content: str
+    ) -> None:
+        """Persist + broadcast + fan out an automation result message."""
+        auto_id = str(auto.get("id") or "")
+        name = str(auto.get("name") or "Automation")
+        if not content:
+            return
+        assistant = self.db.add_message(conv_id, "assistant", content)
+        await self.ipc.broadcast({
+            "type": "message", "conversation_id": conv_id, "message": assistant,
+        })
+        await self.ipc.broadcast({
+            "type": "automation",
+            "automation_id": auto_id,
+            "name": name,
+            "conversation_id": conv_id,
+            "content": content,
+        })
+        deliveries = auto.get("delivery_channels")
+        if isinstance(deliveries, str):
+            try:
+                deliveries = json.loads(deliveries)
+            except (TypeError, ValueError):
+                deliveries = []
+        targets = {
+            str(d) for d in (deliveries or [])
+            if str(d) in self.messengers.channels
+        }
+        targets.update(self.messengers.automation_targets())
+        for target in sorted(targets):
+            await self.messengers.deliver(target, f"🔔 {name}\n\n{content}")
+
+    async def _run_dream_manual(self) -> dict[str, Any]:
+        """Manual 'Review now' trigger (Settings -> Memory)."""
+        if self.loop is None:
+            result = await self._configure()
+            if not result.get("configured"):
+                return {
+                    "changed": False,
+                    "reason": "not_configured",
+                    "message": "I need a model provider set up before I can review my memory.",
+                }
+        from collie_core.memory.dream import run_dream
+
+        return await run_dream(
+            workspace=self.workspace,
+            db=self.db,
+            loop=self.loop,
+            version_store=self.versions,
+        )
+
+    async def _run_gardener_manual(self) -> dict[str, Any]:
+        """Manual 'Suggest improvements' trigger (Settings -> Memory).
+
+        Runs the same pipeline as the weekly automation and publishes the
+        review cards into the 🔔 conversation, so a manual run has the same
+        review surface as the scheduled one.
+        """
+        auto = {
+            "id": "collie-gardener-suggestions",
+            "name": "Improvement suggestions",
+            "delivery_channels": ["in_app"],
+        }
+        return await self._run_gardener(auto) or {}
+
+    async def _run_memory_maintenance(self, auto: dict[str, Any]) -> None:
+        """Weekly Dream pass: consolidate long-term memory, versioned + undoable."""
+        if self.loop is None:
+            result = await self._configure()
+            if not result.get("configured"):
+                logger.info("Memory maintenance skipped — no provider configured yet")
+                return
+        from collie_core.memory.dream import run_dream
+
+        conv_id = self._automation_conversation_id(auto)
+        outcome = await run_dream(
+            workspace=self.workspace,
+            db=self.db,
+            loop=self.loop,
+            version_store=self.versions,
+        )
+        content = str(outcome.get("message") or "Memory maintenance ran.")
+        if outcome.get("changed"):
+            content += (
+                "\n\nChanged my long-term memory file. You can review the diff "
+                "and undo it in Settings → Memory → History."
+            )
+        await self._announce_automation_result(auto, conv_id, content)
+
+    async def _run_gardener(self, auto: dict[str, Any]) -> dict[str, Any] | None:
+        """Weekly Gardener pass: evidence → suggestions → review cards."""
+        if self.loop is None:
+            result = await self._configure()
+            if not result.get("configured"):
+                logger.info("Gardener skipped — no provider configured yet")
+                return None
+        from collie_core.gardener.runner import run_gardener
+
+        conv_id = self._automation_conversation_id(auto)
+        outcome = await run_gardener(
+            workspace=self.workspace,
+            db=self.db,
+            loop=self.loop,
+            version_store=self.versions,
+        )
+        content = str(outcome.get("message") or "Gardener ran.")
+        suggestions = outcome.get("suggestions") or []
+        if suggestions:
+            card = self.db.add_message(
+                conv_id,
+                "assistant",
+                content,
+                card_type="gardener_suggestion",
+                card_data={"suggestions": suggestions},
+            )
+            await self.ipc.broadcast({
+                "type": "message", "conversation_id": conv_id, "message": card,
+            })
+            await self.ipc.broadcast({
+                "type": "automation",
+                "automation_id": str(auto.get("id") or ""),
+                "name": str(auto.get("name") or "Automation"),
+                "conversation_id": conv_id,
+                "content": content,
+            })
+            return outcome
+        await self._announce_automation_result(auto, conv_id, content)
+        return outcome
 
     async def _shutdown_loop(self) -> None:
         await self.messengers.stop()

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -540,6 +540,9 @@ class CollieRuntime:
 
     async def _configure_provider_candidate(self, candidate: dict[str, Any]) -> dict[str, Any]:
         """Validate, activate, and verify one provider candidate transactionally."""
+        from collie_core.catalog import CatalogueStore
+        from collie_core.providers.validation import probe_api_key
+
         async with self._configure_lock:
             try:
                 normalized = self._validated_provider_candidate(candidate)
@@ -567,6 +570,17 @@ class CollieRuntime:
             try:
                 if supplied_key is not None:
                     collie_settings.set_api_key(secret_name, supplied_key)
+                # Catalogue providers arrive without an endpoint or model:
+                # Collie fills protocol/base URL/default model (the strategy
+                # doc's rule — never make a normie pick an endpoint).
+                catalogue = CatalogueStore()
+                runtime_name = str(normalized.get("runtime_name") or "")
+                catalogue_entry = catalogue.get_provider(runtime_name)
+                if catalogue_entry is not None:
+                    if not normalized.get("api_base"):
+                        normalized["api_base"] = catalogue_entry.get("api_base")
+                    if not normalized.get("model"):
+                        normalized["model"] = catalogue_entry.get("default_model")
                 provider = self.db.configure_provider_candidate_record(**normalized)
                 configured = await self._configure_locked(
                     probe_api_base=normalized.get("api_base")
@@ -581,6 +595,61 @@ class CollieRuntime:
                 rollback = await self._restore_provider_snapshot_locked(transaction)
                 return {"configured": False, "error": str(error), **rollback}
 
+            # Key validation: a tiny read-only request with the user's key.
+            # The probe is the authority — prefix hints are only suggestions.
+            # On a definitive failure the whole transaction rolls back so a
+            # bad key never leaves the app half-configured.
+            key_for_probe = supplied_key if supplied_key is not None else previous_key
+            probe: dict[str, Any] = {}
+            if key_for_probe and (
+                catalogue_entry is not None or normalized.get("api_base")
+            ):
+                probe = await probe_api_key(
+                    provider_id=runtime_name or secret_name,
+                    api_key=str(key_for_probe),
+                    api_base=normalized.get("api_base"),
+                    protocol=str(normalized.get("protocol") or "openai"),
+                    model=normalized.get("model"),
+                    catalogue=catalogue,
+                )
+                if not probe.get("ok"):
+                    error_kind = str(probe.get("error") or "invalid")
+                    # Catalogue providers use known-good endpoints: any probe
+                    # failure is meaningful. Custom endpoints are an advanced
+                    # escape hatch — only a definitive auth rejection (401/403)
+                    # is treated as a failure there.
+                    hard_fail = (
+                        error_kind == "auth"
+                        or (catalogue_entry is not None and error_kind != "invalid")
+                    )
+                    if not hard_fail:
+                        logger.info(
+                            "Connect probe inconclusive for {} ({}) — continuing",
+                            runtime_name,
+                            error_kind,
+                        )
+                    else:
+                        rollback = await self._restore_provider_snapshot_locked(transaction)
+                        if error_kind == "auth":
+                            message = (
+                                "That key didn't work. Double-check it, or get help here → "
+                                "https://heycollie.com/get-started"
+                            )
+                        elif error_kind == "network":
+                            message = (
+                                "I couldn't reach that provider to check the key. "
+                                "Check your connection and try again."
+                            )
+                        else:
+                            message = "That provider didn't accept the key. Double-check it and try again."
+                        return {
+                            "configured": False,
+                            "validated": False,
+                            "error": message,
+                            "error_kind": error_kind,
+                            **rollback,
+                        }
+
             self._provider_config_generation += 1
             transaction_id = uuid.uuid4().hex
             transaction["generation"] = self._provider_config_generation
@@ -588,11 +657,17 @@ class CollieRuntime:
             while len(self._provider_rollbacks) > 16:
                 oldest = next(iter(self._provider_rollbacks))
                 self._provider_rollbacks.pop(oldest, None)
-            return {
+            result: dict[str, Any] = {
                 "provider": provider,
                 **configured,
                 "transaction_id": transaction_id,
             }
+            if key_for_probe and probe.get("ok"):
+                result["validated"] = True
+                result["model_label"] = probe.get("model_label") or (
+                    configured.get("model") or normalized.get("model")
+                )
+            return result
 
     async def _finalize_provider_candidate(self, transaction_id: str) -> dict[str, Any]:
         """Forget a successful candidate's compensating rollback snapshot."""

--- a/collie-core/collie_core/subagents/loader.py
+++ b/collie-core/collie_core/subagents/loader.py
@@ -23,6 +23,7 @@ import yaml
 from loguru import logger
 
 from collie_core.db import CollieDB
+from collie_core.versions import VersionStore
 
 __all__ = [
     "STARTERS",
@@ -117,6 +118,26 @@ class SubagentLoader:
     def __init__(self, workspace: Path, db: CollieDB) -> None:
         self.dir = workspace / "subagents"
         self.db = db
+
+    # -- versioning (Gardener rollback rail) --------------------------------
+
+    def _snapshot(
+        self, filename: str, before: str, after: str, *, source: str = "user"
+    ) -> str | None:
+        """Snapshot a subagent file edit; never breaks the write on failure."""
+        try:
+            return VersionStore(self.db).snapshot(
+                "subagent", filename, before, after, source=source
+            )
+        except Exception:
+            logger.exception("subagent version snapshot failed (swallowed)")
+            return None
+
+    def latest_version_id(self, filename: str) -> str | None:
+        try:
+            return VersionStore(self.db).latest_version_id("subagent", filename)
+        except Exception:
+            return None
 
     # -- disk <-> db sync ----------------------------------------------------
 
@@ -235,6 +256,7 @@ class SubagentLoader:
             filename=filename,
             execution_posture=execution_posture,
         )
+        self._snapshot(filename, "", path.read_text(encoding="utf-8"))
         logger.info("Subagent created: {}", filename)
         return row
 
@@ -278,9 +300,14 @@ class SubagentLoader:
             if old_path.exists():
                 old_path.rename(self.dir / new_filename)
             filename = new_filename
-        (self.dir / filename).write_text(
+        before = ""
+        target_path = self.dir / filename
+        if target_path.exists():
+            before = target_path.read_text(encoding="utf-8")
+        target_path.write_text(
             self._render(new_name, new_desc, new_prompt, posture), encoding="utf-8"
         )
+        self._snapshot(filename, before, target_path.read_text(encoding="utf-8"))
         return self.db.upsert_subagent(
             new_name,
             description=new_desc,
@@ -299,7 +326,9 @@ class SubagentLoader:
         if filename:
             file_path = self.dir / filename
             if file_path.exists():
+                before = file_path.read_text(encoding="utf-8")
                 file_path.unlink()
+                self._snapshot(filename, before, "")
         self.db.delete_subagent(subagent_id)
         logger.info("Subagent deleted: {}", filename or subagent_id)
 

--- a/collie-core/collie_core/versions.py
+++ b/collie-core/collie_core/versions.py
@@ -1,0 +1,151 @@
+"""Versioned artifact store — snapshot, diff, and roll back Collie artifacts.
+
+Every user-visible artifact edit (subagent files, ``VISION.md`` /
+``AGENTS.md`` / ``MEMORY.md``, dream consolidations, Gardener applies) is
+snapshotted into the ``artifact_versions`` table with a before/after text
+pair and a unified diff. The one-action rollback restores the prior text
+**only when the current content still matches the snapshotted ``after``
+text** — a newer owner edit is never clobbered (the no-clobber guard).
+
+The store is deliberately text-generic: reading the current artifact text
+and writing the restored text is the caller's job (each artifact type has
+its own on-disk location and re-sync rules). This keeps ``VersionStore``
+independent of the workspace layout.
+"""
+
+from __future__ import annotations
+
+import difflib
+from typing import Any
+
+from collie_core.db import CollieDB
+
+__all__ = ["VersionStore", "VersionConflictError"]
+
+
+class VersionConflictError(Exception):
+    """Raised when a rollback would clobber newer content than the version."""
+
+
+def make_diff(before: str, after: str, key: str) -> str:
+    """Build a unified diff between two texts (empty when identical)."""
+    return "".join(
+        difflib.unified_diff(
+            (before or "").splitlines(keepends=True),
+            (after or "").splitlines(keepends=True),
+            fromfile=f"{key} (before)",
+            tofile=f"{key} (after)",
+        )
+    )
+
+
+class VersionStore:
+    """Snapshot artifact edits and roll them back without clobbering."""
+
+    def __init__(self, db: CollieDB) -> None:
+        self.db = db
+
+    # -- snapshot ------------------------------------------------------------
+
+    def snapshot(
+        self,
+        artifact_type: str,
+        key: str,
+        current_text: str,
+        new_text: str,
+        *,
+        evidence: Any = None,
+        source: str = "user",
+    ) -> str | None:
+        """Record a version for an artifact edit; returns the version id.
+
+        Returns ``None`` when the texts are identical (nothing changed).
+        ``evidence`` is an optional JSON-serializable dict (e.g. Gardener
+        trigger evidence: run ids, tool stats).
+        """
+        before = current_text or ""
+        after = new_text or ""
+        if before == after:
+            return None
+        row = self.db.snapshot_artifact(
+            artifact_type,
+            key,
+            before,
+            after,
+            make_diff(before, after, key),
+            evidence=evidence,
+            source=source,
+        )
+        return str(row["id"])
+
+    def latest_version_id(self, artifact_type: str, key: str) -> str | None:
+        """Return the newest applied version id for an artifact, if any."""
+        rows = self.db.list_artifact_versions(
+            artifact_type=artifact_type, artifact_key=key, limit=1
+        )
+        if not rows:
+            return None
+        for row in rows:
+            if row.get("status") == "applied":
+                return str(row["id"])
+        return None
+
+    # -- rollback ------------------------------------------------------------
+
+    def rollback(
+        self,
+        artifact_type: str,
+        key: str,
+        *,
+        to_version: int | None = None,
+        current_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Prepare a rollback to ``before_text`` of the target version.
+
+        * ``to_version`` — the version to undo (defaults to the newest
+          applied version of the artifact).
+        * ``current_text`` — the artifact's current content, read by the
+          caller before calling. When it differs from the target version's
+          ``after_text`` the rollback is refused (never clobber newer
+          owner edits).
+
+        The version row is marked ``rolled_back`` and the caller writes the
+        returned ``restored_text`` to the artifact (and re-syncs as needed).
+        """
+        rows = self.db.list_artifact_versions(
+            artifact_type=artifact_type, artifact_key=key, limit=200
+        )
+        applied = [r for r in rows if r.get("status") == "applied"]
+        if not applied:
+            raise VersionConflictError("There's nothing to undo for this item yet.")
+        target: dict[str, Any] | None = None
+        if to_version is not None:
+            target = next(
+                (r for r in applied if int(r.get("version") or 0) == to_version),
+                None,
+            )
+        else:
+            target = max(applied, key=lambda r: int(r.get("version") or 0))
+        if target is None:
+            raise VersionConflictError(
+                f"Version {to_version} was already undone or never existed."
+            )
+
+        after_text = target.get("after_text") or ""
+        current = current_text if current_text is not None else ""
+        if current != after_text:
+            raise VersionConflictError(
+                "That edit has already been changed since — I won't overwrite "
+                "the newer version. Undo the most recent change first."
+            )
+
+        restored = target.get("before_text") or ""
+        self.db.mark_artifact_rolled_back(str(target["id"]))
+        return {
+            "version_id": str(target["id"]),
+            "artifact_type": artifact_type,
+            "artifact_key": key,
+            "version": int(target.get("version") or 0),
+            "restored_text": restored,
+            "status": "rolled_back",
+        }

--- a/collie-core/tests/collie/test_catalogue.py
+++ b/collie-core/tests/collie/test_catalogue.py
@@ -1,0 +1,171 @@
+"""Tests for the bundled provider catalogue (models.dev snapshot + curated layer)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from collie_core.catalog import BUNDLED_SNAPSHOT_PATH, CatalogueStore
+from collie_core.catalog.snapshot_util import (
+    trim_live_catalogue,
+    validate_catalogue_schema,
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> CatalogueStore:
+    return CatalogueStore(settings=None, snapshot_path=tmp_path / "missing.json")
+
+
+def test_bundled_snapshot_exists_and_is_valid() -> None:
+    assert BUNDLED_SNAPSHOT_PATH.is_file(), "run tools/update_catalogue_snapshot.py"
+    store = CatalogueStore(settings=None)
+    providers = store.providers()
+    assert len(providers) >= 10
+    ids = [p["id"] for p in providers]
+    assert "deepseek" in ids and "openai" in ids and "anthropic" in ids
+
+
+def test_bundled_snapshot_is_trimmed() -> None:
+    size_kb = BUNDLED_SNAPSHOT_PATH.stat().st_size / 1024
+    assert size_kb < 500, f"bundled snapshot too large: {size_kb:.0f} KB"
+
+
+def test_curated_defaults_and_labels() -> None:
+    store = CatalogueStore(settings=None)
+    deepseek = store.get_provider("deepseek")
+    assert deepseek is not None
+    assert deepseek["name"] == "DeepSeek"
+    assert deepseek["protocol"] == "openai"
+    assert deepseek["api_base"] == "https://api.deepseek.com"
+    assert deepseek["default_model"] == "deepseek-v4-flash"
+    assert deepseek["tested"] is True
+    assert store.model_label("deepseek", "deepseek-v4-flash") == "DeepSeek V4 Flash"
+    # A model id missing from the snapshot falls back to the raw id.
+    assert store.model_label("deepseek", "unknown-model") == "unknown-model"
+
+
+def test_prefix_detection_longest_match_wins() -> None:
+    store = CatalogueStore(settings=None)
+    assert store.detect_provider_for_key("gsk_abc123") == ["groq"]
+    assert store.detect_provider_for_key("sk-ant-abc") == ["anthropic"]
+    assert store.detect_provider_for_key("sk-or-v1-abc") == ["openrouter"]
+    assert store.detect_provider_for_key("AIzaSyB-xyz") == ["google"]
+    assert store.detect_provider_for_key("xai-abc") == ["xai"]
+    assert store.detect_provider_for_key("pplx-abc") == ["perplexity"]
+    # sk- is shared by OpenAI and DeepSeek → ambiguous, both candidates kept.
+    assert set(store.detect_provider_for_key("sk-abc")) == {"openai", "deepseek"}
+    assert store.detect_provider_for_key("") == []
+    assert store.detect_provider_for_key("totally-unknown") == []
+
+
+def test_trim_live_catalogue_builds_curated_snapshot() -> None:
+    raw = {
+        "deepseek": {
+            "name": "DeepSeek",
+            "api": "https://api.deepseek.com",
+            "doc": "https://api-docs.deepseek.com",
+            "models": {
+                "deepseek-v4-flash": {"name": "DeepSeek V4 Flash"},
+                "deepseek-reasoner": {"name": "DeepSeek Reasoner"},
+            },
+        },
+        "some-unknown-provider": {
+            "name": "Other",
+            "models": {"x": {"name": "X"}},
+        },
+    }
+    trimmed = trim_live_catalogue(raw, generated_at="2026-08-05T00:00:00Z")
+    assert trimmed is not None
+    assert validate_catalogue_schema(trimmed)
+    ids = [p["id"] for p in trimmed["providers"]]
+    # Unknown providers are dropped; curated overrides win over the feed.
+    assert ids == ["deepseek"]
+    assert trimmed["providers"][0]["api_base"] == "https://api.deepseek.com"
+    assert trimmed["providers"][0]["default_model"] == "deepseek-v4-flash"
+    assert trimmed["source"]["providers_count"] == 2
+    assert trimmed["source"]["sha256"]
+
+
+def test_trim_rejects_garbage() -> None:
+    assert trim_live_catalogue({}, "2026-08-05T00:00:00Z") is None
+    assert trim_live_catalogue([1, 2, 3], "2026-08-05T00:00:00Z") is None  # type: ignore[arg-type]
+    assert trim_live_catalogue({"providers": "nope"}, "2026-08-05T00:00:00Z") is None
+
+
+def test_validate_catalogue_schema_rejects_bad_shapes() -> None:
+    good = trim_live_catalogue(
+        {
+            "deepseek": {
+                "name": "DeepSeek",
+                "models": {"m": {"name": "M"}},
+            }
+        },
+        "2026-08-05T00:00:00Z",
+    )
+    assert good is not None and validate_catalogue_schema(good)
+    assert not validate_catalogue_schema({"schema_version": 999, "providers": [], "source": {}})
+    assert not validate_catalogue_schema({"schema_version": 1, "providers": "nope", "source": {}})
+    assert not validate_catalogue_schema({"schema_version": 1, "providers": [{"id": ""}], "source": {}})
+    assert not validate_catalogue_schema(None)
+    assert not validate_catalogue_schema("html error page")
+
+
+class _FakeSettings:
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
+
+    def get_setting(self, key: str, default: object = None) -> object:
+        return self.data.get(key, default)
+
+    def set_setting(self, key: str, value: object) -> None:
+        self.data[key] = str(value)
+
+    def delete_setting(self, key: str) -> None:
+        self.data.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_overlay_and_rollback_restores_bundled(tmp_path: Path) -> None:
+    settings = _FakeSettings()
+    store = CatalogueStore(settings=settings, snapshot_path=tmp_path / "missing.json")
+    # No bundled file → empty; after a successful refresh the overlay serves.
+    assert store.providers() == []
+
+    from collie_core.catalog import refresh as refresh_module
+
+    raw = {
+        "deepseek": {
+            "name": "DeepSeek",
+            "models": {"deepseek-v4-flash": {"name": "DeepSeek V4 Flash"}},
+        },
+        "openai": {"name": "OpenAI", "models": {"gpt-5.5": {"name": "GPT-5.5"}}},
+    }
+    calls: list[str] = []
+
+    async def _fake_fetch(url: str) -> bytes:
+        calls.append(url)
+        if len(calls) == 1:
+            raise TimeoutError("offline")
+        import json
+
+        return json.dumps(raw).encode("utf-8")
+
+    original = refresh_module._fetch_async
+    refresh_module._fetch_async = _fake_fetch  # type: ignore[assignment]
+    try:
+        failed = await store.refresh(url="https://models.dev/api.json")
+        assert failed["refreshed"] is False  # network failure keeps previous state
+        assert store.providers() == []
+
+        refreshed = await store.refresh(url="https://models.dev/api.json")
+    finally:
+        refresh_module._fetch_async = original  # type: ignore[assignment]
+    assert refreshed["refreshed"] is True
+    assert store.providers() != []
+    assert store.refresh_state()["refreshed_at"]
+
+    rollback = store.rollback()
+    assert rollback["rolled_back"] is True
+    assert store.providers() == []

--- a/collie-core/tests/collie/test_connect_validation.py
+++ b/collie-core/tests/collie/test_connect_validation.py
@@ -1,0 +1,217 @@
+"""Tests for connect-time key validation probes (read-only, never log keys)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiohttp import web
+
+from collie_core.catalog import CatalogueStore
+from collie_core.providers.validation import (
+    detect_local_ollama,
+    detect_models_for_base_url,
+    detect_provider_for_key,
+    probe_api_key,
+)
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _fake_openai_app(*, models_status: int = 200, chat_status: int = 200) -> web.Application:
+    async def models(request: web.Request) -> web.Response:
+        auth = request.headers.get("Authorization", "")
+        if models_status in (401, 403):
+            return web.json_response({"error": "bad key"}, status=models_status)
+        if models_status != 200:
+            return web.json_response({"error": "nope"}, status=models_status)
+        if auth != "Bearer sk-good":
+            return web.json_response({"error": "unauthorized"}, status=401)
+        return web.json_response({
+            "data": [
+                {"id": "deepseek-v4-flash", "object": "model"},
+                {"id": "deepseek-reasoner", "object": "model"},
+            ]
+        })
+
+    async def chat(request: web.Request) -> web.Response:
+        if chat_status != 200:
+            return web.json_response({"error": "nope"}, status=chat_status)
+        body = json.loads(await request.text())
+        return web.json_response({
+            "id": "chatcmpl-fake",
+            "object": "chat.completion",
+            "model": body.get("model"),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }],
+        })
+
+    app = web.Application()
+    app.router.add_get("/v1/models", models)
+    app.router.add_post("/v1/chat/completions", chat)
+    return app
+
+
+@pytest.fixture()
+async def openai_server():
+    runner = web.AppRunner(_fake_openai_app())
+    await runner.setup()
+    port = _free_port()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    yield f"http://127.0.0.1:{port}/v1"
+    await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_probe_api_key_success_via_models_endpoint(openai_server: str) -> None:
+    result = await probe_api_key(
+        provider_id="deepseek",
+        api_key="sk-good",
+        api_base=openai_server,
+        protocol="openai",
+        model="deepseek-v4-flash",
+        catalogue=CatalogueStore(),
+    )
+    assert result["ok"] is True
+    assert result["model"] == "deepseek-v4-flash"
+    assert result["model_label"] == "DeepSeek V4 Flash"
+    assert "deepseek-reasoner" in result["models"]
+
+
+@pytest.mark.asyncio
+async def test_probe_api_key_rejects_bad_key(openai_server: str) -> None:
+    result = await probe_api_key(
+        provider_id="deepseek",
+        api_key="sk-wrong",
+        api_base=openai_server,
+        protocol="openai",
+        model="deepseek-v4-flash",
+    )
+    assert result["ok"] is False
+    assert result["error"] == "auth"
+
+
+@pytest.mark.asyncio
+async def test_probe_api_key_falls_back_to_one_token_completion() -> None:
+    app = web.Application()
+
+    async def models(request: web.Request) -> web.Response:
+        return web.json_response({"error": "not found"}, status=404)
+
+    async def chat(request: web.Request) -> web.Response:
+        return web.json_response({
+            "id": "chatcmpl-fake",
+            "object": "chat.completion",
+            "model": "deepseek-v4-flash",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }],
+        })
+
+    app.router.add_get("/v1/models", models)
+    app.router.add_post("/v1/chat/completions", chat)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    port = _free_port()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    try:
+        result = await probe_api_key(
+            provider_id="deepseek",
+            api_key="sk-good",
+            api_base=f"http://127.0.0.1:{port}/v1",
+            protocol="openai",
+            model="deepseek-v4-flash",
+            catalogue=CatalogueStore(),
+        )
+    finally:
+        await runner.cleanup()
+    assert result["ok"] is True
+    assert result["model"] == "deepseek-v4-flash"
+    assert result["model_label"] == "DeepSeek V4 Flash"
+
+
+@pytest.mark.asyncio
+async def test_probe_api_key_network_error_is_not_auth() -> None:
+    result = await probe_api_key(
+        provider_id="deepseek",
+        api_key="sk-good",
+        api_base="http://127.0.0.1:9/v1",  # nothing listens here
+        protocol="openai",
+        model="deepseek-v4-flash",
+    )
+    assert result["ok"] is False
+    assert result["error"] == "network"
+
+
+@pytest.mark.asyncio
+async def test_detect_provider_for_key_uses_prefix_for_unambiguous(openai_server: str) -> None:
+    # gsk_ is unambiguous → instant, no probing needed.
+    result = await detect_provider_for_key("gsk_abc", catalogue=CatalogueStore())
+    assert result == {"detected": True, "provider_id": "groq", "reason": "prefix"}
+
+
+@pytest.mark.asyncio
+async def test_detect_provider_for_key_probes_ambiguous_sk(monkeypatch: pytest.MonkeyPatch) -> None:
+    from collie_core.providers import validation
+
+    calls: list[str] = []
+
+    async def fake_probe(**kwargs: object) -> dict[str, object]:
+        provider_id = str(kwargs["provider_id"])
+        calls.append(provider_id)
+        if provider_id == "deepseek":
+            return {"ok": True, "model": "deepseek-v4-flash", "model_label": "DeepSeek V4 Flash"}
+        return {"ok": False, "error": "auth"}
+
+    monkeypatch.setattr(validation, "probe_api_key", fake_probe)
+    result = await detect_provider_for_key("sk-abc", catalogue=CatalogueStore())
+    assert result == {"detected": True, "provider_id": "deepseek", "reason": "probe"}
+    # Ambiguous sk- is resolved by probing candidates in order; first accept wins.
+    assert calls == ["openai", "deepseek"]
+
+
+@pytest.mark.asyncio
+async def test_detect_provider_for_key_nothing_matches() -> None:
+    result = await detect_provider_for_key("no-match-xyz", catalogue=CatalogueStore())
+    assert result["detected"] is False
+    assert result["reason"] == "no_prefix_match"
+
+
+@pytest.mark.asyncio
+async def test_detect_models_for_custom_base_url(openai_server: str) -> None:
+    result = await detect_models_for_base_url(openai_server, protocol="openai", api_key="sk-good")
+    assert result["detected"] is True
+    assert result["models"] == ["deepseek-v4-flash", "deepseek-reasoner"]
+
+
+@pytest.mark.asyncio
+async def test_detect_models_handles_missing_base_url() -> None:
+    result = await detect_models_for_base_url("", protocol="openai")
+    assert result["detected"] is False
+    assert result["error"] == "missing_base_url"
+
+
+@pytest.mark.asyncio
+async def test_detect_local_ollama_empty_when_not_running() -> None:
+    # Nothing listens on an unlikely port; OLLAMA_HOST forces the probe there.
+    import os
+
+    os.environ["OLLAMA_HOST"] = "http://127.0.0.1:9"
+    try:
+        result = await detect_local_ollama()
+    finally:
+        os.environ.pop("OLLAMA_HOST", None)
+    assert result == {"available": False, "models": []}

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 13
+    assert db.schema_version == 14
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,17 +25,18 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 13
+    assert d2.schema_version == 14
     d2.close()
 
 
-def test_incremental_migrations_v1_through_v12(tmp_path: Path) -> None:
+def test_incremental_migrations_v1_through_latest(tmp_path: Path) -> None:
     """Every schema version must upgrade cleanly to the latest, preserving data."""
     import sqlite3
 
     import collie_core.db as db_mod
 
-    for target in range(1, 14):
+    latest = len(db_mod._MIGRATIONS)
+    for target in range(1, latest + 1):
         path = tmp_path / f"v{target}.db"
         conn = sqlite3.connect(path)
         conn.executescript(db_mod._SCHEMA_V1)
@@ -51,7 +52,7 @@ def test_incremental_migrations_v1_through_v12(tmp_path: Path) -> None:
         conn.close()
 
         upgraded = CollieDB(path)
-        assert upgraded.schema_version == 13, f"v{target} did not reach v13"
+        assert upgraded.schema_version == latest, f"v{target} did not reach v{latest}"
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
         upgraded.close()
 
@@ -76,8 +77,9 @@ def test_migration_failure_rolls_back_atomically(
     with pytest.raises(sqlite3.OperationalError):
         CollieDB(path)
 
-    # The failed migration rolled everything back: version still 13 and the
-    # partial table is gone, so a normal boot migrates cleanly again.
+    # The failed migration rolled everything back: version still at the
+    # pre-failure latest and the partial table is gone, so a normal boot
+    # migrates cleanly again.
     conn = sqlite3.connect(path)
     try:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
@@ -86,11 +88,11 @@ def test_migration_failure_rolls_back_atomically(
         ).fetchone()
     finally:
         conn.close()
-    assert version == 13
+    assert version == len(db_mod._MIGRATIONS) - 1
     assert half is None
     monkeypatch.undo()
     fresh = CollieDB(path)
-    assert fresh.schema_version == 13
+    assert fresh.schema_version == len(db_mod._MIGRATIONS)
     fresh.close()
 
 
@@ -131,7 +133,7 @@ def test_v8_removes_only_legacy_system_subagent_allow(tmp_path: Path) -> None:
         row["name"] for row in migrated._rows("PRAGMA table_info(messages)")
     }
     assert "task_state" in columns
-    assert migrated.schema_version == 13
+    assert migrated.schema_version == len(db_mod._MIGRATIONS)
     migrated.close()
 
 
@@ -179,7 +181,7 @@ def test_v9_upgrade_adds_plan_change_terminal_message_id(tmp_path: Path) -> None
             row["name"]
             for row in upgraded._rows("PRAGMA table_info(plan_change_requests)")
         }
-        assert upgraded.schema_version == 13
+        assert upgraded.schema_version == len(db_mod._MIGRATIONS)
         assert "terminal_message_id" in columns
         assert request is not None
         assert request["reason"] == "Change it"
@@ -345,7 +347,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.set_profile("dietary", "vegan")
     db.add_person("Sam")
     data = db.export_all()
-    assert data["schema_version"] == 13
+    assert data["schema_version"] == 14
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_dream_collie.py
+++ b/collie-core/tests/collie/test_dream_collie.py
@@ -1,0 +1,292 @@
+"""Dream wiring tests (Gardener Foundations PR 3).
+
+Covers ``collie_core/memory/dream.py`` against a fake loop/provider:
+memory consolidation updates ``memory/MEMORY.md``, the cursor advances only
+on success, a no-change run is a no-op, rollback restores the prior file,
+dream sessions are pruned, and the built-in automation seeds correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from collie_core.automations.scheduler import (
+    GARDENER_AUTOMATIONS,
+    seed_gardener_automations,
+)
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.memory.dream import run_dream
+from collie_core.versions import VersionStore
+from nanobot.agent.memory import MemoryStore
+from nanobot.session.manager import SessionManager
+
+
+class FakeRunner:
+    """Stands in for ``SubagentManager.runner``; returns queued results."""
+
+    def __init__(self) -> None:
+        self.responses: list[Any] = []
+        self.specs: list[Any] = []
+
+    async def run(self, spec: Any) -> Any:
+        self.specs.append(spec)
+        return self.responses.pop(0)
+
+
+class FakeSubagents:
+    def __init__(self) -> None:
+        self.runner = FakeRunner()
+        self.hook_factories: list[Any] = []
+
+
+class FakeLoop:
+    """Minimal AgentLoop stand-in with a real MemoryStore."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.context = SimpleNamespace(memory=MemoryStore(workspace))
+        self.subagents = FakeSubagents()
+
+    def llm_runtime(self) -> Any:
+        return SimpleNamespace(model="fake-model")
+
+    @property
+    def sessions(self) -> Any:
+        return SimpleNamespace(sessions_dir=Path(self.workspace) / "sessions")
+
+
+def _result(content: str, stop_reason: str = "completed") -> Any:
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        final_content=content,
+        tools_used=[],
+        messages=[],
+        error=None,
+    )
+
+
+def _seed_dream_sessions(workspace: Path, count: int) -> None:
+    sessions_dir = workspace / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        key = f"dream:20260805-{100000 + i:06d}"
+        path = sessions_dir / f"{SessionManager._storage_key(key)}.jsonl"
+        path.write_text('{"_type": "metadata"}\n', encoding="utf-8")
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+async def test_dream_updates_memory_and_advances_cursor(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("User prefers concise replies.")
+    built = store.build_dream_prompt()
+    assert built is not None
+    _, cursor = built
+
+    proposed = "# Long-term Memory\n- User prefers concise replies.\n- Projects: Collie"
+    loop.subagents.runner.responses.append(_result(proposed))
+
+    versions = VersionStore(db)
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=versions
+    )
+
+    assert outcome["changed"] is True
+    assert outcome["version_id"] is not None
+    memory_file = workspace / "memory" / "MEMORY.md"
+    assert memory_file.read_text(encoding="utf-8").strip() == proposed.strip()
+
+    # Bounded, read-only, tool-less turn: exactly one model call.
+    spec = loop.subagents.runner.specs[0]
+    assert spec.max_iterations == 1
+    assert spec.execution_posture == "read_only"
+    assert spec.session_key.startswith("dream:")
+    assert not spec.tools.get_definitions()
+
+    # Cursor advanced only on success.
+    assert store.get_last_dream_cursor() == cursor
+
+    # Versioned as memory_dream with a diff.
+    rows = db.list_artifact_versions(artifact_type="memory_dream")
+    assert len(rows) == 1
+    assert rows[0]["artifact_key"] == "MEMORY.md"
+    assert rows[0]["source"] == "collie"
+    assert "-" in rows[0]["diff_text"] and "+" in rows[0]["diff_text"]
+    evidence = json.loads(rows[0]["evidence_json"])
+    assert evidence["cursor"] == cursor
+
+
+async def test_dream_no_new_history_is_noop(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is False
+    assert outcome["reason"] == "no_new_history"
+    assert not (workspace / "memory" / "MEMORY.md").exists()
+
+
+async def test_dream_no_change_second_run_advances_cursor(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("First entry.")
+    built = store.build_dream_prompt()
+    _, cursor1 = built
+    proposed = "# Long-term Memory\n- First entry."
+    loop.subagents.runner.responses.append(_result(proposed))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+    assert store.get_last_dream_cursor() == cursor1
+
+    # New history arrives, but the model proposes identical content.
+    store.append_history("Second entry.")
+    built = store.build_dream_prompt()
+    assert built is not None
+    _, cursor2 = built
+    loop.subagents.runner.responses.append(_result(proposed))
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is False
+    assert outcome["reason"] == "no_content_change"
+    # History is processed even when nothing changed — no re-processing loop.
+    assert store.get_last_dream_cursor() == cursor2
+    # No extra version rows for a no-op run.
+    assert len(db.list_artifact_versions(artifact_type="memory_dream")) == 1
+
+
+async def test_dream_error_does_not_advance_cursor_or_write(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("", stop_reason="error"))
+
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is False
+    assert store.get_last_dream_cursor() == 0
+    assert not (workspace / "memory" / "MEMORY.md").exists()
+    assert db.list_artifact_versions(artifact_type="memory_dream") == []
+
+
+async def test_dream_rollback_restores_prior_memory(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("User prefers concise replies.")
+    proposed = "# Long-term Memory\n- User prefers concise replies."
+    loop.subagents.runner.responses.append(_result(proposed))
+    versions = VersionStore(db)
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=versions)
+
+    memory_file = workspace / "memory" / "MEMORY.md"
+    current = memory_file.read_text(encoding="utf-8")
+    result = versions.rollback(
+        "memory_dream", "MEMORY.md", current_text=current
+    )
+    memory_file.write_text(result["restored_text"], encoding="utf-8")
+    assert memory_file.read_text(encoding="utf-8").strip() == ""
+    assert db.list_artifact_versions(artifact_type="memory_dream")[0]["status"] == "rolled_back"
+
+
+async def test_dream_prune_keeps_10(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _seed_dream_sessions(workspace, 12)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("# Long-term Memory\n- Entry."))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+
+    remaining = list((workspace / "sessions").glob("*.jsonl"))
+    assert len(remaining) == 10
+
+
+async def test_dream_fenced_response_is_extracted(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(
+        _result("```markdown\n# Long-term Memory\n- Entry.\n```")
+    )
+    outcome = await run_dream(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["changed"] is True
+    memory_file = workspace / "memory" / "MEMORY.md"
+    assert "# Long-term Memory" in memory_file.read_text(encoding="utf-8")
+    assert "```" not in memory_file.read_text(encoding="utf-8")
+
+
+def test_seed_gardener_automations_once_and_never_resurrects(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    seed_gardener_automations(db)
+    automations = {a["id"]: a for a in db.list_automations()}
+    assert "collie-memory-maintenance" in automations
+    assert "collie-gardener-suggestions" in automations
+    assert automations["collie-memory-maintenance"]["action_type"] == "memory_maintenance"
+    assert automations["collie-gardener-suggestions"]["action_type"] == "gardener"
+
+    # Deleting one built-in never resurrects it on later seeds.
+    db.delete_automation("collie-memory-maintenance")
+    seed_gardener_automations(db)
+    ids = {a["id"] for a in db.list_automations()}
+    assert "collie-memory-maintenance" not in ids
+    assert "collie-gardener-suggestions" in ids
+
+    # The seed data matches the builtin list shape.
+    assert {a["id"] for a in GARDENER_AUTOMATIONS} == {
+        "collie-memory-maintenance",
+        "collie-gardener-suggestions",
+    }
+
+
+async def test_ipc_run_dream_and_history(tmp_path: Path, db: CollieDB) -> None:
+    class _FakeConn:
+        async def send(self, payload: dict[str, Any]) -> None:
+            pass
+
+    async def fake_dream_runner() -> dict[str, Any]:
+        return {"changed": False, "reason": "no_new_history", "message": "All tidy."}
+
+    srv = CollieIPCServer(db, port=0, dream_runner=fake_dream_runner)
+    conn = _FakeConn()
+    outcome = await srv._cmd_run_dream(conn, {})
+    assert outcome["changed"] is False
+    history = await srv._cmd_get_dream_history(conn, {})
+    assert history["versions"] == []
+
+    unset = CollieIPCServer(db, port=0)
+    with pytest.raises(ValueError):
+        await unset._cmd_run_dream(conn, {})

--- a/collie-core/tests/collie/test_gardener_mvp.py
+++ b/collie-core/tests/collie/test_gardener_mvp.py
@@ -1,0 +1,561 @@
+"""Gardener MVP tests (Gardener Foundations PR 4).
+
+Covers ``collie_core/gardener/`` against seeded telemetry rows:
+
+- evidence queries (repeated failures, repeated workflows, stopped turns,
+  memory bloat) read the seeded ``turn_events`` / ``tool_events``;
+- proposal validation rejects out-of-scope targets (permissions, settings,
+  secrets, connectors, non-allowlisted artifact types, unsafe keys, size
+  overruns) deterministically;
+- the bounded proposal turn (fake loop) returns validated suggestions and
+  reports rejected ones;
+- approve applies + versions through the rollback rail; dismiss applies
+  nothing; rollback restores the prior text and marks the version.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.gardener.evidence import (
+    collect_evidence,
+    memory_bloat,
+    recent_failures,
+    repeated_workflows,
+    user_stops,
+)
+from collie_core.gardener.propose import (
+    MAX_PROPOSED_CHARS,
+    ProposalValidationError,
+    propose,
+    validate_suggestion,
+)
+from collie_core.gardener.runner import apply_suggestion, run_gardener
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.versions import VersionStore
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / "memory").mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _seed_turn(db: CollieDB, turn_id: str, status: str = "ok", **extra: Any) -> None:
+    db.record_turn_event(
+        turn_id=turn_id,
+        conversation_id=extra.pop("conversation_id", "conv-1"),
+        turn_kind="chat",
+        status=status,
+        started_at=extra.pop("started_at", "2026-07-25T10:00:00"),
+        finished_at="2026-07-25T10:00:30",
+        **extra,
+    )
+
+
+def _seed_tool(
+    db: CollieDB,
+    tool_id: str,
+    turn_id: str,
+    tool_name: str,
+    status: str = "ok",
+    error_message: str | None = None,
+    started_at: str = "2026-07-25T10:00:05",
+) -> None:
+    db.record_tool_event(
+        tool_id=tool_id,
+        turn_id=turn_id,
+        tool_name=tool_name,
+        status=status,
+        error_message=error_message,
+        started_at=started_at,
+        finished_at="2026-07-25T10:00:10",
+    )
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.responses: list[Any] = []
+        self.specs: list[Any] = []
+
+    async def run(self, spec: Any) -> Any:
+        self.specs.append(spec)
+        return self.responses.pop(0)
+
+
+class FakeSubagents:
+    def __init__(self) -> None:
+        self.runner = FakeRunner()
+        self.hook_factories: list[Any] = []
+
+
+class FakeLoop:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.subagents = FakeSubagents()
+
+    def llm_runtime(self) -> Any:
+        return SimpleNamespace(model="fake-model")
+
+
+def _result(content: str, stop_reason: str = "completed") -> Any:
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        final_content=content,
+        tools_used=[],
+        messages=[],
+        error=None,
+    )
+
+
+def _valid_subagent_suggestion(**overrides: Any) -> dict[str, Any]:
+    suggestion = {
+        "artifact_type": "subagent",
+        "artifact_key": "helper.md",
+        "proposed_text": "# Helper\n\nYou help with research tasks.\n",
+        "rationale": "The user repeats multi-step research; a specialist helps.",
+        "evidence_ids": ["workflows:search,web_fetch"],
+    }
+    suggestion.update(overrides)
+    return suggestion
+
+
+# -- evidence queries -------------------------------------------------------
+
+
+def test_recent_failures_counts_and_samples(db: CollieDB) -> None:
+    _seed_turn(db, "t1")
+    for i in range(3):
+        _seed_tool(
+            db,
+            f"tool-{i}",
+            "t1",
+            "web_fetch",
+            status="error",
+            error_message=f"HTTP 500 attempt {i}",
+        )
+    _seed_tool(db, "ok-tool", "t1", "web_search", status="ok")
+
+    failures = recent_failures(db)
+    assert len(failures) == 1
+    row = failures[0]
+    assert row["tool_name"] == "web_fetch"
+    assert row["failures"] == 3
+    assert row["statuses"] == ["error"]
+    assert "HTTP 500" in row["sample_errors"][0]
+    # Successful tools never appear.
+    assert all(r["tool_name"] != "web_search" for r in failures)
+
+
+def test_recent_failures_respects_since_window(db: CollieDB) -> None:
+    _seed_turn(db, "t1")
+    _seed_tool(db, "old", "t1", "web_fetch", status="error", started_at="2026-06-01T10:00:05")
+    failures = recent_failures(db, since="2026-07-01T00:00:00")
+    assert failures == []
+
+
+def test_repeated_workflows_groups_tool_sequences(db: CollieDB) -> None:
+    for i in range(3):
+        turn_id = f"turn-{i}"
+        _seed_turn(db, turn_id)
+        _seed_tool(db, f"{turn_id}-a", turn_id, "web_search", status="ok")
+        _seed_tool(db, f"{turn_id}-b", turn_id, "web_fetch", status="ok")
+
+    workflows = repeated_workflows(db)
+    assert len(workflows) == 1
+    assert workflows[0]["workflow"] == ["web_search", "web_fetch"]
+    assert workflows[0]["repeats"] == 3
+
+
+def test_repeated_workflows_ignores_singletons(db: CollieDB) -> None:
+    for i in range(3):
+        turn_id = f"turn-{i}"
+        _seed_turn(db, turn_id)
+        _seed_tool(db, f"{turn_id}-a", turn_id, "web_search", status="ok")
+    assert repeated_workflows(db) == []
+
+
+def test_user_stops_lists_stopped_turns(db: CollieDB) -> None:
+    _seed_turn(db, "ok-turn", status="ok")
+    _seed_turn(db, "stopped-turn", status="stopped")
+    _seed_turn(db, "cancelled-turn", status="cancelled")
+
+    stops = user_stops(db)
+    assert {s["turn_id"] for s in stops} == {"stopped-turn", "cancelled-turn"}
+
+
+def test_memory_bloat_flags_size_and_duplicate_headings(workspace: Path) -> None:
+    (workspace / "memory" / "MEMORY.md").write_text(
+        "# Memory\n- fact one\n" * 200, encoding="utf-8"
+    )
+    (workspace / "MEMORY.md").write_text(
+        "# About\n# About\n- duplicate heading\n", encoding="utf-8"
+    )
+
+    findings = {f["kind"]: f for f in memory_bloat(workspace)}
+    assert findings["memory"]["bloated"] is True  # size
+    assert findings["profile"]["bloated"] is True  # duplicate heading
+    assert "about" in findings["profile"]["duplicate_headings"]
+
+
+def test_collect_evidence_aggregates(db: CollieDB, workspace: Path) -> None:
+    _seed_turn(db, "t1")
+    _seed_tool(db, "x1", "t1", "web_fetch", status="error", error_message="boom")
+    _seed_tool(db, "x2", "t1", "web_fetch", status="error", error_message="boom")
+    (workspace / "memory" / "MEMORY.md").write_text("# M\n- a\n" * 100, encoding="utf-8")
+
+    evidence = collect_evidence(db, workspace)
+    assert evidence["failures"][0]["tool_name"] == "web_fetch"
+    assert evidence["memory"][0]["kind"] == "memory"
+    assert evidence["since"]
+
+
+# -- proposal validation ----------------------------------------------------
+
+
+def test_validate_suggestion_accepts_allowlisted_targets() -> None:
+    for artifact_type, key in (
+        ("subagent", "helper.md"),
+        ("agents", "AGENTS.md"),
+        ("vision", "VISION.md"),
+        ("memory_dream", "MEMORY.md"),
+    ):
+        cleaned = validate_suggestion(
+            {
+                "artifact_type": artifact_type,
+                "artifact_key": key,
+                "proposed_text": "# New content\n",
+                "rationale": "Based on evidence.",
+                "evidence_ids": ["failures:web_fetch"],
+            }
+        )
+        assert cleaned["artifact_type"] == artifact_type
+        assert cleaned["artifact_key"] == key
+
+
+@pytest.mark.parametrize(
+    "artifact_type,key",
+    [
+        ("settings", "anything"),
+        ("skill", "resume-writer.md"),
+        ("connectors", "notion"),
+        ("subagent", "../escape.md"),
+        ("subagent", "nested/path.md"),
+        ("agents", "OTHER.md"),
+        ("vision", "AGENTS.md"),
+        ("memory_dream", "memory/MEMORY.md"),
+    ],
+)
+def test_validate_suggestion_rejects_out_of_scope_targets(
+    artifact_type: str, key: str
+) -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(
+            {
+                "artifact_type": artifact_type,
+                "artifact_key": key,
+                "proposed_text": "# Content\n",
+                "rationale": "Reason.",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Change the permission model to allow file writes.",
+        "Update the api key handling in settings.",
+        "Reconfigure the notion connector.",
+        "Store credentials in the profile.",
+        "Turn on auto-approve for tools.",
+    ],
+)
+def test_validate_suggestion_rejects_forbidden_language(text: str) -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(_valid_subagent_suggestion(proposed_text=text))
+
+
+def test_validate_suggestion_rejects_oversize_proposal() -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(
+            _valid_subagent_suggestion(proposed_text="x" * (MAX_PROPOSED_CHARS + 1))
+        )
+
+
+def test_validate_suggestion_rejects_empty_proposal() -> None:
+    with pytest.raises(ProposalValidationError):
+        validate_suggestion(_valid_subagent_suggestion(proposed_text=""))
+
+
+# -- bounded proposal turn --------------------------------------------------
+
+
+async def test_propose_returns_validated_suggestions(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(
+        _result(
+            json.dumps(
+                [
+                    _valid_subagent_suggestion(),
+                    {
+                        "artifact_type": "memory_dream",
+                        "artifact_key": "MEMORY.md",
+                        "proposed_text": "# Long-term Memory\n- tidy\n",
+                        "rationale": "Memory had duplicate headings.",
+                        "evidence_ids": ["memory:bloat"],
+                    },
+                ]
+            )
+        )
+    )
+    evidence = collect_evidence(db, workspace)
+    valid, rejected = await propose(loop, workspace, evidence)
+    assert len(valid) == 2
+    spec = loop.subagents.runner.specs[0]
+    assert spec.max_iterations == 1
+    assert spec.execution_posture == "read_only"
+    assert not spec.tools.get_definitions()
+    assert spec.session_key.startswith("gardener:")
+    assert rejected == []
+
+
+async def test_propose_drops_out_of_scope_and_reports(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(
+        _result(
+            json.dumps(
+                [
+                    _valid_subagent_suggestion(),
+                    {
+                        "artifact_type": "settings",
+                        "artifact_key": "provider",
+                        "proposed_text": "Switch the provider key.",
+                        "rationale": "Nope.",
+                    },
+                    {
+                        "artifact_type": "subagent",
+                        "artifact_key": "helper.md",
+                        "proposed_text": "Allow auto-approve for everything.",
+                        "rationale": "Faster.",
+                    },
+                ]
+            )
+        )
+    )
+    valid, rejected = await propose(loop, workspace, collect_evidence(db, workspace))
+    assert len(valid) == 1
+    assert len(rejected) == 2
+    reasons = [r["reason"] for r in rejected]
+    assert any("settings" in reason for reason in reasons)
+    assert any("approve" in reason for reason in reasons)
+
+
+async def test_propose_empty_json_is_empty(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(_result("[]"))
+    valid, rejected = await propose(loop, workspace, collect_evidence(db, workspace))
+    assert valid == []
+    assert rejected == []
+
+
+async def test_propose_turn_error_is_rejected(workspace: Path, db: CollieDB) -> None:
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(_result("", stop_reason="error"))
+    valid, rejected = await propose(loop, workspace, collect_evidence(db, workspace))
+    assert valid == []
+    assert any(r["reason"].startswith("stop_reason") for r in rejected)
+
+
+# -- runner: run -> review -> apply -> rollback -----------------------------
+
+
+async def test_run_gardener_no_signals_is_quiet(db: CollieDB, workspace: Path) -> None:
+    loop = FakeLoop(workspace)
+    outcome = await run_gardener(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert outcome["suggestions"] == []
+    assert "healthy" in outcome["message"]
+
+
+async def test_run_gardener_with_signals_proposes(db: CollieDB, workspace: Path) -> None:
+    _seed_turn(db, "t1")
+    _seed_tool(db, "f1", "t1", "web_fetch", status="error", error_message="500")
+    _seed_tool(db, "f2", "t1", "web_fetch", status="error", error_message="500")
+    loop = FakeLoop(workspace)
+    loop.subagents.runner.responses.append(_result(json.dumps([_valid_subagent_suggestion()])))
+
+    outcome = await run_gardener(
+        workspace=workspace, db=db, loop=loop, version_store=VersionStore(db)
+    )
+    assert len(outcome["suggestions"]) == 1
+    assert outcome["suggestions"][0]["artifact_type"] == "subagent"
+    assert "2 suggestion" in outcome["message"] or "1 suggestion" in outcome["message"]
+
+
+def test_apply_suggestion_writes_and_versions(db: CollieDB, workspace: Path) -> None:
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    original = "# Helper\n\nOld instructions.\n"
+    (sub_dir / "helper.md").write_text(original, encoding="utf-8")
+
+    result = apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(
+            proposed_text="# Helper\n\nNew research instructions.\n"
+        ),
+        version_store=VersionStore(db),
+    )
+    assert result["applied"] is True
+    assert result["version_id"] is not None
+    assert (sub_dir / "helper.md").read_text(encoding="utf-8") == (
+        "# Helper\n\nNew research instructions.\n"
+    )
+
+    rows = db.list_artifact_versions(artifact_type="subagent")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["artifact_key"] == "helper.md"
+    assert row["source"] == "gardener"
+    assert row["status"] == "applied"
+    assert row["before_text"] == original
+    assert "-" in row["diff_text"] and "+" in row["diff_text"]
+
+
+def test_apply_suggestion_revalidates_forged_input(db: CollieDB, workspace: Path) -> None:
+    with pytest.raises(ProposalValidationError):
+        apply_suggestion(
+            workspace=workspace,
+            suggestion=_valid_subagent_suggestion(
+                proposed_text="Change permission settings to allow everything."
+            ),
+            version_store=VersionStore(db),
+        )
+    assert db.list_artifact_versions() == []
+
+
+def test_apply_suggestion_no_change_is_noop(db: CollieDB, workspace: Path) -> None:
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    (sub_dir / "helper.md").write_text("# Helper\n\nSame text.\n", encoding="utf-8")
+    result = apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(proposed_text="# Helper\n\nSame text."),
+        version_store=VersionStore(db),
+    )
+    assert result["no_change"] is True
+    assert result["version_id"] is None
+    assert db.list_artifact_versions() == []
+
+
+def test_dismiss_applies_nothing(db: CollieDB, workspace: Path) -> None:
+    """Dismiss is a review-surface decision: no core write, no version."""
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    original = "# Helper\n\nOld instructions.\n"
+    (sub_dir / "helper.md").write_text(original, encoding="utf-8")
+
+    # run_gardener produced suggestions, but the user dismisses: nothing is
+    # applied and nothing is versioned.
+    outcome = {"suggestions": [_valid_subagent_suggestion()]}
+    assert outcome["suggestions"]
+    assert (sub_dir / "helper.md").read_text(encoding="utf-8") == original
+    assert db.list_artifact_versions() == []
+
+
+def test_rollback_restores_prior_text(db: CollieDB, workspace: Path) -> None:
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    original = "# Helper\n\nOld instructions.\n"
+    (sub_dir / "helper.md").write_text(original, encoding="utf-8")
+
+    versions = VersionStore(db)
+    apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(
+            proposed_text="# Helper\n\nNew research instructions.\n"
+        ),
+        version_store=versions,
+    )
+
+    current = (sub_dir / "helper.md").read_text(encoding="utf-8")
+    rollback = versions.rollback("subagent", "helper.md", current_text=current)
+    (sub_dir / "helper.md").write_text(rollback["restored_text"], encoding="utf-8")
+
+    assert (sub_dir / "helper.md").read_text(encoding="utf-8") == original
+    row = db.list_artifact_versions(artifact_type="subagent")[0]
+    assert row["status"] == "rolled_back"
+
+
+def test_rollback_refuses_when_current_diverges(db: CollieDB, workspace: Path) -> None:
+    from collie_core.versions import VersionConflictError
+
+    sub_dir = workspace / "subagents"
+    sub_dir.mkdir(exist_ok=True)
+    (sub_dir / "helper.md").write_text("# Helper\n\nOld.\n", encoding="utf-8")
+    versions = VersionStore(db)
+    apply_suggestion(
+        workspace=workspace,
+        suggestion=_valid_subagent_suggestion(proposed_text="# Helper\n\nNew.\n"),
+        version_store=versions,
+    )
+    # A newer owner edit lands on top.
+    (sub_dir / "helper.md").write_text("# Helper\n\nUser's own newer edit.\n", encoding="utf-8")
+
+    with pytest.raises(VersionConflictError):
+        versions.rollback(
+            "subagent", "helper.md", current_text=(sub_dir / "helper.md").read_text()
+        )
+
+
+# -- IPC surface ------------------------------------------------------------
+
+
+async def test_ipc_run_gardener_and_apply(db: CollieDB, workspace: Path) -> None:
+    class _FakeConn:
+        async def send(self, payload: dict[str, Any]) -> None:
+            pass
+
+    async def fake_gardener_runner() -> dict[str, Any]:
+        return {"suggestions": [_valid_subagent_suggestion()], "message": "One idea."}
+
+    srv = CollieIPCServer(db, port=0, gardener_runner=fake_gardener_runner)
+    conn = _FakeConn()
+    outcome = await srv._cmd_run_gardener(conn, {})
+    assert outcome["suggestions"]
+    assert "message" in outcome
+
+    unset = CollieIPCServer(db, port=0)
+    with pytest.raises(ValueError):
+        await unset._cmd_run_gardener(conn, {})
+
+    # Apply through the IPC command path (uses the real apply + versioning).
+    srv_with_apply = CollieIPCServer(db, port=0, gardener_runner=fake_gardener_runner)
+    with pytest.raises(ValueError):
+        await srv_with_apply._cmd_apply_gardener_suggestion(conn, {})
+    with pytest.raises(ValueError):
+        await srv_with_apply._cmd_apply_gardener_suggestion(
+            conn,
+            {
+                "suggestion": {
+                    "artifact_type": "settings",
+                    "artifact_key": "x",
+                    "proposed_text": "y",
+                }
+            },
+        )

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 13
+    assert db.schema_version == 14
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_onboarding.py
+++ b/collie-core/tests/collie/test_onboarding.py
@@ -1,0 +1,166 @@
+"""Tests for the starter conversation (greeting seed, name capture, commands)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from collie_core.commands import CommandController, parse_command
+from collie_core.db import CollieDB
+from collie_core.memory.profile import PROFILE_KEYS, ProfileStore
+from collie_core.onboarding import (
+    STARTER_GREETING,
+    capture_starter_name,
+    ensure_starter_conversation,
+    is_starter_conversation,
+)
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    instance = CollieDB(tmp_path / "collie.db")
+    yield instance
+    instance.close()
+
+
+@pytest.fixture()
+def profile(db: CollieDB, tmp_path: Path) -> ProfileStore:
+    return ProfileStore(db, tmp_path / "workspace")
+
+
+def test_profile_keys_include_name() -> None:
+    assert PROFILE_KEYS["name"] == "Name"
+
+
+def test_ensure_starter_creates_and_seeds_greeting(db: CollieDB) -> None:
+    result = ensure_starter_conversation(db)
+    conv_id = str(result["conversation"]["id"])
+    assert result["greeted"] is True
+    assert result["conversation"]["title"] == "Getting started"
+    assert result["greeting"] is not None
+    messages = db.get_messages(conv_id)
+    assert len(messages) == 1
+    assert messages[0]["role"] == "assistant"
+    assert "Hey, welcome! I'm Collie" in messages[0]["content"]
+    assert STARTER_GREETING in messages[0]["content"]
+    # The conversation is tracked so later calls are idempotent.
+    assert is_starter_conversation(db, conv_id)
+
+
+def test_ensure_starter_is_idempotent_no_second_greeting(db: CollieDB) -> None:
+    first = ensure_starter_conversation(db)
+    second = ensure_starter_conversation(db)
+    assert second["greeted"] is False
+    assert second["greeting"] is None
+    assert second["conversation"]["id"] == first["conversation"]["id"]
+    assert len(db.get_messages(str(first["conversation"]["id"]))) == 1
+
+
+def test_ensure_starter_recreates_after_delete(db: CollieDB) -> None:
+    first = ensure_starter_conversation(db)
+    db.delete_conversation(str(first["conversation"]["id"]))
+    second = ensure_starter_conversation(db)
+    assert second["greeted"] is True
+    assert second["conversation"]["id"] != first["conversation"]["id"]
+
+
+def test_ensure_starter_reuses_empty_conversation(db: CollieDB) -> None:
+    empty = db.create_conversation(title="New chat")
+    result = ensure_starter_conversation(db, reuse_conversation_id=str(empty["id"]))
+    assert result["conversation"]["id"] == empty["id"]
+    assert result["greeted"] is True
+    # A conversation with messages is never reused.
+    busy = db.create_conversation(title="Busy")
+    db.add_message(str(busy["id"]), "user", "hello")
+    fresh = ensure_starter_conversation(db, reuse_conversation_id=str(busy["id"]))
+    assert fresh["conversation"]["id"] != busy["id"]
+
+
+def test_capture_starter_name_stores_first_reply(db: CollieDB, profile: ProfileStore) -> None:
+    starter = ensure_starter_conversation(db)
+    conv_id = str(starter["conversation"]["id"])
+    assert capture_starter_name(db, profile, conv_id, "Rick") is True
+    assert profile.get("name") == "Rick"
+    # MEMORY.md carries the name for the model's bootstrap context.
+    assert "Name" in profile.memory_file.read_text(encoding="utf-8")
+    # Second reply does not overwrite the name.
+    assert capture_starter_name(db, profile, conv_id, "Not Rick") is False
+    assert profile.get("name") == "Rick"
+
+
+def test_capture_starter_name_only_in_starter_thread(db: CollieDB, profile: ProfileStore) -> None:
+    other = db.create_conversation(title="Other")
+    assert capture_starter_name(db, profile, str(other["id"]), "Rick") is False
+    assert profile.get("name") is None
+
+
+def test_capture_starter_name_never_forces_long_or_empty(
+    db: CollieDB, profile: ProfileStore
+) -> None:
+    starter = ensure_starter_conversation(db)
+    conv_id = str(starter["conversation"]["id"])
+    assert capture_starter_name(db, profile, conv_id, "") is False
+    assert capture_starter_name(db, profile, conv_id, "   ") is False
+    long_reply = "I'd rather not say right now, but you can call me later maybe, once we know each other better"
+    assert len(long_reply) > 64
+    assert capture_starter_name(db, profile, conv_id, long_reply) is False
+    assert profile.get("name") is None
+    # A multi-line answer is not a name either.
+    assert capture_starter_name(db, profile, conv_id, "Rick\nand also Sam") is False
+
+
+def test_capture_starter_name_requires_only_greeting_before_reply(
+    db: CollieDB, profile: ProfileStore
+) -> None:
+    starter = ensure_starter_conversation(db)
+    conv_id = str(starter["conversation"]["id"])
+    db.add_message(conv_id, "user", "Hi")
+    # The thread already has a real user message → this is not the first reply.
+    assert capture_starter_name(db, profile, conv_id, "Rick") is False
+    assert profile.get("name") is None
+
+
+def test_parse_command_recognizes_get_started() -> None:
+    assert parse_command("/get-started") == ("get-started", "")
+    assert parse_command("/start") == ("start", "")
+
+
+def _controller() -> CommandController:
+    return CommandController(
+        workspace=Path("/tmp"),
+        subagent_loader=None,
+        loop_provider=lambda: None,
+        status_provider=lambda: {"model": "test"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_desktop_get_started_returns_starter_flag() -> None:
+    result = await _controller().execute(
+        "/get-started", session_key="s", origin="desktop"
+    )
+    assert result == {"handled": True, "starter_conversation": True, "content": ""}
+
+
+@pytest.mark.asyncio
+async def test_desktop_start_returns_starter_flag() -> None:
+    result = await _controller().execute("/start", session_key="s", origin="desktop")
+    assert result is not None
+    assert result["starter_conversation"] is True
+
+
+@pytest.mark.asyncio
+async def test_messenger_start_keeps_command_menu() -> None:
+    result = await _controller().execute("/start", session_key="s", origin="telegram")
+    assert result is not None
+    assert result.get("starter_conversation") is None
+    assert "Here are my commands:" in str(result["content"])
+
+
+@pytest.mark.asyncio
+async def test_messenger_get_started_keeps_command_menu() -> None:
+    result = await _controller().execute("/get-started", session_key="s", origin="telegram")
+    assert result is not None
+    assert result.get("starter_conversation") is None
+    assert "Getting started lives in the Collie desktop app" in str(result["content"])

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -85,7 +85,7 @@ def _build_db_at_version(path: Path, version: int) -> None:
 def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "collie.db")
     try:
-        assert db.schema_version == 13
+        assert db.schema_version == 14
         columns = {
             row["name"]
             for row in db._rows("PRAGMA table_info(turn_events)")
@@ -109,7 +109,7 @@ def test_old_rows_null_hashes(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 13
+        assert upgraded.schema_version == 14
         rows = upgraded.list_turn_events()
         assert len(rows) == 1
         assert rows[0]["prompt_hash"] is None

--- a/collie-core/tests/collie/test_provider_configuration.py
+++ b/collie-core/tests/collie/test_provider_configuration.py
@@ -251,3 +251,67 @@ async def test_concurrent_candidates_are_serialized(
     assert runtime.db.default_provider()["id"] == "api-second"
     await runtime._finalize_provider_candidate(first["transaction_id"])
     await runtime._finalize_provider_candidate(second["transaction_id"])
+
+
+@pytest.mark.asyncio
+async def test_probe_auth_failure_rolls_back_with_warm_error_copy(
+    runtime: CollieRuntime,
+) -> None:
+    """P2 wiring seam: a 401 from the connect probe must roll back and show
+    the warm "That key didn't work" copy, not a network-style error."""
+    from aiohttp import web
+
+    # Seed a working provider WITH an api_base: the real rebuild path
+    # validates it (nanobot provider factory), unlike the mocked-path tests
+    # that use _seed_working_provider()'s api_base=None.
+    runtime.db.configure_provider_candidate_record(
+        "api-old-provider",
+        name="old-provider",
+        auth_type="api-key",
+        model="old-model",
+        runtime_name="old-provider",
+        protocol="openai",
+        api_base="http://127.0.0.1:9/v1",
+        secret_name="old-provider",
+    )
+    collie_settings.set_api_key("old-provider", "old-secret")
+    runtime.loop = object()
+    old = runtime.db.get_provider("api-old-provider")
+
+    async def models(request: web.Request) -> web.Response:
+        return web.json_response({"error": "unauthorized"}, status=401)
+
+    async def chat(request: web.Request) -> web.Response:
+        return web.json_response({"error": "unauthorized"}, status=401)
+
+    app = web.Application()
+    app.router.add_get("/v1/models", models)
+    app.router.add_post("/v1/chat/completions", chat)
+    runner = web.AppRunner(app)
+    await runner.setup()
+
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = int(sock.getsockname()[1])
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    api_base = f"http://127.0.0.1:{port}/v1"
+
+    try:
+        result = await runtime._configure_provider_candidate(
+            _candidate("probe-fail", key="sk-wrong", model="deepseek-v4-flash", api_base=api_base)
+        )
+    finally:
+        await runner.cleanup()
+
+    assert result["configured"] is False
+    assert result["validated"] is False
+    assert result["error_kind"] == "auth"
+    assert "That key didn't work" in result["error"]
+    assert "get-started" in result["error"]
+    assert result["rolled_back"] is True
+    assert runtime.db.default_provider()["id"] == old["id"]
+    assert runtime.db.get_provider("api-probe-fail") is None
+    assert collie_settings.get_api_key("probe-fail") is None

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -94,7 +94,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 13
+    assert db.schema_version == 14
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -116,7 +116,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 13
+        assert upgraded.schema_version == 14
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 13
+    assert db.schema_version == 14
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/collie-core/tests/collie/test_versions.py
+++ b/collie-core/tests/collie/test_versions.py
@@ -1,0 +1,376 @@
+"""Versioned artifact store tests (Gardener Foundations PR 2).
+
+Covers the ``artifact_versions`` schema (V14), the ``VersionStore`` API
+(snapshot/diff/rollback + no-clobber guard), the write-path wiring
+(subagent loader, ProfileStore, workspace file writes) and the IPC
+surface (list_versions / rollback_artifact).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.memory.profile import ProfileStore
+from collie_core.subagents.loader import SubagentLoader
+from collie_core.versions import VersionConflictError, VersionStore
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CollieDB:
+    d = CollieDB(tmp_path / "collie.db")
+    yield d
+    d.close()
+
+
+class _FakeConn:
+    """Minimal stand-in for a ServerConnection (direct handler calls)."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+
+# -- schema -------------------------------------------------------------------
+
+
+def test_v14_creates_artifact_versions_on_fresh_db(db: CollieDB) -> None:
+    assert db.schema_version == 14
+    rows = db._rows("SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'")
+    assert len(rows) == 1
+    columns = {row["name"] for row in db._rows("PRAGMA table_info(artifact_versions)")}
+    assert {
+        "id", "artifact_type", "artifact_key", "version", "before_text",
+        "after_text", "diff_text", "evidence_json", "source", "status",
+        "created_at",
+    } <= columns
+
+
+def test_v13_db_upgrades_to_v14_preserving_data(tmp_path: Path) -> None:
+    import collie_core.db as db_mod
+
+    path = tmp_path / "v13.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(db_mod._SCHEMA_V1)
+    for migration in db_mod._MIGRATIONS[1:13]:
+        conn.executescript(migration)
+    conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (13)")
+    conn.commit()
+    conn.close()
+
+    upgraded = CollieDB(path)
+    try:
+        assert upgraded.schema_version == 14
+        assert upgraded._rows(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
+        )
+    finally:
+        upgraded.close()
+
+
+# -- DB methods ----------------------------------------------------------------
+
+
+def test_snapshot_versions_are_monotonic_per_artifact(db: CollieDB) -> None:
+    r1 = db.snapshot_artifact("subagent", "researcher.md", "", "v1", "- +v1")
+    r2 = db.snapshot_artifact("subagent", "researcher.md", "v1", "v2", "- +v2")
+    r3 = db.snapshot_artifact("subagent", "analyst.md", "", "a1", "- +a1")
+    assert (r1["artifact_type"], r1["artifact_key"], r1["version"]) == ("subagent", "researcher.md", 1)
+    assert (r2["artifact_type"], r2["artifact_key"], r2["version"]) == ("subagent", "researcher.md", 2)
+    assert (r3["artifact_type"], r3["artifact_key"], r3["version"]) == ("subagent", "analyst.md", 1)
+    assert db.latest_artifact_version("subagent", "researcher.md") == 2
+
+    rows = db.list_artifact_versions(artifact_type="subagent", artifact_key="researcher.md")
+    assert [r["version"] for r in rows] == [2, 1]
+    assert rows[0]["status"] == "applied"
+    assert rows[0]["source"] == "user"
+
+    got = db.get_artifact_version(r2["id"])
+    assert got is not None and got["after_text"] == "v2"
+    db.mark_artifact_rolled_back(r2["id"])
+    assert db.get_artifact_version(r2["id"])["status"] == "rolled_back"
+
+
+def test_snapshot_unique_constraint_per_version(db: CollieDB) -> None:
+    """(type, key, version) is unique — enforced at the DB level."""
+    r1 = db.snapshot_artifact("vision", "VISION.md", "", "a", "- +a")
+    # The API auto-increments, so a collision requires a direct insert.
+    with pytest.raises(sqlite3.IntegrityError):
+        db._conn.execute(
+            "INSERT INTO artifact_versions (id, artifact_type, artifact_key, "
+            "version, before_text, after_text, diff_text, source, status, "
+            "created_at) VALUES (?, ?, ?, ?, '', '', '', 'user', 'applied', ?)",
+            ("dup", "vision", "VISION.md", r1["version"], "2026-01-01"),
+        )
+    # Clear the failed transaction so later statements succeed.
+    db._conn.rollback()
+    # Same type, same version, different key is fine; different type same key fine.
+    db.snapshot_artifact("vision", "AGENTS.md", "", "a", "- +a")
+
+
+# -- VersionStore --------------------------------------------------------------
+
+
+def test_snapshot_returns_id_and_diff(db: CollieDB) -> None:
+    store = VersionStore(db)
+    vid = store.snapshot("agents", "AGENTS.md", "old", "new", source="user")
+    assert vid is not None
+    row = db.get_artifact_version(vid)
+    assert row is not None
+    assert row["before_text"] == "old"
+    assert row["after_text"] == "new"
+    assert "-old" in row["diff_text"] and "+new" in row["diff_text"]
+
+    assert store.snapshot("agents", "AGENTS.md", "new", "new") is None
+
+
+def test_rollback_restores_before_text(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("subagent", "researcher.md", "", "v1")
+    store.snapshot("subagent", "researcher.md", "v1", "v2")
+
+    result = store.rollback("subagent", "researcher.md", current_text="v2")
+    assert result["version"] == 2
+    assert result["restored_text"] == "v1"
+    assert db.get_artifact_version(result["version_id"])["status"] == "rolled_back"
+
+    # Next rollback targets the remaining applied version.
+    result = store.rollback("subagent", "researcher.md", current_text="v1")
+    assert result["version"] == 1
+    assert result["restored_text"] == ""
+
+    with pytest.raises(VersionConflictError):
+        store.rollback("subagent", "researcher.md", current_text="anything")
+
+
+def test_rollback_no_clobber_guard(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("agents", "AGENTS.md", "old", "new")
+    # The file was edited again after the snapshot -> refuse.
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", current_text="newer edit")
+    # Still applied (nothing was marked).
+    assert db.get_artifact_version(store.latest_version_id("agents", "AGENTS.md") or "")["status"] == "applied"
+
+
+def test_rollback_targets_specific_version(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("agents", "AGENTS.md", "", "a")
+    store.snapshot("agents", "AGENTS.md", "a", "b")
+    store.snapshot("agents", "AGENTS.md", "b", "c")
+    # Undoing an older version while a newer edit sits on top refuses: current
+    # text ("c") no longer matches the older version's after_text ("b").
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", to_version=2, current_text="c")
+    # Undo the latest first, then the older one becomes undoable.
+    result = store.rollback("agents", "AGENTS.md", current_text="c")
+    assert result["version"] == 3
+    assert result["restored_text"] == "b"
+    result = store.rollback("agents", "AGENTS.md", to_version=2, current_text="b")
+    assert result["version"] == 2
+    assert result["restored_text"] == "a"
+    # Undoing an already-rolled-back version is refused.
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", to_version=2, current_text="a")
+
+
+# -- subagent loader wiring ------------------------------------------------------
+
+
+def test_subagent_edit_versions_and_rollback_restores_file_and_db(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    loader = SubagentLoader(workspace, db)
+    created = loader.create("Researcher", "researches", "You research things.")
+    filename = created["filename"]
+    versions = db.list_artifact_versions(artifact_type="subagent", artifact_key=filename)
+    assert len(versions) == 1
+    assert versions[0]["before_text"] == ""
+    assert "You research things." in versions[0]["after_text"]
+
+    loader.update(created["id"], system_prompt="You research very carefully.")
+    versions = db.list_artifact_versions(artifact_type="subagent", artifact_key=filename)
+    assert len(versions) == 2
+    assert versions[0]["before_text"].strip().endswith("You research things.")
+
+    # Roll back the update: file restored, DB row in sync via sync().
+    target = workspace / "subagents" / filename
+    current = target.read_text(encoding="utf-8")
+    result = VersionStore(db).rollback(
+        "subagent", filename, current_text=current
+    )
+    target.write_text(result["restored_text"], encoding="utf-8")
+    loader.sync()
+    row = loader.find("Researcher")
+    assert row is not None
+    assert "You research things." in row["system_prompt"]
+
+    # Delete snapshots an empty after; rollback restores the file + row.
+    loader.delete(created["id"])
+    assert not target.exists()
+    versions = db.list_artifact_versions(artifact_type="subagent", artifact_key=filename)
+    assert versions[0]["after_text"] == ""
+    result = VersionStore(db).rollback(
+        "subagent", filename, current_text=""
+    )
+    target.write_text(result["restored_text"], encoding="utf-8")
+    loader.sync()
+    assert target.exists()
+    assert loader.find("Researcher") is not None
+
+
+def test_subagent_sync_is_not_versioned(tmp_path: Path, db: CollieDB) -> None:
+    """Reconciliation (sync) must not create version rows — only user edits."""
+    workspace = tmp_path / "workspace"
+    loader = SubagentLoader(workspace, db)
+    loader.create("Analyst", "analyzes", "You analyze.")
+    before = len(db.list_artifact_versions(artifact_type="subagent"))
+    loader.sync()
+    assert len(db.list_artifact_versions(artifact_type="subagent")) == before
+
+
+# -- ProfileStore wiring ---------------------------------------------------------
+
+
+def test_profile_edit_versions_memory_md(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    store = ProfileStore(db, workspace, version_store=VersionStore(db))
+    store.regenerate_memory_md()
+    store.set("dietary", "vegan")
+    versions = db.list_artifact_versions(
+        artifact_type="memory_profile", artifact_key="MEMORY.md"
+    )
+    assert len(versions) == 1
+    assert "vegan" in versions[0]["after_text"]
+    # The before snapshot is the prior generated file (the empty-state text).
+    assert "Nothing here yet" in versions[0]["before_text"]
+
+    # Rollback restores the prior MEMORY.md text.
+    result = VersionStore(db).rollback(
+        "memory_profile", "MEMORY.md", current_text=versions[0]["after_text"]
+    )
+    (workspace / "MEMORY.md").write_text(result["restored_text"], encoding="utf-8")
+    assert "vegan" not in (workspace / "MEMORY.md").read_text(encoding="utf-8")
+
+
+def test_profile_edit_without_version_store_still_works(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    store = ProfileStore(db, workspace)
+    store.set("location", "Berlin")
+    assert "Berlin" in (workspace / "MEMORY.md").read_text(encoding="utf-8")
+
+
+# -- IPC surface -----------------------------------------------------------------
+
+
+def _make_server(tmp_path: Path, db: CollieDB) -> CollieIPCServer:
+    workspace = tmp_path / "workspace"
+    loader = SubagentLoader(workspace, db)
+    srv = CollieIPCServer(db, port=0, subagent_loader=loader)
+    srv._test_loader = loader  # type: ignore[attr-defined]
+    return srv
+
+
+async def test_ipc_list_versions_and_rollback(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path))
+    db = CollieDB(tmp_path / "collie.db")
+    srv = _make_server(tmp_path, db)
+    try:
+        loader: SubagentLoader = srv._test_loader  # type: ignore[attr-defined]
+        created = loader.create("Researcher", "researches", "You research things.")
+        filename = created["filename"]
+
+        conn = _FakeConn()
+        result = await srv._cmd_list_versions(conn, {"artifact_type": "subagent"})
+        versions = result["versions"]
+        assert len(versions) == 1
+        assert versions[0]["artifact_key"] == filename
+
+        # Update the subagent (v2), then roll it back through the IPC path.
+        loader.update(created["id"], system_prompt="You research very carefully.")
+        target = tmp_path / "workspace" / "subagents" / filename
+        current = target.read_text(encoding="utf-8")
+        assert "very carefully" in current
+        rolled = await srv._cmd_rollback_artifact(
+            conn,
+            {"version_id": db.list_artifact_versions(
+                artifact_type="subagent", artifact_key=filename, limit=1
+            )[0]["id"]},
+        )
+        assert rolled["rolled_back"] is True
+        assert "very carefully" not in target.read_text(encoding="utf-8")
+        assert "You research things." in target.read_text(encoding="utf-8")
+        # DB row is back in sync with the restored file.
+        assert loader.find("Researcher") is not None
+
+        # A newer owner edit must be refused (no-clobber guard).
+        create_version = db.list_artifact_versions(
+            artifact_type="subagent", artifact_key=filename, limit=2
+        )[1]["id"]
+        target.write_text("newer hand edit", encoding="utf-8")
+        with pytest.raises(ValueError, match="newer"):
+            await srv._cmd_rollback_artifact(conn, {"version_id": create_version})
+
+        # Restore the file to the snapshotted state; undoing the create now
+        # removes the artifact again.
+        create_row = db.get_artifact_version(create_version)
+        target.write_text(create_row["after_text"], encoding="utf-8")
+        rolled = await srv._cmd_rollback_artifact(
+            conn, {"version_id": create_version}
+        )
+        assert rolled["rolled_back"] is True
+        assert not target.exists()
+        assert loader.find("Researcher") is None
+
+        with pytest.raises(ValueError):
+            await srv._cmd_rollback_artifact(conn, {"version_id": "missing-id"})
+    finally:
+        db.close()
+
+
+async def test_ipc_write_file_versions_suggest_apply_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The suggest-card apply path (_cmd_write_file) versions VISION/AGENTS."""
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path))
+    db = CollieDB(tmp_path / "collie.db")
+    srv = _make_server(tmp_path, db)
+    try:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        (workspace / "AGENTS.md").write_text("old about me", encoding="utf-8")
+        conn = _FakeConn()
+        result = await srv._cmd_write_file(
+            conn, {"path": "AGENTS.md", "content": "new about me"}
+        )
+        assert result["saved"] is True
+        assert result["version_id"] is not None
+        assert "-old about me" in (result["diff_text"] or "")
+        rows = db.list_artifact_versions(artifact_type="agents", artifact_key="AGENTS.md")
+        assert len(rows) == 1
+
+        # Writing the same content again creates no version.
+        result = await srv._cmd_write_file(
+            conn, {"path": "AGENTS.md", "content": "new about me"}
+        )
+        assert result["version_id"] is None
+        assert len(db.list_artifact_versions(artifact_type="agents")) == 1
+
+        # Non-artifact files are written but not versioned.
+        result = await srv._cmd_write_file(
+            conn, {"path": "notes.txt", "content": "hello"}
+        )
+        assert result["saved"] is True and result["version_id"] is None
+    finally:
+        db.close()

--- a/collie-core/tools/update_catalogue_snapshot.py
+++ b/collie-core/tools/update_catalogue_snapshot.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regenerate the bundled catalogue snapshot from a models.dev api.json dump.
+
+Usage (from collie-core/):
+
+    .venv/bin/python tools/update_catalogue_snapshot.py /tmp/modelsdev.json
+
+Writes ``collie_core/catalog/snapshot.json`` (the reviewed, trimmed snapshot
+that ships with every release so onboarding works offline). The Collie-owned
+curated layer (``collie_core/catalog/curated.py``) is merged in here — a
+refresh at runtime applies the same trim, so the two can never drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from collie_core.catalog.snapshot_util import trim_live_catalogue, validate_catalogue_schema
+
+REPO_CORE = Path(__file__).resolve().parent.parent
+OUTPUT = REPO_CORE / "collie_core" / "catalog" / "snapshot.json"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    source = Path(sys.argv[1])
+    if not source.is_file():
+        print(f"Source not found: {source}", file=sys.stderr)
+        return 2
+    raw = json.loads(source.read_text(encoding="utf-8"))
+    trimmed = trim_live_catalogue(raw, generated_at=datetime.now(timezone.utc).isoformat())
+    if trimmed is None:
+        print("Trim failed: the source is not a usable models.dev document.", file=sys.stderr)
+        return 1
+    if not validate_catalogue_schema(trimmed):
+        print("Trimmed snapshot failed schema validation.", file=sys.stderr)
+        return 1
+    payload = json.dumps(trimmed, ensure_ascii=False, indent=1) + "\n"
+    OUTPUT.write_text(payload, encoding="utf-8")
+    size_kb = len(payload.encode("utf-8")) / 1024
+    providers = len(trimmed["providers"])
+    models = sum(len(p["models"]) for p in trimmed["providers"])
+    print(f"Wrote {OUTPUT}")
+    print(f"  {providers} providers, {models} models, {size_kb:.1f} KB")
+    print(f"  source sha256: {trimmed['source']['sha256'][:16]}…")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/collie-ui/src/renderer/src/App.tsx
+++ b/collie-ui/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ export default function App(): React.JSX.Element {
   const [screen, setScreen] = useState<Screen>('loading')
   const [view, setView] = useState<AppView>('chat')
   const [replayingOnboarding, setReplayingOnboarding] = useState(false)
+  const [autoOpenStarter, setAutoOpenStarter] = useState(false)
   const [offlineMessage, setOfflineMessage] = useState('')
   const t = useT()
 
@@ -151,6 +152,8 @@ export default function App(): React.JSX.Element {
         onDone={() => {
           setScreen('app')
           setReplayingOnboarding(false)
+          // Straight to chat: ChatScreen opens the starter conversation.
+          setAutoOpenStarter(true)
         }}
         onCancel={replayingOnboarding ? () => {
           setScreen('app')
@@ -164,6 +167,7 @@ export default function App(): React.JSX.Element {
     <ChatScreen
       activeView={view}
       onNavigate={setView}
+      autoOpenStarter={autoOpenStarter}
       onRedoOnboarding={() => {
         setReplayingOnboarding(true)
         setScreen('welcome')

--- a/collie-ui/src/renderer/src/components/BrandLogo.tsx
+++ b/collie-ui/src/renderer/src/components/BrandLogo.tsx
@@ -52,6 +52,7 @@ const LOGOS: Record<string, string> = {
   dropbox: dropboxLogo,
   figma: figmaLogo,
   gemini: geminiLogo,
+  google: geminiLogo,
   github: githubLogo,
   gmail: gmailLogo,
   'google-calendar': googleCalendarLogo,

--- a/collie-ui/src/renderer/src/components/ChatInput.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.tsx
@@ -264,6 +264,8 @@ interface Props {
   onTranscribe: (audio: string) => Promise<string>
   commandCatalog?: CommandCatalog
   taskProgress?: TaskState | null
+  /** Focus the composer once on mount (fresh onboarding straight into chat). */
+  autofocus?: boolean
 }
 
 export default function ChatInput({
@@ -289,7 +291,8 @@ export default function ChatInput({
   onTypingChange,
   onTranscribe,
   commandCatalog,
-  taskProgress
+  taskProgress,
+  autofocus = false
 }: Props): React.JSX.Element {
   const [text, setText] = useState('')
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
@@ -358,6 +361,15 @@ export default function ChatInput({
     onTypingChangeRef.current?.(true)
     requestAnimationFrame(() => textareaRef.current?.focus())
   }, [])
+
+  useEffect(() => {
+    if (!autofocus) return
+    // Short delay: the shell may still be settling after connect.
+    const timer = window.setTimeout(() => {
+      textareaRef.current?.focus()
+    }, 200)
+    return () => window.clearTimeout(timer)
+  }, [autofocus])
 
   useEffect(() => {
     if (text || steering) return

--- a/collie-ui/src/renderer/src/components/cards/CardRenderer.tsx
+++ b/collie-ui/src/renderer/src/components/cards/CardRenderer.tsx
@@ -12,6 +12,7 @@ import PlanCard from '../plans/PlanCard'
 import CapabilityListCard from './CapabilityListCard'
 import StatusCard from './StatusCard'
 import SuggestionCard from './SuggestionCard'
+import GardenerCard from './GardenerCard'
 import FilesChangedCard from './FilesChangedCard'
 
 interface Props {
@@ -49,6 +50,8 @@ export default function CardRenderer({ cardType, cardData }: Props): React.JSX.E
       return <StatusCard data={cardData} />
     case 'profile_suggestion':
       return <SuggestionCard data={cardData} />
+    case 'gardener_suggestion':
+      return <GardenerCard data={cardData} />
     case 'files_changed':
       return <FilesChangedCard data={cardData} />
     default:

--- a/collie-ui/src/renderer/src/components/cards/DiffView.tsx
+++ b/collie-ui/src/renderer/src/components/cards/DiffView.tsx
@@ -1,0 +1,55 @@
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+
+interface Props {
+  diff: string
+  /** Default collapsed state (only shows a summary line until opened). */
+  defaultCollapsed?: boolean
+  label?: string
+}
+
+/** Render a unified diff as friendly, color-coded lines. */
+export default function DiffView({ diff, defaultCollapsed = true, label }: Props): React.JSX.Element {
+  const [open, setOpen] = useState(!defaultCollapsed)
+
+  const { lines, added, removed } = useMemo(() => {
+    const raw = (diff || '').split('\n')
+    const lines = raw.filter((line) => !line.startsWith('+++') && !line.startsWith('---') && !line.startsWith('@@'))
+    const added = lines.filter((line) => line.startsWith('+')).length
+    const removed = lines.filter((line) => line.startsWith('-')).length
+    return { lines, added, removed }
+  }, [diff])
+
+  if (!diff) return <div />
+
+  const summary = label ?? `What changed: ${added} line${added === 1 ? '' : 's'} added, ${removed} removed`
+
+  return (
+    <div className="diff-view">
+      <button
+        type="button"
+        className="diff-toggle"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        <span>{summary}</span>
+      </button>
+      {open && (
+        <pre className="diff-text">
+          {lines.map((line, index) => {
+            const isAdded = line.startsWith('+')
+            const isRemoved = line.startsWith('-')
+            const cls = isAdded ? 'is-added' : isRemoved ? 'is-removed' : ''
+            return (
+              <span key={index} className={cls}>
+                {line === '' ? ' ' : line}
+                {'\n'}
+              </span>
+            )
+          })}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/collie-ui/src/renderer/src/components/cards/GardenerCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/GardenerCard.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { Check, Sparkles, Undo2, X } from 'lucide-react'
+import { collieClient, type GardenerSuggestion } from '../../lib/ipc'
+import DiffView from './DiffView'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+type Status = 'pending' | 'applying' | 'applied' | 'dismissed'
+
+const TYPE_LABELS: Record<string, string> = {
+  subagent: 'a subagent',
+  agents: 'Collie’s instructions (AGENTS.md)',
+  vision: 'Collie’s personality (VISION.md)',
+  memory_dream: 'long-term memory'
+}
+
+/** One Gardener suggestion: evidence + proposed change + Approve/Dismiss. */
+export default function GardenerCard({ data }: Props): React.JSX.Element {
+  const suggestions = (data.suggestions ?? []) as GardenerSuggestion[]
+  if (suggestions.length === 0) return <div />
+
+  return (
+    <div className="gardener-card">
+      <div className="suggestion-card-heading">
+        <Sparkles size={15} />
+        <span className="suggestion-card-label">Collie’s improvement ideas</span>
+      </div>
+      <p className="suggestion-card-text">
+        I looked at recent run records and found a few small things worth
+        reviewing. Approve any you like — everything stays undoable.
+      </p>
+      {suggestions.map((suggestion, index) => (
+        <GardenerRow
+          key={`${suggestion.artifact_type}:${suggestion.artifact_key}:${index}`}
+          suggestion={suggestion}
+        />
+      ))}
+    </div>
+  )
+}
+
+function GardenerRow({
+  suggestion
+}: {
+  suggestion: GardenerSuggestion
+}): React.JSX.Element {
+  const [status, setStatus] = useState<Status>('pending')
+  const [busy, setBusy] = useState(false)
+  const [versionId, setVersionId] = useState<string | null>(null)
+  const [diffText, setDiffText] = useState<string | null>(null)
+  const [notice, setNotice] = useState('')
+
+  const label = TYPE_LABELS[suggestion.artifact_type] ?? suggestion.artifact_key
+  const fileName =
+    suggestion.artifact_type === 'subagent'
+      ? `subagents/${suggestion.artifact_key}`
+      : suggestion.artifact_key
+
+  const handleApprove = async (): Promise<void> => {
+    setStatus('applying')
+    setBusy(true)
+    setNotice('')
+    try {
+      const result = await collieClient.applyGardenerSuggestion(suggestion)
+      setVersionId(result.version_id ?? null)
+      setDiffText(result.diff_text ?? null)
+      setStatus('applied')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not apply that change.')
+      setStatus('pending')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUndo = async (): Promise<void> => {
+    if (!versionId) return
+    setBusy(true)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      setVersionId(null)
+      setDiffText(null)
+      setNotice('Undone — the change was rolled back.')
+      setStatus('pending')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDismiss = (): void => {
+    setStatus('dismissed')
+  }
+
+  return (
+    <div className="gardener-row">
+      <div className="gardener-row-head">
+        <b>Improve {label}</b>
+        <span className="gardener-file">{fileName}</span>
+      </div>
+      {suggestion.rationale && (
+        <p className="suggestion-card-text">{suggestion.rationale}</p>
+      )}
+      {suggestion.evidence_ids.length > 0 && (
+        <p className="gardener-evidence">
+          Based on: {suggestion.evidence_ids.join(' · ')}
+        </p>
+      )}
+      {status === 'dismissed' ? (
+        <p className="suggestion-card-text">Dismissed — nothing changed.</p>
+      ) : status === 'applied' ? (
+        <>
+          <p className="suggestion-card-text">Applied. You can undo it any time.</p>
+          {diffText && <DiffView diff={diffText} label="See what changed" />}
+          {notice && <p className="suggestion-card-text">{notice}</p>}
+          {versionId && (
+            <div className="suggestion-card-actions">
+              <button
+                type="button"
+                className="suggestion-btn undo"
+                onClick={() => void handleUndo()}
+                disabled={busy}
+              >
+                <Undo2 size={14} /> {busy ? 'Undoing…' : 'Undo'}
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <pre className="gardener-proposed">{suggestion.proposed_text}</pre>
+          {notice && <p className="suggestion-card-text">{notice}</p>}
+          <div className="suggestion-card-actions">
+            <button
+              type="button"
+              className="suggestion-btn approve"
+              onClick={() => void handleApprove()}
+              disabled={busy || status === 'applying'}
+            >
+              <Check size={14} /> {status === 'applying' ? 'Applying…' : 'Approve'}
+            </button>
+            <button
+              type="button"
+              className="suggestion-btn dismiss"
+              onClick={handleDismiss}
+              disabled={busy}
+            >
+              <X size={14} /> Dismiss
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/collie-ui/src/renderer/src/components/cards/SuggestionCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/SuggestionCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Check, X, FileText, Sparkles } from 'lucide-react'
+import { Check, Undo2, X, FileText, Sparkles } from 'lucide-react'
 import { collieClient } from '../../lib/ipc'
+import DiffView from './DiffView'
 
 interface Props {
   data: Record<string, unknown>
@@ -15,6 +16,8 @@ export function mergeSuggestion(existing: string, suggestion: string): string {
   return `${current}\n\n${trimmed}\n`
 }
 
+type Status = 'pending' | 'checking' | 'saving' | 'saved' | 'dismissed'
+
 export default function SuggestionCard({ data }: Props): React.JSX.Element {
   const file = String(data.file || '')
   const label = String(data.label || '')
@@ -22,7 +25,11 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
   const reasoning = String(data.reasoning || '')
   const fileName = file || 'AGENTS.md'
 
-  const [status, setStatus] = useState<'pending' | 'checking' | 'saving' | 'saved' | 'dismissed'>('checking')
+  const [status, setStatus] = useState<Status>('checking')
+  const [busy, setBusy] = useState(false)
+  const [versionId, setVersionId] = useState<string | null>(null)
+  const [diffText, setDiffText] = useState<string | null>(null)
+  const [undoNotice, setUndoNotice] = useState('')
 
   const isPersonality = file === 'VISION.md'
   const Icon = isPersonality ? Sparkles : FileText
@@ -42,8 +49,10 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
     return () => { cancelled = true }
   }, [fileName, suggestion])
 
-  const handleApprove = async () => {
+  const handleApprove = async (): Promise<void> => {
     setStatus('saving')
+    setBusy(true)
+    setUndoNotice('')
     try {
       const { content } = await collieClient.readFile(fileName)
       if (content.trim() === suggestion.trim()) {
@@ -53,14 +62,35 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
       // Merge, never overwrite: the target file may hold user-authored
       // content the suggestion must not destroy.
       const applied = mergeSuggestion(content, suggestion)
-      await collieClient.writeFile(fileName, applied)
+      const result = await collieClient.writeFile(fileName, applied)
+      setVersionId(result.version_id ?? null)
+      setDiffText(result.diff_text ?? null)
       setStatus('saved')
     } catch {
       setStatus('pending')
+    } finally {
+      setBusy(false)
     }
   }
 
-  const handleDismiss = () => {
+  const handleUndo = async (): Promise<void> => {
+    if (!versionId) return
+    setBusy(true)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      setVersionId(null)
+      setDiffText(null)
+      setUndoNotice('Undone — the change was rolled back.')
+      setStatus('pending')
+    } catch (error) {
+      setUndoNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+      setStatus('saved')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDismiss = (): void => {
     setStatus('dismissed')
   }
 
@@ -76,6 +106,20 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
           <span className="suggestion-card-label">Applied to {label}</span>
         </div>
         <p className="suggestion-card-text">{reasoning}</p>
+        {diffText && <DiffView diff={diffText} label="See what changed" />}
+        {undoNotice && <p className="suggestion-card-text">{undoNotice}</p>}
+        {versionId && (
+          <div className="suggestion-card-actions">
+            <button
+              type="button"
+              className="suggestion-btn undo"
+              onClick={() => void handleUndo()}
+              disabled={busy}
+            >
+              <Undo2 size={14} /> {busy ? 'Undoing…' : 'Undo'}
+            </button>
+          </div>
+        )}
       </div>
     )
   }
@@ -108,10 +152,10 @@ export default function SuggestionCard({ data }: Props): React.JSX.Element {
       <div className="suggestion-card-actions">
         <button
           className="suggestion-btn approve"
-          onClick={handleApprove}
+          onClick={() => void handleApprove()}
           disabled={status === 'saving'}
         >
-          {status === 'saving' ? 'Applying\u2026' : 'Approve edit'}
+          {status === 'saving' ? 'Applying…' : 'Approve edit'}
         </button>
         <button
           className="suggestion-btn dismiss"

--- a/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Check, Pencil, Plus, Trash2, X } from 'lucide-react'
-import { collieClient } from '../../lib/ipc'
+import { Check, History, Pencil, Plus, Sparkles, Trash2, Undo2, X } from 'lucide-react'
+import { collieClient, type ArtifactVersion } from '../../lib/ipc'
+import DiffView from '../cards/DiffView'
 
 interface Props {
   onNotice: (msg: string) => void
@@ -76,6 +77,26 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
     label: '',
     recurring: 0
   })
+  const [versions, setVersions] = useState<ArtifactVersion[]>([])
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [undoingId, setUndoingId] = useState<string | null>(null)
+  const [reviewBusy, setReviewBusy] = useState<'dream' | 'gardener' | null>(null)
+  const [reviewMsg, setReviewMsg] = useState('')
+
+  const refreshHistory = useCallback(async (): Promise<void> => {
+    try {
+      const [profile, dream] = await Promise.all([
+        collieClient.listVersions({ artifact_type: 'memory_profile', limit: 50 }),
+        collieClient.listVersions({ artifact_type: 'memory_dream', limit: 50 })
+      ])
+      const merged = [...profile.versions, ...dream.versions].sort((a, b) =>
+        b.created_at.localeCompare(a.created_at)
+      )
+      setVersions(merged)
+    } catch {
+      setVersions([])
+    }
+  }, [])
 
   const refresh = useCallback(async () => {
     const [pData, ppl, dateData] = await Promise.all([
@@ -86,7 +107,53 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
     setProfile(pData.profile || {})
     setPeople(ppl.people || [])
     setDates(dateData.dates || [])
-  }, [])
+    await refreshHistory()
+  }, [refreshHistory])
+
+  const undoVersion = async (versionId: string): Promise<void> => {
+    setUndoingId(versionId)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      await refreshHistory()
+      onNotice('Undone — the earlier version is back.')
+    } catch (error) {
+      onNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+    } finally {
+      setUndoingId(null)
+    }
+  }
+
+  const runSelfReview = async (kind: 'dream' | 'gardener'): Promise<void> => {
+    setReviewBusy(kind)
+    setReviewMsg('')
+    try {
+      const outcome =
+        kind === 'dream'
+          ? await collieClient.runDream()
+          : await collieClient.runGardener()
+      const message =
+        outcome.message ??
+        (kind === 'dream'
+          ? 'Memory review done.'
+          : 'Improvement suggestions are ready — check the chat for the review cards.')
+      setReviewMsg(message)
+      if (kind === 'dream') await refreshHistory()
+      onNotice(message)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'That review could not run right now.'
+      setReviewMsg(message)
+      onNotice(message)
+    } finally {
+      setReviewBusy(null)
+    }
+  }
+
+  const versionLabel = (version: ArtifactVersion): string => {
+    if (version.artifact_type === 'memory_dream') return "Collie's weekly memory review"
+    if (version.source === 'gardener') return "Collie's improvement suggestions"
+    return 'Your memory edit'
+  }
 
   useEffect(() => {
     void refresh().catch(() => undefined).finally(() => setLoading(false))
@@ -577,6 +644,89 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
           )}
         </>
       )}
+
+      <section className="memory-section">
+        <h3><Sparkles size={14} /> Collie's self-review</h3>
+        <p className="memory-note">
+          Run a memory review (tidies long-term memory, undoable) or ask for
+          improvement suggestions from recent run records. Suggestions appear
+          as review cards in the 🔔 conversation.
+        </p>
+        <div className="memory-toolbar">
+          <button
+            type="button"
+            className="settings-button"
+            disabled={reviewBusy !== null}
+            onClick={() => void runSelfReview('dream')}
+          >
+            <History size={13} />{' '}
+            {reviewBusy === 'dream' ? 'Reviewing…' : 'Review memory now'}
+          </button>
+          <button
+            type="button"
+            className="settings-button"
+            disabled={reviewBusy !== null}
+            onClick={() => void runSelfReview('gardener')}
+          >
+            <Sparkles size={13} />{' '}
+            {reviewBusy === 'gardener' ? 'Thinking…' : 'Suggest improvements'}
+          </button>
+        </div>
+        {reviewMsg && <p className="memory-note">{reviewMsg}</p>}
+      </section>
+
+      <section className="memory-section">
+        <h3><History size={14} /> History</h3>
+        <p className="memory-note">
+          Every memory change is snapshotted — edits, Collie's weekly memory reviews,
+          and improvement suggestions — so anything can be undone.
+        </p>
+        <div className="memory-toolbar">
+          <button
+            type="button"
+            className="settings-button"
+            onClick={() => setHistoryOpen((current) => !current)}
+            aria-expanded={historyOpen}
+          >
+            {historyOpen ? 'Hide history' : `Show history (${versions.length})`}
+          </button>
+        </div>
+        {historyOpen && (
+          versions.length === 0 ? (
+            <p className="memory-note">No changes recorded yet.</p>
+          ) : (
+            <div className="version-list">
+              {versions.map((version) => (
+                <div className="version-row" key={version.id}>
+                  <div className="version-row-main">
+                    <b>{versionLabel(version)}</b>
+                    <span>
+                      {version.status === 'rolled_back' ? 'Already undone · ' : ''}
+                      {new Date(version.created_at).toLocaleString()}
+                    </span>
+                    {version.diff_text && (
+                      <DiffView
+                        diff={version.diff_text}
+                        label={`Version ${version.version} — see what changed`}
+                      />
+                    )}
+                  </div>
+                  {version.status === 'applied' && (
+                    <button
+                      type="button"
+                      className="settings-button"
+                      disabled={undoingId === version.id}
+                      onClick={() => void undoVersion(version.id)}
+                    >
+                      <Undo2 size={13} /> {undoingId === version.id ? 'Undoing…' : 'Undo'}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )
+        )}
+      </section>
     </div>
   )
 }

--- a/collie-ui/src/renderer/src/components/settings/ProviderManager.tsx
+++ b/collie-ui/src/renderer/src/components/settings/ProviderManager.tsx
@@ -52,12 +52,50 @@ export default function ProviderManager({
   const [busyOAuth, setBusyOAuth] = useState<string | null>(null)
   const [busyAction, setBusyAction] = useState('')
   const [secretProviders, setSecretProviders] = useState<string[]>([])
+  const [catalogueUpdatedAt, setCatalogueUpdatedAt] = useState<string>('')
+  const [catalogueBusy, setCatalogueBusy] = useState(false)
   const oauthAttemptRef = useRef(0)
 
   useEffect(() => {
     if (typeof window.collie?.listSecrets !== 'function') return
     void window.collie.listSecrets().then(setSecretProviders).catch(() => undefined)
   }, [status.providers])
+
+  useEffect(() => {
+    void collieClient
+      .getProviderCatalogue()
+      .then((data) => setCatalogueUpdatedAt(data.refresh?.refreshed_at || ''))
+      .catch(() => undefined)
+  }, [])
+
+  const checkCatalogue = useCallback(async (): Promise<void> => {
+    setCatalogueBusy(true)
+    try {
+      const result = await collieClient.refreshProviderCatalogue()
+      if (result.refreshed) {
+        onNotice(`Provider catalogue updated — ${result.providers_count} providers.`)
+        setCatalogueUpdatedAt(result.refreshed_at || '')
+      } else {
+        onNotice(result.error || 'Catalogue check came back empty — I kept the bundled one.')
+      }
+    } catch (error) {
+      onNotice(error instanceof Error ? error.message : 'I could not check the catalogue right now.')
+    } finally {
+      setCatalogueBusy(false)
+    }
+  }, [onNotice])
+
+  function catalogueAge(): string {
+    if (!catalogueUpdatedAt) return ''
+    const updated = new Date(catalogueUpdatedAt).getTime()
+    if (Number.isNaN(updated)) return ''
+    const minutes = Math.max(1, Math.round((Date.now() - updated) / 60_000))
+    if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'}`
+    const hours = Math.round(minutes / 60)
+    if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'}`
+    const days = Math.round(hours / 24)
+    return `${days} day${days === 1 ? '' : 's'}`
+  }
 
   const providers = [...(status.providers || [])]
   const currentAuth = String(settings['provider.auth'] || '')
@@ -249,6 +287,19 @@ export default function ProviderManager({
           <Plus size={14} /> Add provider
         </button>
       </div>
+      <p className="provider-catalogue-line">
+        {catalogueAge()
+          ? `Provider catalogue updated ${catalogueAge()} ago.`
+          : 'Using the bundled provider catalogue.'}{' '}
+        <button
+          type="button"
+          className="catalogue-check"
+          disabled={catalogueBusy}
+          onClick={() => void checkCatalogue()}
+        >
+          {catalogueBusy ? 'Checking…' : 'Check for updates'}
+        </button>
+      </p>
 
       <div className="provider-list">
         {providers.map((item) => (

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -315,6 +315,38 @@ export interface ToolEvent {
   finished_at?: string | null
 }
 
+/** One snapshotted artifact edit (PR 2 versioned rollback rail). */
+export interface ArtifactVersion {
+  id: string
+  artifact_type: string
+  artifact_key: string
+  version: number
+  before_text?: string | null
+  after_text?: string | null
+  diff_text?: string | null
+  evidence_json?: string | null
+  source: string
+  status: string
+  created_at: string
+}
+
+export interface RollbackArtifactResult {
+  rolled_back: boolean
+  version_id: string
+  artifact_type: string
+  artifact_key: string
+  version: number
+}
+
+/** One validated Gardener suggestion (proposed artifact change). */
+export interface GardenerSuggestion {
+  artifact_type: 'subagent' | 'agents' | 'vision' | 'memory_dream'
+  artifact_key: string
+  proposed_text: string
+  rationale: string
+  evidence_ids: string[]
+}
+
 /** A user-facing progress snapshot. It deliberately excludes tool traffic and model reasoning. */
 export interface TaskStep {
   key: string
@@ -635,6 +667,58 @@ export class CollieClient {
     return this.command('get_tool_events', opts ?? {})
   }
 
+  listVersions(opts?: {
+    artifact_type?: string
+    artifact_key?: string
+    limit?: number
+  }): Promise<{ versions: ArtifactVersion[] }> {
+    return this.command('list_versions', opts ?? {})
+  }
+
+  rollbackArtifact(versionId: string): Promise<RollbackArtifactResult> {
+    return this.command('rollback_artifact', { version_id: versionId })
+  }
+
+  /** Manual trigger: run one Dream consolidation pass (Settings -> Memory). */
+  runDream(): Promise<{
+    changed: boolean
+    reason?: string
+    version_id?: string | null
+    diff?: string
+    cursor?: string
+    message?: string
+  }> {
+    return this.command('run_dream', {})
+  }
+
+  /** Past Dream consolidations (memory_dream versions), newest first. */
+  getDreamHistory(): Promise<{ versions: ArtifactVersion[] }> {
+    return this.command('get_dream_history', {})
+  }
+
+  /** Manual trigger: run one Gardener pass (evidence -> suggestions). */
+  runGardener(): Promise<{
+    suggestions: GardenerSuggestion[]
+    rejected?: Array<{ reason: string; artifact_type: string; artifact_key: string }>
+    message?: string
+  }> {
+    return this.command('run_gardener', {})
+  }
+
+  /** Approve one suggestion: re-validated, applied, versioned (undoable). */
+  applyGardenerSuggestion(
+    suggestion: GardenerSuggestion
+  ): Promise<{
+    applied: boolean
+    no_change?: boolean
+    version_id?: string | null
+    diff_text?: string
+    artifact_type: string
+    artifact_key: string
+  }> {
+    return this.command('apply_gardener_suggestion', { suggestion })
+  }
+
   stopConversation(
     conversationId: string
   ): Promise<{
@@ -745,7 +829,10 @@ export class CollieClient {
     return this.command('read_file', { path })
   }
 
-  writeFile(path: string, content: string): Promise<{ saved: boolean }> {
+  writeFile(
+    path: string,
+    content: string
+  ): Promise<{ saved: boolean; version_id?: string | null; diff_text?: string | null }> {
     return this.command('write_file', { path, content })
   }
 

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -90,9 +90,30 @@ export interface ProviderCandidateResult {
   configured: boolean
   model?: string
   error?: string
+  error_kind?: string
+  validated?: boolean
+  model_label?: string
   rolled_back?: boolean
   rollback_error?: string | null
   transaction_id?: string
+}
+
+export interface CatalogueProviderModel {
+  id: string
+  name: string
+}
+
+export interface CatalogueProvider {
+  id: string
+  name: string
+  auth_type: string
+  protocol: 'openai' | 'anthropic'
+  api_base?: string | null
+  default_model?: string | null
+  key_prefixes: string[]
+  tested: boolean
+  help_url?: string | null
+  models: CatalogueProviderModel[]
 }
 
 export interface RuntimeStatus {
@@ -651,6 +672,74 @@ export class CollieClient {
 
   newConversation(title = 'New chat'): Promise<Conversation> {
     return this.command('new_conversation', { title })
+  }
+
+  getStarterConversation(conversationId?: string | null): Promise<{
+    conversation: Conversation
+    greeted: boolean
+  }> {
+    return this.command('get_starter_conversation', {
+      conversation_id: conversationId ?? ''
+    })
+  }
+
+  getProviderCatalogue(): Promise<{
+    providers: CatalogueProvider[]
+    snapshot: {
+      schema_version?: number
+      generated_at?: string
+      source_url?: string
+      source_sha256?: string
+      source_providers_count?: number
+    }
+    refresh: {
+      available: boolean
+      version?: string
+      sha256?: string
+      refreshed_at?: string
+    }
+  }> {
+    return this.command('get_provider_catalogue')
+  }
+
+  refreshProviderCatalogue(url?: string): Promise<{
+    refreshed: boolean
+    error?: string
+    version?: string
+    sha256?: string
+    refreshed_at?: string
+    providers_count?: number
+  }> {
+    return this.command('refresh_provider_catalogue', { url })
+  }
+
+  rollbackProviderCatalogue(): Promise<{ rolled_back: boolean; error?: string }> {
+    return this.command('rollback_provider_catalogue')
+  }
+
+  detectProviderForKey(apiKey: string): Promise<{
+    detected: boolean
+    provider_id: string | null
+    reason?: string
+    candidates?: string[]
+  }> {
+    return this.command('detect_provider_for_key', { api_key: apiKey })
+  }
+
+  detectModels(
+    apiBase: string,
+    protocol: 'openai' | 'anthropic' = 'openai',
+    apiKey?: string
+  ): Promise<{ detected: boolean; error?: string | null; models: string[] }> {
+    return this.command('detect_models', {
+      api_base: apiBase,
+      protocol,
+      api_key: apiKey
+    })
+  }
+
+  detectLocalModels(): Promise<{ available: boolean; models: string[] }> {
+    return this.command('detect_local_models')
   }
 
   renameConversation(conversationId: string, title: string): Promise<unknown> {

--- a/collie-ui/src/renderer/src/lib/providerConfiguration.ts
+++ b/collie-ui/src/renderer/src/lib/providerConfiguration.ts
@@ -48,7 +48,9 @@ export function apiKeyProviderCandidate(input: ApiKeyProviderInput): ProviderCan
     protocol,
     api_base: input.baseUrl?.trim() || null,
     secret_name: connectionName,
-    api_key: input.apiKey.trim()
+    // Omit the key entirely for keyless local endpoints — the core rejects
+    // empty-string keys, and "no key" must mean "no api_key field".
+    api_key: input.apiKey?.trim() || undefined
   }
 }
 

--- a/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { ArrowLeft, Bot, Eye, Plus, Shapes, Sparkles, Trash2, Zap, X } from 'lucide-react'
-import { collieClient, type CollieSkill, type Subagent, type SubagentStarter } from '../lib/ipc'
+import { ArrowLeft, Bot, Eye, History, Plus, Shapes, Sparkles, Trash2, Undo2, Zap, X } from 'lucide-react'
+import { collieClient, type ArtifactVersion, type CollieSkill, type Subagent, type SubagentStarter } from '../lib/ipc'
 import AgentAvatar from '../components/AgentAvatar'
 
 function summarizeDescription(description: string): string {
@@ -39,6 +39,8 @@ export default function AgentsScreen(): React.JSX.Element {
   const [notice, setNotice] = useState('')
   const [skills, setSkills] = useState<CollieSkill[]>([])
   const [category, setCategory] = useState<AgentCategory>('All')
+  const [versions, setVersions] = useState<ArtifactVersion[]>([])
+  const [undoingId, setUndoingId] = useState<string | null>(null)
 
   const selected = useMemo(
     () => agents.find((agent) => agent.id === selectedId) ?? null,
@@ -76,6 +78,41 @@ export default function AgentsScreen(): React.JSX.Element {
     setPrompt(selected?.system_prompt ?? '')
     setExecutionPosture(selected?.execution_posture ?? 'read_only')
   }, [selected])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!selected?.filename || new URLSearchParams(window.location.search).has('preview')) {
+      setVersions([])
+      return
+    }
+    collieClient
+      .listVersions({ artifact_type: 'subagent', artifact_key: selected.filename })
+      .then(({ versions }) => {
+        if (!cancelled) setVersions(versions)
+      })
+      .catch(() => {
+        if (!cancelled) setVersions([])
+      })
+    return () => { cancelled = true }
+  }, [selected?.filename])
+
+  const undoVersion = async (versionId: string): Promise<void> => {
+    setUndoingId(versionId)
+    try {
+      await collieClient.rollbackArtifact(versionId)
+      await refresh()
+      const { versions: fresh } = await collieClient.listVersions({
+        artifact_type: 'subagent',
+        artifact_key: selected?.filename
+      })
+      setVersions(fresh)
+      setNotice('Undone — the earlier version is back.')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not undo that change.')
+    } finally {
+      setUndoingId(null)
+    }
+  }
 
   const createAgent = async (
     nextName = name.trim(),
@@ -249,6 +286,49 @@ export default function AgentsScreen(): React.JSX.Element {
                   Save changes
                 </button>
               </div>
+            </section>
+            <section className="detail-card detail-card--wide">
+              <div className="detail-card-heading">
+                <div>
+                  <span className="detail-label">History</span>
+                  <h2>Past versions</h2>
+                </div>
+                <History size={18} />
+              </div>
+              <p className="detail-help">
+                Every edit to {selected.name}'s instructions is kept here, so a change
+                can always be undone.
+              </p>
+              {versions.length === 0 ? (
+                <p className="detail-help">No recorded changes yet.</p>
+              ) : (
+                <div className="version-list">
+                  {versions.map((version) => (
+                    <div className="version-row" key={version.id}>
+                      <div className="version-row-main">
+                        <b>Version {version.version}</b>
+                        <span>
+                          {version.status === 'rolled_back' ? 'Already undone · ' : ''}
+                          {new Date(version.created_at).toLocaleString()}
+                          {version.source === 'collie' || version.source === 'gardener'
+                            ? ` · by ${version.source === 'gardener' ? "Collie's gardener" : 'Collie'}`
+                            : ''}
+                        </span>
+                      </div>
+                      {version.status === 'applied' && (
+                        <button
+                          type="button"
+                          className="settings-button"
+                          disabled={undoingId === version.id}
+                          onClick={() => void undoVersion(version.id)}
+                        >
+                          <Undo2 size={13} /> {undoingId === version.id ? 'Undoing…' : 'Undo'}
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </section>
           </div>
           {notice && <p className="inline-notice" role="status">{notice}</p>}

--- a/collie-ui/src/renderer/src/screens/ChatScreen.starter.test.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.starter.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AttachmentDraft, CollieEvent, Conversation, TaskState } from '../lib/ipc'
+
+interface ChatInputProps {
+  onSend: (text: string, attachments: AttachmentDraft[]) => void
+  onProjectChange: (path: string) => void
+  taskProgress?: TaskState | null
+}
+
+const hooks = vi.hoisted(() => {
+  let listener: ((event: CollieEvent) => void) | undefined
+  const client = {
+    on: vi.fn((next: (event: CollieEvent) => void) => {
+      listener = next
+      return () => {
+        if (listener === next) listener = undefined
+      }
+    }),
+    listConversations: vi.fn(),
+    getStatus: vi.fn(),
+    listCommands: vi.fn(),
+    listPendingApprovals: vi.fn(),
+    getMessages: vi.fn(),
+    getActiveTask: vi.fn(),
+    chat: vi.fn(),
+    steerConversation: vi.fn(),
+    setExecutionMode: vi.fn(),
+    stopConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+    activateProvider: vi.fn(),
+    changePlan: vi.fn(),
+    transcribe: vi.fn(),
+    getStarterConversation: vi.fn()
+  }
+  return {
+    client,
+    listener: (): ((event: CollieEvent) => void) => {
+      if (!listener) throw new Error('ChatScreen did not register its event listener.')
+      return listener
+    }
+  }
+})
+
+vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+vi.mock('../components/Sidebar', () => ({ default: () => <aside /> }))
+vi.mock('../components/ChatInput', () => ({
+  default: () => <form />
+}))
+vi.mock('../components/CollieFace', () => ({ default: () => <span /> }))
+vi.mock('../components/InteractiveColliePortrait', () => ({ default: () => <aside /> }))
+vi.mock('../components/approvals/ApprovalSheet', () => ({ default: () => null }))
+vi.mock('../components/tasks/TaskProgress', () => ({
+  default: () => null,
+  isTaskTerminal: () => false
+}))
+vi.mock('../components/plans/planChange', () => ({
+  PLAN_CHANGE_REQUEST_EVENT: 'collie:change-plan',
+  publishPlanChangeResult: vi.fn()
+}))
+vi.mock('./SettingsScreen', () => ({ default: () => null }))
+vi.mock('./AgentsScreen', () => ({ default: () => null }))
+vi.mock('./SkillsScreen', () => ({ default: () => null }))
+vi.mock('./RoutinesScreen', () => ({ default: () => null }))
+vi.mock('./ConnectorsScreen', () => ({ default: () => null }))
+vi.mock('../components/MessageList', () => ({
+  default: () => <ol />
+}))
+
+import ChatScreen from './ChatScreen'
+
+const starterConversation: Conversation = {
+  id: 'starter-1',
+  title: 'Getting started',
+  created_at: '2026-08-05T00:00:00Z',
+  updated_at: '2026-08-05T00:00:00Z',
+  archived: 0
+}
+
+describe('ChatScreen starter-conversation opening', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(async () => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+      .IS_REACT_ACT_ENVIRONMENT = true
+    localStorage.clear()
+    hooks.client.on.mockClear()
+    hooks.client.chat.mockReset().mockResolvedValue({ conversation_id: 'c-1' })
+    hooks.client.listConversations.mockReset().mockResolvedValue({ conversations: [] })
+    hooks.client.getStatus.mockReset().mockResolvedValue({})
+    hooks.client.listCommands.mockReset().mockResolvedValue({ commands: [], agents: [], skills: [] })
+    hooks.client.listPendingApprovals.mockReset().mockResolvedValue({ approvals: [] })
+    hooks.client.getMessages.mockReset().mockResolvedValue({ messages: [] })
+    hooks.client.getActiveTask.mockReset().mockResolvedValue({ task: null })
+    hooks.client.getStarterConversation
+      .mockReset()
+      .mockResolvedValue({ conversation: starterConversation, greeted: true })
+    Object.defineProperty(window, 'collie', {
+      configurable: true,
+      value: {
+        updateActiveWork: vi.fn(),
+        petCommand: vi.fn(),
+        pickProjectFolder: vi.fn()
+      }
+    })
+    container = document.createElement('div')
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+  })
+
+  it('opens the starter conversation (seeded greeting) right after connect', async () => {
+    await act(async () => {
+      root.render(
+        <ChatScreen activeView="chat" onNavigate={vi.fn()} onRedoOnboarding={vi.fn()} autoOpenStarter />
+      )
+      await Promise.resolve()
+    })
+    // The empty active conversation is offered as the seed target.
+    expect(hooks.client.getStarterConversation).toHaveBeenCalledWith(null)
+    // The returned conversation becomes the open one.
+    expect(hooks.client.getMessages).toHaveBeenCalledWith('starter-1')
+  })
+
+  it('does not open the starter when the shell did not just connect', async () => {
+    await act(async () => {
+      root.render(<ChatScreen activeView="chat" onNavigate={vi.fn()} onRedoOnboarding={vi.fn()} />)
+      await Promise.resolve()
+    })
+    expect(hooks.client.getStarterConversation).not.toHaveBeenCalled()
+  })
+
+  it('seeds the starter only once per mount (idempotent, no nagging)', async () => {
+    await act(async () => {
+      root.render(
+        <ChatScreen activeView="chat" onNavigate={vi.fn()} onRedoOnboarding={vi.fn()} autoOpenStarter />
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(hooks.client.getStarterConversation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -45,6 +45,8 @@ interface Props {
   activeView: AppView
   onNavigate: (view: AppView) => void
   onRedoOnboarding: () => void
+  /** True right after first connect: open the starter conversation, no empty state. */
+  autoOpenStarter?: boolean
 }
 
 interface TaskTiming {
@@ -124,7 +126,8 @@ function loadRecentProjects(): string[] {
 export default function ChatScreen({
   activeView,
   onNavigate,
-  onRedoOnboarding
+  onRedoOnboarding,
+  autoOpenStarter = false
 }: Props): React.JSX.Element {
   const [conversations, setConversations] = useState<Conversation[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -804,6 +807,29 @@ export default function ChatScreen({
     void openConversation(null)
   }, [onNavigate, openConversation])
 
+  /** Open (or create, once) the getting-started conversation with its greeting. */
+  const getStarted = useCallback(async () => {
+    onNavigate('chat')
+    try {
+      const { conversation } = await collieClient.getStarterConversation(
+        activeIdRef.current
+      )
+      await openConversation(conversation.id)
+      void refreshConversations()
+    } catch {
+      // Core may still be starting — the sidebar lists the conversation once ready.
+    }
+  }, [onNavigate, openConversation, refreshConversations])
+
+  // After first connect: straight into the starter conversation, never an
+  // empty state. Runs once (the prop stays true across remounts of the shell).
+  const starterOpenedRef = useRef(false)
+  useEffect(() => {
+    if (!autoOpenStarter || starterOpenedRef.current) return
+    starterOpenedRef.current = true
+    void getStarted()
+  }, [autoOpenStarter, getStarted])
+
   const addProject = useCallback(async () => {
     try {
       const path = await window.collie.pickProjectFolder()
@@ -933,7 +959,11 @@ export default function ChatScreen({
       />
       {activeView === 'settings' ? (
         <main className="settings-workspace min-w-0 flex-1 overflow-hidden">
-          <SettingsScreen onRedoOnboarding={onRedoOnboarding} onNavigate={onNavigate} />
+          <SettingsScreen
+            onRedoOnboarding={onRedoOnboarding}
+            onNavigate={onNavigate}
+            onGetStarted={() => void getStarted()}
+          />
         </main>
       ) : activeView === 'agents' ? (
         <AgentsScreen />
@@ -1026,6 +1056,7 @@ export default function ChatScreen({
               onTranscribe={async (audio) => (await collieClient.transcribe(audio)).text}
               commandCatalog={commandCatalog}
               taskProgress={activeTask && !isTaskTerminal(activeTask) ? activeTask : null}
+              autofocus={autoOpenStarter}
             />
           </div>
         </div>

--- a/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
@@ -98,6 +98,8 @@ interface Props {
   initialTab?: Tab
   onRedoOnboarding?: () => void
   onNavigate?: (view: AppView) => void
+  /** Open the getting-started conversation (greeting + first chat). */
+  onGetStarted?: () => void
 }
 
 export function clearAllDataNotice(result: ClearAllDataResult): string {
@@ -143,7 +145,8 @@ const TAB_COPY: Record<Tab, { title: string; description: string }> = {
 export default function SettingsScreen({
   initialTab = 'models',
   onRedoOnboarding,
-  onNavigate
+  onNavigate,
+  onGetStarted
 }: Props): React.JSX.Element {
   const [tab, setTab] = useState<Tab>(initialTab)
   const [status, setStatus] = useState<RuntimeStatus>({})
@@ -275,19 +278,37 @@ export default function SettingsScreen({
         return <UpdateTab />
       case 'onboarding':
         return (
-          <section className="settings-card onboarding-card">
-            <div className="settings-card-icon"><RotateCcw size={19} /></div>
-            <div>
-              <h3>Run setup again</h3>
-              <p>
-                Revisit provider sign-in and connection choices. Your chats, memories, and
-                existing settings stay intact.
-              </p>
-            </div>
-            <button className="settings-button is-primary" onClick={onRedoOnboarding}>
-              Start onboarding
-            </button>
-          </section>
+          <div className="flex flex-col gap-4">
+            <section className="settings-card onboarding-card">
+              <div className="settings-card-icon"><RotateCcw size={19} /></div>
+              <div>
+                <h3>Getting started</h3>
+                <p>
+                  Reopen the welcome chat — the one where Collie asks your name.
+                  It picks up right where you left off.
+                </p>
+              </div>
+              <button
+                className="settings-button is-primary"
+                onClick={() => onGetStarted?.()}
+              >
+                Getting started
+              </button>
+            </section>
+            <section className="settings-card onboarding-card">
+              <div className="settings-card-icon"><RotateCcw size={19} /></div>
+              <div>
+                <h3>Run setup again</h3>
+                <p>
+                  Revisit provider sign-in and connection choices. Your chats, memories, and
+                  existing settings stay intact.
+                </p>
+              </div>
+              <button className="settings-button is-primary" onClick={onRedoOnboarding}>
+                Start onboarding
+              </button>
+            </section>
+          </div>
         )
       case 'safety':
         return <SafetyApprovalsTab />

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.test.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import WelcomeScreen from './WelcomeScreen'
+import type { CatalogueProvider } from '../lib/ipc'
+
+const hooks = vi.hoisted(() => {
+  const client = {
+    connected: true,
+    on: vi.fn(() => () => undefined),
+    getProviderCatalogue: vi.fn(),
+    detectLocalModels: vi.fn(),
+    detectProviderForKey: vi.fn(),
+    detectModels: vi.fn(),
+    configure: vi.fn(),
+    oauthLogin: vi.fn(),
+    cancelOAuthLogin: vi.fn()
+  }
+  const configureApiKeyProvider = vi.fn()
+  return { client, configureApiKeyProvider }
+})
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => null,
+  ChevronDown: () => null,
+  ChevronUp: () => null,
+  Search: () => null,
+  Sparkles: () => null
+}))
+vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+vi.mock('../lib/providerConfiguration', () => ({
+  configureApiKeyProvider: hooks.configureApiKeyProvider
+}))
+vi.mock('../components/BrandLogo', () => ({ default: () => <span /> }))
+vi.mock('../components/CollieFace', () => ({ default: () => <span /> }))
+
+const providers: CatalogueProvider[] = [
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    auth_type: 'api-key',
+    protocol: 'openai',
+    api_base: 'https://api.openai.com/v1',
+    default_model: 'gpt-5.5',
+    key_prefixes: ['sk-proj-', 'sk-'],
+    tested: true,
+    models: [{ id: 'gpt-5.5', name: 'GPT-5.5' }]
+  },
+  {
+    id: 'deepseek',
+    name: 'DeepSeek',
+    auth_type: 'api-key',
+    protocol: 'openai',
+    api_base: 'https://api.deepseek.com',
+    default_model: 'deepseek-v4-flash',
+    key_prefixes: ['sk-'],
+    tested: true,
+    models: [{ id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' }]
+  },
+  {
+    id: 'groq',
+    name: 'Groq',
+    auth_type: 'api-key',
+    protocol: 'openai',
+    api_base: 'https://api.groq.com/openai/v1',
+    default_model: 'llama-3.3-70b-versatile',
+    key_prefixes: ['gsk_'],
+    tested: true,
+    models: [{ id: 'llama-3.3-70b-versatile', name: 'Llama 3.3 70B' }]
+  }
+]
+
+const roots: Root[] = []
+
+function renderWelcome(onDone = vi.fn()): { container: HTMLElement; onDone: ReturnType<typeof vi.fn> } {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => {
+    root.render(<WelcomeScreen onDone={onDone} />)
+  })
+  return { container, onDone }
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+  act(() => {
+    setter.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+async function expandApiKeyForm(container: HTMLElement): Promise<void> {
+  const card = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent?.includes('I have an API key')
+  )!
+  act(() => card.click())
+  // Let the mocked catalogue promise resolve so the picker shows real names.
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+beforeEach(() => {
+  hooks.client.getProviderCatalogue.mockReset().mockResolvedValue({ providers, snapshot: {}, refresh: {} })
+  hooks.client.detectLocalModels.mockReset().mockResolvedValue({ available: false, models: [] })
+  hooks.client.detectProviderForKey.mockReset().mockResolvedValue({ detected: false, provider_id: null })
+  hooks.configureApiKeyProvider.mockReset()
+  Object.defineProperty(window, 'collie', {
+    configurable: true,
+    value: { openExternal: vi.fn() }
+  })
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('WelcomeScreen first-run choices', () => {
+  it('shows the three choice cards, the help card, and the corrected footer', () => {
+    const { container } = renderWelcome()
+    const text = container.textContent!
+    expect(text).toContain('I have a ChatGPT subscription')
+    expect(text).toContain('I have a Claude subscription')
+    expect(text).toContain('I have an API key')
+    expect(text).toContain("I don't have anything yet")
+    // The footer now points at the real tab (review P1-5).
+    expect(text).toContain('Settings → Models & API keys')
+  })
+
+  it('points the "nothing yet" help at heycollie.com/get-started', () => {
+    const { container } = renderWelcome()
+    const card = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes("I don't have anything yet")
+    )!
+    act(() => card.click())
+    expect(window.collie.openExternal).toHaveBeenCalledWith('https://heycollie.com/get-started')
+  })
+})
+
+describe('WelcomeScreen API-key form', () => {
+  it('collapses connection name / model / base URL behind Advanced', async () => {
+    const { container } = renderWelcome()
+    await expandApiKeyForm(container)
+
+    const keyField = container.querySelector<HTMLInputElement>('input[placeholder="Paste your API key"]')
+    expect(keyField).not.toBeNull()
+    const connectButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Connect'
+    )
+    expect(connectButton).not.toBeNull()
+    // Normie fields only: no jargon up front.
+    expect(container.querySelector('input[placeholder="Connection name (optional)"]')).toBeNull()
+    expect(container.querySelector('input[placeholder="Custom base URL (optional)"]')).toBeNull()
+
+    const advanced = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Advanced'
+    )!
+    act(() => advanced.click())
+    expect(container.querySelector('input[placeholder="Connection name (optional)"]')).not.toBeNull()
+    expect(container.querySelector('input[placeholder="Custom base URL (optional)"]')).not.toBeNull()
+  })
+
+  it('offers a searchable provider picker and switches provider on selection', async () => {
+    const { container } = renderWelcome()
+    await expandApiKeyForm(container)
+
+    const picker = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'OpenAI'
+    )!
+    act(() => picker.click())
+    const search = container.querySelector<HTMLInputElement>('input[placeholder="Search providers…"]')
+    expect(search).not.toBeNull()
+
+    typeInto(search!, 'deepseek')
+    const dropdown = container.querySelector<HTMLElement>('[class*="max-h-56"]')!
+    const rows = Array.from(dropdown.querySelectorAll<HTMLButtonElement>('button'))
+    // The search filters the catalogue; Custom stays pinned as the escape hatch.
+    expect(rows.map((row) => row.textContent)).toEqual(['DeepSeek', 'Custom (OpenAI-compatible)'])
+    act(() => rows[0].click())
+    expect(container.textContent).toContain('DeepSeek')
+  })
+
+  it('auto-selects the provider from an unambiguous key prefix on paste', async () => {
+    const { container } = renderWelcome()
+    await expandApiKeyForm(container)
+    const keyField = container.querySelector<HTMLInputElement>('input[placeholder="Paste your API key"]')!
+    typeInto(keyField, 'gsk_abc123')
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(hooks.client.detectProviderForKey).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Groq')
+  })
+
+  it('shows "Connected — using …" on a validated connect and finishes', async () => {
+    vi.useFakeTimers()
+    hooks.configureApiKeyProvider.mockResolvedValue({
+      configured: true,
+      transaction_id: 'tx-1',
+      validated: true,
+      model_label: 'DeepSeek V4 Flash'
+    })
+    const { container, onDone } = renderWelcome()
+    await expandApiKeyForm(container)
+    const keyField = container.querySelector<HTMLInputElement>('input[placeholder="Paste your API key"]')!
+    typeInto(keyField, 'sk-test-123')
+    const connectButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Connect'
+    )!
+    act(() => connectButton.click())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('Connected — using DeepSeek V4 Flash')
+    expect(onDone).not.toHaveBeenCalled()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_200)
+    })
+    expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the warm bad-key copy (not a network error) when the probe rejects', async () => {
+    hooks.configureApiKeyProvider.mockRejectedValue(
+      new Error(
+        "That key didn't work. Double-check it, or get help here → https://heycollie.com/get-started"
+      )
+    )
+    const { container } = renderWelcome()
+    await expandApiKeyForm(container)
+    const keyField = container.querySelector<HTMLInputElement>('input[placeholder="Paste your API key"]')!
+    typeInto(keyField, 'sk-wrong')
+    const connectButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Connect'
+    )!
+    act(() => connectButton.click())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain("That key didn't work")
+    expect(container.textContent).not.toContain('could not reach that provider')
+    const helpLink = container.querySelector<HTMLAnchorElement>('a[href="https://heycollie.com/get-started"]')
+    expect(helpLink).not.toBeNull()
+  })
+})
+
+describe('WelcomeScreen local-model card', () => {
+  it('hides the local-model card when no Ollama install is detected', async () => {
+    hooks.client.detectLocalModels.mockResolvedValue({ available: false, models: [] })
+    const { container } = renderWelcome()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(container.textContent).not.toContain('Use a model on this computer')
+  })
+
+  it('offers detected local models as a fourth choice', async () => {
+    hooks.client.detectLocalModels.mockResolvedValue({ available: true, models: ['llama3.2'] })
+    const { container } = renderWelcome()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('Use a model on this computer')
+    expect(container.querySelector<HTMLSelectElement>('select')?.textContent).toContain('llama3.2')
+  })
+})

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
@@ -1,19 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowLeft, Sparkles } from 'lucide-react'
-import { collieClient } from '../lib/ipc'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowLeft, ChevronDown, ChevronUp, Search, Sparkles } from 'lucide-react'
+import { collieClient, type CatalogueProvider } from '../lib/ipc'
 import { configureApiKeyProvider } from '../lib/providerConfiguration'
 import BrandLogo from '../components/BrandLogo'
 import CollieFace from '../components/CollieFace'
 
-const PROVIDERS = [
-  { id: 'openai', label: 'OpenAI' },
-  { id: 'anthropic', label: 'Anthropic' },
-  { id: 'openrouter', label: 'OpenRouter' },
-  { id: 'deepseek', label: 'DeepSeek' },
-  { id: 'groq', label: 'Groq' },
-  { id: 'ollama', label: 'Ollama (local)' },
-  { id: 'custom', label: 'Custom (OpenAI-compatible)' }
-]
+const HELP_URL = 'https://heycollie.com/get-started'
+const CUSTOM_PROVIDER_ID = 'custom'
+const OLLAMA_BASE_URL = 'http://localhost:11434/v1'
 
 interface Props {
   onDone: () => void
@@ -22,20 +16,63 @@ interface Props {
 
 export const configureWelcomeApiKey = configureApiKeyProvider
 
+/** Turn bare URLs inside error copy into real links (warm copy, clickable help). */
+function linkify(text: string): React.ReactNode[] {
+  const parts = text.split(/(https?:\/\/[^\s]+)/g)
+  return parts.map((part, index) =>
+    /^https?:\/\//.test(part) ? (
+      <a
+        key={index}
+        href={part}
+        onClick={(event) => {
+          event.preventDefault()
+          void window.collie?.openExternal(part)
+        }}
+        className="underline"
+      >
+        {part}
+      </a>
+    ) : (
+      <span key={index}>{part}</span>
+    )
+  )
+}
+
 export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.Element {
   const [busyOAuth, setBusyOAuth] = useState<string | null>(null)
   const [busyKey, setBusyKey] = useState(false)
   const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
   const [showKeyForm, setShowKeyForm] = useState(false)
+  const [showAdvanced, setShowAdvanced] = useState(false)
   const [provider, setProvider] = useState('openai')
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [pickerQuery, setPickerQuery] = useState('')
   const [displayName, setDisplayName] = useState('')
   const [protocol, setProtocol] = useState<'openai' | 'anthropic'>('openai')
   const [apiKey, setApiKey] = useState('')
   const [model, setModel] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
+  const [catalogue, setCatalogue] = useState<CatalogueProvider[]>([])
+  const [detectHint, setDetectHint] = useState('')
+  const [customModels, setCustomModels] = useState<string[]>([])
+  const [detectingModels, setDetectingModels] = useState(false)
+  const [localModels, setLocalModels] = useState<{ available: boolean; models: string[] }>({
+    available: false,
+    models: []
+  })
+  const [localModel, setLocalModel] = useState('')
+  const [busyLocal, setBusyLocal] = useState(false)
   const [wsConnected, setWsConnected] = useState(false)
   const mountedRef = useRef(true)
   const oauthAttemptRef = useRef(0)
+  const pickerRef = useRef<HTMLDivElement>(null)
+
+  const custom = provider === CUSTOM_PROVIDER_ID
+  const selectedProvider = catalogue.find((item) => item.id === provider)
+  const protocolForProvider: 'openai' | 'anthropic' = custom
+    ? protocol
+    : selectedProvider?.protocol || 'openai'
 
   useEffect(() => {
     mountedRef.current = true
@@ -44,10 +81,37 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
       if (event.type === 'ready') setWsConnected(true)
     })
     setWsConnected(collieClient.connected)
+    void collieClient
+      .getProviderCatalogue()
+      .then((data) => {
+        if (mountedRef.current) setCatalogue(data.providers)
+      })
+      .catch(() => undefined)
+    // Local-model card: only shown when an Ollama install is actually there.
+    void collieClient
+      .detectLocalModels()
+      .then((result) => {
+        if (!mountedRef.current) return
+        setLocalModels(result)
+        if (result.available && result.models.length > 0) {
+          setLocalModel(result.models[0])
+        }
+      })
+      .catch(() => undefined)
     return () => {
       mountedRef.current = false
       off()
     }
+  }, [])
+
+  useEffect(() => {
+    const onPointerDown = (event: MouseEvent): void => {
+      if (pickerRef.current && !pickerRef.current.contains(event.target as Node)) {
+        setPickerOpen(false)
+      }
+    }
+    window.addEventListener('pointerdown', onPointerDown)
+    return () => window.removeEventListener('pointerdown', onPointerDown)
   }, [])
 
   const finish = useCallback(async (): Promise<void> => {
@@ -75,6 +139,7 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
     oauthAttemptRef.current = attempt
     setBusyOAuth(kind)
     setError('')
+    setSuccess('')
     try {
       await collieClient.oauthLogin(kind)
       if (oauthAttemptRef.current !== attempt || !mountedRef.current) return
@@ -87,32 +152,176 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
     }
   }, [finish])
 
+  const pickProvider = useCallback(
+    (value: string) => {
+      setProvider(value)
+      setPickerOpen(false)
+      setPickerQuery('')
+      setError('')
+      setCustomModels([])
+      if (value !== CUSTOM_PROVIDER_ID) {
+        setDetectHint('')
+        setModel('')
+        setBaseUrl('')
+      }
+    },
+    []
+  )
+
+  const filteredProviders = useMemo(() => {
+    const query = pickerQuery.trim().toLowerCase()
+    const list = query
+      ? catalogue.filter((item) => item.name.toLowerCase().includes(query))
+      : catalogue
+    return [...list, { id: CUSTOM_PROVIDER_ID, name: 'Custom (OpenAI-compatible)' } as CatalogueProvider]
+  }, [catalogue, pickerQuery])
+
+  /** Paste-time provider auto-detection: prefixes are hints, the probe decides. */
+  const detectFromKey = useCallback(
+    async (key: string): Promise<void> => {
+      if (!key.trim() || custom) {
+        setDetectHint('')
+        return
+      }
+      // Instant local hint from the catalogue's key prefixes (longest wins).
+      const matches: { length: number; id: string }[] = []
+      for (const item of catalogue) {
+        for (const prefix of item.key_prefixes || []) {
+          if (prefix && key.startsWith(prefix)) {
+            matches.push({ length: prefix.length, id: item.id })
+            break
+          }
+        }
+      }
+      matches.sort((a, b) => b.length - a.length)
+      const longest = matches[0]?.length
+      const candidates = matches.filter((item) => item.length === longest)
+      if (candidates.length === 1) {
+        const id = candidates[0].id
+        if (id !== provider) {
+          setProvider(id)
+          setDetectHint(`${catalogue.find((item) => item.id === id)?.name || id} — looks like this key belongs to them.`)
+        }
+        return
+      }
+      if (candidates.length > 1) {
+        // Ambiguous (sk-): let the core probe each candidate endpoint.
+        setDetectHint('Checking which provider this key belongs to…')
+        try {
+          const result = await collieClient.detectProviderForKey(key)
+          if (!mountedRef.current) return
+          if (result.detected && result.provider_id && result.provider_id !== provider) {
+            setProvider(result.provider_id)
+            setDetectHint(
+              `Looks like this key belongs to ${catalogue.find((item) => item.id === result.provider_id)?.name || result.provider_id}.`
+            )
+          } else if (result.detected) {
+            setDetectHint('')
+          } else {
+            setDetectHint('')
+          }
+        } catch {
+          if (mountedRef.current) setDetectHint('')
+        }
+      }
+    },
+    [catalogue, custom, provider]
+  )
+
   const saveApiKey = useCallback(async (): Promise<void> => {
     if (!apiKey.trim()) return
     const connectionName = displayName.trim() || provider
-    if (provider === 'custom' && (!displayName.trim() || !baseUrl.trim() || !model.trim())) {
-      setError('A custom API needs a name, base URL, and model ID.')
+    if (custom && (!baseUrl.trim() || !model.trim())) {
+      setError('A custom API needs a base URL and a model. Use "Detect models" to find one.')
       return
     }
     setBusyKey(true)
     setError('')
+    setSuccess('')
     try {
-      await configureWelcomeApiKey({
+      const result = await configureWelcomeApiKey({
         provider,
         displayName: connectionName,
-        protocol,
+        protocol: protocolForProvider,
         apiKey,
-        model,
-        baseUrl
+        model: custom ? model : model || undefined,
+        baseUrl: custom ? baseUrl : baseUrl || undefined
       })
-      if (mountedRef.current) onDone()
+      if (!mountedRef.current) return
+      const label = result.model_label || model || 'your model'
+      setSuccess(`Connected — using ${label}. You can switch models in chat anytime.`)
+      window.setTimeout(() => {
+        if (mountedRef.current) void onDone()
+      }, 1100)
     } catch (e) {
       if (!mountedRef.current) return
       setError(e instanceof Error ? e.message : String(e))
     } finally {
       if (mountedRef.current) setBusyKey(false)
     }
-  }, [apiKey, displayName, provider, protocol, model, baseUrl, onDone])
+  }, [apiKey, displayName, provider, protocolForProvider, custom, model, baseUrl, onDone])
+
+  const detectCustomModels = useCallback(async (): Promise<void> => {
+    if (!baseUrl.trim()) {
+      setError('Paste the base URL first, then I can look for models on it.')
+      return
+    }
+    setDetectingModels(true)
+    setError('')
+    try {
+      const result = await collieClient.detectModels(
+        baseUrl.trim(),
+        protocolForProvider,
+        apiKey.trim() || undefined
+      )
+      if (!mountedRef.current) return
+      if (result.detected && result.models.length > 0) {
+        setCustomModels(result.models)
+        setModel(result.models[0])
+      } else {
+        setError(
+          "I couldn't find a model list on that URL. You can still type the model name below if you know it."
+        )
+      }
+    } catch {
+      if (mountedRef.current) {
+        setError("I couldn't reach that URL to look for models. Check it and try again.")
+      }
+    } finally {
+      if (mountedRef.current) setDetectingModels(false)
+    }
+  }, [baseUrl, protocolForProvider, apiKey])
+
+  const connectLocal = useCallback(async (): Promise<void> => {
+    if (!localModel) return
+    setBusyLocal(true)
+    setError('')
+    setSuccess('')
+    try {
+      const result = await configureWelcomeApiKey({
+        provider: CUSTOM_PROVIDER_ID,
+        displayName: 'Local model (Ollama)',
+        protocol: 'openai',
+        apiKey: '',
+        model: localModel,
+        baseUrl: OLLAMA_BASE_URL
+      })
+      if (!mountedRef.current) return
+      setSuccess(`Connected — using ${localModel} on this computer.`)
+      window.setTimeout(() => {
+        if (mountedRef.current) void onDone()
+      }, 1100)
+    } catch (e) {
+      if (!mountedRef.current) return
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      if (mountedRef.current) setBusyLocal(false)
+    }
+  }, [localModel, onDone])
+
+  const modelOptions = custom
+    ? customModels
+    : (selectedProvider?.models || []).map((item) => item.id)
 
   return (
     <div className="onboarding-shell flex h-full flex-col overflow-y-auto">
@@ -135,7 +344,7 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
 
         <button
           onClick={() => void signInOAuth('chatgpt')}
-          disabled={busyOAuth !== null || busyKey}
+          disabled={busyOAuth !== null || busyKey || busyLocal}
           className="rounded-xl border p-4 text-left transition hover:shadow-md disabled:opacity-50"
           style={{ borderColor: 'var(--collie-border)', background: 'var(--collie-surface)' }}
         >
@@ -163,7 +372,7 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
 
         <button
           onClick={() => void signInOAuth('claude')}
-          disabled={busyOAuth !== null || busyKey}
+          disabled={busyOAuth !== null || busyKey || busyLocal}
           className="rounded-xl border p-4 text-left transition hover:shadow-md disabled:opacity-50"
           style={{ borderColor: 'var(--collie-border)', background: 'var(--collie-surface)' }}
         >
@@ -198,95 +407,259 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
               setShowKeyForm(!showKeyForm)
               if (busyOAuth) cancelOAuth(busyOAuth as 'chatgpt' | 'claude')
             }}
-            disabled={busyKey}
+            disabled={busyKey || busyLocal}
             className="flex w-full items-center gap-3 text-left"
           >
             <BrandLogo brand={provider} size={32} />
             <div>
               <div className="font-medium">I have an API key</div>
               <div className="text-sm" style={{ color: 'var(--collie-text-muted)' }}>
-                OpenAI, Anthropic, OpenRouter, DeepSeek, Ollama, and more
+                Paste a key and Collie figures out the rest.
               </div>
             </div>
           </button>
           {showKeyForm && (
             <div className="mt-4 flex flex-col gap-3">
-              <select
-                value={provider}
-                onChange={(e) => {
-                  const value = e.target.value
-                  setProvider(value)
-                  setProtocol(value === 'anthropic' ? 'anthropic' : 'openai')
-                  if (value !== 'custom') setDisplayName('')
-                }}
-                className="rounded-lg border px-3 py-2"
-                style={{ borderColor: 'var(--collie-border)' }}
-              >
-                {PROVIDERS.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.label}
-                  </option>
-                ))}
-              </select>
-              <input
-                type="text"
-                placeholder={provider === 'custom' ? 'Connection name' : 'Connection name (optional)'}
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                className="rounded-lg border px-3 py-2"
-                style={{ borderColor: 'var(--collie-border)' }}
-              />
-              {provider === 'custom' && (
-                <select
-                  value={protocol}
-                  onChange={(e) => setProtocol(e.target.value as 'openai' | 'anthropic')}
-                  className="rounded-lg border px-3 py-2"
+              <div ref={pickerRef} className="relative">
+                <button
+                  type="button"
+                  onClick={() => setPickerOpen(!pickerOpen)}
+                  className="flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left"
                   style={{ borderColor: 'var(--collie-border)' }}
                 >
-                  <option value="openai">OpenAI-compatible</option>
-                  <option value="anthropic">Anthropic-compatible</option>
-                </select>
+                  <Search size={15} style={{ color: 'var(--collie-text-muted)' }} />
+                  <span className="flex-1">
+                    {selectedProvider?.name || 'Choose a provider'}
+                  </span>
+                  <ChevronDown size={15} style={{ color: 'var(--collie-text-muted)' }} />
+                </button>
+                {pickerOpen && (
+                  <div
+                    className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border bg-white shadow-lg"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  >
+                    <input
+                      autoFocus
+                      type="text"
+                      placeholder="Search providers…"
+                      value={pickerQuery}
+                      onChange={(event) => setPickerQuery(event.target.value)}
+                      className="w-full border-b px-3 py-2 outline-none"
+                      style={{ borderColor: 'var(--collie-border)' }}
+                    />
+                    <div className="max-h-56 overflow-y-auto">
+                      {filteredProviders.map((item) => (
+                        <button
+                          key={item.id}
+                          type="button"
+                          onClick={() => pickProvider(item.id)}
+                          className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-black/5"
+                        >
+                          <BrandLogo brand={item.id} size={20} />
+                          <span className="flex-1">{item.name}</span>
+                          {provider === item.id && (
+                            <span style={{ color: 'var(--collie-snoot)' }}>✓</span>
+                          )}
+                        </button>
+                      ))}
+                      {filteredProviders.length === 0 && (
+                        <div className="px-3 py-2 text-sm" style={{ color: 'var(--collie-text-muted)' }}>
+                          No match — pick Custom to use any OpenAI-compatible service.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {custom ? (
+                <>
+                  <input
+                    type="url"
+                    placeholder="Base URL (e.g. http://localhost:11434/v1)"
+                    value={baseUrl}
+                    onChange={(event) => setBaseUrl(event.target.value)}
+                    className="rounded-lg border px-3 py-2"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  />
+                  <select
+                    value={protocol}
+                    onChange={(event) => setProtocol(event.target.value as 'openai' | 'anthropic')}
+                    className="rounded-lg border px-3 py-2"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  >
+                    <option value="openai">OpenAI-compatible</option>
+                    <option value="anthropic">Anthropic-compatible</option>
+                  </select>
+                  <input
+                    type="password"
+                    placeholder="API key (optional for local servers)"
+                    value={apiKey}
+                    onChange={(event) => setApiKey(event.target.value)}
+                    className="rounded-lg border px-3 py-2"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void detectCustomModels()}
+                    disabled={detectingModels || !baseUrl.trim()}
+                    className="rounded-lg border px-4 py-2 text-sm transition disabled:opacity-50"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  >
+                    {detectingModels ? 'Looking for models…' : 'Detect models'}
+                  </button>
+                  <input
+                    type="text"
+                    list="custom-model-list"
+                    placeholder="Model (e.g. llama3.2)"
+                    value={model}
+                    onChange={(event) => setModel(event.target.value)}
+                    className="rounded-lg border px-3 py-2"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  />
+                  <datalist id="custom-model-list">
+                    {customModels.map((item) => (
+                      <option key={item} value={item} />
+                    ))}
+                  </datalist>
+                </>
+              ) : (
+                <>
+                  <input
+                    type="password"
+                    placeholder="Paste your API key"
+                    value={apiKey}
+                    onChange={(event) => {
+                      setApiKey(event.target.value)
+                      void detectFromKey(event.target.value)
+                    }}
+                    className="rounded-lg border px-3 py-2"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  />
+                  {detectHint && (
+                    <p className="text-xs" style={{ color: 'var(--collie-text-muted)' }}>
+                      {detectHint}
+                    </p>
+                  )}
+                </>
               )}
-              <input
-                type="password"
-                placeholder="Paste your API key"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                className="rounded-lg border px-3 py-2"
-                style={{ borderColor: 'var(--collie-border)' }}
-              />
-              <input
-                type="text"
-                placeholder="Model (optional — e.g. deepseek-v4-pro, gpt-5.5)"
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="rounded-lg border px-3 py-2"
-                style={{ borderColor: 'var(--collie-border)' }}
-              />
-              <input
-                type="url"
-                placeholder={provider === 'custom'
-                  ? 'Base URL (e.g. http://localhost:11434/v1)'
-                  : 'Custom base URL (optional)'}
-                value={baseUrl}
-                onChange={(e) => setBaseUrl(e.target.value)}
-                className="rounded-lg border px-3 py-2"
-                style={{ borderColor: 'var(--collie-border)' }}
-              />
+
+              <button
+                onClick={() => {
+                  if (showAdvanced) {
+                    setShowAdvanced(false)
+                  } else {
+                    setShowAdvanced(true)
+                  }
+                }}
+                type="button"
+                className="flex items-center gap-1 text-xs underline"
+                style={{ color: 'var(--collie-text-muted)' }}
+              >
+                Advanced
+                {showAdvanced ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+              </button>
+
+              {showAdvanced && (
+                <div className="flex flex-col gap-3 rounded-lg border p-3"
+                  style={{ borderColor: 'var(--collie-border)' }}
+                >
+                  <input
+                    type="text"
+                    placeholder="Connection name (optional)"
+                    value={displayName}
+                    onChange={(event) => setDisplayName(event.target.value)}
+                    className="rounded-lg border px-3 py-2"
+                    style={{ borderColor: 'var(--collie-border)' }}
+                  />
+                  {!custom && (
+                    <input
+                      type="text"
+                      list="catalogue-model-list"
+                      placeholder="Model (optional — Collie picks a good default)"
+                      value={model}
+                      onChange={(event) => setModel(event.target.value)}
+                      className="rounded-lg border px-3 py-2"
+                      style={{ borderColor: 'var(--collie-border)' }}
+                    />
+                  )}
+                  {!custom && (
+                    <datalist id="catalogue-model-list">
+                      {modelOptions.map((item) => (
+                        <option key={item} value={item} />
+                      ))}
+                    </datalist>
+                  )}
+                  {!custom && (
+                    <input
+                      type="url"
+                      placeholder="Custom base URL (optional)"
+                      value={baseUrl}
+                      onChange={(event) => setBaseUrl(event.target.value)}
+                      className="rounded-lg border px-3 py-2"
+                      style={{ borderColor: 'var(--collie-border)' }}
+                    />
+                  )}
+                </div>
+              )}
+
               <button
                 onClick={() => void saveApiKey()}
-                disabled={busyKey || !apiKey.trim()}
+                disabled={busyKey || !apiKey.trim() || (custom && (!baseUrl.trim() || !model.trim()))}
                 className="rounded-lg px-4 py-2 font-medium text-white transition disabled:opacity-50"
                 style={{ background: 'var(--collie-btn-primary-bg)' }}
               >
-                {busyKey ? 'Connecting...' : 'Continue'}
+                {busyKey ? 'Connecting…' : 'Connect'}
               </button>
             </div>
           )}
         </div>
 
+        {localModels.available && (
+          <div
+            className="rounded-xl border p-4"
+            style={{ borderColor: 'var(--collie-border)', background: 'var(--collie-surface)' }}
+          >
+            <div className="flex items-center gap-3">
+              <BrandLogo brand="ollama" size={32} />
+              <div>
+                <div className="font-medium">Use a model on this computer</div>
+                <div className="text-sm" style={{ color: 'var(--collie-text-muted)' }}>
+                  {localModels.models.length > 0
+                    ? 'I found a local model installed with Ollama. No internet needed.'
+                    : 'A local Ollama install is running.'}
+                </div>
+              </div>
+            </div>
+            {localModels.models.length > 0 && (
+              <div className="mt-3 flex flex-col gap-3">
+                <select
+                  value={localModel}
+                  onChange={(event) => setLocalModel(event.target.value)}
+                  className="rounded-lg border px-3 py-2"
+                  style={{ borderColor: 'var(--collie-border)' }}
+                >
+                  {localModels.models.map((item) => (
+                    <option key={item} value={item}>
+                      {item}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => void connectLocal()}
+                  disabled={busyLocal}
+                  className="rounded-lg px-4 py-2 font-medium text-white transition disabled:opacity-50"
+                  style={{ background: 'var(--collie-btn-primary-bg)' }}
+                >
+                  {busyLocal ? 'Connecting…' : 'Connect'}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
         <button
-          onClick={() => void window.collie?.openExternal('https://collie.ai/get-started')}
+          onClick={() => void window.collie?.openExternal(HELP_URL)}
           className="rounded-xl border border-dashed p-4 text-left transition hover:shadow-md"
           style={{ borderColor: 'var(--collie-border)' }}
         >
@@ -303,16 +676,29 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
 
         {error && (
           <div
-            className="flex items-center gap-2 rounded-lg border p-3 text-sm"
+            className="flex items-start gap-2 rounded-lg border p-3 text-sm"
             style={{ borderColor: 'var(--collie-snoot)', color: 'var(--collie-nose)' }}
           >
             <CollieFace size={16} />
-            <span>Uh oh. {error}</span>
+            <span>
+              <span>Uh oh. </span>
+              {linkify(error)}
+            </span>
+          </div>
+        )}
+
+        {success && (
+          <div
+            className="flex items-center gap-2 rounded-lg border p-3 text-sm"
+            style={{ borderColor: 'var(--collie-gold)', color: 'var(--collie-text)' }}
+          >
+            <CollieFace size={16} />
+            <span>{success}</span>
           </div>
         )}
 
         <p className="text-center text-xs" style={{ color: 'var(--collie-text-muted)' }}>
-          You can add more providers later in Settings → Account.
+          You can add more providers later in Settings → Models &amp; API keys.
         </p>
       </div>
     </div>

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1010,6 +1010,121 @@ button {
   color: var(--ink);
 }
 
+/* Gardener suggestion card (evidence -> propose -> approve/dismiss) */
+.gardener-card {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--card);
+  padding: 12px 14px;
+  margin: 4px 0 10px;
+}
+.gardener-row {
+  border-top: 1px dashed var(--line);
+  margin-top: 10px;
+  padding-top: 10px;
+}
+.gardener-row:first-of-type {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 0;
+}
+.gardener-row-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.gardener-row-head b {
+  font-size: 14px;
+  color: var(--ink);
+}
+.gardener-file {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: var(--font-mono, monospace);
+}
+.gardener-evidence {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.gardener-proposed {
+  max-height: 220px;
+  margin: 8px 0 12px;
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bone);
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ink);
+}
+
+/* Diff view (versioned rollback rail — added/removed lines) */
+.diff-view {
+  margin: 4px 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bone);
+  overflow: hidden;
+}
+.diff-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 7px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+.diff-toggle:hover { color: var(--ink); }
+.diff-text {
+  max-height: 220px;
+  margin: 0;
+  padding: 8px 10px;
+  overflow: auto;
+  border-top: 1px solid var(--line);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+.diff-text .is-added { color: #1a7f37; background: rgba(26, 127, 55, 0.08); }
+.diff-text .is-removed { color: #c0392b; background: rgba(192, 57, 43, 0.08); }
+
+/* Version history rows (Agents + Memory history) */
+.version-list { display: grid; gap: 6px; }
+.version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--card);
+}
+.version-row-main { display: grid; gap: 2px; min-width: 0; }
+.version-row-main b { font-size: 13px; color: var(--ink); }
+.version-row-main span { font-size: 11.5px; color: var(--muted); }
+.version-row .settings-button {
+  flex: none;
+  min-height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  border-radius: 8px;
+}
+
 .settings-lead { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
 .settings-card { margin-bottom: 14px; border: 1px solid var(--collie-border); border-radius: 14px; padding: 15px; }
 .settings-card h3 { display: flex; gap: 7px; align-items: center; margin: 0 0 12px; font-size: 14px; }

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -28,8 +28,9 @@ are not part of this public source tree.
 ### Python core: `collie-core/`
 
 - `collie_core/` owns storage, settings, memory, permissions, plans, tools,
-  connectors, agents, routines, messengers, pet control, IPC, telemetry
-  (run records), runtime composition, and the internal headless engine
+  connectors, agents, routines, messengers, pet control, IPC, provider
+  onboarding (catalogue + key validation), telemetry (run records),
+  runtime composition, and the internal headless engine
   mode (`collie_core/headless.py` — one task, one JSON result document,
   exit; an engineering-only benchmark entry, not a user-facing CLI).
 - `nanobot/` contains the adapted upstream engine. Changes should remain

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -32,6 +32,32 @@ are not part of this public source tree.
   (run records), runtime composition, and the internal headless engine
   mode (`collie_core/headless.py` — one task, one JSON result document,
   exit; an engineering-only benchmark entry, not a user-facing CLI).
+- **Self-improvement stack** (Gardener Foundations, architecture:
+  `docs/engineering/architecture/gardener-foundations.md`):
+  - `collie_core/versions.py` — `VersionStore`: every user-visible artifact
+    edit (subagent files, `VISION.md`/`AGENTS.md`/`MEMORY.md`, dream
+    consolidations, Gardener applies) is snapshotted into the
+    `artifact_versions` table (schema V14) with a before/after text pair +
+    unified diff; one-action rollback that never clobbers newer owner
+    edits. Wired into `SubagentLoader`, `ProfileStore`, IPC `write_file`
+    (workspace artifacts), Dream, and Gardener applies.
+  - `collie_core/memory/dream.py` — `run_dream()`: bounded, read-only
+    consolidation of nanobot's long-term `memory/MEMORY.md` (vendored
+    Dream machinery: cursor, prompt builder, session pruning); versioned
+    as `memory_dream`, undoable in Settings → Memory.
+  - `collie_core/gardener/` — the self-improvement loop:
+    `evidence.py` (read-only telemetry queries: repeated tool failures,
+    repeated workflows, stopped turns, memory bloat), `propose.py`
+    (bounded subagent turn + deterministic validation: allowlisted
+    artifact types only, keyword gate against permissions/settings/
+    secrets/connectors, size budgets), `runner.py` (`run_gardener` +
+    `apply_suggestion` through the versioned rollback rail).
+  - Triggers: built-in automations (`memory_maintenance` Sun 09:00,
+    `gardener` Sun 10:00, seeded once, disabled by default) + manual IPC
+    (`run_dream`, `run_gardener`) from Settings → Memory → "Collie's
+    self-review". Review cards (`gardener_suggestion`) render in chat with
+    Approve/Dismiss/Undo.
+
 - `nanobot/` contains the adapted upstream engine. Changes should remain
   surgical and preserve third-party attribution.
 - `tests/` contains Python unit, integration, IPC, safety, and end-to-end

--- a/docs/engineering/architecture/gardener-foundations.md
+++ b/docs/engineering/architecture/gardener-foundations.md
@@ -1,0 +1,223 @@
+# Gardener Foundations — run records, versioned artifacts, Dream memory, and the Gardener MVP
+
+> **Status (2026-08-05):** fully landed. PR 1 (run records) merged on
+> `main`; PRs 2–4 (version store, Dream wiring, Gardener MVP) ship together
+> on `feat/gardener` as one branch. This document records the decisions and
+> the *shipped* shape — where it differs from the original plan, the
+> difference is deliberate and noted below.
+
+## Goal
+
+Give Collie a safe, evidence-driven self-improvement story:
+
+1. **Run records** — per-turn and per-tool telemetry (already merged, PR 1).
+2. **Version store** — every user-visible artifact edit is snapshotted with
+   a before/after text pair and a unified diff, and can be rolled back with
+   one action **without ever clobbering a newer owner edit**.
+3. **Episodic memory (Dream)** — wire nanobot's already-vendored Dream
+   machinery into Collie's automation scheduler with a review + undo surface.
+4. **Gardener MVP** — evidence queries → bounded proposal turn → review
+   cards with Approve/Dismiss → versioned, undoable applies.
+
+The four pieces are deliberately additive: three narrow packages in
+`collie_core/` (plus the telemetry package already on `main`), additive IPC
+commands, and no edits to the nanobot orchestration core.
+
+## Architecture
+
+### 1. Run records (`collie_core/telemetry/`, merged on main)
+
+- Schema V11: `turn_events` + `tool_events`; V12 adds prompt-hash columns
+  (`prompt_hash`, `tool_schema_hash`, `config_hash`) for the evaluation lab.
+- `RunRecorder` writes through a fire-and-forget writer thread (bounded
+  queue, drop counter, event-time timestamps) — telemetry never delays or
+  breaks a turn.
+- `TelemetryHook` observes every turn kind (chat, plan, routine, cron,
+  subagent, automation) through the existing `AgentHook` chain. Zero loop
+  edits.
+- All stored summaries pass through `redact_parameters` + truncation;
+  secrets never enter telemetry.
+
+The Gardener's evidence layer is the first real consumer of these tables.
+
+### 2. Version store (`collie_core/versions.py`, this branch)
+
+Schema V14 adds `artifact_versions`:
+
+| column | meaning |
+| --- | --- |
+| `artifact_type` | `subagent` \| `vision` \| `agents` \| `memory_profile` \| `memory_dream` \| `skill` |
+| `artifact_key` | plain filename (subagent file name, `VISION.md`, `AGENTS.md`, `MEMORY.md`, …) |
+| `version` | per-(type, key) monotonic counter |
+| `before_text` / `after_text` | full text pair |
+| `diff_text` | `difflib.unified_diff` |
+| `evidence_json` | Gardener trigger evidence (run ids, tool stats) |
+| `source` | `user` \| `collie` \| `gardener` |
+| `status` | `applied` \| `rolled_back` |
+
+`VersionStore.snapshot()` returns `None` when the texts are identical
+(nothing changed → no version row). `VersionStore.rollback()` restores the
+`before_text` of the target version **only when the artifact's current text
+still equals that version's `after_text`** — otherwise it raises
+`VersionConflictError` ("Undo the most recent change first"). The caller
+writes the restored text; each artifact type knows its own re-sync rules.
+
+**Wired write paths** (every one snapshots *before* writing):
+
+- `SubagentLoader.create/update/delete` → `subagent` versions; rollback
+  re-runs `loader.sync()` so the disk→DB mirror stays consistent.
+- `ProfileStore` mutation methods (`set`, `delete`, person/date CRUD) →
+  `memory_profile` versions of workspace `MEMORY.md`.
+- IPC `_cmd_write_file` classifies workspace files
+  (`VISION.md`, `AGENTS.md`, `MEMORY.md`, `memory/MEMORY.md`,
+  `subagents/*.md`) and snapshots automatically, returning
+  `version_id` + `diff_text` so the caller can offer Undo. This is the
+  suggest-card apply path: `SuggestionCard` reads, merges, writes, and
+  renders the returned diff with an **Undo** button.
+- Dream consolidations → `memory_dream` versions (`source="collie"`).
+- Gardener applies → `source="gardener"` with the evidence + rationale in
+  `evidence_json`.
+
+**UI (minimal but real):** `DiffView` (collapsible, color-coded unified
+diff), Undo on `SuggestionCard`, a History expansion in
+`AgentsScreen` and Settings → Memory (per-version diff + Undo), and a
+rollback rail in Settings → Memory → History.
+
+> **Schema note:** the original plan numbered the version store V12. By the
+> time it landed, V12 (prompt hashes) and V13 (`memory_journal`) were
+> already shipped on `main`, so `artifact_versions` is **V14**. Shipped
+> migrations are never edited.
+
+### 3. Dream memory (`collie_core/memory/dream.py`, this branch)
+
+Nanobot's Dream machinery (cursor, prompt builder, session keys, pruning)
+was vendored but dead; Collie had zero references. `run_dream()` wires it:
+
+1. `MemoryStore.build_dream_prompt()` — nothing new to review → early
+   return, cursor untouched.
+2. One **bounded, read-only** subagent turn under a `dream:<ts>` session
+   key: `max_iterations=1`, an **empty tool registry** (no tools, so
+   read-only by construction), `execution_posture="read_only"`. Collie has
+   no file-editing tools, so the output contract asks the model to return
+   the full proposed `memory/MEMORY.md` content (fence-tolerant parser).
+3. If the proposed content differs, write it atomically and snapshot via
+   `VersionStore` (`memory_dream` / `MEMORY.md`, `source="collie"`).
+4. Advance the dream cursor **only on success** (a completed turn — even a
+   no-change one — so history is never re-processed); failed/incomplete
+   turns leave the cursor put.
+5. `prune_dream_sessions(keep=10)` after each run.
+
+Dream never touches `ProfileStore` — it consolidates nanobot's long-term
+`memory/MEMORY.md` only.
+
+**Trigger:** two built-in automations seeded once under their own flag
+(`seed_gardener_automations`, never resurrects deletions), both disabled by
+default so nothing runs without the user enabling it:
+
+- **Memory maintenance** (`memory_maintenance` action type, `Sun 09:00`)
+- **Improvement suggestions** (`gardener` action type, `Sun 10:00`)
+
+The runtime's `_run_automation` dispatches these action types to their own
+bounded pipelines instead of a free-form prompt turn. Results land in the
+🔔 conversation and are broadcast like any automation.
+
+**Manual triggers:** IPC `run_dream` (Settings → Memory → "Review memory
+now") and `run_gardener` ("Suggest improvements") — both available from the
+Settings → Memory → "Collie's self-review" section.
+
+### 4. Gardener MVP (`collie_core/gardener/`, this branch)
+
+The loop: **evidence → propose → review → apply (versioned)**.
+
+**Evidence (`evidence.py`)** — read-only queries over the telemetry tables
+plus workspace files:
+
+- `recent_failures` — per-tool `error`/`denied`/`timeout` counts with
+  sample messages (default window: 14 days, min 2 failures).
+- `repeated_workflows` — per-turn ordered tool sequences appearing ≥ 3×.
+- `user_stops` — turns with status `stopped`/`cancelled`.
+- `memory_bloat` — size + duplicate-heading signals for `memory/MEMORY.md`
+  and `MEMORY.md`.
+
+**Propose (`propose.py`)** — one bounded subagent turn (same machinery as
+Dream: no tools, `read_only`, `max_iterations=1`) with a fixed prompt: the
+evidence summary (≤ ~2k tokens) + current agent/memory texts. Output is a
+JSON array of suggestions. **Nothing the model says is trusted** — every
+suggestion passes `validate_suggestion()`, a deterministic gate:
+
+- **Allowlist:** only `subagent`, `agents`, `vision`, `memory_dream`
+  artifact types may be proposed.
+- **Key safety:** plain filenames only (no path separators / traversal);
+  `agents` → `AGENTS.md`, `vision` → `VISION.md`,
+  `memory_dream` → `MEMORY.md`, `subagent` → `*.md`.
+- **Size budgets:** proposed text ≤ 4 000 chars, rationale ≤ 500 chars,
+  ≤ 3 suggestions per run.
+- **Keyword gate:** proposed text/rationale containing permissions,
+  approvals, settings, secrets, credentials, connectors, providers,
+  billing, or token-like language is rejected outright.
+
+Rejected suggestions are reported (reason + target) but never applied.
+
+**Runner (`runner.py`)** — `run_gardener()` collects evidence, proposes,
+and returns `{suggestions, rejected, evidence, message}`. `apply_suggestion()`
+**re-validates at apply time** (a forged or edited card cannot bypass the
+scope guard), snapshots through the version store (`source="gardener"`),
+writes the file, and re-syncs the subagent loader when needed.
+
+**Review surface:** suggestions render as `gardener_suggestion` chat cards
+(`GardenerCard`) in the 🔔 conversation with rationale, evidence labels,
+proposed text, **Approve / Dismiss**, and — after approval — the diff plus
+**Undo** (rollback through `apply_gardener_suggestion` /
+`rollback_artifact` IPC). Dismiss is a pure UI decision: no core write, no
+version row.
+
+**Scope guard (enforced in code, per the plan):** the Gardener only
+proposes agent instruction and memory consolidation changes. It never
+touches permissions, settings, secrets, or connectors — enforced by the
+allowlist + keyword gate, not by prompt wording.
+
+## Deferred (explicit, not forgotten)
+
+- **Sandbox replay.** The plan's ideal loop would run a proposed change in
+  a sandbox before applying it. The MVP deliberately ships without it: it
+  needs run-record history volume the product doesn't have yet, and the
+  deterministic scope guard + human approval stand in for it. Revisit when
+  telemetry has accumulated.
+- **Dream token-budget cap on injected memory** (`ContextBuilder` memory
+  section) — the vendored Dream machinery and the 3 000-token recent-history
+  cap bound the surface for now; a hard truncation of injected `MEMORY.md`
+  can follow with the memory hygiene work.
+- **Gardener "learn from approval" feedback loop** — the apply path records
+  evidence + rationale in `evidence_json` (so a later pass can learn which
+  suggestion classes get approved), but no learning model consumes it yet.
+
+## Files
+
+| path | role |
+| --- | --- |
+| `collie_core/telemetry/` | run records (PR 1, on `main`) |
+| `collie_core/versions.py` | `VersionStore` + `make_diff` |
+| `collie_core/memory/dream.py` | `run_dream()` consolidation runner |
+| `collie_core/gardener/evidence.py` | read-only evidence queries |
+| `collie_core/gardener/propose.py` | bounded proposal turn + strict validation |
+| `collie_core/gardener/runner.py` | `run_gardener` / `apply_suggestion` |
+| `collie_core/db.py` | schema V14 + `artifact_versions` methods |
+| `collie_core/ipc/server.py` | `list_versions`, `rollback_artifact`, `run_dream`, `get_dream_history`, `run_gardener`, `apply_gardener_suggestion` |
+| `collie_core/automations/scheduler.py` | `seed_gardener_automations` |
+| `collie_core/runtime.py` | version store wiring, Dream/Gardener pipelines, manual triggers |
+| `collie-ui/src/renderer/src/components/cards/DiffView.tsx` | unified-diff renderer |
+| `collie-ui/src/renderer/src/components/cards/GardenerCard.tsx` | review cards |
+| `collie-ui/src/renderer/src/components/settings/MemoryTab.tsx` | self-review buttons + History/Undo |
+| `collie-ui/src/renderer/src/screens/AgentsScreen.tsx` | subagent History/Undo |
+| `tests/collie/test_versions.py`, `test_dream_collie.py`, `test_gardener_mvp.py` | phase tests |
+
+## Verification
+
+- `pytest tests/collie -q --ignore=tests/collie/test_pet_status.py` — new
+  phase tests pass; only the documented Windows-only baseline failures
+  (DPAPI credentials, flaky IPC escape-path) remain.
+- `ruff check nanobot collie_core tests` — clean.
+- `npm run typecheck` + `npx vitest run` — clean.
+- e2e phase gates 1–4 stay green.
+- `tools/update_project_snapshot.py` + `--check` — regenerated for the new
+  packages.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,16 +11,16 @@
 
 ## Source inventory
 
-- Core Python files: **483**
-- Core Python test files: **220**
-- Desktop TypeScript/TSX files: **121**
-- Desktop test files: **36**
+- Core Python files: **493**
+- Core Python test files: **223**
+- Desktop TypeScript/TSX files: **123**
+- Desktop test files: **38**
 - Active Markdown docs: **24**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups
 
-`automations`, `connectors`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
+`automations`, `catalog`, `connectors`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
 
 ## Required orientation files
 

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,16 +11,16 @@
 
 ## Source inventory
 
-- Core Python files: **483**
-- Core Python test files: **220**
-- Desktop TypeScript/TSX files: **121**
+- Core Python files: **492**
+- Core Python test files: **223**
+- Desktop TypeScript/TSX files: **123**
 - Desktop test files: **36**
-- Active Markdown docs: **24**
+- Active Markdown docs: **25**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups
 
-`automations`, `connectors`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
+`automations`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
 
 ## Required orientation files
 


### PR DESCRIPTION
## What this does

First-run onboarding becomes a conversation, not a form — three commits, one per phase.

### Phase 1 — paste-key connect with real validation
- Welcome screen: provider picker (searchable) + API key + **Connect**. Connection name / model / base URL moved behind **Advanced**.
- **Keys are actually validated on Connect**: a read-only model-list request (fallback: 1-token completion) with the candidate key. A wrong key rolls the whole transaction back and shows *"That key didn't work. Double-check it, or get help here →"* — not a generic network error. HTTPError is now classified as an HTTP response, so 401/403 = bad key, 404/405 = fallback probe, 429/5xx = not a key failure.
- Paste-time provider auto-detect from key prefixes (`sk-ant-`, `gsk_`, `AIza`, `xai-`, `pplx-`, `sk-or-`; ambiguous `sk-` resolved by probing).
- Local model as a 4th choice card when an Ollama install is detected.
- Fixed the two dead help pointers: "I don't have anything yet" → `heycollie.com/get-started`; footer → Settings → **Models & API keys**.

### Phase 2 — bundled catalogue + weekly refresh
- Bundled, trimmed, schema-validated models.dev snapshot (~41 KB, 11 curated providers, 536 models) — onboarding works offline. Regenerable via `tools/update_catalogue_snapshot.py`.
- Optional weekly refresh (HTTPS, schema-validated) with version + sha256 retention and rollback to the bundled snapshot; Settings shows "catalogue updated X ago" + a Check for updates button.

### Phase 3 — starter conversation
- After connect: straight to chat, no empty state. The starter thread opens with a **scripted, local greeting** (never model-generated): *"Hey, welcome! I'm Collie — your personal AI. What's your name?"* — input focused.
- The first real reply is remembered as your name (ProfileStore; `name` added to `PROFILE_KEYS` → shows in Settings → Memory and lands in MEMORY.md). Long/multi-line/empty answers are never forced.
- `/get-started` and `/start` (desktop) + a **Getting started** button in Settings reopen the same thread idempotently — greeting appears once, never nags.

## Voice
All new user-facing strings are warm-person copy, zero dog-voice, zero jargon on the normal path (jargon only inside Advanced/custom escape hatches).

## Gates
- `pytest tests/collie -q --ignore=tests/collie/test_pet_status.py`: **565 passed / 5 failed / 1 skipped** — failures are exactly the documented Windows-only set (4× DPAPI `test_services` + the known-flaky `test_read_write_file_rejects_escape_paths`, confirmed failing on pristine `origin/main`). `test_pet_status.py` itself passes on this VM (10/10, tkinter present).
- New core tests: **32 passed** (validation probes, catalogue trim/refresh/rollback, starter conversation).
- `ruff check nanobot collie_core tests`: **All checks passed**.
- `npm run typecheck`: clean.
- `npx vitest run`: **38 files / 191 tests passed** — includes 12 new renderer tests (welcome form + starter-thread behavior).
- e2e phase gates: **10 passed**.
- Secret-scan of the diff: clean (only the models.dev sha256 hash literal; no real credentials).
