### PR TITLE
feat: subagent observability — live roster + settled pet popup

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -5,6 +5,7 @@ Localhost-only JSON protocol between the Electron shell and the Python core.
 Client -> server commands (JSON objects; ``type`` + optional ``id``):
 - ``ping``                     -> ``pong``
 - ``get_status``               -> core status (provider, model, counts)
+- ``get_subagent_activity``    -> live + recently settled subagent roster only
 - ``transcribe``               -> local English microphone dictation
 - ``chat``                     -> start an agent turn; streams events back
 - ``stop``                     -> note a stop request for a conversation
@@ -478,6 +479,23 @@ class CollieIPCServer:
         if self._status_provider is not None:
             status.update(self._status_provider())
         return status
+
+    async def _cmd_get_subagent_activity(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        """Lightweight subagent roster for poll-heavy surfaces (Agents tab).
+
+        Returns only the live + recently settled subagent rows instead of the
+        full status payload (conversation/provider/usage lists), so a 2 s
+        roster poll stays cheap.
+        """
+        if self._status_provider is None:
+            return {"active_agents": [], "recent_agents": []}
+        status = self._status_provider()
+        return {
+            "active_agents": status.get("active_agents") or [],
+            "recent_agents": status.get("recent_agents") or [],
+        }
 
     async def _cmd_list_commands(self, connection: ServerConnection, frame: dict) -> dict:
         if self._command_catalog is None:

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -187,6 +187,7 @@ class CollieIPCServer:
             Callable[[str], Awaitable[dict[str, Any]]] | None
         ) = None,
         status_provider: Callable[[], dict[str, Any]] | None = None,
+        activity_provider: Callable[[], dict[str, Any]] | None = None,
         service_manager: Any = None,
         subagent_loader: Any = None,
         prompt_writer: Callable[[str, str], Awaitable[str]] | None = None,
@@ -220,6 +221,7 @@ class CollieIPCServer:
         self._on_finalize_provider_candidate = on_finalize_provider_candidate
         self._on_rollback_provider_candidate = on_rollback_provider_candidate
         self._status_provider = status_provider
+        self._activity_provider = activity_provider
         self._service_manager = service_manager
         self._subagent_loader = subagent_loader
         self._prompt_writer = prompt_writer
@@ -483,15 +485,18 @@ class CollieIPCServer:
     async def _cmd_get_subagent_activity(
         self, connection: ServerConnection, frame: dict
     ) -> dict:
-        """Lightweight subagent roster for poll-heavy surfaces (Agents tab).
+        """Cheap subagent roster for poll-heavy surfaces (Agents tab).
 
