### PR TITLE
fix(ui): harden OOM recovery — rolling retry window + supervisor tests

### DIFF
--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -29,12 +29,7 @@ import {
   isTrustedRendererUrl,
   shouldAllowAudioPermission
 } from './renderer-security'
-import {
-  INITIAL_RENDERER_RECOVERY_STATE,
-  isRecoverableRendererReason,
-  planRendererRecovery,
-  type RendererRecoveryState
-} from './renderer-recovery'
+import { RendererRecoverySupervisor } from './renderer-recovery'
 
 // A detached dev terminal can close stdout while Electron is still running.
 // Treat that transport failure as harmless instead of surfacing an app error dialog.
@@ -59,7 +54,27 @@ if (isolatedUserData) app.setPath('userData', isolatedUserData)
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let quitting = false
-let rendererRecovery: RendererRecoveryState = INITIAL_RENDERER_RECOVERY_STATE
+const rendererRecoverySupervisor = new RendererRecoverySupervisor({
+  reloadWindow: () => {
+    // Re-check app state before acting: the timer may have outlived a quit
+    // or the window it was scheduled for may have been replaced.
+    if (quitting) return
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.reload()
+    }
+  },
+  scheduleReload: (fn, delayMs) => setTimeout(fn, delayMs),
+  cancelReload: (handle) => {
+    if (handle) clearTimeout(handle as NodeJS.Timeout)
+  },
+  showDialog: () => {
+    dialog.showErrorBox(
+      'Collie needs a restart',
+      'The window crashed several times in a row. Please quit and reopen Collie — your chats and work are safe.'
+    )
+  },
+  now: Date.now
+})
 let updateCheckTimer: NodeJS.Timeout | null = null
 const activeWork = new ActiveWorkTracker()
 const updates = new UpdateController(
@@ -134,6 +149,9 @@ function appIconPath(): string {
 }
 
 function createWindow(): void {
+  // A pending reload belongs to the previous window (if any); a replacement
+  // window must never be reloaded by a stale timer from its predecessor.
+  rendererRecoverySupervisor.cancelPendingReload()
   const iconPath = appIconPath()
   mainWindow = new BrowserWindow({
     width: 1120,
@@ -182,24 +200,7 @@ function createWindow(): void {
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     console.error('[window] render-process-gone reason:', details.reason, 'exitCode:', details.exitCode)
     if (quitting) return
-    const plan = planRendererRecovery(rendererRecovery, Date.now(), details.reason)
-    if (!plan) {
-      // A genuine crash with the reload budget exhausted: a reload would just
-      // loop. The Python core is untouched, so a full restart loses nothing.
-      if (isRecoverableRendererReason(details.reason)) {
-        dialog.showErrorBox(
-          'Collie needs a restart',
-          'The window crashed several times in a row. Please quit and reopen Collie — your chats and work are safe.'
-        )
-      }
-      return
-    }
-    rendererRecovery = plan.next
-    setTimeout(() => {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.reload()
-      }
-    }, plan.delayMs)
+    rendererRecoverySupervisor.renderProcessGone(details.reason)
   })
   mainWindow.on('focus', () => {
     // Returning to the app is an acknowledgement that the user reviewed
@@ -213,6 +214,8 @@ function createWindow(): void {
       e.preventDefault()
       mainWindow?.hide()
     }
+    // A hidden or closing window must not be reloaded by a pending timer.
+    rendererRecoverySupervisor.cancelPendingReload()
   })
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -474,6 +477,8 @@ app.whenReady().then(async () => {
 
 app.on('before-quit', () => {
   quitting = true
+  // A pending reload must not fire after the app has started quitting.
+  rendererRecoverySupervisor.cancelPendingReload()
   if (updateCheckTimer) {
     clearTimeout(updateCheckTimer)
     updateCheckTimer = null

--- a/collie-ui/src/main/renderer-recovery-supervisor.test.ts
+++ b/collie-ui/src/main/renderer-recovery-supervisor.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  RendererRecoverySupervisor,
+  type RendererRecoverySupervisorDeps
+} from './renderer-recovery'
+
+function makeSupervisor(overrides: Partial<RendererRecoverySupervisorDeps> = {}) {
+  const reloadWindow = vi.fn()
+  const showDialog = vi.fn()
+  const deps: RendererRecoverySupervisorDeps = {
+    reloadWindow,
+    showDialog,
+    now: () => Date.now(),
+    scheduleReload: (fn, delayMs) => setTimeout(fn, delayMs),
+    cancelReload: (handle) => clearTimeout(handle as NodeJS.Timeout),
+    ...overrides
+  }
+  const supervisor = new RendererRecoverySupervisor(deps)
+  return { supervisor, deps, reloadWindow, showDialog }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ now: 0 })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('RendererRecoverySupervisor', () => {
+  it('schedules a reload when the renderer crashes', () => {
+    const { supervisor, reloadWindow } = makeSupervisor()
+    expect(supervisor.renderProcessGone('oom')).toBe(true)
+    expect(reloadWindow).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(250)
+    expect(reloadWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies the backoff delay before reloading', () => {
+    const { supervisor, reloadWindow } = makeSupervisor()
+    supervisor.renderProcessGone('crashed')
+    vi.advanceTimersByTime(249)
+    expect(reloadWindow).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(reloadWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the pending reload on quit during the backoff window', () => {
+    // index.ts calls cancelPendingReload() from before-quit: quitting while a
+    // reload is scheduled must NOT still fire the reload.
+    const { supervisor, reloadWindow } = makeSupervisor()
+    supervisor.renderProcessGone('crashed')
+    supervisor.cancelPendingReload()
+    vi.advanceTimersByTime(10_000)
+    expect(reloadWindow).not.toHaveBeenCalled()
+  })
+
+  it('cancels the pending reload when the window is replaced', () => {
+    // index.ts calls cancelPendingReload() at the top of createWindow() so a
+    // stale timer can never reload the WRONG (replacement) window. After the
+    // cancel, a fresh crash schedules a fresh reload and only that one fires.
+    const { supervisor, reloadWindow } = makeSupervisor()
+    supervisor.renderProcessGone('crashed') // delay 250ms
+    supervisor.cancelPendingReload() // window replaced: stale timer dropped
+    supervisor.renderProcessGone('crashed') // fresh crash: delay 500ms
+    expect(reloadWindow).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(250) // the stale 250ms timer would have fired here
+    expect(reloadWindow).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(250) // now the 500ms timer fires
+    expect(reloadWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not double-schedule on duplicate render-process-gone events', () => {
+    const { supervisor, reloadWindow } = makeSupervisor()
+    supervisor.renderProcessGone('oom')
+    expect(vi.getTimerCount()).toBe(1)
+    supervisor.renderProcessGone('oom') // duplicate while one is pending
+    expect(vi.getTimerCount()).toBe(1) // still exactly one pending timer
+    vi.advanceTimersByTime(10_000)
+    expect(reloadWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the recovery dialog exactly once across repeated exhaustion', () => {
+    const { supervisor, showDialog } = makeSupervisor()
+    supervisor.renderProcessGone('oom') // 1st: reload scheduled
+    supervisor.renderProcessGone('oom') // 2nd: reload scheduled
+    supervisor.renderProcessGone('oom') // 3rd: reload scheduled
+    supervisor.renderProcessGone('oom') // 4th: budget exhausted → dialog
+    expect(showDialog).toHaveBeenCalledTimes(1)
+    supervisor.renderProcessGone('oom') // 5th+: still exhausted → log only
+    supervisor.renderProcessGone('oom')
+    expect(showDialog).toHaveBeenCalledTimes(1)
+    expect(supervisor.renderProcessGone('oom')).toBe(false)
+  })
+
+  it('does nothing for launch-failed', () => {
+    // A failed launch is not recoverable: reloading the same window state
+    // would fail again, so no reload is scheduled and no budget is spent.
+    const { supervisor, reloadWindow, showDialog } = makeSupervisor()
+    expect(supervisor.renderProcessGone('launch-failed')).toBe(false)
+    expect(reloadWindow).not.toHaveBeenCalled()
+    expect(showDialog).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does nothing for unrecoverable reasons', () => {
+    const { supervisor, reloadWindow } = makeSupervisor()
+    expect(supervisor.renderProcessGone('clean-exit')).toBe(false)
+    vi.advanceTimersByTime(10_000)
+    expect(reloadWindow).not.toHaveBeenCalled()
+  })
+})

--- a/collie-ui/src/main/renderer-recovery.test.ts
+++ b/collie-ui/src/main/renderer-recovery.test.ts
@@ -14,7 +14,13 @@ describe('isRecoverableRendererReason', () => {
     expect(isRecoverableRendererReason('oom')).toBe(true)
     expect(isRecoverableRendererReason('killed')).toBe(true)
     expect(isRecoverableRendererReason('abnormal-exit')).toBe(true)
-    expect(isRecoverableRendererReason('launch-failed')).toBe(true)
+  })
+
+  it('does not treat a failed launch as recoverable', () => {
+    // Decision (OOM-recovery hardening): a failed launch means the renderer
+    // could not start; reloading the same window state would fail again, so
+    // the recovery budget must not be spent on it.
+    expect(isRecoverableRendererReason('launch-failed')).toBe(false)
   })
 
   it('does not reload on clean exits or unknown reasons', () => {
@@ -33,7 +39,7 @@ describe('planRendererRecovery', () => {
     const plan = planRendererRecovery(INITIAL_RENDERER_RECOVERY_STATE, 1_000, 'oom')
     expect(plan).not.toBeNull()
     expect(plan!.delayMs).toBe(RENDERER_RECOVERY_BASE_DELAY_MS)
-    expect(plan!.next).toEqual({ attempts: 1, windowStartedAt: 1_000 })
+    expect(plan!.next).toEqual({ recentCrashTimes: [1_000] })
   })
 
   it('backs off exponentially across crashes in the same window', () => {
@@ -45,6 +51,7 @@ describe('planRendererRecovery', () => {
       expect(plan!.delayMs).toBe(delay)
       state = plan!.next
     }
+    expect(state.recentCrashTimes).toHaveLength(RENDERER_RECOVERY_MAX_ATTEMPTS)
   })
 
   it('exhausts the budget after the maximum attempts in one window', () => {
@@ -54,11 +61,35 @@ describe('planRendererRecovery', () => {
       expect(plan).not.toBeNull()
       state = plan!.next
     }
-    expect(state.attempts).toBe(RENDERER_RECOVERY_MAX_ATTEMPTS)
+    expect(state.recentCrashTimes).toHaveLength(RENDERER_RECOVERY_MAX_ATTEMPTS)
     expect(planRendererRecovery(state, 20_000, 'crashed')).toBeNull()
   })
 
-  it('opens a fresh window after the rolling window elapses', () => {
+  it('keeps the budget exhausted across the window boundary (rolling window)', () => {
+    // Regression: the window is ROLLING, not fixed. A burst of crashes must
+    // never earn a fresh full budget just because the 60s boundary passes.
+    let state = INITIAL_RENDERER_RECOVERY_STATE
+    for (const t of [0, 10_000, 20_000]) {
+      const plan = planRendererRecovery(state, t, 'crashed')
+      expect(plan).not.toBeNull()
+      state = plan!.next
+    }
+    expect(state.recentCrashTimes).toEqual([0, 10_000, 20_000])
+
+    // 61s in: the t=0 crash has aged out of the window, so only two crashes
+    // remain — the crash is allowed, with the delay for the 3rd crash in the
+    // window (1000ms), NOT a fresh budget's 250ms.
+    const at61s = planRendererRecovery(state, 61_000, 'crashed')
+    expect(at61s).not.toBeNull()
+    expect(at61s!.delayMs).toBe(RENDERER_RECOVERY_BASE_DELAY_MS * 2 ** 2)
+    expect(at61s!.next.recentCrashTimes).toEqual([10_000, 20_000, 61_000])
+
+    // 62s in: the crashes at 10s, 20s and 61s are all still inside the window
+    // — three crashes → blocked. The boundary never grants a fresh budget.
+    expect(planRendererRecovery(at61s!.next, 62_000, 'crashed')).toBeNull()
+  })
+
+  it('opens a fresh window only after every crash has aged out', () => {
     let state = INITIAL_RENDERER_RECOVERY_STATE
     for (let i = 0; i < RENDERER_RECOVERY_MAX_ATTEMPTS; i += 1) {
       const plan = planRendererRecovery(state, 30_000, 'crashed')
@@ -67,11 +98,13 @@ describe('planRendererRecovery', () => {
     }
     expect(planRendererRecovery(state, 30_000, 'crashed')).toBeNull()
 
+    // Once every recorded crash is older than the window, the budget is
+    // genuinely fresh again.
     const later = 30_000 + RENDERER_RECOVERY_WINDOW_MS + 1
     const retry = planRendererRecovery(state, later, 'crashed')
     expect(retry).not.toBeNull()
     expect(retry!.delayMs).toBe(RENDERER_RECOVERY_BASE_DELAY_MS)
-    expect(retry!.next).toEqual({ attempts: 1, windowStartedAt: later })
+    expect(retry!.next).toEqual({ recentCrashTimes: [later] })
   })
 
   it('caps the backoff delay', () => {

--- a/collie-ui/src/main/renderer-recovery.ts
+++ b/collie-ui/src/main/renderer-recovery.ts
@@ -7,6 +7,14 @@
  * becomes a ~1s blip). We mirror the core supervision's RestartBudget
  * discipline: at most N reloads per rolling window, with backoff, so a
  * boot-crash can never reload-loop.
+ *
+ * The window is ROLLING, not fixed: only crashes still inside the last
+ * RENDERER_RECOVERY_WINDOW_MS count towards the budget, so a crash at the
+ * 60s boundary never earns a fresh full budget.
+ *
+ * A failed launch ('launch-failed') is deliberately NOT recoverable: the
+ * renderer could not start, so reloading the same window state would fail
+ * again — the recovery budget must not be spent on it.
  */
 
 export const RENDERER_RECOVERY_WINDOW_MS = 60_000
@@ -16,24 +24,28 @@ export const RENDERER_RECOVERY_MAX_DELAY_MS = 2_000
 
 /**
  * Reasons a renderer can disappear. Only genuine crashes warrant a reload;
- * a clean exit or a failed launch is not something a reload fixes.
+ * a clean exit is not something a reload fixes, and a failed launch means
+ * the renderer could not start — reloading the same window state would fail
+ * again, so the recovery budget is not spent on it.
  */
 export const RECOVERABLE_RENDERER_REASONS = new Set([
   'crashed',
   'oom',
   'killed',
-  'abnormal-exit',
-  'launch-failed'
+  'abnormal-exit'
 ]) as ReadonlySet<string>
 
 export interface RendererRecoveryState {
-  attempts: number
-  windowStartedAt: number | null
+  /**
+   * Timestamps (ms) of recent recoverable crashes, oldest-first. Bounded to
+   * RENDERER_RECOVERY_MAX_ATTEMPTS entries so a long-lived app never grows
+   * it unbounded.
+   */
+  recentCrashTimes: number[]
 }
 
 export const INITIAL_RENDERER_RECOVERY_STATE: RendererRecoveryState = {
-  attempts: 0,
-  windowStartedAt: null
+  recentCrashTimes: []
 }
 
 export function isRecoverableRendererReason(reason: string): boolean {
@@ -43,7 +55,12 @@ export function isRecoverableRendererReason(reason: string): boolean {
 /**
  * Decide whether (and when) to reload after a renderer crash.
  * Returns null when the crash is not recoverable or the reload budget for
- * the current rolling window is exhausted.
+ * the rolling window is exhausted.
+ *
+ * The window is rolling: only crashes still inside the last
+ * RENDERER_RECOVERY_WINDOW_MS count, so crossing the boundary never grants a
+ * fresh full budget. The backoff delay grows with the number of crashes
+ * already inside the window (250/500/1000ms for the 1st/2nd/3rd crashes).
  */
 export function planRendererRecovery(
   state: RendererRecoveryState,
@@ -51,20 +68,84 @@ export function planRendererRecovery(
   reason: string
 ): { delayMs: number; next: RendererRecoveryState } | null {
   if (!isRecoverableRendererReason(reason)) return null
-  const startsNewWindow =
-    state.windowStartedAt === null ||
-    now - state.windowStartedAt >= RENDERER_RECOVERY_WINDOW_MS
-  const attempts = startsNewWindow ? 0 : state.attempts
-  if (attempts >= RENDERER_RECOVERY_MAX_ATTEMPTS) return null
+  const cutoff = now - RENDERER_RECOVERY_WINDOW_MS
+  const recent = state.recentCrashTimes.filter((crashAt) => crashAt > cutoff)
+  if (recent.length >= RENDERER_RECOVERY_MAX_ATTEMPTS) return null
   const delayMs = Math.min(
     RENDERER_RECOVERY_MAX_DELAY_MS,
-    RENDERER_RECOVERY_BASE_DELAY_MS * 2 ** attempts
+    RENDERER_RECOVERY_BASE_DELAY_MS * 2 ** recent.length
   )
   return {
     delayMs,
     next: {
-      attempts: attempts + 1,
-      windowStartedAt: startsNewWindow ? now : state.windowStartedAt
+      recentCrashTimes: [...recent, now].slice(-RENDERER_RECOVERY_MAX_ATTEMPTS)
+    }
+  }
+}
+
+/**
+ * Orchestrates the recovery policy against the live app: records crashes,
+ * schedules the (cancellable) reload on a backoff timer, and surfaces the
+ * exhaustion dialog at most once per app run. Injectable seams keep this
+ * testable without Electron (see renderer-recovery-supervisor.test.ts);
+ * index.ts wires it with real setTimeout / dialog.
+ */
+export interface RendererRecoverySupervisorDeps {
+  /** Actually reload the renderer. Wired in the app to re-check quitting and window identity. */
+  reloadWindow: () => void
+  /** Schedule fn after delayMs; returns a handle for cancelReload. */
+  scheduleReload: (fn: () => void, delayMs: number) => unknown
+  /** Cancel a previously scheduled reload. */
+  cancelReload: (handle: unknown) => void
+  /** Show the exhaustion dialog. Called at most once per app run. */
+  showDialog: () => void
+  /** Time source; injectable for deterministic tests. */
+  now: () => number
+}
+
+export class RendererRecoverySupervisor {
+  private state: RendererRecoveryState = INITIAL_RENDERER_RECOVERY_STATE
+  private pendingReload: unknown = null
+  private dialogShown = false
+
+  constructor(private readonly deps: RendererRecoverySupervisorDeps) {}
+
+  /**
+   * Handle a render-process-gone event. Returns true when a reload was
+   * scheduled. A crash while a reload is already pending cancels the stale
+   * timer and reschedules, so at most one reload timer is ever pending.
+   */
+  renderProcessGone(reason: string): boolean {
+    if (!isRecoverableRendererReason(reason)) return false
+    const plan = planRendererRecovery(this.state, this.deps.now(), reason)
+    if (!plan) {
+      // Budget exhausted: a reload would just loop. The Python core is
+      // untouched, so a full restart loses nothing. Warn the user once per
+      // app run — subsequent exhausted crashes are logged, not dialogued.
+      if (!this.dialogShown) {
+        this.dialogShown = true
+        this.deps.showDialog()
+      }
+      return false
+    }
+    this.state = plan.next
+    this.cancelPendingReload()
+    this.pendingReload = this.deps.scheduleReload(() => {
+      this.pendingReload = null
+      this.deps.reloadWindow()
+    }, plan.delayMs)
+    return true
+  }
+
+  /**
+   * Cancel the pending reload, if any. Called on quit, window close/destroy,
+   * and window replacement (top of createWindow) so a stale timer can never
+   * fire against a window that is gone or no longer the current one.
+   */
+  cancelPendingReload(): void {
+    if (this.pendingReload !== null) {
+      this.deps.cancelReload(this.pendingReload)
+      this.pendingReload = null
     }
   }
 }


### PR DESCRIPTION
## Context

Follow-up hardening for the merged OOM-recovery feature (PR #26), per the Codex deep-review findings that landed just after that merge:

1. **True rolling 60s window** (`renderer-recovery.ts`) — bounded crash timestamps replace the fixed `windowStartedAt` reset, so crossing the 60s boundary never grants a fresh full reload budget (regression tests cover the boundary case).
2. **Pending reload timer is tracked and cancelled** (`index.ts`) — no stale reload can fire after quit, window close, or window replacement; duplicate events can't double-schedule.
3. **Recovery dialog shows once per app run** — budget-exhausted crashes log instead of spamming dialogs.
4. **`launch-failed` documented as non-recoverable** — removed from `RECOVERABLE_RENDERER_REASONS` (the comment claimed reloads don't fix failed launches while the code retried them).
5. **Electron-main integration coverage** — orchestration extracted into an injectable `RendererRecoverySupervisor`; new tests cover quit-during-backoff, window replacement, duplicate events, dialog-once, and launch-failed.

## Verification

- `npm run typecheck` — clean (0 errors)
- `npx vitest run` — 209/209 passed (incl. 18 recovery tests)
