### PR TITLE
feat(updates): detect failed updates and surface a recovery notice

### DIFF
--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -443,14 +443,24 @@ function clampActiveWork(snapshot: ActiveWorkSnapshot): ActiveWorkSnapshot {
 /**
  * Wait for the Python core to reach a settled state after spawnCore, so the
  * post-update boot verification can judge the new version honestly.
+ *
+ * A single 'failed' blip is NOT a verdict: the supervision respawns after
+ * 3s, so a transient failure flips failed → starting → running. We only
+ * resolve as failed when the state stays failed for a sustained period.
  */
-function waitForCoreSettle(timeoutMs = 45_000): Promise<'running' | 'failed'> {
+function waitForCoreSettle(timeoutMs = 60_000): Promise<'running' | 'failed'> {
   return new Promise((resolve) => {
     const started = Date.now()
+    let failedSince: number | null = null
     const poll = (): void => {
       const state = coreState().state
       if (state === 'running') return resolve('running')
-      if (state === 'failed') return resolve('failed')
+      if (state === 'failed') {
+        failedSince ??= Date.now()
+        if (Date.now() - failedSince >= 5_000) return resolve('failed')
+      } else {
+        failedSince = null
+      }
       if (Date.now() - started >= timeoutMs) return resolve('failed')
       setTimeout(poll, 300)
     }
@@ -490,9 +500,12 @@ app.whenReady().then(async () => {
   updates.evaluateBoot(coreHealthy)
   if (petEnabled()) spawnPet(isDev)
   // Let the window and local core settle before contacting the release channel.
+  // A pending rollback notice keeps the stage: the user drives the next check.
   updateCheckTimer = setTimeout(() => {
     updateCheckTimer = null
-    void updates.check()
+    if (updates.getStatus().phase !== 'rollback') {
+      void updates.check()
+    }
   }, 15_000)
 
   app.on('activate', () => {

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -428,6 +428,7 @@ function registerIpc(): void {
   handle('collie:check-for-update', () => updates.check())
   handle('collie:download-update', () => updates.download())
   handle('collie:restart-and-install-update', () => updates.restartAndInstall())
+  handle('collie:dismiss-update-failure', () => updates.dismissUpdateFailure())
   handle('collie:update-active-work', (snapshot: ActiveWorkSnapshot) => {
     if (!isActiveWorkSnapshot(snapshot)) return false
     activeWork.update(clampActiveWork(snapshot))
@@ -516,10 +517,10 @@ app.whenReady().then(async () => {
   updates.evaluateBoot(coreHealthy)
   if (petEnabled()) spawnPet(isDev)
   // Let the window and local core settle before contacting the release channel.
-  // A pending rollback notice keeps the stage: the user drives the next check.
+  // A pending failed-update notice keeps the stage: the user drives the next check.
   updateCheckTimer = setTimeout(() => {
     updateCheckTimer = null
-    if (updates.getStatus().phase !== 'rollback') {
+    if (!updates.getStatus().failedUpdate) {
       void updates.check()
     }
   }, 15_000)

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -30,6 +30,13 @@ import {
   shouldAllowAudioPermission
 } from './renderer-security'
 import { RendererRecoverySupervisor } from './renderer-recovery'
+import {
+  createCoreSettleMachine,
+  sampleCoreSettle,
+  DEFAULT_CORE_SETTLE_CONFIG,
+  type CoreSettleState
+} from './update-boot-settle'
+import { readUpdateBootRecord } from './update-boot-record'
 
 // A detached dev terminal can close stdout while Electron is still running.
 // Treat that transport failure as harmless instead of surfacing an app error dialog.
@@ -444,25 +451,30 @@ function clampActiveWork(snapshot: ActiveWorkSnapshot): ActiveWorkSnapshot {
  * Wait for the Python core to reach a settled state after spawnCore, so the
  * post-update boot verification can judge the new version honestly.
  *
- * A single 'failed' blip is NOT a verdict: the supervision respawns after
- * 3s, so a transient failure flips failed → starting → running. We only
- * resolve as failed when the state stays failed for a sustained period.
+ * The policy lives in update-boot-settle.ts (pure, unit-tested). When a
+ * pending update record matches the running version we require the core to
+ * stay `running` continuously for the probation window — a single ready
+ * message is NOT sustained health, and accepting a core that crashes seconds
+ * later would permanently clear the boot record and hide the notice. On a
+ * normal first boot there is no probation and the first `running` sample
+ * resolves immediately so startup is not delayed.
  */
-function waitForCoreSettle(timeoutMs = 60_000): Promise<'running' | 'failed'> {
+async function waitForCoreSettle(requireProbation: boolean): Promise<'running' | 'failed'> {
+  const config = DEFAULT_CORE_SETTLE_CONFIG
   return new Promise((resolve) => {
-    const started = Date.now()
-    let failedSince: number | null = null
+    let machine = createCoreSettleMachine(Date.now(), requireProbation)
     const poll = (): void => {
-      const state = coreState().state
-      if (state === 'running') return resolve('running')
-      if (state === 'failed') {
-        failedSince ??= Date.now()
-        if (Date.now() - failedSince >= 5_000) return resolve('failed')
-      } else {
-        failedSince = null
+      machine = sampleCoreSettle(
+        machine,
+        coreState().state as CoreSettleState,
+        Date.now(),
+        config
+      )
+      if (machine.verdict !== null) {
+        resolve(machine.verdict)
+        return
       }
-      if (Date.now() - started >= timeoutMs) return resolve('failed')
-      setTimeout(poll, 300)
+      setTimeout(poll, config.pollIntervalMs)
     }
     poll()
   })
@@ -495,8 +507,12 @@ app.whenReady().then(async () => {
   })
   await spawnCore(isDev)
   // If this boot was an update, verify the new version came up healthy
-  // before letting the update ledger treat it as last-known-good.
-  const coreHealthy = (await waitForCoreSettle()) === 'running'
+  // before letting the update ledger treat it as last-known-good. Probation
+  // (sustained running, not just a ready message) applies only when a
+  // pending update record matches the version that just started.
+  const bootRecord = readUpdateBootRecord(bootRecordPath)
+  const requireProbation = bootRecord?.pendingVersion === app.getVersion()
+  const coreHealthy = (await waitForCoreSettle(requireProbation)) === 'running'
   updates.evaluateBoot(coreHealthy)
   if (petEnabled()) spawnPet(isDev)
   // Let the window and local core settle before contacting the release channel.

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -51,6 +51,9 @@ const trustedRendererUrl = isDev && devRendererUrl
 const isolatedUserData = process.env.COLLIE_ELECTRON_USER_DATA?.trim()
 if (isolatedUserData) app.setPath('userData', isolatedUserData)
 
+// Durable record of "is an update pending / did the last one boot healthy".
+const bootRecordPath = join(app.getPath('userData'), 'update-boot-record.json')
+
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let quitting = false
@@ -84,7 +87,8 @@ const updates = new UpdateController(
   activeWork,
   () => {
     quitting = true
-  }
+  },
+  bootRecordPath
 )
 
 function sendPetCommand(command: string): boolean {
@@ -436,6 +440,24 @@ function clampActiveWork(snapshot: ActiveWorkSnapshot): ActiveWorkSnapshot {
   }
 }
 
+/**
+ * Wait for the Python core to reach a settled state after spawnCore, so the
+ * post-update boot verification can judge the new version honestly.
+ */
+function waitForCoreSettle(timeoutMs = 45_000): Promise<'running' | 'failed'> {
+  return new Promise((resolve) => {
+    const started = Date.now()
+    const poll = (): void => {
+      const state = coreState().state
+      if (state === 'running') return resolve('running')
+      if (state === 'failed') return resolve('failed')
+      if (Date.now() - started >= timeoutMs) return resolve('failed')
+      setTimeout(poll, 300)
+    }
+    poll()
+  })
+}
+
 function isActiveWorkSnapshot(value: unknown): value is ActiveWorkSnapshot {
   if (!value || typeof value !== 'object') return false
   const snapshot = value as Record<string, unknown>
@@ -462,6 +484,10 @@ app.whenReady().then(async () => {
     }
   })
   await spawnCore(isDev)
+  // If this boot was an update, verify the new version came up healthy
+  // before letting the update ledger treat it as last-known-good.
+  const coreHealthy = (await waitForCoreSettle()) === 'running'
+  updates.evaluateBoot(coreHealthy)
   if (petEnabled()) spawnPet(isDev)
   // Let the window and local core settle before contacting the release channel.
   updateCheckTimer = setTimeout(() => {

--- a/collie-ui/src/main/update-boot-record.test.ts
+++ b/collie-ui/src/main/update-boot-record.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  emptyUpdateBootRecord,
+  evaluateUpdateBootRecord,
+  readUpdateBootRecord,
+  recordPendingUpdate,
+  writeUpdateBootRecord,
+  type UpdateBootRecord
+} from './update-boot-record'
+
+let dir: string
+let path: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'collie-boot-record-'))
+  path = join(dir, 'update-boot-record.json')
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('read/writeUpdateBootRecord', () => {
+  it('round-trips a record through disk', () => {
+    const record: UpdateBootRecord = {
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4',
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: '2026-08-08T00:00:00.000Z'
+    }
+    writeUpdateBootRecord(path, record)
+    expect(readUpdateBootRecord(path)).toEqual(record)
+  })
+
+  it('returns null for a missing or corrupt file', () => {
+    expect(readUpdateBootRecord(join(dir, 'nope.json'))).toBeNull()
+    writeUpdateBootRecord(path, emptyUpdateBootRecord())
+    expect(readUpdateBootRecord(path)).not.toBeNull()
+  })
+
+  it('tolerates malformed fields', () => {
+    writeUpdateBootRecord(path, {
+      pendingVersion: '',
+      previousVersion: 42 as unknown as string,
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: 42 as unknown as string
+    })
+    const record = readUpdateBootRecord(path)
+    expect(record).toEqual({
+      pendingVersion: null,
+      previousVersion: null,
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: null
+    })
+  })
+})
+
+describe('recordPendingUpdate', () => {
+  it('keeps the last-known-good version and stamps the change', () => {
+    const before = { ...emptyUpdateBootRecord(), lastGoodVersion: '0.1.0-alpha.4' }
+    const next = recordPendingUpdate(before, '0.1.0-alpha.4', '0.1.0-alpha.5')
+    expect(next.pendingVersion).toBe('0.1.0-alpha.5')
+    expect(next.previousVersion).toBe('0.1.0-alpha.4')
+    expect(next.lastGoodVersion).toBe('0.1.0-alpha.4')
+    expect(next.updatedAt).not.toBeNull()
+  })
+})
+
+describe('evaluateUpdateBootRecord', () => {
+  const record: UpdateBootRecord = {
+    pendingVersion: '0.1.0-alpha.5',
+    previousVersion: '0.1.0-alpha.4',
+    lastGoodVersion: '0.1.0-alpha.4',
+    updatedAt: '2026-08-08T00:00:00.000Z'
+  }
+
+  it('accepts the update when the pending version boots healthy', () => {
+    const { evaluation, next } = evaluateUpdateBootRecord(record, '0.1.0-alpha.5', true)
+    expect(evaluation).toEqual({ kind: 'accepted', previousVersion: '0.1.0-alpha.4' })
+    expect(next.pendingVersion).toBeNull()
+    expect(next.previousVersion).toBeNull()
+    expect(next.lastGoodVersion).toBe('0.1.0-alpha.5')
+  })
+
+  it('flags rollback-needed when the pending version boots with a failed core', () => {
+    const { evaluation, next } = evaluateUpdateBootRecord(record, '0.1.0-alpha.5', false)
+    expect(evaluation).toEqual({ kind: 'rollback-needed', previousVersion: '0.1.0-alpha.4' })
+    expect(next).toEqual(record)
+  })
+
+  it('is a noop when no pending install matches the running version', () => {
+    const { evaluation, next } = evaluateUpdateBootRecord(record, '0.1.0-alpha.4', true)
+    expect(evaluation.kind).toBe('noop')
+    expect(next).toEqual(record)
+  })
+})

--- a/collie-ui/src/main/update-boot-record.ts
+++ b/collie-ui/src/main/update-boot-record.ts
@@ -1,0 +1,112 @@
+/**
+ * Durable "did the last update actually come up healthy?" record.
+ *
+ * Written before an install starts (pending version + previous version),
+ * re-read on the next boot: if the installed version matches the pending
+ * one AND the Python core reaches `running`, the update is accepted and the
+ * record clears. If the core fails, the previous version stays the
+ * last-known-good one and the UI surfaces a rollback notice instead of
+ * silently running a broken build.
+ *
+ * The record is deliberately small and tolerant: a missing or corrupt file
+ * reads back as null and the app simply behaves as a normal first boot.
+ */
+import { readFileSync, renameSync, writeFileSync } from 'fs'
+
+export interface UpdateBootRecord {
+  /** Version that was about to be installed when the app quit. */
+  pendingVersion: string | null
+  /** Version the app was running before the pending install. */
+  previousVersion: string | null
+  /** Last version whose core booted healthy. */
+  lastGoodVersion: string | null
+  /** ISO timestamp of the last record change. */
+  updatedAt: string | null
+}
+
+export function emptyUpdateBootRecord(): UpdateBootRecord {
+  return {
+    pendingVersion: null,
+    previousVersion: null,
+    lastGoodVersion: null,
+    updatedAt: null
+  }
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+export function readUpdateBootRecord(path: string): UpdateBootRecord | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>
+    if (typeof parsed !== 'object' || parsed === null) return null
+    return {
+      pendingVersion: pickString(parsed.pendingVersion),
+      previousVersion: pickString(parsed.previousVersion),
+      lastGoodVersion: pickString(parsed.lastGoodVersion),
+      updatedAt: pickString(parsed.updatedAt)
+    }
+  } catch {
+    return null
+  }
+}
+
+export function writeUpdateBootRecord(path: string, record: UpdateBootRecord): void {
+  // Write-then-rename keeps the record atomic for a crash mid-write.
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, JSON.stringify(record, null, 2), 'utf8')
+  renameSync(tmp, path)
+}
+
+export function recordPendingUpdate(
+  current: UpdateBootRecord,
+  previousVersion: string,
+  pendingVersion: string
+): UpdateBootRecord {
+  return {
+    pendingVersion,
+    previousVersion,
+    lastGoodVersion: current.lastGoodVersion,
+    updatedAt: new Date().toISOString()
+  }
+}
+
+export type BootEvaluation =
+  | { kind: 'noop' }
+  | { kind: 'accepted'; previousVersion: string | null }
+  | { kind: 'rollback-needed'; previousVersion: string | null }
+
+/**
+ * Evaluate a boot record against the version that actually started.
+ * - pendingVersion matches currentVersion and the core is healthy → accepted,
+ *   record clears and the current version becomes last-known-good.
+ * - pendingVersion matches but the core failed → rollback-needed; the record
+ *   is kept so the UI can keep showing the notice.
+ * - anything else → noop (first boot, no pending install, or a manual
+ *   reinstall of an old version — nothing to verify).
+ */
+export function evaluateUpdateBootRecord(
+  record: UpdateBootRecord,
+  currentVersion: string,
+  coreHealthy: boolean
+): { evaluation: BootEvaluation; next: UpdateBootRecord } {
+  if (record.pendingVersion === currentVersion) {
+    if (coreHealthy) {
+      return {
+        evaluation: { kind: 'accepted', previousVersion: record.previousVersion },
+        next: {
+          pendingVersion: null,
+          previousVersion: null,
+          lastGoodVersion: currentVersion,
+          updatedAt: new Date().toISOString()
+        }
+      }
+    }
+    return {
+      evaluation: { kind: 'rollback-needed', previousVersion: record.previousVersion },
+      next: record
+    }
+  }
+  return { evaluation: { kind: 'noop' }, next: record }
+}

--- a/collie-ui/src/main/update-boot-record.ts
+++ b/collie-ui/src/main/update-boot-record.ts
@@ -5,8 +5,9 @@
  * re-read on the next boot: if the installed version matches the pending
  * one AND the Python core reaches `running`, the update is accepted and the
  * record clears. If the core fails, the previous version stays the
- * last-known-good one and the UI surfaces a rollback notice instead of
- * silently running a broken build.
+ * last-known-good one and the UI surfaces a failed-update recovery notice —
+ * this is detection, not an automatic rollback: nothing is reinstalled or
+ * restored, the user just learns the new version is unreliable.
  *
  * The record is deliberately small and tolerant: a missing or corrupt file
  * reads back as null and the app simply behaves as a normal first boot.
@@ -81,8 +82,9 @@ export type BootEvaluation =
  * Evaluate a boot record against the version that actually started.
  * - pendingVersion matches currentVersion and the core is healthy → accepted,
  *   record clears and the current version becomes last-known-good.
- * - pendingVersion matches but the core failed → rollback-needed; the record
- *   is kept so the UI can keep showing the notice.
+ * - pendingVersion matches but the core failed → rollback-needed (failed-update
+ *   detection); the record is kept so the UI can keep showing the recovery
+ *   notice until the user dismisses it or a later boot is accepted.
  * - anything else → noop (first boot, no pending install, or a manual
  *   reinstall of an old version — nothing to verify).
  */

--- a/collie-ui/src/main/update-boot-settle.test.ts
+++ b/collie-ui/src/main/update-boot-settle.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createCoreSettleMachine,
+  sampleCoreSettle,
+  type CoreSettleState
+} from './update-boot-settle'
+
+/**
+ * Drive the pure settle machine through a scripted sequence of
+ * [timestamp, state] samples starting at t=0.
+ */
+function settle(
+  samples: Array<[number, CoreSettleState]>,
+  requireProbation: boolean
+): ReturnType<typeof createCoreSettleMachine> {
+  let machine = createCoreSettleMachine(0, requireProbation)
+  for (const [now, state] of samples) {
+    machine = sampleCoreSettle(machine, state, now)
+  }
+  return machine
+}
+
+describe('core settle — fast path (no pending update record)', () => {
+  it('resolves running on the first running sample so startup is not delayed', () => {
+    const machine = settle([[100, 'starting'], [400, 'running']], false)
+    expect(machine.verdict).toBe('running')
+  })
+
+  it('tolerates a short failed blip before the core comes up', () => {
+    const machine = settle([[0, 'failed'], [1000, 'failed'], [2000, 'running']], false)
+    expect(machine.verdict).toBe('running')
+  })
+
+  it('fails only after a sustained failed period', () => {
+    const m1 = settle([[0, 'failed'], [4999, 'failed']], false)
+    expect(m1.verdict).toBeNull()
+    const m2 = sampleCoreSettle(m1, 'failed', 5000)
+    expect(m2.verdict).toBe('failed')
+  })
+
+  it('times out when the core never leaves starting', () => {
+    const m1 = settle([[0, 'starting'], [59999, 'starting']], false)
+    expect(m1.verdict).toBeNull()
+    const m2 = sampleCoreSettle(m1, 'starting', 60000)
+    expect(m2.verdict).toBe('failed')
+  })
+})
+
+describe('core settle — probation (pending update record matches current version)', () => {
+  it('requires the core to run continuously for the full probation window', () => {
+    const m1 = settle([[0, 'starting'], [100, 'running'], [5099, 'running']], true)
+    expect(m1.verdict).toBeNull()
+    const m2 = sampleCoreSettle(m1, 'running', 5100)
+    expect(m2.verdict).toBe('running')
+  })
+
+  it('is failed when the core goes ready then crashes mid-window', () => {
+    const machine = settle([[0, 'running'], [2000, 'running'], [2100, 'failed']], true)
+    expect(machine.verdict).toBe('failed')
+  })
+
+  it('treats any failed sample during probation as an immediate failure', () => {
+    const machine = settle([[0, 'starting'], [300, 'failed']], true)
+    expect(machine.verdict).toBe('failed')
+  })
+
+  it('resets the continuous-running clock when the core respawns', () => {
+    // 4s running → respawn → 4s running again: the interrupted streaks must
+    // NOT accumulate toward the 5s window.
+    const m1 = settle(
+      [[0, 'running'], [4000, 'running'], [4100, 'starting'], [8100, 'running']],
+      true
+    )
+    expect(m1.verdict).toBeNull()
+    expect(m1.runningSince).toBe(8100)
+
+    const m2 = sampleCoreSettle(m1, 'running', 13099)
+    expect(m2.verdict).toBeNull()
+    const m3 = sampleCoreSettle(m2, 'running', 13100)
+    expect(m3.verdict).toBe('running')
+  })
+
+  it('times out when the core never reaches running', () => {
+    const m1 = settle([[0, 'starting'], [30000, 'starting'], [59999, 'starting']], true)
+    expect(m1.verdict).toBeNull()
+    const m2 = sampleCoreSettle(m1, 'starting', 60000)
+    expect(m2.verdict).toBe('failed')
+  })
+})
+
+describe('core settle — verdict stability', () => {
+  it('keeps the verdict once decided', () => {
+    const m1 = settle([[0, 'running'], [5000, 'running']], true)
+    expect(m1.verdict).toBe('running')
+    const m2 = sampleCoreSettle(m1, 'failed', 6000)
+    expect(m2.verdict).toBe('running')
+  })
+})

--- a/collie-ui/src/main/update-boot-settle.ts
+++ b/collie-ui/src/main/update-boot-settle.ts
@@ -1,0 +1,102 @@
+/**
+ * Core "did it really settle?" judgement for post-update boot verification.
+ *
+ * The Python core flips to `running` on its FIRST ready stdout message, which
+ * is not sustained health: a core that crashes seconds later must not be
+ * accepted as last-known-good. When an update boot record is pending (the
+ * just-installed version is the one now starting), we require the core to be
+ * observed CONTINUOUSLY `running` for a probation window before the boot is
+ * judged healthy:
+ *
+ * - any `failed` sample during probation → immediate `failed` verdict;
+ * - any `starting` (or `stopped`) sample resets the continuous-running clock;
+ * - the overall timeout bounds the wait → `failed`.
+ *
+ * On a normal first boot (no pending record) the fast path keeps startup
+ * snappy: the first `running` sample is the verdict, and only a sustained
+ * `failed` period or the overall timeout yields `failed`.
+ *
+ * This module is a pure state machine — all time is passed in, so the policy
+ * is fully unit-testable without timers.
+ */
+
+export type CoreSettleState = 'stopped' | 'starting' | 'running' | 'failed'
+export type CoreSettleVerdict = 'running' | 'failed'
+
+export interface CoreSettleConfig {
+  /** Continuous `running` required before an update boot is accepted. */
+  probationMs: number
+  /** Overall budget before the wait is abandoned as failed. */
+  timeoutMs: number
+  /** How often the main process re-samples coreState(). */
+  pollIntervalMs: number
+}
+
+export const DEFAULT_CORE_SETTLE_CONFIG: CoreSettleConfig = {
+  probationMs: 5_000,
+  timeoutMs: 60_000,
+  pollIntervalMs: 300
+}
+
+export interface CoreSettleMachine {
+  /** Null until the machine has decided. */
+  verdict: CoreSettleVerdict | null
+  /** True when a pending update record demands the probation window. */
+  requireProbation: boolean
+  /** Start of the current uninterrupted `running` streak, or null. */
+  runningSince: number | null
+  /** Start of the current `failed` streak (fast path only), or null. */
+  failedSince: number | null
+  /** Machine creation time; the overall timeout counts from here. */
+  startedAt: number
+}
+
+export function createCoreSettleMachine(
+  now: number,
+  requireProbation: boolean
+): CoreSettleMachine {
+  return {
+    verdict: null,
+    requireProbation,
+    runningSince: null,
+    failedSince: null,
+    startedAt: now
+  }
+}
+
+/**
+ * Feed one core-state sample into the machine. Returns the (possibly
+ * updated) machine; once a verdict is set it is never changed.
+ */
+export function sampleCoreSettle(
+  machine: CoreSettleMachine,
+  state: CoreSettleState,
+  now: number,
+  config: CoreSettleConfig = DEFAULT_CORE_SETTLE_CONFIG
+): CoreSettleMachine {
+  if (machine.verdict !== null) return machine
+
+  if (state === 'running') {
+    const runningSince = machine.runningSince ?? now
+    if (!machine.requireProbation || now - runningSince >= config.probationMs) {
+      return { ...machine, runningSince, verdict: 'running' }
+    }
+    return { ...machine, runningSince }
+  }
+
+  if (state === 'failed') {
+    const failedSince = machine.failedSince ?? now
+    // During probation any failure is fatal; on the fast path only a
+    // sustained failure (the supervision respawns after 3s) is a verdict.
+    if (machine.requireProbation || now - failedSince >= config.probationMs) {
+      return { ...machine, failedSince, verdict: 'failed' }
+    }
+    return { ...machine, failedSince }
+  }
+
+  // 'starting' / 'stopped': not running, so any running streak is over.
+  if (now - machine.startedAt >= config.timeoutMs) {
+    return { ...machine, verdict: 'failed' }
+  }
+  return { ...machine, runningSince: null, failedSince: null }
+}

--- a/collie-ui/src/main/updater-controller.test.ts
+++ b/collie-ui/src/main/updater-controller.test.ts
@@ -1,10 +1,14 @@
 import { EventEmitter } from 'events'
-import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ActiveWorkTracker,
   UpdateController,
   type AutoUpdaterLike
 } from './updater-controller'
+import { readUpdateBootRecord, writeUpdateBootRecord } from './update-boot-record'
 
 class FakeUpdater extends EventEmitter implements AutoUpdaterLike {
   autoDownload = true
@@ -100,5 +104,87 @@ describe('UpdateController', () => {
     expect(controller.restartAndInstall()).toEqual({ installed: true, blockedBy: [] })
     expect(beforeInstall).toHaveBeenCalledOnce()
     expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+  })
+})
+
+describe('UpdateController boot verification', () => {
+  let dir: string
+  let bootRecordPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'collie-update-controller-'))
+    bootRecordPath = join(dir, 'update-boot-record.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function controllerFor(version: string): UpdateController {
+    const updater = new FakeUpdater()
+    const tracker = new ActiveWorkTracker()
+    tracker.update({ chats: 0, approvals: 0, routines: 0, externalActions: 0 })
+    return new UpdateController(updater, version, true, tracker, undefined, bootRecordPath)
+  }
+
+  it('records the pending install before quitting to install', () => {
+    const updater = new FakeUpdater()
+    const tracker = new ActiveWorkTracker()
+    tracker.update({ chats: 0, approvals: 0, routines: 0, externalActions: 0 })
+    const controller = new UpdateController(
+      updater,
+      '0.1.0-alpha.4',
+      true,
+      tracker,
+      undefined,
+      bootRecordPath
+    )
+    updater.emit('update-downloaded', { version: '0.1.0-alpha.5' })
+
+    expect(controller.restartAndInstall().installed).toBe(true)
+    expect(readUpdateBootRecord(bootRecordPath)).toMatchObject({
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4'
+    })
+  })
+
+  it('accepts the update when the pending version boots healthy', () => {
+    const controller = controllerFor('0.1.0-alpha.5')
+    writeUpdateBootRecord(bootRecordPath, {
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4',
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: '2026-08-08T00:00:00.000Z'
+    })
+
+    controller.evaluateBoot(true)
+    expect(controller.getStatus().phase).toBe('current')
+    expect(readUpdateBootRecord(bootRecordPath)).toMatchObject({
+      pendingVersion: null,
+      previousVersion: null,
+      lastGoodVersion: '0.1.0-alpha.5'
+    })
+  })
+
+  it('surfaces a rollback notice when the new version cannot start its core', () => {
+    const controller = controllerFor('0.1.0-alpha.5')
+    writeUpdateBootRecord(bootRecordPath, {
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4',
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: '2026-08-08T00:00:00.000Z'
+    })
+
+    controller.evaluateBoot(false)
+    const status = controller.getStatus()
+    expect(status.phase).toBe('rollback')
+    expect(status.message).toContain('did not start properly')
+    expect(readUpdateBootRecord(bootRecordPath)?.pendingVersion).toBe('0.1.0-alpha.5')
+  })
+
+  it('leaves status untouched when there is no boot record', () => {
+    const controller = controllerFor('0.1.0-alpha.5')
+    controller.evaluateBoot(false)
+    expect(controller.getStatus().phase).toBe('idle')
   })
 })

--- a/collie-ui/src/main/updater-controller.test.ts
+++ b/collie-ui/src/main/updater-controller.test.ts
@@ -166,7 +166,7 @@ describe('UpdateController boot verification', () => {
     })
   })
 
-  it('surfaces a rollback notice when the new version cannot start its core', () => {
+  it('surfaces a failed-update notice when the new version cannot start its core', () => {
     const controller = controllerFor('0.1.0-alpha.5')
     writeUpdateBootRecord(bootRecordPath, {
       pendingVersion: '0.1.0-alpha.5',
@@ -179,7 +179,79 @@ describe('UpdateController boot verification', () => {
     const status = controller.getStatus()
     expect(status.phase).toBe('rollback')
     expect(status.message).toContain('did not start properly')
+    expect(status.failedUpdate).toEqual({
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4'
+    })
     expect(readUpdateBootRecord(bootRecordPath)?.pendingVersion).toBe('0.1.0-alpha.5')
+  })
+
+  it('keeps failedUpdate when a manual check reports no new update', async () => {
+    const controller = controllerFor('0.1.0-alpha.5')
+    writeUpdateBootRecord(bootRecordPath, {
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4',
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: '2026-08-08T00:00:00.000Z'
+    })
+    controller.evaluateBoot(false)
+    expect(controller.getStatus().failedUpdate).not.toBeNull()
+
+    await controller.check()
+    const updater = (controller as unknown as { updater: FakeUpdater }).updater
+    updater.emit('update-not-available', { version: '0.1.0-alpha.5' })
+
+    const status = controller.getStatus()
+    expect(status.phase).toBe('current')
+    expect(status.failedUpdate).toEqual({
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4'
+    })
+    // The unresolved boot record stays on disk for the next boot.
+    expect(readUpdateBootRecord(bootRecordPath)?.pendingVersion).toBe('0.1.0-alpha.5')
+  })
+
+  it('dismissUpdateFailure clears the record and the failure state, keeping lastGoodVersion', () => {
+    const controller = controllerFor('0.1.0-alpha.5')
+    writeUpdateBootRecord(bootRecordPath, {
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4',
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: '2026-08-08T00:00:00.000Z'
+    })
+    controller.evaluateBoot(false)
+    expect(controller.getStatus().failedUpdate).not.toBeNull()
+
+    const status = controller.dismissUpdateFailure()
+    expect(status.phase).toBe('current')
+    expect(status.failedUpdate).toBeNull()
+
+    const record = readUpdateBootRecord(bootRecordPath)
+    expect(record?.pendingVersion).toBeNull()
+    expect(record?.previousVersion).toBeNull()
+    expect(record?.lastGoodVersion).toBe('0.1.0-alpha.4')
+  })
+
+  it('clears failedUpdate when a later boot accepts the update', () => {
+    const controller = controllerFor('0.1.0-alpha.5')
+    writeUpdateBootRecord(bootRecordPath, {
+      pendingVersion: '0.1.0-alpha.5',
+      previousVersion: '0.1.0-alpha.4',
+      lastGoodVersion: '0.1.0-alpha.4',
+      updatedAt: '2026-08-08T00:00:00.000Z'
+    })
+    controller.evaluateBoot(false)
+    expect(controller.getStatus().failedUpdate).not.toBeNull()
+
+    controller.evaluateBoot(true)
+    const status = controller.getStatus()
+    expect(status.phase).toBe('current')
+    expect(status.failedUpdate).toBeNull()
+    expect(readUpdateBootRecord(bootRecordPath)).toMatchObject({
+      pendingVersion: null,
+      previousVersion: null,
+      lastGoodVersion: '0.1.0-alpha.5'
+    })
   })
 
   it('leaves status untouched when there is no boot record', () => {

--- a/collie-ui/src/main/updater-controller.ts
+++ b/collie-ui/src/main/updater-controller.ts
@@ -1,4 +1,11 @@
 import type { EventEmitter } from 'events'
+import {
+  emptyUpdateBootRecord,
+  evaluateUpdateBootRecord,
+  readUpdateBootRecord,
+  recordPendingUpdate,
+  writeUpdateBootRecord
+} from './update-boot-record'
 
 export type UpdatePhase =
   | 'idle'
@@ -8,6 +15,7 @@ export type UpdatePhase =
   | 'ready'
   | 'current'
   | 'failed'
+  | 'rollback'
 
 export interface UpdateStatus {
   phase: UpdatePhase
@@ -79,7 +87,8 @@ export class UpdateController {
     currentVersion: string,
     private readonly enabled: boolean,
     private readonly activeWork: ActiveWorkTracker,
-    private readonly beforeInstall: () => void = () => undefined
+    private readonly beforeInstall: () => void = () => undefined,
+    private readonly bootRecordPath: string | null = null
   ) {
     this.status = { phase: 'idle', currentVersion }
     updater.autoDownload = false
@@ -151,9 +160,56 @@ export class UpdateController {
     if (this.status.phase !== 'ready') return { installed: false, blockedBy: ['update not ready'] }
     const blockedBy = this.activeWork.blockers()
     if (blockedBy.length) return { installed: false, blockedBy }
+    this.recordPendingInstall()
     this.beforeInstall()
     this.updater.quitAndInstall(false, true)
     return { installed: true, blockedBy: [] }
+  }
+
+  /**
+   * Persist the pending install before the app quits, so the next boot can
+   * verify the new version actually came up healthy (see evaluateBoot).
+   */
+  private recordPendingInstall(): void {
+    if (!this.bootRecordPath) return
+    const pendingVersion = this.status.availableVersion
+    if (!pendingVersion) return
+    const current = readUpdateBootRecord(this.bootRecordPath) ?? emptyUpdateBootRecord()
+    writeUpdateBootRecord(
+      this.bootRecordPath,
+      recordPendingUpdate(current, this.status.currentVersion, pendingVersion)
+    )
+  }
+
+  /**
+   * Called once at startup after the Python core settles. Accepts a pending
+   * update whose version booted healthy; surfaces a rollback notice when the
+   * just-installed version could not start its core.
+   */
+  evaluateBoot(coreHealthy: boolean): UpdateStatus {
+    if (!this.bootRecordPath) return this.getStatus()
+    const record = readUpdateBootRecord(this.bootRecordPath)
+    if (!record) return this.getStatus()
+    const { evaluation, next } = evaluateUpdateBootRecord(
+      record,
+      this.status.currentVersion,
+      coreHealthy
+    )
+    if (evaluation.kind === 'accepted') {
+      writeUpdateBootRecord(this.bootRecordPath, next)
+      this.setStatus({
+        phase: 'current',
+        message: `Collie ${this.status.currentVersion} is up to date.`
+      })
+    } else if (evaluation.kind === 'rollback-needed') {
+      // Keep the record so the notice survives until the next accepted boot.
+      this.setStatus({
+        phase: 'rollback',
+        message:
+          'The last update did not start properly. Collie still trusts your previous version and kept its settings.'
+      })
+    }
+    return this.getStatus()
   }
 
   private setStatus(next: Omit<UpdateStatus, 'currentVersion'>): void {

--- a/collie-ui/src/main/updater-controller.ts
+++ b/collie-ui/src/main/updater-controller.ts
@@ -17,12 +17,24 @@ export type UpdatePhase =
   | 'failed'
   | 'rollback'
 
+/** The just-installed version whose core failed to boot healthy. */
+export interface FailedUpdateInfo {
+  pendingVersion: string | null
+  previousVersion: string | null
+}
+
 export interface UpdateStatus {
   phase: UpdatePhase
   currentVersion: string
   availableVersion?: string
   percent?: number
   message?: string
+  /**
+   * Non-null while a failed update needs the user's attention. Survives
+   * every phase transition (checks, downloads, errors) and is only cleared
+   * by an accepted boot or an explicit dismiss.
+   */
+  failedUpdate: FailedUpdateInfo | null
 }
 
 export interface ActiveWorkSnapshot {
@@ -79,7 +91,8 @@ export class ActiveWorkTracker {
 }
 
 export class UpdateController {
-  private status: UpdateStatus
+  private status: Omit<UpdateStatus, 'failedUpdate'>
+  private failedUpdate: FailedUpdateInfo | null = null
   private readonly listeners = new Set<(status: UpdateStatus) => void>()
 
   constructor(
@@ -119,7 +132,7 @@ export class UpdateController {
   }
 
   getStatus(): UpdateStatus {
-    return { ...this.status }
+    return { ...this.status, failedUpdate: this.failedUpdate }
   }
 
   onStatus(listener: (status: UpdateStatus) => void): () => void {
@@ -183,8 +196,9 @@ export class UpdateController {
 
   /**
    * Called once at startup after the Python core settles. Accepts a pending
-   * update whose version booted healthy; surfaces a rollback notice when the
-   * just-installed version could not start its core.
+   * update whose version booted healthy; surfaces a failed-update notice
+   * (detection + a recovery prompt — nothing is reinstalled automatically)
+   * when the just-installed version could not start its core.
    */
   evaluateBoot(coreHealthy: boolean): UpdateStatus {
     if (!this.bootRecordPath) return this.getStatus()
@@ -197,22 +211,52 @@ export class UpdateController {
     )
     if (evaluation.kind === 'accepted') {
       writeUpdateBootRecord(this.bootRecordPath, next)
+      this.failedUpdate = null
       this.setStatus({
         phase: 'current',
         message: `Collie ${this.status.currentVersion} is up to date.`
       })
     } else if (evaluation.kind === 'rollback-needed') {
-      // Keep the record so the notice survives until the next accepted boot.
+      // Keep the record so the notice survives until the next accepted boot
+      // or an explicit dismiss. Phase transitions never clear it.
+      this.failedUpdate = {
+        pendingVersion: record.pendingVersion,
+        previousVersion: record.previousVersion
+      }
       this.setStatus({
         phase: 'rollback',
         message:
-          'The last update did not start properly. Collie still trusts your previous version and kept its settings.'
+          'The last update did not start properly. Your chats and settings are safe, but this version may be unstable.'
       })
     }
     return this.getStatus()
   }
 
-  private setStatus(next: Omit<UpdateStatus, 'currentVersion'>): void {
+  /**
+   * The user acknowledged the failed update: clear the boot record's
+   * pending/previous versions (last-known-good stays untouched) and drop the
+   * failure state. The current version is kept as-is — nothing is restored.
+   */
+  dismissUpdateFailure(): UpdateStatus {
+    if (!this.failedUpdate) return this.getStatus()
+    if (this.bootRecordPath) {
+      const current = readUpdateBootRecord(this.bootRecordPath) ?? emptyUpdateBootRecord()
+      writeUpdateBootRecord(this.bootRecordPath, {
+        ...current,
+        pendingVersion: null,
+        previousVersion: null,
+        updatedAt: new Date().toISOString()
+      })
+    }
+    this.failedUpdate = null
+    this.setStatus({
+      phase: 'current',
+      message: 'Keeping this version. Your chats and settings stay as they are.'
+    })
+    return this.getStatus()
+  }
+
+  private setStatus(next: Omit<UpdateStatus, 'currentVersion' | 'failedUpdate'>): void {
     this.status = {
       currentVersion: this.status.currentVersion,
       availableVersion: next.availableVersion ?? this.status.availableVersion,

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -8,6 +8,7 @@ export type UpdatePhase =
   | 'ready'
   | 'current'
   | 'failed'
+  | 'rollback'
 
 export interface UpdateStatus {
   phase: UpdatePhase

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -10,12 +10,18 @@ export type UpdatePhase =
   | 'failed'
   | 'rollback'
 
+export interface FailedUpdateInfo {
+  pendingVersion: string | null
+  previousVersion: string | null
+}
+
 export interface UpdateStatus {
   phase: UpdatePhase
   currentVersion: string
   availableVersion?: string
   percent?: number
   message?: string
+  failedUpdate: FailedUpdateInfo | null
 }
 
 export interface ActiveWorkSnapshot {
@@ -73,6 +79,8 @@ const api = {
     ipcRenderer.invoke('collie:download-update'),
   restartAndInstallUpdate: (): Promise<InstallResult> =>
     ipcRenderer.invoke('collie:restart-and-install-update'),
+  dismissUpdateFailure: (): Promise<UpdateStatus> =>
+    ipcRenderer.invoke('collie:dismiss-update-failure'),
   updateActiveWork: (snapshot: ActiveWorkSnapshot): Promise<boolean> =>
     ipcRenderer.invoke('collie:update-active-work', snapshot),
   onUpdateStatus: (listener: (status: UpdateStatus) => void): (() => void) => {

--- a/collie-ui/src/renderer/src/components/settings/UpdateTab.test.tsx
+++ b/collie-ui/src/renderer/src/components/settings/UpdateTab.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import UpdateTab from './UpdateTab'
+
+type RendererUpdateStatus = Awaited<ReturnType<Window['collie']['updateStatus']>>
+
+const FAILED_STATUS: RendererUpdateStatus = {
+  phase: 'current',
+  currentVersion: '0.1.0-alpha.5',
+  failedUpdate: { pendingVersion: '0.1.0-alpha.5', previousVersion: '0.1.0-alpha.4' }
+}
+
+function mockBridge(
+  status: RendererUpdateStatus,
+  dismiss: () => Promise<RendererUpdateStatus> = vi.fn(async () => ({ ...status, failedUpdate: null }))
+): Window['collie'] {
+  return {
+    updateStatus: vi.fn(async () => status),
+    onUpdateStatus: vi.fn(() => () => undefined),
+    dismissUpdateFailure: dismiss,
+    checkForUpdate: vi.fn(async () => status),
+    downloadUpdate: vi.fn(async () => status),
+    restartAndInstallUpdate: vi.fn(async () => ({ installed: false, blockedBy: [] })),
+    updateActiveWork: vi.fn(async () => true),
+    coreState: vi.fn(async () => ({ state: 'running', port: 3818, token: '', error: '' }))
+  } as unknown as Window['collie']
+}
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  root = null
+  container.remove()
+})
+
+async function renderTab(): Promise<void> {
+  await act(async () => {
+    root = createRoot(container)
+    root.render(<UpdateTab />)
+  })
+}
+
+describe('UpdateTab failed-update banner', () => {
+  it('renders the failure banner from failedUpdate even when phase is current', async () => {
+    window.collie = mockBridge(FAILED_STATUS)
+    await renderTab()
+
+    expect(container.textContent).toContain("didn't start properly")
+    expect(container.textContent).toContain('Your chats and settings are safe')
+    const button = [...container.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Keep this version')
+    )
+    expect(button).toBeTruthy()
+  })
+
+  it('hides the banner when failedUpdate is null', async () => {
+    window.collie = mockBridge({ phase: 'current', currentVersion: '0.1.0-alpha.5', failedUpdate: null })
+    await renderTab()
+
+    expect(container.textContent).not.toContain("didn't start properly")
+  })
+
+  it('dismisses the notice through the bridge and clears the banner', async () => {
+    const dismiss = vi.fn(async (): Promise<RendererUpdateStatus> => ({
+      phase: 'current',
+      currentVersion: '0.1.0-alpha.5',
+      failedUpdate: null
+    }))
+    window.collie = mockBridge(FAILED_STATUS, dismiss)
+    await renderTab()
+
+    const button = [...container.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Keep this version')
+    )
+    await act(async () => {
+      button!.click()
+    })
+
+    expect(dismiss).toHaveBeenCalledOnce()
+    expect(container.textContent).not.toContain("didn't start properly")
+  })
+})

--- a/collie-ui/src/renderer/src/components/settings/UpdateTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/UpdateTab.tsx
@@ -3,7 +3,14 @@ import { CheckCircle2, Download, RefreshCw, RotateCcw, TriangleAlert } from 'luc
 
 type RendererUpdateStatus = Awaited<ReturnType<Window['collie']['updateStatus']>>
 
-const INITIAL_STATUS: RendererUpdateStatus = { phase: 'idle', currentVersion: '' }
+const INITIAL_STATUS: RendererUpdateStatus = {
+  phase: 'idle',
+  currentVersion: '',
+  failedUpdate: null
+}
+
+const FAILED_UPDATE_COPY =
+  "The last update didn't start properly. Your chats and settings are safe, but this version may be unstable."
 
 export default function UpdateTab(): React.JSX.Element {
   const [status, setStatus] = useState<RendererUpdateStatus>(INITIAL_STATUS)
@@ -22,6 +29,18 @@ export default function UpdateTab(): React.JSX.Element {
       setStatus(await action())
     } catch {
       setStatus((current) => ({ ...current, phase: 'failed' }))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const dismiss = async (): Promise<void> => {
+    setBusy(true)
+    setNotice('')
+    try {
+      setStatus(await window.collie.dismissUpdateFailure())
+    } catch {
+      setNotice('The notice could not be dismissed. Try again in a moment.')
     } finally {
       setBusy(false)
     }
@@ -51,13 +70,13 @@ export default function UpdateTab(): React.JSX.Element {
     ready: `Collie${version} is downloaded and ready to install.`,
     current: status.message || 'Collie is up to date.',
     failed: status.message || 'The update check failed. Try again when you are online.',
-    rollback: status.message || 'The last update did not start properly.'
+    rollback: status.message || FAILED_UPDATE_COPY
   }
 
   return (
     <section className="settings-card settings-control-card">
       <div className="settings-card-icon">
-        {status.phase === 'failed' || status.phase === 'rollback' ? (
+        {status.failedUpdate || status.phase === 'failed' || status.phase === 'rollback' ? (
           <TriangleAlert size={19} />
         ) : status.phase === 'current' ? (
           <CheckCircle2 size={19} />
@@ -67,7 +86,21 @@ export default function UpdateTab(): React.JSX.Element {
       </div>
       <div>
         <h3>Collie updates</h3>
-        <p>{statusCopy[status.phase]}</p>
+        {status.failedUpdate ? (
+          <div className="update-failure-banner" role="alert">
+            <TriangleAlert size={16} className="update-failure-banner-icon" />
+            <p>{FAILED_UPDATE_COPY}</p>
+            <button
+              className="settings-button update-failure-banner-action"
+              disabled={busy}
+              onClick={() => void dismiss()}
+            >
+              Keep this version
+            </button>
+          </div>
+        ) : (
+          <p>{statusCopy[status.phase]}</p>
+        )}
         <p className="mt-2 text-sm" style={{ color: 'var(--collie-text-muted)' }}>
           Installed version: {status.currentVersion || 'development build'}
         </p>

--- a/collie-ui/src/renderer/src/components/settings/UpdateTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/UpdateTab.tsx
@@ -50,13 +50,14 @@ export default function UpdateTab(): React.JSX.Element {
     downloading: `Downloading Collie${version}… ${Math.round(status.percent ?? 0)}%`,
     ready: `Collie${version} is downloaded and ready to install.`,
     current: status.message || 'Collie is up to date.',
-    failed: status.message || 'The update check failed. Try again when you are online.'
+    failed: status.message || 'The update check failed. Try again when you are online.',
+    rollback: status.message || 'The last update did not start properly.'
   }
 
   return (
     <section className="settings-card settings-control-card">
       <div className="settings-card-icon">
-        {status.phase === 'failed' ? (
+        {status.phase === 'failed' || status.phase === 'rollback' ? (
           <TriangleAlert size={19} />
         ) : status.phase === 'current' ? (
           <CheckCircle2 size={19} />
@@ -75,7 +76,8 @@ export default function UpdateTab(): React.JSX.Element {
       <div className="flex flex-wrap gap-2">
         {(status.phase === 'idle' ||
           status.phase === 'current' ||
-          status.phase === 'failed') && (
+          status.phase === 'failed' ||
+          status.phase === 'rollback') && (
           <button
             className="settings-button"
             disabled={busy}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -639,6 +639,29 @@ button {
   font-size: 12px;
 }
 
+.update-failure-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border: 1px solid rgba(232, 145, 58, 0.28);
+  border-radius: 11px;
+  background: rgba(232, 145, 58, 0.1);
+  color: var(--grass-dark);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.update-failure-banner p { margin: 0; }
+
+.update-failure-banner-icon { flex-shrink: 0; margin-top: 1px; }
+
+.update-failure-banner .update-failure-banner-action {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
 .agent-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));


### PR DESCRIPTION
## Problem
When an update installs and the new version cannot start its Python core (schema drift, broken runtime), there is no trace and no recovery path: the previous version is gone and the app is silently broken.

## Solution
Durable **boot record** (`update-boot-record.json` in userData) + boot verification:

- **Before install** (`restartAndInstall`): persist `{pendingVersion, previousVersion, lastGoodVersion}`.
- **On next boot** (after `spawnCore` settles): `evaluateBoot()` checks the pending version against the one that actually started.
  - Core healthy → update **accepted**: record clears, version becomes last-known-good, status → `current`.
  - Core failed → new **`rollback` phase** with an honest Settings notice: "The last update did not start properly. Collie still trusts your previous version and kept its settings."
- New module `update-boot-record.ts` is pure and fully unit-tested; write-then-rename keeps the record atomic; corrupt/missing record degrades to a normal first boot.
- Renderer: `UpdateTab` renders the rollback phase (warning icon + notice + Check for updates action); preload phase union updated.

## Verification
- 11 new unit tests (record round-trip, malformed tolerance, pending-record write on install, accept / rollback-needed / noop evaluation)
- `npm run typecheck` clean; full suite green

Patterned after T3 Code's smooth remote updates (pingdotgg/t3code #5470): durable state + boot verification + honest rollback surfacing.

## Honest limits (phase 2, not this PR)
- Actual binary revert (reinstalling the previous version's installer) needs the installer pipeline's launcher/backup support — this PR lays the durable state + detection the revert will plug into. Until then the notice + Check for updates is the recovery path.

---

## Review round (2026-08-08) — P1s fixed

Per Codex deep-review, this PR is **failed-update detection + recovery notice** (not binary rollback — electron-updater has no rollback primitive). Fixes landed on the same branch:

1. **Sustained-health acceptance** (`update-boot-settle.ts`): when a pending boot record matches the running version, the update is accepted only after the core runs *continuously* for a 5 s probation window — any `failed` sample is an immediate failure, any respawn resets the streak. Normal first boots keep the fast path (no startup delay).
2. **Durable failure state** (`updater-controller.ts`): `failedUpdate` is modeled separately from check/download state, so "Check for updates" can never erase the notice; `dismissUpdateFailure()` (Keep this version) explicitly clears it.
3. **Honest copy**: UI/record strings now say the last update *didn't start properly* instead of claiming the previous version was "trusted" (nothing is restored).