-        Returns only the live + recently settled subagent rows instead of the
-        full status payload (conversation/provider/usage lists), so a 2 s
-        roster poll stays cheap.
+        Prefers the dedicated activity provider (runtime.subagent_activity,
+        which reads the manager's active + settled collections directly);
+        falls back to the status provider's roster keys when no dedicated
+        provider was wired in. Either way the payload is just the two
+        roster arrays — never the full status payload.
         """
-        if self._status_provider is None:
+        provider = self._activity_provider or self._status_provider
+        if provider is None:
             return {"active_agents": [], "recent_agents": []}
-        status = self._status_provider()
+        status = provider()
         return {
             "active_agents": status.get("active_agents") or [],
             "recent_agents": status.get("recent_agents") or [],

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -15,6 +15,7 @@ import inspect
 import json
 import os
 import sys
+import time
 import urllib.parse
 import uuid
 from contextlib import suppress
@@ -315,7 +316,7 @@ class CollieRuntime:
             try:
                 statuses = self.loop.subagents.get_running_statuses_by_session(session_key)
             except Exception:
-                logger.exception("Failed to list subagents for session {}", session_key)
+                logger.exception("Failed to list subagents for session {session_key}")
                 continue
             for agent in statuses:
                 agent_id = str(agent.get("id") or "")
@@ -323,8 +324,58 @@ class CollieRuntime:
                     continue
                 if agent_id:
                     seen.add(agent_id)
-                active.append({**agent, "conversation_id": conversation_id})
+                active.append(self._decorate_subagent(agent, conversation_id))
         return sorted(active, key=lambda item: float(item.get("started_at") or 0))
+
+    def recent_subagents_for_conversation(
+        self, conversation_id: str
+    ) -> list[dict[str, Any]]:
+        """List UI-safe specialists that recently finished for a conversation.
+
+        Mirrors :meth:`active_subagents_for_conversation` but reads the
+        manager's bounded settled-status retention, so the roster can show
+        "earlier" rows (outcome + elapsed) without any persistence.
+        """
+        if self.loop is None:
+            return []
+        recent: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for session_key in sorted(self.session_keys_for_conversation(conversation_id)):
+            try:
+                statuses = self.loop.subagents.get_recent_statuses_by_session(session_key)
+            except Exception:
+                logger.exception("Failed to list recent subagents for session {session_key}")
+                continue
+            for agent in statuses:
+                agent_id = str(agent.get("id") or "")
+                if agent_id and agent_id in seen:
+                    continue
+                if agent_id:
+                    seen.add(agent_id)
+                recent.append(self._decorate_subagent(agent, conversation_id))
+        return sorted(
+            recent,
+            key=lambda item: float(item.get("ended_at") or item.get("started_at") or 0),
+            reverse=True,
+        )
+
+    @staticmethod
+    def _decorate_subagent(agent: dict[str, Any], conversation_id: str) -> dict[str, Any]:
+        """Attach wall-clock ms + conversation scoping to a UI-safe subagent row.
+
+        The manager reports ``time.monotonic()`` values; the renderer needs
+        epoch ms so elapsed time can be computed and frozen across polls.
+        """
+        now_mono = time.monotonic()
+        offset_ms = (time.time() - now_mono) * 1000.0
+        started_ms = agent.get("started_at")
+        if isinstance(started_ms, (int, float)):
+            agent["started_at_ms"] = int(started_ms * 1000.0 + offset_ms)
+        ended_at = agent.get("ended_at")
+        if isinstance(ended_at, (int, float)):
+            agent["ended_at_ms"] = int(ended_at * 1000.0 + offset_ms)
+        agent["conversation_id"] = conversation_id
+        return agent
 
     async def cancel_subagents_for_conversation(self, conversation_id: str) -> int:
         """Cancel specialists across every session mapped to a conversation."""
@@ -1144,11 +1195,17 @@ class CollieRuntime:
                 pass
             try:
                 active_agents: list[dict[str, Any]] = []
+                recent_agents: list[dict[str, Any]] = []
                 for conversation in self.db.list_conversations(include_archived=True):
+                    conversation_id = str(conversation["id"])
                     active_agents.extend(
-                        self.active_subagents_for_conversation(str(conversation["id"]))
+                        self.active_subagents_for_conversation(conversation_id)
+                    )
+                    recent_agents.extend(
+                        self.recent_subagents_for_conversation(conversation_id)
                     )
                 status["active_agents"] = active_agents
+                status["recent_agents"] = recent_agents
             except Exception:
                 pass
         return status

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -131,6 +131,7 @@ class CollieRuntime:
             on_finalize_provider_candidate=self._finalize_provider_candidate,
             on_rollback_provider_candidate=self._rollback_provider_candidate,
             status_provider=self._status,
+            activity_provider=self.subagent_activity,
             service_manager=self.services,
             subagent_loader=self.subagents,
             prompt_writer=self._write_subagent_prompt,
@@ -376,6 +377,48 @@ class CollieRuntime:
             agent["ended_at_ms"] = int(ended_at * 1000.0 + offset_ms)
         agent["conversation_id"] = conversation_id
         return agent
+
+    @staticmethod
+    def _conversation_id_for_session(session_key: str | None) -> str:
+        """Map an engine session key back to a desktop conversation id.
+
+        Desktop session keys embed the conversation id (``collie:<id>``).
+        Messenger session keys cannot be reverse-mapped to a desktop
+        conversation, so those rows surface with an empty conversation id —
+        they appear in the Agents-tab roster but never match a desktop
+        conversation in ChatScreen.
+        """
+        if session_key and session_key.startswith("collie:"):
+            return session_key[len("collie:"):]
+        return ""
+
+    def subagent_activity(self) -> dict[str, list[dict[str, Any]]]:
+        """Live + settled roster feed for poll-heavy surfaces.
+
+        Reads the SubagentManager's active and settled collections directly
+        instead of walking every conversation, so the cost is O(active
+        sessions) rather than O(all conversations) — safe to poll every
+        couple of seconds from the event loop.
+        """
+        if self.loop is None:
+            return {"active_agents": [], "recent_agents": []}
+        active: list[dict[str, Any]] = []
+        recent: list[dict[str, Any]] = []
+        try:
+            manager = self.loop.subagents
+            for agent in manager.get_running_statuses():
+                active.append(self._decorate_subagent(
+                    agent,
+                    self._conversation_id_for_session(agent.get("session_key")),
+                ))
+            for agent in manager.get_recent_statuses():
+                recent.append(self._decorate_subagent(
+                    agent,
+                    self._conversation_id_for_session(agent.get("session_key")),
+                ))
+        except Exception:
+            logger.exception("Failed to build the subagent activity feed")
+        return {"active_agents": active, "recent_agents": recent}
 
     async def cancel_subagents_for_conversation(self, conversation_id: str) -> int:
         """Cancel specialists across every session mapped to a conversation."""
@@ -1186,6 +1229,7 @@ class CollieRuntime:
             "workspace": str(self.workspace),
             "db_path": str(self.db.path),
             "active_agents": [],
+            "recent_agents": [],
         }
         if self.loop is not None:
             try:
@@ -1194,18 +1238,9 @@ class CollieRuntime:
             except Exception:
                 pass
             try:
-                active_agents: list[dict[str, Any]] = []
-                recent_agents: list[dict[str, Any]] = []
-                for conversation in self.db.list_conversations(include_archived=True):
-                    conversation_id = str(conversation["id"])
-                    active_agents.extend(
-                        self.active_subagents_for_conversation(conversation_id)
-                    )
-                    recent_agents.extend(
-                        self.recent_subagents_for_conversation(conversation_id)
-                    )
-                status["active_agents"] = active_agents
-                status["recent_agents"] = recent_agents
+                activity = self.subagent_activity()
+                status["active_agents"] = activity["active_agents"]
+                status["recent_agents"] = activity["recent_agents"]
             except Exception:
                 pass
         return status

--- a/collie-core/nanobot/agent/subagent.py
+++ b/collie-core/nanobot/agent/subagent.py
@@ -62,6 +62,42 @@ class SubagentStatus:
     outcome: str | None = None       # ok | error | cancelled
 
 
+@dataclass(frozen=True, slots=True)
+class SubagentSnapshot:
+    """Immutable, lightweight settled-state record for a finished subagent.
+
+    Deliberately tiny: the roster only needs these fields, and retaining full
+    ``SubagentStatus`` objects (with their ``tool_events`` list and ``usage``
+    dict) for a bounded window would pin potentially large payloads in memory
+    for no UI benefit.
+    """
+
+    task_id: str
+    label: str
+    phase: str
+    task_description: str
+    started_at: float          # time.monotonic()
+    ended_at: float | None     # time.monotonic(); set on every terminal state
+    outcome: str | None        # ok | error | cancelled
+    execution_posture: str
+    session_key: str | None
+
+
+def _recent_row(snapshot: SubagentSnapshot) -> dict[str, Any]:
+    """UI-safe dict for a settled snapshot (shared by the by-session and
+    all-session roster surfaces)."""
+    return {
+        "id": snapshot.task_id,
+        "name": snapshot.label,
+        "phase": snapshot.phase,
+        "task_description": snapshot.task_description,
+        "started_at": snapshot.started_at,
+        "ended_at": snapshot.ended_at,
+        "outcome": snapshot.outcome,
+        "execution_posture": snapshot.execution_posture,
+    }
+
+
 class _SubagentHook(AgentHook):
     """Hook for subagent execution — logs tool calls and updates status."""
 
@@ -161,9 +197,9 @@ class SubagentManager:
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
-        # Recently finished statuses, oldest first; bounded so the roster
+        # Recently finished snapshots, oldest first; bounded so the roster
         # cannot grow without bound (no persistence — T3-style client fold).
-        self._recent_statuses: deque[SubagentStatus] = deque(maxlen=self.recent_status_limit)
+        self._recent_statuses: deque[SubagentSnapshot] = deque(maxlen=self.recent_status_limit)
 
     def set_provider(self, provider: LLMProvider, model: str) -> None:
         """Update the deprecated runtime source used by legacy ``spawn`` calls."""
@@ -286,8 +322,9 @@ class SubagentManager:
         def _cleanup(_: asyncio.Task) -> None:
             self._running_tasks.pop(task_id, None)
             if task_id in self._task_statuses:
-                # Retain the finished status briefly so clients can render
-                # settled rows (outcome, elapsed) before it ages out.
+                # Retain a small immutable snapshot of the finished status so
+                # clients can render settled rows (outcome, elapsed) before
+                # it ages out — never the full status with tool_events/usage.
                 if status.ended_at is None:
                     status.ended_at = time.monotonic()
                 if status.outcome is None:
@@ -297,7 +334,17 @@ class SubagentManager:
                     # dangling "working" row.
                     status.phase = "cancelled"
                     status.outcome = "cancelled"
-                self._recent_statuses.append(status)
+                self._recent_statuses.append(SubagentSnapshot(
+                    task_id=status.task_id,
+                    label=status.label,
+                    phase=status.phase,
+                    task_description=status.task_description,
+                    started_at=status.started_at,
+                    ended_at=status.ended_at,
+                    outcome=status.outcome,
+                    execution_posture=status.execution_posture,
+                    session_key=status.session_key,
+                ))
             self._task_statuses.pop(task_id, None)
             if session_key and (ids := self._session_tasks.get(session_key)):
                 ids.discard(task_id)
@@ -590,6 +637,45 @@ class SubagentManager:
             })
         return sorted(statuses, key=lambda item: float(item["started_at"]))
 
+    def get_running_statuses(self) -> list[dict[str, Any]]:
+        """Return UI-safe details for every currently running subagent.
+
+        Covers all sessions (desktop + messenger) in one pass, so the
+        roster feed stays O(active tasks) instead of O(conversations).
+        """
+        rows: list[dict[str, Any]] = []
+        for task_id, task in self._running_tasks.items():
+            status = self._task_statuses.get(task_id)
+            if task is None or task.done() or status is None:
+                continue
+            rows.append({
+                "id": status.task_id,
+                "name": status.label,
+                "phase": status.phase,
+                "task_description": status.task_description,
+                "started_at": status.started_at,
+                "execution_posture": status.execution_posture,
+                "session_key": status.session_key,
+            })
+        return sorted(rows, key=lambda item: float(item["started_at"]))
+
+    def get_recent_statuses(self) -> list[dict[str, Any]]:
+        """Return UI-safe settled rows across every session, newest first.
+
+        Reads the bounded snapshot retention directly (no per-conversation
+        walk), so poll-heavy surfaces stay cheap on large chat histories.
+        """
+        rows: list[dict[str, Any]] = []
+        for snapshot in self._recent_statuses:
+            row = _recent_row(snapshot)
+            row["session_key"] = snapshot.session_key
+            rows.append(row)
+        return sorted(
+            rows,
+            key=lambda item: float(item.get("ended_at") or item["started_at"]),
+            reverse=True,
+        )
+
     def get_recent_statuses_by_session(self, session_key: str) -> list[dict[str, Any]]:
         """Return UI-safe details for subagents that recently finished for a session.
 
@@ -597,22 +683,13 @@ class SubagentManager:
         can render "earlier" rows with outcome and elapsed time before they
         age out. Newest first.
         """
-        statuses: list[dict[str, Any]] = []
-        for status in self._recent_statuses:
-            if status.session_key != session_key:
+        rows: list[dict[str, Any]] = []
+        for snapshot in self._recent_statuses:
+            if snapshot.session_key != session_key:
                 continue
-            statuses.append({
-                "id": status.task_id,
-                "name": status.label,
-                "phase": status.phase,
-                "task_description": status.task_description,
-                "started_at": status.started_at,
-                "ended_at": status.ended_at,
-                "outcome": status.outcome,
-                "execution_posture": status.execution_posture,
-            })
+            rows.append(_recent_row(snapshot))
         return sorted(
-            statuses,
+            rows,
             key=lambda item: float(item.get("ended_at") or item["started_at"]),
             reverse=True,
         )

--- a/collie-core/nanobot/agent/subagent.py
+++ b/collie-core/nanobot/agent/subagent.py
@@ -5,6 +5,7 @@ import json
 import time
 import uuid
 import warnings
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -50,12 +51,15 @@ class SubagentStatus:
     task_description: str
     started_at: float          # time.monotonic()
     execution_posture: str = "read_only"
-    phase: str = "initializing"  # initializing | awaiting_tools | tools_completed | final_response | done | error
+    phase: str = "initializing"  # initializing | awaiting_tools | tools_completed | final_response | done | error | cancelled
     iteration: int = 0
     tool_events: list = field(default_factory=list)   # [{name, status, detail}, ...]
     usage: dict = field(default_factory=dict)          # token usage
     stop_reason: str | None = None
     error: str | None = None
+    session_key: str | None = None
+    ended_at: float | None = None    # time.monotonic(); set on every terminal state
+    outcome: str | None = None       # ok | error | cancelled
 
 
 class _SubagentHook(AgentHook):
@@ -102,6 +106,7 @@ class SubagentManager:
         fail_on_tool_error: bool | None = None,
         llm_wall_timeout_for_session: Callable[[str | None], float | None] | None = None,
         hook_factories: list[AgentTurnHookFactory] | None = None,
+        recent_status_limit: int = 24,
     ):
         if workspace is None:
             raise TypeError("SubagentManager.__init__() missing required argument: 'workspace'")
@@ -149,12 +154,16 @@ class SubagentManager:
             if fail_on_tool_error is not None
             else defaults.fail_on_tool_error
         )
+        self.recent_status_limit = recent_status_limit
         self.runner = AgentRunner()
         self._llm_wall_timeout_for_session = llm_wall_timeout_for_session
         self.hook_factories: list[AgentTurnHookFactory] = list(hook_factories or [])
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
+        # Recently finished statuses, oldest first; bounded so the roster
+        # cannot grow without bound (no persistence — T3-style client fold).
+        self._recent_statuses: deque[SubagentStatus] = deque(maxlen=self.recent_status_limit)
 
     def set_provider(self, provider: LLMProvider, model: str) -> None:
         """Update the deprecated runtime source used by legacy ``spawn`` calls."""
@@ -253,6 +262,7 @@ class SubagentManager:
             task_description=task,
             started_at=time.monotonic(),
             execution_posture=execution_posture,
+            session_key=session_key,
         )
         self._task_statuses[task_id] = status
 
@@ -275,6 +285,19 @@ class SubagentManager:
 
         def _cleanup(_: asyncio.Task) -> None:
             self._running_tasks.pop(task_id, None)
+            if task_id in self._task_statuses:
+                # Retain the finished status briefly so clients can render
+                # settled rows (outcome, elapsed) before it ages out.
+                if status.ended_at is None:
+                    status.ended_at = time.monotonic()
+                if status.outcome is None:
+                    # The task ended without recording a terminal state (e.g.
+                    # cancelled before its first await, or killed externally).
+                    # Treat it as stopped so the roster never shows a
+                    # dangling "working" row.
+                    status.phase = "cancelled"
+                    status.outcome = "cancelled"
+                self._recent_statuses.append(status)
             self._task_statuses.pop(task_id, None)
             if session_key and (ids := self._session_tasks.get(session_key)):
                 ids.discard(task_id)
@@ -387,8 +410,10 @@ class SubagentManager:
                 reset_request_context(request_token)
             status.phase = "done"
             status.stop_reason = result.stop_reason
+            status.ended_at = time.monotonic()
 
             if result.stop_reason == "tool_error":
+                status.outcome = "error"
                 status.tool_events = list(result.tool_events)
                 await self._announce_result(
                     task_id, label, task,
@@ -396,18 +421,29 @@ class SubagentManager:
                     origin, "error", origin_message_id,
                 )
             elif result.stop_reason == "error":
+                status.outcome = "error"
                 await self._announce_result(
                     task_id, label, task,
                     result.error or "Error: subagent execution failed.",
                     origin, "error", origin_message_id,
                 )
             else:
+                status.outcome = "ok"
                 final_result = result.final_content or "Task completed but no final response was generated."
                 logger.info("Subagent [{}] completed successfully", task_id)
                 await self._announce_result(task_id, label, task, final_result, origin, "ok", origin_message_id)
 
+        except asyncio.CancelledError:
+            # Stop-everything path: record the settle state before the
+            # cleanup callback retains the status.
+            status.phase = "cancelled"
+            status.outcome = "cancelled"
+            status.ended_at = time.monotonic()
+            raise
         except Exception as e:
             status.phase = "error"
+            status.outcome = "error"
+            status.ended_at = time.monotonic()
             status.error = str(e)
             logger.exception("Subagent [{}] failed", task_id)
             await self._announce_result(task_id, label, task, f"Error: {e}", origin, "error", origin_message_id)
@@ -553,3 +589,30 @@ class SubagentManager:
                 "execution_posture": status.execution_posture,
             })
         return sorted(statuses, key=lambda item: float(item["started_at"]))
+
+    def get_recent_statuses_by_session(self, session_key: str) -> list[dict[str, Any]]:
+        """Return UI-safe details for subagents that recently finished for a session.
+
+        Settled statuses are retained for a short, bounded window so clients
+        can render "earlier" rows with outcome and elapsed time before they
+        age out. Newest first.
+        """
+        statuses: list[dict[str, Any]] = []
+        for status in self._recent_statuses:
+            if status.session_key != session_key:
+                continue
+            statuses.append({
+                "id": status.task_id,
+                "name": status.label,
+                "phase": status.phase,
+                "task_description": status.task_description,
+                "started_at": status.started_at,
+                "ended_at": status.ended_at,
+                "outcome": status.outcome,
+                "execution_posture": status.execution_posture,
+            })
+        return sorted(
+            statuses,
+            key=lambda item: float(item.get("ended_at") or item["started_at"]),
+            reverse=True,
+        )

--- a/collie-core/tests/collie/test_subagent_observability.py
+++ b/collie-core/tests/collie/test_subagent_observability.py
@@ -193,10 +193,116 @@ class TestSettledRetention:
         assert status.outcome is None
         assert status.session_key is None
 
+    @pytest.mark.asyncio
+    async def test_retained_settled_records_are_lightweight_snapshots(
+        self, tmp_path
+    ) -> None:
+        """The bounded retention keeps a small immutable snapshot, not the
+        full live status: no tool_events / usage / error payloads survive."""
+        sm = _manager(tmp_path)
+        sm.runner.run = AsyncMock(return_value=AgentRunResult(
+            final_content="ok", messages=[], stop_reason="completed",
+            tool_events=[{"name": "read_file", "status": "ok", "detail": "x"}],
+        ))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            await sm.spawn(**_spawn_kwargs(
+                "collie:conv-1", "Do the thing", label="Trip Planner"
+            ))
+            await _drain(sm)
+
+        retained = list(sm._recent_statuses)
+        assert len(retained) == 1
+        snapshot = retained[0]
+        # Heavy live-state fields must not be retained.
+        assert not hasattr(snapshot, "tool_events")
+        assert not hasattr(snapshot, "usage")
+        assert not hasattr(snapshot, "error")
+        assert not hasattr(snapshot, "stop_reason")
+        assert not hasattr(snapshot, "iteration")
+        # Everything the roster needs is present and correct.
+        assert snapshot.session_key == "collie:conv-1"
+        assert snapshot.label == "Trip Planner"
+        assert snapshot.outcome == "ok"
+        assert snapshot.ended_at is not None
+        assert snapshot.ended_at >= snapshot.started_at
+
+
+# ---------------------------------------------------------------------------
+# All-session feed getters (SubagentManager)
+# ---------------------------------------------------------------------------
+
+
+class TestAllSessionGetters:
+    @pytest.mark.asyncio
+    async def test_get_running_statuses_covers_every_session(self, tmp_path) -> None:
+        sm = _manager(tmp_path)
+
+        async def _blocking(*args, **kwargs):
+            await asyncio.sleep(30)
+
+        sm.runner.run = AsyncMock(side_effect=_blocking)
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            await sm.spawn(**_spawn_kwargs(
+                "collie:conv-1", "Plan trip", label="Trip Planner"
+            ))
+            await sm.spawn(**_spawn_kwargs(
+                "telegram:42", "Send note", label="Messenger Helper"
+            ))
+            await asyncio.sleep(0.05)
+
+        rows = sm.get_running_statuses()
+        assert len(rows) == 2
+        assert {row["session_key"] for row in rows} == {"collie:conv-1", "telegram:42"}
+        assert {row["name"] for row in rows} == {"Trip Planner", "Messenger Helper"}
+        # Clean up the still-running tasks.
+        for task in list(sm._running_tasks.values()):
+            task.cancel()
+        await _drain(sm)
+
+    @pytest.mark.asyncio
+    async def test_get_recent_statuses_covers_every_session_newest_first(
+        self, tmp_path
+    ) -> None:
+        sm = _manager(tmp_path)
+        sm.runner.run = AsyncMock(return_value=AgentRunResult(
+            final_content="ok", messages=[], stop_reason="completed",
+        ))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            await sm.spawn(**_spawn_kwargs("collie:conv-1", "First", label="A"))
+            await _drain(sm)
+            await asyncio.sleep(0.02)
+            await sm.spawn(**_spawn_kwargs("telegram:42", "Second", label="B"))
+            await _drain(sm)
+
+        rows = sm.get_recent_statuses()
+        assert [row["name"] for row in rows] == ["B", "A"]
+        assert {row["session_key"] for row in rows} == {"collie:conv-1", "telegram:42"}
+        # The by-session surface still works alongside the all-session one.
+        assert len(sm.get_recent_statuses_by_session("collie:conv-1")) == 1
+
 
 # ---------------------------------------------------------------------------
 # Runtime + IPC plumbing
 # ---------------------------------------------------------------------------
+
+
+def _activity_manager(rows_active=None, rows_recent=None):
+    """Manager stub exposing the all-session feed used by subagent_activity()."""
+    calls = {"active": 0, "recent": 0}
+
+    def _active():
+        calls["active"] += 1
+        return list(rows_active or [])
+
+    def _recent():
+        calls["recent"] += 1
+        return list(rows_recent or [])
+
+    return SimpleNamespace(
+        get_running_statuses=_active,
+        get_recent_statuses=_recent,
+        _calls_log=calls,
+    )
 
 
 class TestRuntimeRoster:
@@ -208,21 +314,19 @@ class TestRuntimeRoster:
         runtime = CollieRuntime(port=0, db=db)
         now = time.monotonic()
 
-        runtime.loop = SimpleNamespace(
-            subagents=SimpleNamespace(
-                get_running_statuses_by_session=lambda key: [],
-                get_recent_statuses_by_session=lambda key: [{
-                    "id": "abc123",
-                    "name": "Trip Planner",
-                    "phase": "done",
-                    "task_description": "Plan Barcelona",
-                    "started_at": now - 10.0,
-                    "ended_at": now - 2.0,
-                    "outcome": "ok",
-                    "execution_posture": "read_only",
-                }],
-            )
-        )
+        runtime.loop = SimpleNamespace(subagents=_activity_manager(
+            rows_recent=[{
+                "id": "abc123",
+                "name": "Trip Planner",
+                "phase": "done",
+                "task_description": "Plan Barcelona",
+                "started_at": now - 10.0,
+                "ended_at": now - 2.0,
+                "outcome": "ok",
+                "execution_posture": "read_only",
+                "session_key": "collie:" + conv["id"],
+            }],
+        ))
         try:
             status = runtime._status()
             recent = status["recent_agents"]
@@ -246,12 +350,7 @@ class TestRuntimeRoster:
         db = CollieDB(tmp_path / "c.db")
         db.create_conversation("trip")
         runtime = CollieRuntime(port=0, db=db)
-        runtime.loop = SimpleNamespace(
-            subagents=SimpleNamespace(
-                get_running_statuses_by_session=lambda key: [],
-                get_recent_statuses_by_session=lambda key: [],
-            )
-        )
+        runtime.loop = SimpleNamespace(subagents=_activity_manager())
         try:
             payload = runtime._status()
             assert "recent_agents" in payload
@@ -260,20 +359,121 @@ class TestRuntimeRoster:
             runtime.loop = None
             db.close()
 
+    def test_subagent_activity_never_walks_conversation_history(self, tmp_path) -> None:
+        """The cheap feed reads the manager directly: db.list_conversations is
+        not touched, so cost is independent of how many conversations exist."""
+        from collie_core.db import CollieDB
+
+        db = CollieDB(tmp_path / "c.db")
+        for index in range(300):
+            db.create_conversation(f"conv-{index}")
+        runtime = CollieRuntime(port=0, db=db)
+        now = time.monotonic()
+        manager = _activity_manager(
+            rows_active=[{
+                "id": "live1", "name": "Trip Planner", "phase": "awaiting_tools",
+                "task_description": "Plan Barcelona", "started_at": now,
+                "execution_posture": "read_only", "session_key": "collie:conv-7",
+            }],
+            rows_recent=[{
+                "id": "done1", "name": "Budget Checker", "phase": "done",
+                "task_description": "Compare prices", "started_at": now - 30,
+                "ended_at": now - 5, "outcome": "ok",
+                "execution_posture": "read_only", "session_key": "collie:conv-7",
+            }],
+        )
+        runtime.loop = SimpleNamespace(subagents=manager)
+        try:
+            with patch.object(
+                db, "list_conversations", wraps=db.list_conversations
+            ) as spy:
+                activity = runtime.subagent_activity()
+            spy.assert_not_called()
+            # One all-session pass, not one pass per conversation.
+            assert manager._calls_log == {"active": 1, "recent": 1}
+            assert [row["id"] for row in activity["active_agents"]] == ["live1"]
+            assert [row["id"] for row in activity["recent_agents"]] == ["done1"]
+        finally:
+            runtime.loop = None
+            db.close()
+
+    def test_messenger_session_rows_surface_without_conversation_id(
+        self, tmp_path
+    ) -> None:
+        """Messenger session keys cannot be reverse-mapped to a desktop
+        conversation, so those rows get conversation_id '' (roster-only)."""
+        from collie_core.db import CollieDB
+
+        db = CollieDB(tmp_path / "c.db")
+        runtime = CollieRuntime(port=0, db=db)
+        now = time.monotonic()
+        manager = _activity_manager(
+            rows_active=[{
+                "id": "live1", "name": "Trip Planner", "phase": "awaiting_tools",
+                "task_description": "Plan Barcelona", "started_at": now,
+                "execution_posture": "read_only", "session_key": "collie:conv-9",
+            }],
+            rows_recent=[{
+                "id": "done1", "name": "Messenger Helper", "phase": "done",
+                "task_description": "Send note", "started_at": now - 30,
+                "ended_at": now - 5, "outcome": "ok",
+                "execution_posture": "read_only", "session_key": "telegram:42",
+            }],
+        )
+        runtime.loop = SimpleNamespace(subagents=manager)
+        try:
+            activity = runtime.subagent_activity()
+            by_id = {
+                row["id"]: row
+                for row in activity["active_agents"] + activity["recent_agents"]
+            }
+            assert by_id["live1"]["conversation_id"] == "conv-9"
+            assert by_id["done1"]["conversation_id"] == ""
+        finally:
+            runtime.loop = None
+            db.close()
+
 
 class TestIpcActivity:
     @pytest.mark.asyncio
-    async def test_get_subagent_activity_returns_roster_only(self, tmp_path) -> None:
+    async def test_get_subagent_activity_uses_dedicated_activity_provider(
+        self, tmp_path
+    ) -> None:
+        db = MagicMock()
+        status_provider = MagicMock(return_value={
+            "configured": True,
+            "active_agents": [{"id": "a1"}],
+            "recent_agents": [{"id": "a2"}],
+        })
+        activity_provider = MagicMock(return_value={
+            "active_agents": [{"id": "a1", "name": "Working"}],
+            "recent_agents": [{"id": "a2", "name": "Done"}],
+        })
+        srv = CollieIPCServer(
+            db,
+            status_provider=status_provider,
+            activity_provider=activity_provider,
+        )
+        result = await srv._cmd_get_subagent_activity(MagicMock(), {})
+        assert result == {
+            "active_agents": [{"id": "a1", "name": "Working"}],
+            "recent_agents": [{"id": "a2", "name": "Done"}],
+        }
+        activity_provider.assert_called_once_with()
+        status_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_subagent_activity_falls_back_to_status_provider(
+        self, tmp_path
+    ) -> None:
         db = MagicMock()
         srv = CollieIPCServer(
             db,
             status_provider=lambda: {
                 "configured": True,
-                "workspace": "/tmp",
                 "active_agents": [{"id": "a1", "name": "Working"}],
                 "recent_agents": [{"id": "a2", "name": "Done"}],
                 "conversations": 99,
-                "providers": [],
             },
         )
         result = await srv._cmd_get_subagent_activity(MagicMock(), {})

--- a/collie-core/tests/collie/test_subagent_observability.py
+++ b/collie-core/tests/collie/test_subagent_observability.py
@@ -1,0 +1,289 @@
+"""Tests for subagent observability — settled-status retention and roster feeds.
+
+Covers the bounded "recent" retention added for the live roster + pet popup:
+terminal outcome/ended_at recording (ok / error / cancelled), the
+``get_recent_statuses_by_session`` surface, and the runtime/IPC plumbing that
+turns the manager's monotonic clocks into UI-safe wall-clock rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.runtime import CollieRuntime
+from nanobot.agent import SubagentManager
+from nanobot.agent.runner import AgentRunResult
+from nanobot.agent.subagent import SubagentStatus
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import GenerationSettings, LLMProvider
+from nanobot.utils.llm_runtime import LLMRuntime
+
+
+def _manager(tmp_path, **kw) -> SubagentManager:
+    defaults = dict(
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_tool_result_chars=16_000,
+    )
+    defaults.update(kw)
+    return SubagentManager(**defaults)
+
+
+def _runtime(*, model: str = "test-model") -> LLMRuntime:
+    provider = MagicMock(spec=LLMProvider)
+    provider.generation = GenerationSettings(temperature=0.1, max_tokens=4096)
+    return LLMRuntime.capture(provider, model, context_window_tokens=128_000)
+
+
+def _spawn_kwargs(session_key: str, task: str, **extra) -> dict:
+    """Spawn kwargs scoped to a collie conversation session."""
+    return {
+        "task": task,
+        "origin_channel": "collie",
+        "origin_chat_id": session_key.rsplit(":", 1)[-1],
+        "session_key": session_key,
+        "runtime": _runtime(),
+        **extra,
+    }
+
+
+async def _drain(sm: SubagentManager) -> None:
+    tasks = [t for t in sm._running_tasks.values() if not t.done()]
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# Settled-status retention (SubagentManager)
+# ---------------------------------------------------------------------------
+
+
+class TestSettledRetention:
+    @pytest.mark.asyncio
+    async def test_successful_spawn_retains_settled_status(self, tmp_path) -> None:
+        sm = _manager(tmp_path)
+        sm.runner.run = AsyncMock(return_value=AgentRunResult(
+            final_content="Barcelona sorted!", messages=[], stop_reason="completed",
+        ))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            result = await sm.spawn(
+                **_spawn_kwargs("collie:conv-1", "Plan Barcelona", label="Trip Planner")
+            )
+            task_id = result.split("id: ")[1].split(")")[0]
+            await _drain(sm)
+
+        assert sm.get_running_count() == 0
+        recent = sm.get_recent_statuses_by_session("collie:conv-1")
+        assert len(recent) == 1
+        row = recent[0]
+        assert row["id"] == task_id
+        assert row["name"] == "Trip Planner"
+        assert row["phase"] == "done"
+        assert row["outcome"] == "ok"
+        assert row["ended_at"] is not None
+        assert row["ended_at"] >= row["started_at"]
+
+    @pytest.mark.asyncio
+    async def test_tool_error_records_error_outcome(self, tmp_path) -> None:
+        sm = _manager(tmp_path)
+        sm.runner.run = AsyncMock(return_value=AgentRunResult(
+            final_content=None, messages=[], stop_reason="tool_error",
+            tool_events=[{"name": "read_file", "status": "error", "detail": "nope"}],
+        ))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            await sm.spawn(**_spawn_kwargs("collie:conv-1", "Do the thing"))
+            await _drain(sm)
+
+        recent = sm.get_recent_statuses_by_session("collie:conv-1")
+        assert len(recent) == 1
+        assert recent[0]["phase"] == "done"
+        assert recent[0]["outcome"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_exception_records_error_outcome(self, tmp_path) -> None:
+        sm = _manager(tmp_path)
+        sm.runner.run = AsyncMock(side_effect=RuntimeError("LLM down"))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            await sm.spawn(**_spawn_kwargs("collie:conv-1", "Do the thing"))
+            await _drain(sm)
+
+        recent = sm.get_recent_statuses_by_session("collie:conv-1")
+        assert len(recent) == 1
+        assert recent[0]["phase"] == "error"
+        assert recent[0]["outcome"] == "error"
+        assert recent[0]["ended_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_cancel_records_cancelled_outcome(self, tmp_path) -> None:
+        sm = _manager(tmp_path)
+
+        async def _slow_run(*args, **kwargs):
+            await asyncio.sleep(30)
+
+        sm.runner.run = AsyncMock(side_effect=_slow_run)
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            await sm.spawn(**_spawn_kwargs(
+                "collie:conv-1", "Do the thing", label="Web Searcher"
+            ))
+            cancelled = await sm.cancel_by_session("collie:conv-1")
+            await _drain(sm)
+
+        assert cancelled == 1
+        recent = sm.get_recent_statuses_by_session("collie:conv-1")
+        assert len(recent) == 1
+        assert recent[0]["phase"] == "cancelled"
+        assert recent[0]["outcome"] == "cancelled"
+        assert recent[0]["ended_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_recent_rows_are_session_scoped_and_newest_first(
+        self, tmp_path
+    ) -> None:
+        sm = _manager(tmp_path)
+        sm.runner.run = AsyncMock(return_value=AgentRunResult(
+            final_content="ok", messages=[], stop_reason="completed",
+        ))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            first = (await sm.spawn(
+                **_spawn_kwargs("collie:conv-1", "First", label="A")
+            )).split("id: ")[1].split(")")[0]
+            await _drain(sm)
+            await asyncio.sleep(0.02)
+            second = (await sm.spawn(
+                **_spawn_kwargs("collie:conv-1", "Second", label="B")
+            )).split("id: ")[1].split(")")[0]
+            await _drain(sm)
+            await sm.spawn(**_spawn_kwargs("collie:conv-2", "Other conv", label="C"))
+            await _drain(sm)
+
+        rows = sm.get_recent_statuses_by_session("collie:conv-1")
+        assert [r["id"] for r in rows] == [second, first]
+        assert len(sm.get_recent_statuses_by_session("collie:conv-2")) == 1
+
+    @pytest.mark.asyncio
+    async def test_recent_retention_is_bounded(self, tmp_path) -> None:
+        sm = _manager(tmp_path, recent_status_limit=3)
+        sm.runner.run = AsyncMock(return_value=AgentRunResult(
+            final_content="ok", messages=[], stop_reason="completed",
+        ))
+        with patch.object(sm, "_announce_result", new_callable=AsyncMock):
+            for index in range(5):
+                await sm.spawn(**_spawn_kwargs(
+                    "collie:conv-1", f"Task {index}", label=f"Agent {index}"
+                ))
+                await _drain(sm)
+
+        rows = sm.get_recent_statuses_by_session("collie:conv-1")
+        assert len(rows) == 3
+        # Oldest dropped; newest retained.
+        assert [r["name"] for r in rows] == ["Agent 4", "Agent 3", "Agent 2"]
+
+    def test_status_defaults_stay_optional(self) -> None:
+        status = SubagentStatus(
+            task_id="t", label="l", task_description="d", started_at=1.0
+        )
+        assert status.ended_at is None
+        assert status.outcome is None
+        assert status.session_key is None
+
+
+# ---------------------------------------------------------------------------
+# Runtime + IPC plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeRoster:
+    def test_status_includes_recent_agents_with_wall_clock_ms(self, tmp_path) -> None:
+        from collie_core.db import CollieDB
+
+        db = CollieDB(tmp_path / "c.db")
+        conv = db.create_conversation("trip")
+        runtime = CollieRuntime(port=0, db=db)
+        now = time.monotonic()
+
+        runtime.loop = SimpleNamespace(
+            subagents=SimpleNamespace(
+                get_running_statuses_by_session=lambda key: [],
+                get_recent_statuses_by_session=lambda key: [{
+                    "id": "abc123",
+                    "name": "Trip Planner",
+                    "phase": "done",
+                    "task_description": "Plan Barcelona",
+                    "started_at": now - 10.0,
+                    "ended_at": now - 2.0,
+                    "outcome": "ok",
+                    "execution_posture": "read_only",
+                }],
+            )
+        )
+        try:
+            status = runtime._status()
+            recent = status["recent_agents"]
+            assert len(recent) == 1
+            row = recent[0]
+            assert row["conversation_id"] == conv["id"]
+            assert row["outcome"] == "ok"
+            assert isinstance(row["started_at_ms"], int)
+            assert isinstance(row["ended_at_ms"], int)
+            assert row["ended_at_ms"] > row["started_at_ms"]
+            # Monotonic -> epoch conversion lands within a second of wall clock.
+            assert abs(row["ended_at_ms"] - time.time() * 1000) < 5_000
+            assert status["active_agents"] == []
+        finally:
+            runtime.loop = None
+            db.close()
+
+    def test_activity_does_not_include_full_status_payload(self, tmp_path) -> None:
+        from collie_core.db import CollieDB
+
+        db = CollieDB(tmp_path / "c.db")
+        db.create_conversation("trip")
+        runtime = CollieRuntime(port=0, db=db)
+        runtime.loop = SimpleNamespace(
+            subagents=SimpleNamespace(
+                get_running_statuses_by_session=lambda key: [],
+                get_recent_statuses_by_session=lambda key: [],
+            )
+        )
+        try:
+            payload = runtime._status()
+            assert "recent_agents" in payload
+            assert "configured" in payload
+        finally:
+            runtime.loop = None
+            db.close()
+
+
+class TestIpcActivity:
+    @pytest.mark.asyncio
+    async def test_get_subagent_activity_returns_roster_only(self, tmp_path) -> None:
+        db = MagicMock()
+        srv = CollieIPCServer(
+            db,
+            status_provider=lambda: {
+                "configured": True,
+                "workspace": "/tmp",
+                "active_agents": [{"id": "a1", "name": "Working"}],
+                "recent_agents": [{"id": "a2", "name": "Done"}],
+                "conversations": 99,
+                "providers": [],
+            },
+        )
+        result = await srv._cmd_get_subagent_activity(MagicMock(), {})
+        assert result == {
+            "active_agents": [{"id": "a1", "name": "Working"}],
+            "recent_agents": [{"id": "a2", "name": "Done"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_subagent_activity_without_provider(self, tmp_path) -> None:
+        srv = CollieIPCServer(MagicMock())
+        result = await srv._cmd_get_subagent_activity(MagicMock(), {})
+        assert result == {"active_agents": [], "recent_agents": []}

--- a/collie-ui/src/renderer/src/components/InteractiveColliePortrait.expiry.test.tsx
+++ b/collie-ui/src/renderer/src/components/InteractiveColliePortrait.expiry.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActiveAgent } from '../lib/ipc'
+import InteractiveColliePortrait from './InteractiveColliePortrait'
+
+const settled = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => ({
+  id: 's1',
+  name: 'Budget Checker',
+  phase: 'done',
+  task_description: 'Compare hotel prices.',
+  conversation_id: 'conv-1',
+  started_at_ms: 900_000,
+  ended_at_ms: 1_100_000,
+  outcome: 'ok',
+  ...overrides
+})
+
+let root: Root | null = null
+let host: HTMLElement | null = null
+
+function render(props: Partial<React.ComponentProps<typeof InteractiveColliePortrait>> = {}): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => {
+    root!.render(
+      <InteractiveColliePortrait
+        thinking={null}
+        phrase=""
+        isTyping={false}
+        activeAgents={[]}
+        recentAgents={[]}
+        {...props}
+      />
+    )
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }) as unknown as typeof window.matchMedia
+})
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  root = null
+  host?.remove()
+  host = null
+  vi.useRealTimers()
+})
+
+describe('InteractiveColliePortrait settled-row expiry', () => {
+  it('unmounts the empty agent list and stops the ticker once rows expire', () => {
+    const ended = Date.now() - 60_000
+    render({
+      recentAgents: [settled({ ended_at_ms: ended, started_at_ms: ended - 120_000 })]
+    })
+
+    expect(host!.textContent).toContain('Budget Checker')
+    expect(host!.querySelector('.portrait-agent-list')).not.toBeNull()
+    const timersWhileVisible = vi.getTimerCount()
+
+    // The 1 s ticker keeps the elapsed/age calculation live up to the
+    // 3-minute boundary.
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    expect(host!.textContent).toContain('Budget Checker')
+
+    // Past the boundary: rows gone, the empty container unmounts, and the
+    // ticker is cleared — no forever-mounted empty list.
+    act(() => {
+      vi.advanceTimersByTime(2 * 60_000 + 1_000)
+    })
+    expect(host!.textContent).not.toContain('Budget Checker')
+    expect(host!.querySelector('.portrait-agent-list')).toBeNull()
+    expect(vi.getTimerCount()).toBeLessThan(timersWhileVisible)
+  })
+
+  it('keeps rows visible while fresh settled rows arrive', () => {
+    const ended = Date.now() - 10_000
+    render({
+      recentAgents: [settled({ ended_at_ms: ended, started_at_ms: ended - 120_000 })]
+    })
+    expect(host!.textContent).toContain('Budget Checker')
+
+    act(() => {
+      vi.advanceTimersByTime(120_000)
+    })
+    expect(host!.textContent).toContain('Budget Checker')
+  })
+})

