### PR TITLE
fix(ui): recover from renderer OOM/crash with a bounded reload

### DIFF
--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -29,6 +29,12 @@ import {
   isTrustedRendererUrl,
   shouldAllowAudioPermission
 } from './renderer-security'
+import {
+  INITIAL_RENDERER_RECOVERY_STATE,
+  isRecoverableRendererReason,
+  planRendererRecovery,
+  type RendererRecoveryState
+} from './renderer-recovery'
 
 // A detached dev terminal can close stdout while Electron is still running.
 // Treat that transport failure as harmless instead of surfacing an app error dialog.
@@ -53,6 +59,7 @@ if (isolatedUserData) app.setPath('userData', isolatedUserData)
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let quitting = false
+let rendererRecovery: RendererRecoveryState = INITIAL_RENDERER_RECOVERY_STATE
 let updateCheckTimer: NodeJS.Timeout | null = null
 const activeWork = new ActiveWorkTracker()
 const updates = new UpdateController(
@@ -172,8 +179,27 @@ function createWindow(): void {
   mainWindow.on('ready-to-show', () => { console.log('[window] ready-to-show'); mainWindow?.show() })
   mainWindow.on('show', () => console.log('[window] show event'))
   mainWindow.on('hide', () => console.log('[window] hide event'))
-  mainWindow.webContents.on('render-process-gone', (_e, details) => {
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
     console.error('[window] render-process-gone reason:', details.reason, 'exitCode:', details.exitCode)
+    if (quitting) return
+    const plan = planRendererRecovery(rendererRecovery, Date.now(), details.reason)
+    if (!plan) {
+      // A genuine crash with the reload budget exhausted: a reload would just
+      // loop. The Python core is untouched, so a full restart loses nothing.
+      if (isRecoverableRendererReason(details.reason)) {
+        dialog.showErrorBox(
+          'Collie needs a restart',
+          'The window crashed several times in a row. Please quit and reopen Collie — your chats and work are safe.'
+        )
+      }
+      return
+    }
+    rendererRecovery = plan.next
+    setTimeout(() => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.reload()
+      }
+    }, plan.delayMs)
   })
   mainWindow.on('focus', () => {
     // Returning to the app is an acknowledgement that the user reviewed

--- a/collie-ui/src/main/renderer-recovery.test.ts
+++ b/collie-ui/src/main/renderer-recovery.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INITIAL_RENDERER_RECOVERY_STATE,
+  RENDERER_RECOVERY_BASE_DELAY_MS,
+  RENDERER_RECOVERY_MAX_ATTEMPTS,
+  RENDERER_RECOVERY_WINDOW_MS,
+  isRecoverableRendererReason,
+  planRendererRecovery
+} from './renderer-recovery'
+
+describe('isRecoverableRendererReason', () => {
+  it('treats real crash reasons as recoverable', () => {
+    expect(isRecoverableRendererReason('crashed')).toBe(true)
+    expect(isRecoverableRendererReason('oom')).toBe(true)
+    expect(isRecoverableRendererReason('killed')).toBe(true)
+    expect(isRecoverableRendererReason('abnormal-exit')).toBe(true)
+    expect(isRecoverableRendererReason('launch-failed')).toBe(true)
+  })
+
+  it('does not reload on clean exits or unknown reasons', () => {
+    expect(isRecoverableRendererReason('clean-exit')).toBe(false)
+    expect(isRecoverableRendererReason('integrity-failure')).toBe(false)
+    expect(isRecoverableRendererReason('')).toBe(false)
+  })
+})
+
+describe('planRendererRecovery', () => {
+  it('returns no plan for an unrecoverable reason', () => {
+    expect(planRendererRecovery(INITIAL_RENDERER_RECOVERY_STATE, 0, 'clean-exit')).toBeNull()
+  })
+
+  it('starts a recovery window on the first crash', () => {
+    const plan = planRendererRecovery(INITIAL_RENDERER_RECOVERY_STATE, 1_000, 'oom')
+    expect(plan).not.toBeNull()
+    expect(plan!.delayMs).toBe(RENDERER_RECOVERY_BASE_DELAY_MS)
+    expect(plan!.next).toEqual({ attempts: 1, windowStartedAt: 1_000 })
+  })
+
+  it('backs off exponentially across crashes in the same window', () => {
+    let state = INITIAL_RENDERER_RECOVERY_STATE
+    const expected = [250, 500, 1_000]
+    for (const delay of expected) {
+      const plan = planRendererRecovery(state, 10_000, 'crashed')
+      expect(plan).not.toBeNull()
+      expect(plan!.delayMs).toBe(delay)
+      state = plan!.next
+    }
+  })
+
+  it('exhausts the budget after the maximum attempts in one window', () => {
+    let state = INITIAL_RENDERER_RECOVERY_STATE
+    for (let i = 0; i < RENDERER_RECOVERY_MAX_ATTEMPTS; i += 1) {
+      const plan = planRendererRecovery(state, 20_000, 'crashed')
+      expect(plan).not.toBeNull()
+      state = plan!.next
+    }
+    expect(state.attempts).toBe(RENDERER_RECOVERY_MAX_ATTEMPTS)
+    expect(planRendererRecovery(state, 20_000, 'crashed')).toBeNull()
+  })
+
+  it('opens a fresh window after the rolling window elapses', () => {
+    let state = INITIAL_RENDERER_RECOVERY_STATE
+    for (let i = 0; i < RENDERER_RECOVERY_MAX_ATTEMPTS; i += 1) {
+      const plan = planRendererRecovery(state, 30_000, 'crashed')
+      expect(plan).not.toBeNull()
+      state = plan!.next
+    }
+    expect(planRendererRecovery(state, 30_000, 'crashed')).toBeNull()
+
+    const later = 30_000 + RENDERER_RECOVERY_WINDOW_MS + 1
+    const retry = planRendererRecovery(state, later, 'crashed')
+    expect(retry).not.toBeNull()
+    expect(retry!.delayMs).toBe(RENDERER_RECOVERY_BASE_DELAY_MS)
+    expect(retry!.next).toEqual({ attempts: 1, windowStartedAt: later })
+  })
+
+  it('caps the backoff delay', () => {
+    // A window that somehow accumulates more attempts than the cap would
+    // still never exceed the max delay.
+    expect(RENDERER_RECOVERY_BASE_DELAY_MS * 2 ** (RENDERER_RECOVERY_MAX_ATTEMPTS - 1)).toBe(1_000)
+  })
+})

--- a/collie-ui/src/main/renderer-recovery.ts
+++ b/collie-ui/src/main/renderer-recovery.ts
@@ -1,0 +1,70 @@
+/**
+ * Renderer crash recovery policy: bounded auto-reload after the renderer
+ * process is gone (crashed / OOM / killed / abnormal exit).
+ *
+ * The renderer is disposable — the Python core is a separate process, so a
+ * reload fully rehydrates the UI from it (the white-screen-after-OOM failure
+ * becomes a ~1s blip). We mirror the core supervision's RestartBudget
+ * discipline: at most N reloads per rolling window, with backoff, so a
+ * boot-crash can never reload-loop.
+ */
+
+export const RENDERER_RECOVERY_WINDOW_MS = 60_000
+export const RENDERER_RECOVERY_MAX_ATTEMPTS = 3
+export const RENDERER_RECOVERY_BASE_DELAY_MS = 250
+export const RENDERER_RECOVERY_MAX_DELAY_MS = 2_000
+
+/**
+ * Reasons a renderer can disappear. Only genuine crashes warrant a reload;
+ * a clean exit or a failed launch is not something a reload fixes.
+ */
+export const RECOVERABLE_RENDERER_REASONS = new Set([
+  'crashed',
+  'oom',
+  'killed',
+  'abnormal-exit',
+  'launch-failed'
+]) as ReadonlySet<string>
+
+export interface RendererRecoveryState {
+  attempts: number
+  windowStartedAt: number | null
+}
+
+export const INITIAL_RENDERER_RECOVERY_STATE: RendererRecoveryState = {
+  attempts: 0,
+  windowStartedAt: null
+}
+
+export function isRecoverableRendererReason(reason: string): boolean {
+  return RECOVERABLE_RENDERER_REASONS.has(reason)
+}
+
+/**
+ * Decide whether (and when) to reload after a renderer crash.
+ * Returns null when the crash is not recoverable or the reload budget for
+ * the current rolling window is exhausted.
+ */
+export function planRendererRecovery(
+  state: RendererRecoveryState,
+  now: number,
+  reason: string
+): { delayMs: number; next: RendererRecoveryState } | null {
+  if (!isRecoverableRendererReason(reason)) return null
+  const startsNewWindow =
+    state.windowStartedAt === null ||
+    now - state.windowStartedAt >= RENDERER_RECOVERY_WINDOW_MS
+  const attempts = startsNewWindow ? 0 : state.attempts
+  if (attempts >= RENDERER_RECOVERY_MAX_ATTEMPTS) return null
+  const delayMs = Math.min(
+    RENDERER_RECOVERY_MAX_DELAY_MS,
+    RENDERER_RECOVERY_BASE_DELAY_MS * 2 ** attempts
+  )
+  return {
+    delayMs,
+    next: {
+      attempts: attempts + 1,
+      windowStartedAt: startsNewWindow ? now : state.windowStartedAt
+    }
+  }
+}


### PR DESCRIPTION
## Problem
The desktop renderer OOMs (V8 heap ceiling) or crashes on long sessions and dies to a white screen. The window frame survives, the core keeps running invisibly behind a dead UI — `render-process-gone` was only logged.

## Solution
- New `renderer-recovery.ts`: pure recovery-policy module — at most 3 reloads per rolling 60s window, exponential backoff (250→500→1000ms), only for genuine crash reasons (crashed/oom/killed/abnormal-exit/launch-failed).
- `index.ts`: the handler now reloads the window on a recoverable crash (white screen becomes a ~1s blip); when the budget is exhausted it shows an honest restart dialog instead of looping.
- Reuses the same bounded-retry discipline as the core supervision's `RestartBudget` (3 abnormal exits / 5 min).

## Verification
- 8 new unit tests (recoverable reasons, backoff schedule, budget exhaustion, rolling-window reset, reason filtering)
- `npm run typecheck` clean; full suite 39 files / 199 tests green

Patterned after T3 Code's renderer OOM recovery (pingdotgg/t3code #5148).

## Follow-ups (not in this PR)
- Renderer memory-growth containment audit (chat DOM retention, event-log trimming) — needs profiling, separate PR.