--- a/collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx
+++ b/collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx
@@ -7,7 +7,8 @@ import {
   agentOutcomeLabel,
   agentPhaseLabel,
   formatAgentElapsed,
-  isAgentSettled
+  isAgentSettled,
+  settledRowsWithinWindow
 } from '../lib/agentActivity'
 import { quantizePortraitPointer } from './colliePortraitMotion'
 import {
@@ -24,8 +25,6 @@ const pawFront = new URL('../assets/portrait/paw-front-brand.webp', import.meta.
 
 const MAX_WORKING_ROWS = 3
 const MAX_SETTLED_ROWS = 2
-/** How long a settled row stays visible next to the pet (ms). */
-const SETTLED_VISIBILITY_MS = 3 * 60_000
 
 interface Props {
   thinking: ThinkingState | null
@@ -142,9 +141,17 @@ export default function InteractiveColliePortrait({
   }, [frames.length, paused, reducedMotion, state])
 
   // One 1 s tick so agent rows' elapsed labels stay live without re-rendering
-  // the whole chat screen; freezes as soon as nothing is shown.
-  const showWorking = activeAgents.length > 0
-  const showSettled = recentAgents.length > 0
+  // the whole chat screen; freezes as soon as nothing visible remains. The
+  // show flags derive from the VISIBLE (expiry-filtered) rows so that once
+  // the last settled row ages out, the ticker is cleared and the empty
+  // container unmounts instead of lingering forever.
+  const workingRows = activeAgents.slice(0, MAX_WORKING_ROWS)
+  const overflowCount = activeAgents.length - workingRows.length
+  const settledRows = settledRowsWithinWindow(recentAgents, now)
+    .filter((agent) => isAgentSettled(agent))
+    .slice(0, MAX_SETTLED_ROWS)
+  const showWorking = workingRows.length > 0
+  const showSettled = settledRows.length > 0
   useEffect(() => {
     if (!showWorking && !showSettled) return
     const timer = window.setInterval(() => setNow(Date.now()), 1000)
@@ -165,18 +172,6 @@ export default function InteractiveColliePortrait({
   }
 
   const status = copyPool[copyIndex] || 'Ready when you are.'
-
-  const workingRows = activeAgents.slice(0, MAX_WORKING_ROWS)
-  const overflowCount = activeAgents.length - workingRows.length
-  const settledRows = recentAgents
-    .filter((agent) => isAgentSettled(agent))
-    .filter((agent) => {
-      // Settled rows age out next to the pet: once the chat stops polling,
-      // the last snapshot would otherwise linger forever.
-      const ended = agent.ended_at_ms
-      return typeof ended === 'number' && now - ended < SETTLED_VISIBILITY_MS
-    })
-    .slice(0, MAX_SETTLED_ROWS)
 
   return (
     <section

--- a/collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx
+++ b/collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Ban, Check, CircleX } from 'lucide-react'
 import type { ActiveAgent, ThinkingState } from '../lib/ipc'
+import {
+  agentActivityLine,
+  agentElapsedMs,
+  agentOutcomeLabel,
+  agentPhaseLabel,
+  formatAgentElapsed,
+  isAgentSettled
+} from '../lib/agentActivity'
 import { quantizePortraitPointer } from './colliePortraitMotion'
 import {
   PORTRAIT_FRAME_DURATION,
@@ -13,30 +22,64 @@ import ColliePortraitFrame from './ColliePortraitFrame'
 
 const pawFront = new URL('../assets/portrait/paw-front-brand.webp', import.meta.url).href
 
+const MAX_WORKING_ROWS = 3
+const MAX_SETTLED_ROWS = 2
+/** How long a settled row stays visible next to the pet (ms). */
+const SETTLED_VISIBILITY_MS = 3 * 60_000
+
 interface Props {
   thinking: ThinkingState | null
   phrase: string
   elapsedLabel?: React.ReactNode
   isTyping: boolean
   activeAgents: ActiveAgent[]
+  /** Settled rows for this conversation (recent_agents), newest first. */
+  recentAgents?: ActiveAgent[]
 }
 
-const PHASE_LABELS: Record<string, string> = {
-  initializing: 'Getting ready',
-  awaiting_tools: 'Using tools',
-  tools_completed: 'Putting it together',
-  final_response: 'Wrapping up'
+function OutcomeIcon({ outcome }: { outcome: ActiveAgent['outcome'] }): React.JSX.Element {
+  if (outcome === 'error') return <CircleX size={12} className="agent-outcome-icon is-error" aria-hidden />
+  if (outcome === 'cancelled') return <Ban size={12} className="agent-outcome-icon is-cancelled" aria-hidden />
+  return <Check size={12} className="agent-outcome-icon is-ok" aria-hidden />
 }
 
-function conciseTask(agent: ActiveAgent): string {
-  const source = (
-    agent.task_description ||
-    PHASE_LABELS[agent.phase] ||
-    agent.phase ||
-    'Working'
-  ).replace(/\s+/g, ' ').trim()
-  const sentence = source.split(/(?<=[.!?])\s/)[0]
-  return sentence.length > 72 ? `${sentence.slice(0, 69).trimEnd()}…` : sentence
+/** One compact row: dog portrait, name + elapsed, one-line activity/status. */
+function AgentPopupRow({
+  agent,
+  now,
+  settled
+}: {
+  agent: ActiveAgent
+  now: number
+  settled: boolean
+}): React.JSX.Element {
+  const elapsed = agentElapsedMs(agent, now)
+  const elapsedLabel = elapsed !== null ? formatAgentElapsed(elapsed) : ''
+  return (
+    <span
+      className={settled ? 'portrait-agent-row is-settled' : 'portrait-agent-row'}
+      title={`${agent.name} · ${agentPhaseLabel(agent)}`}
+    >
+      <AgentAvatar identity={agent.id || agent.name} name={agent.name} size={34} />
+      <b>
+        {agent.name}
+        <em className="portrait-agent-elapsed">{elapsedLabel}</em>
+      </b>
+      <small>
+        {settled ? (
+          <>
+            <OutcomeIcon outcome={agent.outcome} />
+            {agentOutcomeLabel(agent.outcome)}
+          </>
+        ) : (
+          <>
+            <span className="agent-live-dot" aria-hidden />
+            {agentActivityLine(agent)}
+          </>
+        )}
+      </small>
+    </span>
+  )
 }
 
 export default function InteractiveColliePortrait({
@@ -44,11 +87,13 @@ export default function InteractiveColliePortrait({
   phrase,
   elapsedLabel,
   isTyping,
-  activeAgents
+  activeAgents,
+  recentAgents = []
 }: Props): React.JSX.Element {
   const [pointerTarget, setPointerTarget] = useState<number | null>(null)
   const [copyIndex, setCopyIndex] = useState(0)
   const [frameIndex, setFrameIndex] = useState(0)
+  const [now, setNow] = useState(Date.now)
   const { state, pawVisible, paused, reducedMotion, gazeDirection, triggerReaction } = useColliePortraitState(
     thinking,
     isTyping,
@@ -96,6 +141,16 @@ export default function InteractiveColliePortrait({
     return () => window.clearInterval(timer)
   }, [frames.length, paused, reducedMotion, state])
 
+  // One 1 s tick so agent rows' elapsed labels stay live without re-rendering
+  // the whole chat screen; freezes as soon as nothing is shown.
+  const showWorking = activeAgents.length > 0
+  const showSettled = recentAgents.length > 0
+  useEffect(() => {
+    if (!showWorking && !showSettled) return
+    const timer = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(timer)
+  }, [showWorking, showSettled])
+
   function handlePointerMove(event: React.PointerEvent<HTMLDivElement>): void {
     const bounds = event.currentTarget.getBoundingClientRect()
     const x = (event.clientX - bounds.left - bounds.width / 2) / (bounds.width / 2)
@@ -110,6 +165,18 @@ export default function InteractiveColliePortrait({
   }
 
   const status = copyPool[copyIndex] || 'Ready when you are.'
+
+  const workingRows = activeAgents.slice(0, MAX_WORKING_ROWS)
+  const overflowCount = activeAgents.length - workingRows.length
+  const settledRows = recentAgents
+    .filter((agent) => isAgentSettled(agent))
+    .filter((agent) => {
+      // Settled rows age out next to the pet: once the chat stops polling,
+      // the last snapshot would otherwise linger forever.
+      const ended = agent.ended_at_ms
+      return typeof ended === 'number' && now - ended < SETTLED_VISIBILITY_MS
+    })
+    .slice(0, MAX_SETTLED_ROWS)
 
   return (
     <section
@@ -147,14 +214,21 @@ export default function InteractiveColliePortrait({
         <span key={status}>{status}</span>
         {elapsedLabel ? <small>{elapsedLabel}</small> : null}
       </div>
-      {activeAgents.length > 0 && (
-        <div className="portrait-agent-list" aria-label={`${activeAgents.length} supporting agents`}>
-          {activeAgents.slice(0, 3).map((agent) => (
-            <span key={agent.id} title={`${agent.name} · ${agent.phase}`}>
-              <AgentAvatar identity={agent.id || agent.name} name={agent.name} size={34} />
-              <b>{agent.name}</b>
-              <small>{conciseTask(agent)}</small>
+      {(showWorking || showSettled) && (
+        <div
+          className="portrait-agent-list"
+          aria-label={`${activeAgents.length} agents working, ${settledRows.length} recently finished`}
+        >
+          {workingRows.map((agent) => (
+            <AgentPopupRow key={`w-${agent.id}`} agent={agent} now={now} settled={false} />
+          ))}
+          {overflowCount > 0 && (
+            <span className="portrait-agent-overflow" aria-hidden>
+              +{overflowCount} more
             </span>
+          )}
+          {settledRows.map((agent) => (
+            <AgentPopupRow key={`s-${agent.id}`} agent={agent} now={now} settled />
           ))}
         </div>
       )}

--- a/collie-ui/src/renderer/src/components/SubagentRoster.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/SubagentRoster.dom.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ActiveAgent } from '../lib/ipc'
+import SubagentRoster from './SubagentRoster'
+
+const working = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => ({
+  id: 'a1',
+  name: 'Trip Planner',
+  phase: 'awaiting_tools',
+  task_description: 'Checking hotel prices in Eixample.',
+  conversation_id: 'conv-1',
+  started_at_ms: 1_000_000,
+  ...overrides
+})
+
+const settled = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => ({
+  id: 'a2',
+  name: 'Budget Checker',
+  phase: 'done',
+  task_description: 'Compare hotel prices.',
+  conversation_id: 'conv-1',
+  started_at_ms: 900_000,
+  ended_at_ms: 1_100_000,
+  outcome: 'ok',
+  ...overrides
+})
+
+let root: Root | null = null
+let host: HTMLElement | null = null
+
+function render(element: React.ReactNode): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => {
+    root!.render(element)
+  })
+}
+
+function text(): string {
+  return host?.textContent ?? ''
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  root = null
+  host?.remove()
+  host = null
+})
+
+describe('SubagentRoster', () => {
+  it('renders nothing when no agents are active or recent', () => {
+    render(<SubagentRoster active={[]} recent={[]} nowMs={1_200_000} />)
+    expect(host!.children.length).toBe(0)
+  })
+
+  it('shows Working now rows with the activity line and elapsed', () => {
+    render(<SubagentRoster active={[working()]} recent={[]} nowMs={1_200_000} />)
+    expect(text()).toContain('Working now')
+    expect(text()).toContain('Trip Planner')
+    expect(text()).toContain('Checking hotel prices in Eixample.')
+    expect(text()).toContain('3m 20s')
+    expect(text()).not.toContain('Earlier')
+  })
+
+  it('shows settled rows under Earlier with outcome copy', () => {
+    render(
+      <SubagentRoster
+        active={[]}
+        recent={[settled(), settled({ id: 'a3', name: 'Web Searcher', outcome: 'cancelled' })]}
+        nowMs={1_200_000}
+      />
+    )
+    expect(text()).toContain('Earlier')
+    expect(text()).toContain('Budget Checker')
+    expect(text()).toContain('Done')
+    expect(text()).toContain('Web Searcher')
+    expect(text()).toContain('Stopped')
+    // Settled elapsed is frozen at ended_at - started_at = 3m 20s.
+    expect(text()).toContain('3m 20s')
+    expect(text()).not.toContain('Working now')
+  })
+
+  it('combines working and settled groups in order', () => {
+    render(
+      <SubagentRoster
+        active={[working()]}
+        recent={[settled()]}
+        nowMs={1_200_000}
+      />
+    )
+    const workingIndex = text().indexOf('Working now')
+    const earlierIndex = text().indexOf('Earlier')
+    expect(workingIndex).toBeGreaterThan(-1)
+    expect(earlierIndex).toBeGreaterThan(workingIndex)
+  })
+
+  it('caps the working rows and shows the overflow count', () => {
+    const many = Array.from({ length: 8 }, (_, index) =>
+      working({ id: `w${index}`, name: `Agent ${index}` })
+    )
+    render(<SubagentRoster active={many} recent={[]} nowMs={1_200_000} />)
+    expect(text()).toContain('+2 more working')
+    expect(text()).toContain('Agent 0')
+    expect(text()).toContain('Agent 5')
+    expect(text()).not.toContain('Agent 7')
+  })
+})

--- a/collie-ui/src/renderer/src/components/SubagentRoster.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/SubagentRoster.dom.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ActiveAgent } from '../lib/ipc'
 import SubagentRoster from './SubagentRoster'
 
@@ -108,5 +108,34 @@ describe('SubagentRoster', () => {
     expect(text()).toContain('Agent 0')
     expect(text()).toContain('Agent 5')
     expect(text()).not.toContain('Agent 7')
+  })
+
+  it('ages settled rows out after the visibility window and stops the ticker', () => {
+    vi.useFakeTimers()
+    const ended = Date.now() - 60_000
+    render(
+      <SubagentRoster
+        active={[]}
+        recent={[settled({ ended_at_ms: ended, started_at_ms: ended - 120_000 })]}
+      />
+    )
+    expect(text()).toContain('Budget Checker')
+    expect(text()).toContain('Earlier')
+
+    // The 1 s ticker keeps the row alive up to the 3-minute boundary.
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    expect(text()).toContain('Budget Checker')
+
+    // Past the boundary the row disappears, the container unmounts and the
+    // ticker stops — no empty section lingering with a live interval.
+    act(() => {
+      vi.advanceTimersByTime(2 * 60_000 + 1_000)
+    })
+    expect(text()).not.toContain('Budget Checker')
+    expect(host!.children.length).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
   })
 })

--- a/collie-ui/src/renderer/src/components/SubagentRoster.tsx
+++ b/collie-ui/src/renderer/src/components/SubagentRoster.tsx
@@ -5,7 +5,8 @@ import {
   agentActivityLine,
   agentElapsedMs,
   agentOutcomeLabel,
-  formatAgentElapsed
+  formatAgentElapsed,
+  settledRowsWithinWindow
 } from '../lib/agentActivity'
 import AgentAvatar from './AgentAvatar'
 
@@ -70,7 +71,15 @@ interface Props {
  */
 export default function SubagentRoster({ active, recent, nowMs }: Props): React.JSX.Element | null {
   const [now, setNow] = useState(nowMs ?? Date.now)
-  const hasLive = active.length > 0 || recent.length > 0
+
+  const working = active.slice(0, MAX_WORKING_ROWS)
+  const workingOverflow = active.length - working.length
+  // Settled rows age out after SETTLED_VISIBILITY_MS so a stale roster
+  // snapshot never lingers (or keeps a 1 s ticker alive) once the chat has
+  // stopped polling.
+  const settled = settledRowsWithinWindow(recent, now).slice(0, MAX_SETTLED_ROWS)
+  // The ticker + container live only while there are VISIBLE rows.
+  const hasLive = working.length > 0 || settled.length > 0
 
   useEffect(() => {
     if (nowMs !== undefined) return
@@ -80,10 +89,6 @@ export default function SubagentRoster({ active, recent, nowMs }: Props): React.
   }, [hasLive, nowMs])
 
   if (!hasLive) return null
-
-  const working = active.slice(0, MAX_WORKING_ROWS)
-  const workingOverflow = active.length - working.length
-  const settled = recent.slice(0, MAX_SETTLED_ROWS)
 
   return (
     <section className="subagent-roster" aria-label="Agents activity">

--- a/collie-ui/src/renderer/src/components/SubagentRoster.tsx
+++ b/collie-ui/src/renderer/src/components/SubagentRoster.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { Ban, Check, CircleX } from 'lucide-react'
+import type { ActiveAgent } from '../lib/ipc'
+import {
+  agentActivityLine,
+  agentElapsedMs,
+  agentOutcomeLabel,
+  formatAgentElapsed
+} from '../lib/agentActivity'
+import AgentAvatar from './AgentAvatar'
+
+const MAX_WORKING_ROWS = 6
+const MAX_SETTLED_ROWS = 6
+
+function OutcomeIcon({ outcome }: { outcome: ActiveAgent['outcome'] }): React.JSX.Element {
+  if (outcome === 'error') return <CircleX size={14} className="agent-outcome-icon is-error" aria-hidden />
+  if (outcome === 'cancelled') return <Ban size={14} className="agent-outcome-icon is-cancelled" aria-hidden />
+  return <Check size={14} className="agent-outcome-icon is-ok" aria-hidden />
+}
+
+function RosterRow({
+  agent,
+  now,
+  settled
+}: {
+  agent: ActiveAgent
+  now: number
+  settled: boolean
+}): React.JSX.Element {
+  const elapsed = agentElapsedMs(agent, now)
+  const elapsedLabel = elapsed !== null ? formatAgentElapsed(elapsed) : ''
+  return (
+    <div
+      className={settled ? 'roster-row is-settled' : 'roster-row'}
+      title={agent.task_description || undefined}
+    >
+      <span className="roster-row-avatar">
+        <AgentAvatar identity={agent.id || agent.name} name={agent.name} size={34} />
+        {!settled && <span className="agent-live-dot" aria-hidden />}
+      </span>
+      <span className="roster-row-copy">
+        <b>{agent.name}</b>
+        <small>
+          {settled ? (
+            <>
+              <OutcomeIcon outcome={agent.outcome} />
+              {agentOutcomeLabel(agent.outcome)}
+            </>
+          ) : (
+            agentActivityLine(agent)
+          )}
+        </small>
+      </span>
+      <em className="roster-row-elapsed">{elapsedLabel}</em>
+    </div>
+  )
+}
+
+interface Props {
+  active: ActiveAgent[]
+  recent: ActiveAgent[]
+  /** Test seam: inject a fixed "now" (defaults to a live 1 s tick). */
+  nowMs?: number
+}
+
+/**
+ * Live subagent roster for the Agents tab: "Working now" on top, settled
+ * "Earlier" rows below, agent definitions render underneath (AgentsScreen).
+ * Pure presentational — the screen owns the poll.
+ */
+export default function SubagentRoster({ active, recent, nowMs }: Props): React.JSX.Element | null {
+  const [now, setNow] = useState(nowMs ?? Date.now)
+  const hasLive = active.length > 0 || recent.length > 0
+
+  useEffect(() => {
+    if (nowMs !== undefined) return
+    if (!hasLive) return
+    const timer = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(timer)
+  }, [hasLive, nowMs])
+
+  if (!hasLive) return null
+
+  const working = active.slice(0, MAX_WORKING_ROWS)
+  const workingOverflow = active.length - working.length
+  const settled = recent.slice(0, MAX_SETTLED_ROWS)
+
+  return (
+    <section className="subagent-roster" aria-label="Agents activity">
+      {active.length > 0 && (
+        <div className="roster-group">
+          <div className="roster-heading">
+            <span className="roster-heading-dot" aria-hidden />
+            Working now
+            {active.length > 1 ? ` · ${active.length}` : ''}
+          </div>
+          <div className="roster-list">
+            {working.map((agent) => (
+              <RosterRow key={`w-${agent.id}`} agent={agent} now={now} settled={false} />
+            ))}
+            {workingOverflow > 0 && (
+              <div className="roster-overflow">+{workingOverflow} more working</div>
+            )}
+          </div>
+        </div>
+      )}
+      {settled.length > 0 && (
+        <div className="roster-group">
+          <div className="roster-heading">Earlier</div>
+          <div className="roster-list">
+            {settled.map((agent) => (
+              <RosterRow key={`s-${agent.id}`} agent={agent} now={now} settled />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/lib/agentActivity.test.ts
+++ b/collie-ui/src/renderer/src/lib/agentActivity.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import type { ActiveAgent } from './ipc'
+import {
+  agentActivityLine,
+  agentElapsedMs,
+  agentOutcomeLabel,
+  agentPhaseLabel,
+  formatAgentElapsed,
+  isAgentSettled
+} from './agentActivity'
+
+const workingAgent = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => ({
+  id: 'a1',
+  name: 'Trip Planner',
+  phase: 'awaiting_tools',
+  task_description: 'Checking hotel prices in Eixample.',
+  conversation_id: 'conv-1',
+  started_at_ms: 1_000_000,
+  ...overrides
+})
+
+describe('agentPhaseLabel', () => {
+  it('maps engine phases to friendly copy', () => {
+    expect(agentPhaseLabel({ phase: 'awaiting_tools' })).toBe('Using tools')
+    expect(agentPhaseLabel({ phase: 'final_response' })).toBe('Wrapping up')
+    expect(agentPhaseLabel({ phase: 'cancelled' })).toBe('Stopped')
+  })
+
+  it('falls back to the raw phase for unknown values', () => {
+    expect(agentPhaseLabel({ phase: 'barking' })).toBe('barking')
+  })
+})
+
+describe('agentActivityLine', () => {
+  it('prefers the task description', () => {
+    expect(agentActivityLine(workingAgent())).toBe('Checking hotel prices in Eixample.')
+  })
+
+  it('falls back to the phase label and truncates long tasks', () => {
+    expect(agentActivityLine(workingAgent({ task_description: undefined })))
+      .toBe('Using tools')
+    const long = 'x'.repeat(100)
+    const line = agentActivityLine(workingAgent({ task_description: long }))
+    expect(line.length).toBeLessThanOrEqual(72)
+    expect(line.endsWith('…')).toBe(true)
+  })
+})
+
+describe('agentOutcomeLabel', () => {
+  it('labels each outcome', () => {
+    expect(agentOutcomeLabel('ok')).toBe('Done')
+    expect(agentOutcomeLabel('error')).toBe('Couldn’t finish')
+    expect(agentOutcomeLabel('cancelled')).toBe('Stopped')
+  })
+})
+
+describe('formatAgentElapsed', () => {
+  it('formats seconds, minutes and hours compactly', () => {
+    expect(formatAgentElapsed(5_000)).toBe('5s')
+    expect(formatAgentElapsed(134_000)).toBe('2m 14s')
+    expect(formatAgentElapsed(60_000)).toBe('1m')
+    expect(formatAgentElapsed(3_781_000)).toBe('1h 3m')
+  })
+})
+
+describe('agentElapsedMs', () => {
+  it('freezes settled rows at ended_at', () => {
+    const agent = workingAgent({
+      ended_at_ms: 1_200_000,
+      outcome: 'ok'
+    })
+    expect(agentElapsedMs(agent, 9_000_000)).toBe(200_000)
+  })
+
+  it('ticks working rows against now', () => {
+    expect(agentElapsedMs(workingAgent(), 1_200_000)).toBe(200_000)
+  })
+
+  it('returns null without a started_at_ms', () => {
+    expect(agentElapsedMs(workingAgent({ started_at_ms: undefined }), 1_200_000)).toBeNull()
+  })
+})
+
+describe('isAgentSettled', () => {
+  it('recognizes terminal outcomes', () => {
+    expect(isAgentSettled(workingAgent({ outcome: 'ok' }))).toBe(true)
+    expect(isAgentSettled(workingAgent({ outcome: 'error' }))).toBe(true)
+    expect(isAgentSettled(workingAgent({ outcome: 'cancelled' }))).toBe(true)
+    expect(isAgentSettled(workingAgent({ outcome: undefined }))).toBe(false)
+  })
+})

--- a/collie-ui/src/renderer/src/lib/agentActivity.test.ts
+++ b/collie-ui/src/renderer/src/lib/agentActivity.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import type { ActiveAgent } from './ipc'
 import {
+  SETTLED_VISIBILITY_MS,
   agentActivityLine,
   agentElapsedMs,
   agentOutcomeLabel,
   agentPhaseLabel,
   formatAgentElapsed,
-  isAgentSettled
+  isAgentSettled,
+  settledRowsWithinWindow
 } from './agentActivity'
 
 const workingAgent = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => ({
@@ -87,5 +89,28 @@ describe('isAgentSettled', () => {
     expect(isAgentSettled(workingAgent({ outcome: 'error' }))).toBe(true)
     expect(isAgentSettled(workingAgent({ outcome: 'cancelled' }))).toBe(true)
     expect(isAgentSettled(workingAgent({ outcome: undefined }))).toBe(false)
+  })
+})
+
+describe('settledRowsWithinWindow', () => {
+  it('keeps only settled rows inside the visibility window', () => {
+    const now = Date.now()
+    const fresh = workingAgent({
+      ended_at_ms: now - 60_000,
+      outcome: 'ok'
+    })
+    const expired = workingAgent({
+      id: 'a2',
+      ended_at_ms: now - SETTLED_VISIBILITY_MS - 1_000,
+      outcome: 'ok'
+    })
+    const stillWorking = workingAgent({ id: 'a3', outcome: undefined })
+    expect(settledRowsWithinWindow([fresh, expired, stillWorking], now)).toEqual([fresh])
+  })
+
+  it('drops rows with no wall-clock ended_at', () => {
+    const now = Date.now()
+    const missing = workingAgent({ id: 'a4', ended_at_ms: undefined, outcome: 'ok' })
+    expect(settledRowsWithinWindow([missing], now)).toEqual([])
   })
 })

--- a/collie-ui/src/renderer/src/lib/agentActivity.ts
+++ b/collie-ui/src/renderer/src/lib/agentActivity.ts
@@ -1,5 +1,12 @@
 import type { ActiveAgent, SubagentOutcome } from './ipc'
 
+/**
+ * How long a settled subagent row stays visible next to the pet / in the
+ * roster (ms). Shared by both surfaces so the expiry behavior is one
+ * decision, not two.
+ */
+export const SETTLED_VISIBILITY_MS = 3 * 60_000
+
 /** Friendly labels for the engine's subagent lifecycle phases. */
 export const AGENT_PHASE_LABELS: Record<string, string> = {
   initializing: 'Getting ready',
@@ -68,4 +75,20 @@ export function agentElapsedMs(
 
 export function isAgentSettled(agent: ActiveAgent): boolean {
   return agent.outcome === 'ok' || agent.outcome === 'error' || agent.outcome === 'cancelled'
+}
+
+/**
+ * Settled rows still inside the visibility window. Rows age out after
+ * SETTLED_VISIBILITY_MS from ended_at, and rows without a wall-clock
+ * ended_at_ms are dropped — once polling stops, the last snapshot must not
+ * linger (or keep a 1 s ticker alive) forever.
+ */
+export function settledRowsWithinWindow(
+  agents: ActiveAgent[],
+  nowMs: number
+): ActiveAgent[] {
+  return agents.filter((agent) => {
+    const ended = agent.ended_at_ms
+    return typeof ended === 'number' && nowMs - ended < SETTLED_VISIBILITY_MS
+  })
 }

--- a/collie-ui/src/renderer/src/lib/agentActivity.ts
+++ b/collie-ui/src/renderer/src/lib/agentActivity.ts
@@ -1,0 +1,71 @@
+import type { ActiveAgent, SubagentOutcome } from './ipc'
+
+/** Friendly labels for the engine's subagent lifecycle phases. */
+export const AGENT_PHASE_LABELS: Record<string, string> = {
+  initializing: 'Getting ready',
+  awaiting_tools: 'Using tools',
+  tools_completed: 'Putting it together',
+  final_response: 'Wrapping up',
+  done: 'Done',
+  error: 'Had trouble',
+  cancelled: 'Stopped'
+}
+
+export function agentPhaseLabel(agent: Pick<ActiveAgent, 'phase'>): string {
+  return AGENT_PHASE_LABELS[agent.phase] || agent.phase || 'Working'
+}
+
+/** One-line activity for a roster/popup row: task first, phase as fallback. */
+export function agentActivityLine(agent: ActiveAgent): string {
+  const source = (
+    agent.task_description ||
+    agentPhaseLabel(agent) ||
+    'Working'
+  ).replace(/\s+/g, ' ').trim()
+  const sentence = source.split(/(?<=[.!?])\s/)[0]
+  return sentence.length > 72 ? `${sentence.slice(0, 69).trimEnd()}…` : sentence
+}
+
+export const AGENT_OUTCOME_LABELS: Record<SubagentOutcome, string> = {
+  ok: 'Done',
+  error: 'Couldn’t finish',
+  cancelled: 'Stopped'
+}
+
+export function agentOutcomeLabel(outcome: SubagentOutcome | undefined): string {
+  return outcome ? AGENT_OUTCOME_LABELS[outcome] : 'Done'
+}
+
+/** Format a millisecond duration compactly: 42s, 2m 14s, 1h 3m. */
+export function formatAgentElapsed(milliseconds: number): string {
+  const totalSeconds = Math.max(1, Math.floor(milliseconds / 1000))
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (totalMinutes < 60) return seconds ? `${totalMinutes}m ${seconds}s` : `${totalMinutes}m`
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes ? `${hours}h ${minutes}m` : `${hours}h`
+}
+
+/**
+ * Elapsed time for an agent row in ms. Settled rows freeze at ended_at;
+ * working rows tick against the supplied "now".
+ */
+export function agentElapsedMs(
+  agent: ActiveAgent,
+  nowMs: number,
+  fallbackNowMs = Date.now()
+): number | null {
+  const start = agent.started_at_ms
+  if (typeof start !== 'number' || !Number.isFinite(start)) return null
+  const end = agent.ended_at_ms
+  if (typeof end === 'number' && Number.isFinite(end)) {
+    return Math.max(0, end - start)
+  }
+  return Math.max(0, (Number.isFinite(nowMs) ? nowMs : fallbackNowMs) - start)
+}
+
+export function isAgentSettled(agent: ActiveAgent): boolean {
+  return agent.outcome === 'ok' || agent.outcome === 'error' || agent.outcome === 'cancelled'
+}

--- a/collie-ui/src/renderer/src/lib/ipc.test.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.test.ts
@@ -151,4 +151,14 @@ describe('CollieClient connection startup', () => {
     await expect(reply).resolves.toEqual({ conversation_id: 'conversation-1' })
     client.close()
   })
+
+  it('gives getSubagentActivity a short default timeout for 2 s polls', async () => {
+    const client = new CollieClient(4321)
+    const commandSpy = vi
+      .spyOn(client, 'command')
+      .mockResolvedValue({ active_agents: [], recent_agents: [] })
+    void client.getSubagentActivity()
+    expect(commandSpy).toHaveBeenCalledWith('get_subagent_activity', {}, 5_000)
+    commandSpy.mockRestore()
+  })
 })

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -53,12 +53,19 @@ export interface ThinkingState {
   conversation_id?: string
 }
 
+export type SubagentOutcome = 'ok' | 'error' | 'cancelled'
+
 export interface ActiveAgent {
   id: string
   name: string
   phase: string
   task_description?: string
   conversation_id: string
+  /** Wall-clock epoch ms (monotonic on the core converted for the UI). */
+  started_at_ms?: number
+  /** Present only on settled rows (recent activity). */
+  ended_at_ms?: number
+  outcome?: SubagentOutcome
 }
 
 export interface ProviderInfo {
@@ -122,6 +129,8 @@ export interface RuntimeStatus {
   workspace?: string
   providers?: ProviderInfo[]
   active_agents?: ActiveAgent[]
+  /** Settled subagent rows (outcome + ended_at_ms), newest first. */
+  recent_agents?: ActiveAgent[]
 }
 
 export interface ClearDataWarning {
@@ -836,6 +845,14 @@ export class CollieClient {
 
   getStatus(timeoutMs = 120_000): Promise<RuntimeStatus> {
     return this.command('get_status', {}, timeoutMs)
+  }
+
+  /** Lightweight roster for poll-heavy surfaces (Agents tab live section). */
+  getSubagentActivity(timeoutMs = 30_000): Promise<{
+    active_agents: ActiveAgent[]
+    recent_agents: ActiveAgent[]
+  }> {
+    return this.command('get_subagent_activity', {}, timeoutMs)
   }
 
   getSettings(): Promise<{ settings: Record<string, unknown> }> {

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -848,7 +848,7 @@ export class CollieClient {
   }
 
   /** Lightweight roster for poll-heavy surfaces (Agents tab live section). */
-  getSubagentActivity(timeoutMs = 30_000): Promise<{
+  getSubagentActivity(timeoutMs = 5_000): Promise<{
     active_agents: ActiveAgent[]
     recent_agents: ActiveAgent[]
   }> {

--- a/collie-ui/src/renderer/src/screens/AgentsScreen.poll.test.tsx
+++ b/collie-ui/src/renderer/src/screens/AgentsScreen.poll.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActiveAgent } from '../lib/ipc'
+import AgentsScreen from './AgentsScreen'
+
+interface Activity {
+  active_agents: ActiveAgent[]
+  recent_agents: ActiveAgent[]
+}
+
+const working = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => ({
+  id: 'w1',
+  name: 'Trip Planner',
+  phase: 'awaiting_tools',
+  task_description: 'Checking hotel prices in Eixample.',
+  conversation_id: 'conv-1',
+  started_at_ms: 1_000_000,
+  ...overrides
+})
+
+const settled = (overrides: Partial<ActiveAgent> = {}): ActiveAgent => {
+  const endedAt = Date.now() - 60_000
+  return {
+    id: 's1',
+    name: 'Budget Checker',
+    phase: 'done',
+    task_description: 'Compare hotel prices.',
+    conversation_id: 'conv-1',
+    started_at_ms: endedAt - 120_000,
+    ended_at_ms: endedAt,
+    outcome: 'ok',
+    ...overrides
+  }
+}
+
+const hooks = vi.hoisted(() => {
+  const client = {
+    listSubagents: vi.fn(),
+    listSkills: vi.fn(),
+    getSubagentActivity: vi.fn(),
+    listVersions: vi.fn(),
+    rollbackArtifact: vi.fn(),
+    createSubagent: vi.fn(),
+    updateSubagent: vi.fn(),
+    deleteSubagent: vi.fn()
+  }
+  return { client }
+})
+
+vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+let root: Root | null = null
+let host: HTMLElement | null = null
+
+function render(): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => {
+    root!.render(<AgentsScreen />)
+  })
+}
+
+function unmount(): void {
+  act(() => {
+    root?.unmount()
+  })
+  root = null
+}
+
+function text(): string {
+  return host?.textContent ?? ''
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  hooks.client.listSubagents.mockReset()
+  hooks.client.listSkills.mockReset()
+  hooks.client.getSubagentActivity.mockReset()
+  hooks.client.listSubagents.mockResolvedValue({ subagents: [], starters: [] })
+  hooks.client.listSkills.mockResolvedValue({ skills: [] })
+})
+
+afterEach(() => {
+  unmount()
+  host?.remove()
+  host = null
+  vi.useRealTimers()
+})
+
+describe('AgentsScreen live roster poll', () => {
+  it('does not stack requests while the core is slow', async () => {
+    const pending = deferred<Activity>()
+    hooks.client.getSubagentActivity.mockReturnValue(pending.promise)
+    render()
+
+    // The initial poll is in flight; the 2 s ticks must NOT fire more
+    // requests on top of it (the old setInterval would have stacked ~3).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000)
+    })
+    expect(hooks.client.getSubagentActivity).toHaveBeenCalledTimes(1)
+  })
+
+  it('schedules the next tick only after the previous poll completes', async () => {
+    const first = deferred<Activity>()
+    const second = deferred<Activity>()
+    hooks.client.getSubagentActivity
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    render()
+
+    // First request still pending after 4 s: no second request.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000)
+    })
+    expect(hooks.client.getSubagentActivity).toHaveBeenCalledTimes(1)
+
+    // Completing it arms the next tick; a new request fires 2 s later.
+    await act(async () => {
+      first.resolve({ active_agents: [working()], recent_agents: [] })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000)
+    })
+    expect(hooks.client.getSubagentActivity).toHaveBeenCalledTimes(2)
+    expect(text()).toContain('Trip Planner')
+
+    // The latest response wins: newer rows replace older ones.
+    await act(async () => {
+      second.resolve({ active_agents: [working({ id: 'w2', name: 'Web Searcher' })], recent_agents: [] })
+    })
+    expect(text()).toContain('Web Searcher')
+    expect(text()).not.toContain('Trip Planner')
+  })
+
+  it('a stale response from an earlier poll cannot overwrite newer rows', async () => {
+    const first = deferred<Activity>()
+    const second = deferred<Activity>()
+    hooks.client.getSubagentActivity
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    render()
+
+    // First poll settles with older data.
+    await act(async () => {
+      first.resolve({ active_agents: [working()], recent_agents: [] })
+    })
+    expect(text()).toContain('Trip Planner')
+
+    // Second poll fires only after the first settled (completion-driven).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000)
+    })
+    expect(hooks.client.getSubagentActivity).toHaveBeenCalledTimes(2)
+
+    // Newer data lands and sticks — an out-of-order late response would have
+    // to fight the generation guard, and with serialized polling it never
+    // even starts while an older request is pending.
+    await act(async () => {
+      second.resolve({ active_agents: [working({ id: 'w2', name: 'Web Searcher' })], recent_agents: [] })
+    })
+    expect(text()).toContain('Web Searcher')
+    expect(text()).not.toContain('Trip Planner')
+  })
+
+  it('stops polling and ignores late responses after unmount', async () => {
+    const pending = deferred<Activity>()
+    hooks.client.getSubagentActivity.mockReturnValue(pending.promise)
+    render()
+    await act(async () => {})
+
+    expect(hooks.client.getSubagentActivity).toHaveBeenCalledTimes(1)
+    unmount()
+
+    // Resolving after unmount must not apply state or re-arm the timer.
+    await act(async () => {
+      pending.resolve({ active_agents: [working()], recent_agents: [] })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000)
+    })
+    expect(hooks.client.getSubagentActivity).toHaveBeenCalledTimes(1)
+    expect(text()).not.toContain('Trip Planner')
+  })
+
+  it('clears stale working rows after three consecutive failures', async () => {
+    const roster = { active_agents: [working()], recent_agents: [settled()] }
+    hooks.client.getSubagentActivity
+      .mockResolvedValueOnce(roster)
+      .mockRejectedValueOnce(new Error('core down'))
+      .mockRejectedValueOnce(new Error('core down'))
+      .mockRejectedValueOnce(new Error('core down'))
+    render()
+    await act(async () => {})
+
+    expect(text()).toContain('Trip Planner')
+    expect(text()).toContain('Budget Checker')
+
+    // Three failed polls in a row: working rows clear, settled rows stay.
+    for (let index = 0; index < 3; index += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000)
+      })
+    }
+    expect(text()).not.toContain('Trip Planner')
+    expect(text()).toContain('Budget Checker')
+
+    // A successful poll restores the roster and resets the failure counter.
+    hooks.client.getSubagentActivity.mockResolvedValue(roster)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000)
+    })
+    expect(text()).toContain('Trip Planner')
+  })
+})

--- a/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
@@ -77,26 +77,46 @@ export default function AgentsScreen(): React.JSX.Element {
     void refresh()
   }, [])
 
-  // Live roster: light 2 s poll of the subagent activity feed while this
-  // screen is mounted. Stops on unmount; nothing is persisted client-side.
+  // Live roster: serialized 2 s poll of the subagent activity feed while
+  // this screen is mounted. Requests never overlap — the next tick is
+  // scheduled only after the previous one settles (success or failure) — and
+  // a stale response can never overwrite newer state. Three failed polls in a
+  // row clear the "working" rows so a stalled core doesn't leave ghosts.
+  // Nothing is persisted client-side; polling stops on unmount.
   useEffect(() => {
     if (new URLSearchParams(window.location.search).has('preview')) return
     let cancelled = false
+    let inFlight = false
+    let generation = 0
+    let consecutiveFailures = 0
+    let timer: number | undefined
     const poll = async (): Promise<void> => {
+      if (inFlight || cancelled) return
+      inFlight = true
+      const requestGeneration = ++generation
       try {
         const activity = await collieClient.getSubagentActivity()
-        if (cancelled) return
+        if (cancelled || requestGeneration !== generation) return
+        consecutiveFailures = 0
         setActiveAgents(activity.active_agents)
         setRecentAgents(activity.recent_agents)
       } catch {
-        // The local core may be starting; keep the last known roster.
+        if (cancelled || requestGeneration !== generation) return
+        consecutiveFailures += 1
+        if (consecutiveFailures >= 3) {
+          // The core has been unreachable for a while: stop showing stale
+          // "working" rows. Settled rows are historical facts and may stay.
+          setActiveAgents([])
+        }
+      } finally {
+        inFlight = false
+        if (!cancelled) timer = window.setTimeout(() => void poll(), 2000)
       }
     }
     void poll()
-    const timer = window.setInterval(() => void poll(), 2000)
     return () => {
       cancelled = true
-      window.clearInterval(timer)
+      if (timer !== undefined) window.clearTimeout(timer)
     }
   }, [])
 

--- a/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/AgentsScreen.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { ArrowLeft, Bot, Eye, History, Plus, Shapes, Sparkles, Trash2, Undo2, Zap, X } from 'lucide-react'
-import { collieClient, type ArtifactVersion, type CollieSkill, type Subagent, type SubagentStarter } from '../lib/ipc'
+import { collieClient, type ActiveAgent, type ArtifactVersion, type CollieSkill, type Subagent, type SubagentStarter } from '../lib/ipc'
 import AgentAvatar from '../components/AgentAvatar'
+import SubagentRoster from '../components/SubagentRoster'
 
 function summarizeDescription(description: string): string {
   const clean = description.replace(/\s+/g, ' ').trim()
@@ -41,6 +42,8 @@ export default function AgentsScreen(): React.JSX.Element {
   const [category, setCategory] = useState<AgentCategory>('All')
   const [versions, setVersions] = useState<ArtifactVersion[]>([])
   const [undoingId, setUndoingId] = useState<string | null>(null)
+  const [activeAgents, setActiveAgents] = useState<ActiveAgent[]>([])
+  const [recentAgents, setRecentAgents] = useState<ActiveAgent[]>([])
 
   const selected = useMemo(
     () => agents.find((agent) => agent.id === selectedId) ?? null,
@@ -72,6 +75,29 @@ export default function AgentsScreen(): React.JSX.Element {
 
   useEffect(() => {
     void refresh()
+  }, [])
+
+  // Live roster: light 2 s poll of the subagent activity feed while this
+  // screen is mounted. Stops on unmount; nothing is persisted client-side.
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).has('preview')) return
+    let cancelled = false
+    const poll = async (): Promise<void> => {
+      try {
+        const activity = await collieClient.getSubagentActivity()
+        if (cancelled) return
+        setActiveAgents(activity.active_agents)
+        setRecentAgents(activity.recent_agents)
+      } catch {
+        // The local core may be starting; keep the last known roster.
+      }
+    }
+    void poll()
+    const timer = window.setInterval(() => void poll(), 2000)
+    return () => {
+      cancelled = true
+      window.clearInterval(timer)
+    }
   }, [])
 
   useEffect(() => {
@@ -364,6 +390,7 @@ export default function AgentsScreen(): React.JSX.Element {
 
       <div className="section-scroll">
         {notice && <p className="inline-notice" role="status">{notice}</p>}
+        <SubagentRoster active={activeAgents} recent={recentAgents} />
         <div className="catalog-filters" aria-label="Filter agents by category">
           {AGENT_CATEGORIES.map((item) => (
             <button

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -606,6 +606,9 @@ export default function ChatScreen({
   const activeAgents = (runtimeStatus.active_agents || []).filter(
     (agent) => agent.conversation_id === activeId
   )
+  const recentAgents = (runtimeStatus.recent_agents || []).filter(
+    (agent) => agent.conversation_id === activeId
+  )
   const activeTiming = activeId ? taskTimings[activeId] : undefined
   const activeTask = activeId ? tasksByConversation[activeId] : undefined
   const taskIsActive = activeTask ? !isTaskTerminal(activeTask) : false
@@ -1031,6 +1034,7 @@ export default function ChatScreen({
               elapsedLabel={elapsedLabel}
               isTyping={isTyping}
               activeAgents={activeAgents}
+              recentAgents={recentAgents}
             />
             <ChatInput
               onSend={(text, attachments) => void send(text, attachments)}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -689,6 +689,99 @@ button {
 .agent-card-meta { display: flex; grid-column: 1 / -1; align-items: center; gap: 7px; color: var(--grass-dark); font-size: var(--collie-min-font-size); font-weight: 650; }
 .agent-card-meta > span { display: inline-flex; align-items: center; gap: 4px; padding: 3px 7px; border-radius: 999px; background: var(--bone); }
 
+/* Live subagent roster (Agents tab) — "Working now" / "Earlier". */
+.subagent-roster {
+  display: grid;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+.roster-group { display: grid; gap: 8px; }
+.roster-heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.roster-heading-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d4a72c;
+  box-shadow: 0 0 0 3px rgba(212, 167, 44, 0.18);
+  animation: agent-live-pulse 1.6s ease-in-out infinite;
+}
+.roster-list {
+  display: grid;
+  gap: 7px;
+}
+.roster-row {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px 8px 8px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+}
+.roster-row.is-settled {
+  opacity: 0.78;
+  border-style: dashed;
+  background: #fbfaf7;
+}
+.roster-row-avatar { position: relative; display: grid; place-items: center; }
+.roster-row-avatar .agent-live-dot {
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+}
+.roster-row-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+.roster-row-copy b {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roster-row-copy small {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--collie-min-font-size);
+  font-weight: 520;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roster-row-elapsed {
+  color: var(--muted);
+  font-size: var(--collie-min-font-size);
+  font-style: normal;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.roster-overflow {
+  padding: 2px 2px 0 52px;
+  color: var(--muted);
+  font-size: var(--collie-min-font-size);
+  font-weight: 600;
+}
+
 .agent-access-control {
   margin: 0 0 16px;
   padding: 0;
@@ -2785,7 +2878,7 @@ button {
   gap: 7px;
 }
 
-.portrait-agent-list > span {
+.portrait-agent-list > span:not(.portrait-agent-overflow) {
   display: grid;
   width: 190px;
   grid-template-columns: 38px minmax(0, 1fr);
@@ -2802,25 +2895,76 @@ button {
   font-weight: 650;
   text-align: left;
 }
+.portrait-agent-list > span.is-settled {
+  opacity: 0.82;
+  border-style: dashed;
+}
 .portrait-agent-list .agent-portrait {
   grid-row: 1 / 3;
   border: 2px solid rgba(210, 145, 31, 0.72);
   border-radius: 50%;
   box-shadow: 0 0 0 2px var(--card);
 }
-.portrait-agent-list b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.portrait-agent-list b { color: var(--ink); font-size: var(--collie-min-font-size); }
+.portrait-agent-list > span.is-settled .agent-portrait {
+  border-color: rgba(45, 38, 27, 0.28);
+}
+.portrait-agent-list b {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: var(--collie-min-font-size);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.portrait-agent-list b em.portrait-agent-elapsed {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--muted);
+  font-size: calc(var(--collie-min-font-size) - 1px);
+  font-style: normal;
+  font-weight: 560;
+}
 .portrait-agent-list small {
-  display: -webkit-box;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
   overflow: hidden;
   color: var(--muted);
   font-size: var(--collie-min-font-size);
   font-weight: 520;
   line-height: 1.25;
-  white-space: normal;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
+.portrait-agent-overflow {
+  color: var(--muted);
+  font-size: var(--collie-min-font-size);
+  font-weight: 600;
+  padding: 1px 4px 0 42px;
+}
+
+/* Shared live/settled status affordances for agent rows (popup + roster). */
+.agent-live-dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #d4a72c;
+  box-shadow: 0 0 0 3px rgba(212, 167, 44, 0.18);
+  animation: agent-live-pulse 1.6s ease-in-out infinite;
+}
+@keyframes agent-live-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.82); }
+}
+.agent-outcome-icon { flex: 0 0 auto; }
+.agent-outcome-icon.is-ok { color: #3f9d63; }
+.agent-outcome-icon.is-error { color: #c0493f; }
+.agent-outcome-icon.is-cancelled { color: var(--muted); }
 
 .collie-portrait-stage.is-paused *,
 .collie-portrait-stage.is-paused *::before,


### PR DESCRIPTION
## Sub-agent observability — see what your helpers are doing 🐾

Collie already had the seed of this: the pet popup next to the Collie head lists working sub-agents with their dog portraits. But subagents were still a **black box** — no elapsed time, no stage, no settled state, and the Agents tab was definitions-only. This PR makes the fleet visible, borrowing T3 Code's shipped approach (PR #5219): **zero new tables, no persistence** — widen what the event/status layer reports and derive the roster client-side.

### What changed

**A. Pet popup (next to the Collie head) — live + settled**
- Working rows now show a pulsing ●, a one-line task ("checking hotel prices…") and a **ticking elapsed timer** (1 s DOM tick, no chat re-renders).
- When an agent finishes, its row collapses to one quiet line: ✓ **Done** / ✕ **Couldn't finish** / ⏹ **Stopped**, with the elapsed **frozen** at completion.
- Settled rows age out after 3 minutes (the chat stops polling once work ends, so stale snapshots can't linger).
- Overflow: `+N more` chip beyond 3 working rows.

**B. Agents tab — live roster on top, definitions below**
- New **"Working now"** section: live rows with dog portrait, activity line, elapsed — across all conversations.
- **"Earlier"** section below it: recently settled agents with outcome icon + frozen elapsed (bounded, newest first).
- Lightweight `get_subagent_activity` IPC command feeds a 2 s poll while the tab is mounted — no full-status payload, no persistence, no new tables.

**C. Stop-everything (already shipped, now visible)**
- The chat Stop button already cancels the parent turn **and** all live subagents (`cancel_subagents_for_conversation`); those cancels now surface as ⏹ **Stopped** rows instead of vanishing.

### Plumbing

| Layer | Change |
|---|---|
| `nanobot/agent/subagent.py` | `SubagentStatus` gains `session_key`, `ended_at`, `outcome` (`ok`/`error`/`cancelled`); terminal states recorded on success/error and a new `CancelledError` path; finished statuses retained in a bounded deque (default 24) + `get_recent_statuses_by_session()` |
| `collie_core/runtime.py` | `_status()` adds `recent_agents`; both active + recent rows get wall-clock `started_at_ms`/`ended_at_ms` (manager clocks are `time.monotonic()`) |
| `collie-core/collie_core/ipc/server.py` | New `get_subagent_activity` command (auto-dispatched) |
| `collie-ui` | `SubagentRoster` (Agents tab), popup upgrade in `InteractiveColliePortrait`, `lib/agentActivity.ts` shared helpers, `AgentsScreen` 2 s poll |

### Design rules followed (from T3's live-testing)
- One steady **"Working"** state while in flight (no pending/waiting variants — idle dots read as stuck); only settled states differentiate (✓ green / ✕ red / ⏹ grey).
- Elapsed ticks via a 1 s state tick in the components that show it; settled rows freeze at `ended_at`.
- Quiet chat: no new chat bubbles — activity lives in the popup/roster, exactly where the pet already points.

### Tests
- Backend: `tests/collie/test_subagent_observability.py` (11 tests) — settled retention, outcome recording (ok/error/cancelled incl. pre-first-await cancel race), session scoping, deque bound, runtime roster feed with wall-clock conversion, IPC command. Plus existing lifecycle/visibility suites green.
- Frontend: `agentActivity.test.ts` (11) + `SubagentRoster.dom.test.tsx` (5).
- Gates: `pytest tests/collie` → **646 passed, 5 failed** (known baseline: `test_ipc::test_read_write_file_rejects_escape_paths` flaky on Linux + Windows-DPAPI `test_services.py`); FE `npm run typecheck` clean; `vitest run` → **206 passed**; ruff clean on touched files.

### Follow-ups (not in this PR)
- Per-agent tool-step activity lines (the manager already tracks `tool_events` — surfacing "✓ found 3 options in Eixample" steps is a natural next slice).
- `SubagentEvent` on `OUTBOUND_META_AGENT_UI` for push-based delivery + Telegram text fallback (the design note's next phase — polling covers desktop for now).
