### PR TITLE
feat(ui): takeaway card at end of long answers

### DIFF
--- a/collie-ui/src/renderer/src/components/MessageBubble.tsx
+++ b/collie-ui/src/renderer/src/components/MessageBubble.tsx
@@ -1,15 +1,20 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FileText, Image, X } from 'lucide-react'
 import CardRenderer from './cards/CardRenderer'
+import TakeawayCard from './cards/TakeawayCard'
 import type { MessageAttachment, TaskState } from '../lib/ipc'
 import MarkdownContent from './MarkdownContent'
 import { visibleStreamText } from '../lib/stream'
+import { buildTakeawayDigest } from '../lib/takeaway'
 import TaskProgress, { isTaskTerminal } from './tasks/TaskProgress'
 
 interface Props {
   role: 'user' | 'assistant'
   content: string
   streaming?: boolean
+  /** False for the in-flight streaming bubble; the takeaway closer only
+   * appears once the answer is complete and committed. */
+  settled?: boolean
   cardType?: string | null
   cardData?: Record<string, unknown> | null
   attachments?: MessageAttachment[] | null
@@ -29,12 +34,13 @@ function attachmentPreviewSource(attachment: MessageAttachment): string | null {
   return /^data:image\/(?:png|jpeg|webp|gif);base64,/i.test(source) ? source : null
 }
 
-function MessageBubble({ role, content, streaming, cardType, cardData, attachments, taskState }: Props): React.JSX.Element {
+function MessageBubble({ role, content, streaming, settled = true, cardType, cardData, attachments, taskState }: Props): React.JSX.Element {
   const [preview, setPreview] = useState<{ name: string; source: string } | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const returnFocusRef = useRef<HTMLButtonElement | null>(null)
   const isUser = role === 'user'
   const visibleContent = isUser ? content : visibleStreamText(content)
+  const takeaway = useMemo(() => buildTakeawayDigest(content), [content])
 
   const closePreview = useCallback((): void => {
     setPreview(null)
@@ -108,6 +114,11 @@ function MessageBubble({ role, content, streaming, cardType, cardData, attachmen
           <TaskProgress task={taskState} readOnly />
         </div>
       ) : null}
+      {!isUser && settled && !streaming && takeaway && (
+        <div className="flex justify-start collie-reveal mt-1">
+          <TakeawayCard digest={takeaway} />
+        </div>
+      )}
       {preview ? (
         <div
           className="attachment-lightbox"

--- a/collie-ui/src/renderer/src/components/MessageList.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.tsx
@@ -76,7 +76,7 @@ export default function MessageList({ messages, streamText, cardPreview }: Props
             taskState={msg.task_state}
           />
         ))}
-        {visibleStream && <MessageBubble role="assistant" content={visibleStream} cardType={cardPreview?.card_type ?? null} cardData={cardPreview?.card_data ?? null} />}
+        {visibleStream && <MessageBubble role="assistant" content={visibleStream} cardType={cardPreview?.card_type ?? null} cardData={cardPreview?.card_data ?? null} settled={false} />}
         <div ref={endRef} />
       </div>
     </div>

--- a/collie-ui/src/renderer/src/components/cards/TakeawayCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/TakeawayCard.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { buildTakeawayDigest } from '../../lib/takeaway'
+import type { CollieMessage } from '../../lib/ipc'
+import TakeawayCard from './TakeawayCard'
+import MessageList from '../MessageList'
+
+const roots: Root[] = []
+
+function render(element: React.ReactNode): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(element))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+const LONG_ANSWER = `Here is a detailed walkthrough of the plan for the garden project.
+
+## Steps
+
+- Clear the flower beds and remove the old trellis
+- Plant the tomatoes and the basil in the sunny corner
+- Lay down mulch across all three beds before the weekend
+- Set up the drip irrigation system with a timer
+
+## Timing
+
+**Start**: Saturday morning
+**Budget**: $120 total for soil and seeds
+
+Some extra detail: the soil in the north bed tested quite acidic this year, so
+we will mix in a little lime when we turn the beds over, and the basil should
+go in last since it grows fastest in the warm weather.`
+
+function assistantMessage(content: string): CollieMessage {
+  return {
+    id: 'm1',
+    conversation_id: 'c1',
+    role: 'assistant',
+    content,
+    created_at: '2026-01-01T00:00:00Z'
+  }
+}
+
+describe('buildTakeawayDigest', () => {
+  it('turns headings and bullets into key points and key-value lines into chips', () => {
+    const digest = buildTakeawayDigest(LONG_ANSWER)
+
+    expect(digest).not.toBeNull()
+    expect(digest!.points.map((point) => point.text)).toEqual([
+      'Steps',
+      'Clear the flower beds and remove the old trellis',
+      'Plant the tomatoes and the basil in the sunny corner',
+      'Lay down mulch across all three beds before the weekend',
+      'Set up the drip irrigation system with a timer'
+    ])
+    expect(digest!.chips).toEqual([
+      { key: 'Start', value: 'Saturday morning' },
+      { key: 'Budget', value: '$120 total for soil and seeds' }
+    ])
+  })
+
+  it('returns null for short answers', () => {
+    expect(buildTakeawayDigest('Sure — here you go.')).toBeNull()
+  })
+
+  it('returns null for long prose without any structure', () => {
+    const prose = `This is a long conversational answer that simply keeps going
+    and going without using any headings, bullet lists or bold labels at all.
+    It talks at length about the weather, about the neighborhood, about the
+    plants on the balcony, about the coffee that was left to cool, and about
+    how the afternoon light falls across the kitchen floor. There is nothing
+    to extract here, no structure to hang a recap on, just words that flow on
+    and on like a river that never quite reaches the sea.`
+    expect(buildTakeawayDigest(prose)).toBeNull()
+  })
+
+  it('attaches a sparkline series when a point contains several numbers', () => {
+    const digest = buildTakeawayDigest(`${'Intro words. '.repeat(40)}
+
+- Track the scores across rounds: 12, 18, 23 and 30 points
+- Water the seedlings twice a day
+- Feed the plants weekly`)
+
+    expect(digest).not.toBeNull()
+    const scored = digest!.points.find((point) => point.numbers)
+    expect(scored?.numbers).toEqual([12, 18, 23, 30])
+  })
+
+  it('ignores fenced code blocks', () => {
+    const digest = buildTakeawayDigest(`${'Intro words. '.repeat(40)}
+
+## Steps
+
+- Install the new shelf
+
+\`\`\`
+- this is code, not a bullet
+- and so is this
+\`\`\`
+
+- Paint the wall`)
+
+    expect(digest).not.toBeNull()
+    expect(digest!.points.some((point) => point.text.includes('this is code'))).toBe(false)
+    expect(digest!.points.some((point) => point.text.includes('Paint the wall'))).toBe(true)
+  })
+})
+
+describe('TakeawayCard', () => {
+  it('renders the recap with points, chips and a sparkline for numbers', () => {
+    const digest = buildTakeawayDigest(LONG_ANSWER)!
+    const container = render(<TakeawayCard digest={digest} />)
+
+    expect(container.querySelector('[aria-label="Quick recap"]')).not.toBeNull()
+    expect(container.textContent).toContain('Clear the flower beds and remove the old trellis')
+    expect(container.textContent).toContain('Saturday morning')
+    expect(container.textContent).toContain('$120 total for soil and seeds')
+  })
+
+  it('renders tiny bars when a point carries a numeric series', () => {
+    const digest = buildTakeawayDigest(`${'Intro words. '.repeat(40)}
+
+- Scores across the season: 12, 18, 23 and 30 points
+- Keep the courts dry
+- Book the courts for Saturday`)!
+    const container = render(<TakeawayCard digest={digest} />)
+
+    expect(container.querySelector('[title="12 → 18 → 23 → 30"]')).not.toBeNull()
+  })
+})
+
+describe('MessageList takeaway integration', () => {
+  it('shows the recap under a committed long answer while keeping the full text', () => {
+    const container = render(<MessageList messages={[assistantMessage(LONG_ANSWER)]} streamText="" />)
+
+    expect(container.querySelector('[aria-label="Quick recap"]')).not.toBeNull()
+    expect(container.textContent).toContain('Clear the flower beds and remove the old trellis')
+    expect(container.textContent).toContain('we will mix in a little lime when we turn the beds over')
+  })
+
+  it('hides the recap while the answer is still streaming', () => {
+    const container = render(<MessageList messages={[]} streamText={LONG_ANSWER} />)
+
+    expect(container.querySelector('[aria-label="Quick recap"]')).toBeNull()
+    expect(container.textContent).toContain('Clear the flower beds')
+  })
+
+  it('shows no recap for short committed answers', () => {
+    const container = render(<MessageList messages={[assistantMessage('All set — done!')]} streamText="" />)
+
+    expect(container.querySelector('[aria-label="Quick recap"]')).toBeNull()
+  })
+})

--- a/collie-ui/src/renderer/src/components/cards/TakeawayCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/TakeawayCard.tsx
@@ -1,0 +1,72 @@
+import { PawPrint } from 'lucide-react'
+import type { TakeawayChip, TakeawayDigest, TakeawayPoint } from '../../lib/takeaway'
+
+function MiniBars({ numbers }: { numbers: number[] }): React.JSX.Element {
+  const max = Math.max(...numbers, 1)
+  return (
+    <span
+      className="mt-1 flex items-end gap-[3px]"
+      aria-hidden="true"
+      title={numbers.join(' → ')}
+    >
+      {numbers.map((value, index) => (
+        <span
+          key={`${value}-${index}`}
+          className="w-1.5 rounded-sm bg-amber-400/80"
+          style={{ height: `${Math.max(4, Math.round((value / max) * 14))}px` }}
+        />
+      ))}
+    </span>
+  )
+}
+
+function PointRow({ point }: { point: TakeawayPoint }): React.JSX.Element {
+  return (
+    <li className="flex items-start gap-2 text-sm leading-snug text-stone-700">
+      <span className="mt-[7px] size-1.5 shrink-0 rounded-full bg-amber-400" aria-hidden="true" />
+      <span className="min-w-0">
+        {point.text}
+        {point.numbers && point.numbers.length > 0 && <MiniBars numbers={point.numbers} />}
+      </span>
+    </li>
+  )
+}
+
+function ChipPill({ chip }: { chip: TakeawayChip }): React.JSX.Element {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-stone-100 px-2.5 py-1 text-xs text-stone-600">
+      <span className="font-medium text-stone-900">{chip.key}</span>
+      <span className="text-stone-300" aria-hidden="true">·</span>
+      <span>{chip.value}</span>
+    </span>
+  )
+}
+
+/**
+ * A friendly closer shown under long answers: a few key points, optional
+ * key/value chips and tiny bar sparklines when numbers appear. It always
+ * renders *below* the full streamed text — never instead of it.
+ */
+export default function TakeawayCard({ digest }: { digest: TakeawayDigest }): React.JSX.Element {
+  return (
+    <section
+      aria-label="Quick recap"
+      className="my-2 w-full max-w-2xl rounded-xl border border-stone-200 bg-white text-stone-900 shadow-sm"
+    >
+      <div className="flex items-center gap-3 px-4 pt-3">
+        <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-amber-50 text-amber-700">
+          <PawPrint size={16} />
+        </span>
+        <h2 className="text-sm font-semibold">Quick recap</h2>
+      </div>
+      <ul className="space-y-2 px-4 py-3">
+        {digest.points.map((point, index) => <PointRow point={point} key={index} />)}
+      </ul>
+      {digest.chips.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 border-t border-stone-100 px-4 py-2.5">
+          {digest.chips.map((chip, index) => <ChipPill chip={chip} key={`${chip.key}-${index}`} />)}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/lib/takeaway.ts
+++ b/collie-ui/src/renderer/src/lib/takeaway.ts
@@ -1,0 +1,172 @@
+/**
+ * Takeaway digest — a small UI-side "closer" for long assistant answers.
+ *
+ * The streamed markdown stays the source of truth; this module only derives
+ * a compact summary from the *final* text so the card can never lose
+ * information. Short answers get no card at all.
+ *
+ * Extraction rules (deliberately conservative — junk is dropped, never shown):
+ *   - headings, list items, bold-led lines and blockquotes → key points
+ *   - "Key: value" lines, "**Key**: value" lines and 2-cell table rows → chips
+ *   - points containing 3+ numbers get a tiny sparkline series
+ */
+
+export interface TakeawayPoint {
+  text: string
+  /** Numeric series found in the point, kept for a tiny sparkline. */
+  numbers?: number[]
+}
+
+export interface TakeawayChip {
+  key: string
+  value: string
+}
+
+export interface TakeawayDigest {
+  points: TakeawayPoint[]
+  chips: TakeawayChip[]
+}
+
+/** Answers shorter than this are too brief to need a recap. */
+export const MIN_TAKEAWAY_ANSWER_LENGTH = 400
+export const MAX_TAKEAWAY_POINTS = 5
+export const MAX_TAKEAWAY_CHIPS = 4
+const MAX_POINT_LENGTH = 140
+const MAX_CHIP_VALUE_LENGTH = 80
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function extractNumbers(text: string): number[] {
+  const matches = text.match(/\d+(?:\.\d+)?/g)
+  if (!matches) return []
+  const numbers = matches.map((raw) => Number.parseFloat(raw)).filter(Number.isFinite)
+  return numbers.slice(0, 8)
+}
+
+type Candidate = { kind: 'point'; text: string } | { kind: 'chip'; key: string; value: string }
+
+/** Classify one markdown line into a point, a chip, or nothing. */
+function classifyLine(line: string): Candidate | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  if (/^(?:[-*_]{3,}|={3,})$/.test(trimmed)) return null
+
+  const heading = /^#{1,6}\s+(.+)$/.exec(trimmed)
+  if (heading) return { kind: 'point', text: heading[1] }
+
+  const quote = /^>\s?(.+)$/.exec(trimmed)
+  if (quote) return { kind: 'point', text: quote[1] }
+
+  const bullet = /^[-*+]\s+(.+)$/.exec(trimmed)
+  if (bullet) return { kind: 'point', text: bullet[1] }
+
+  const numbered = /^\d+[.)]\s+(.+)$/.exec(trimmed)
+  if (numbered) return { kind: 'point', text: numbered[1] }
+
+  if (trimmed.startsWith('|')) {
+    const cells = trimmed.split('|').map((cell) => cell.trim()).filter(Boolean)
+    if (cells.length === 2 && cells[0] && cells[1]) {
+      return { kind: 'chip', key: cells[0], value: cells[1] }
+    }
+    return null
+  }
+
+  const boldValue = /^\*\*([^*]+)\*\*\s*[:：]\s*(.+)$/.exec(trimmed)
+  if (boldValue) return { kind: 'chip', key: boldValue[1], value: boldValue[2] }
+
+  const keyValue = /^([A-Za-z][^:：\n]{1,48}?)\s*[:：]\s*(.+)$/.exec(trimmed)
+  if (keyValue && trimmed.length <= 120) {
+    return { kind: 'chip', key: keyValue[1], value: keyValue[2] }
+  }
+
+  const boldLead = /^\*\*([^*]+)\*\*/.exec(trimmed)
+  if (boldLead) return { kind: 'point', text: trimmed }
+
+  return null
+}
+
+function dedupeKey(text: string): string {
+  return text.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ').trim()
+}
+
+/**
+ * True when the line at `index` is mid-paragraph: the next non-blank line
+ * continues the sentence (starts lowercase), so a "Key: value" match here is
+ * probably wrapped prose, not a standalone chip.
+ */
+function continuesProse(lines: string[], index: number): boolean {
+  for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+    const next = lines[cursor].trim()
+    if (!next) continue
+    return /^[a-z]/.test(next)
+  }
+  return false
+}
+
+/**
+ * Build a takeaway digest from the final markdown of an assistant answer.
+ * Returns null when the answer is too short or has no extractable structure,
+ * so short/plain answers render no card at all.
+ */
+export function buildTakeawayDigest(markdown: string): TakeawayDigest | null {
+  if (!markdown || markdown.trim().length < MIN_TAKEAWAY_ANSWER_LENGTH) return null
+
+  const points: TakeawayPoint[] = []
+  const chips: TakeawayChip[] = []
+  const seenPoints = new Set<string>()
+  const seenChips = new Set<string>()
+
+  const lines = markdown.split('\n')
+  let inFence = false
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim()
+    if (/^```/.test(trimmed)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+
+    const candidate = classifyLine(trimmed)
+    if (!candidate) continue
+
+    if (candidate.kind === 'chip') {
+      if (continuesProse(lines, index)) continue
+      const key = stripMarkdown(candidate.key)
+      const value = stripMarkdown(candidate.value)
+      if (key.length < 2 || key.length > 40 || value.length < 1 || value.length > MAX_CHIP_VALUE_LENGTH) continue
+      const dedupe = dedupeKey(key)
+      if (seenChips.has(dedupe)) continue
+      seenChips.add(dedupe)
+      chips.push({ key, value })
+      if (chips.length === MAX_TAKEAWAY_CHIPS) continue
+    } else {
+      if (points.length >= MAX_TAKEAWAY_POINTS) continue
+      const clean = stripMarkdown(candidate.text)
+      if (!clean) continue
+      const dedupe = dedupeKey(clean)
+      if (dedupe.length < 3 || seenPoints.has(dedupe)) continue
+      seenPoints.add(dedupe)
+      const truncated = clean.length > MAX_POINT_LENGTH ? `${clean.slice(0, MAX_POINT_LENGTH - 3).trimEnd()}…` : clean
+      const numbers = extractNumbers(clean)
+      points.push(numbers.length >= 3
+        ? { text: truncated, numbers }
+        : { text: truncated })
+    }
+  }
+
+  if (points.length < 2) return null
+  if (points.length < 3 && chips.length < 2) return null
+
+  return { points, chips }
+}


### PR DESCRIPTION
## What

Long assistant answers now end with a friendly **"Quick recap"** card — a small visual closer that sits *below* the full streamed text. The transcript stays exactly as it is; the card is just a digest of it, so nothing is ever hidden or replaced.

The card shows:
- **3–5 key points** pulled from headings, bullet lists, bold-led lines and quotes
- **Key-value chips** for things like `Start · Saturday morning` or `Budget · $120`
- **Tiny bar sparklines** when a point mentions several numbers (e.g. `12 → 18 → 23 → 30`)

Short answers get **no card** — the digest only appears for answers longer than ~400 characters that actually have structure to summarize.

## Why

Design goal: *less read, more see*. Recaps are a familiar, friendly pattern — but the full answer must always remain the source of truth (explicit user requirement: no context loss). So the card is derived **from** the final answer text and rendered **after** it, never instead of it, and never while the answer is still streaming.

## How (design decision)

**UI-side digest, not a model-emitted card.** Chosen because it fits the existing architecture with the least new machinery:

- The existing card protocol (`cardType`/`cardData`) is emitted by explicit backend code paths (slash commands, tool results) at send-time. A model-emitted takeaway card would need prompt changes plus new parsing in the engine, and would depend on the model reliably emitting it.
- A pure client-side digest is deterministic, works for *every* long answer, needs zero core/engine/IPC changes, and is fully testable in vitest.
- It derives from the settled transcript, so "no context loss" holds by construction.

Implementation:

- `collie-ui/src/renderer/src/lib/takeaway.ts` — `buildTakeawayDigest(markdown)` is a pure function: length gate (>400 chars), structure extraction (headings/bullets/bold/quotes → points; `Key: value`, `**Key**: value`, 2-cell table rows → chips; 3+ numbers in a point → sparkline series), conservative filtering (code fences ignored, wrapped prose rejected, dedup, caps at 5 points / 4 chips). Returns `null` for short or unstructured answers → no card.
- `collie-ui/src/renderer/src/components/cards/TakeawayCard.tsx` — card component following existing card conventions (`FilesChangedCard` styling: white surface, `rounded-xl`, soft border), with Collie's amber accent and a paw-print icon (dog only in visuals 🐾). Warm voice, zero dev jargon: the heading is **"Quick recap"**.
- `MessageBubble.tsx` — renders the card below the text for settled assistant messages; `MessageList.tsx` marks the in-flight streaming bubble `settled={false}` so the card only appears when the answer is complete.

## Tests

- `cd collie-ui && npm test` — **48 files / 272 tests passed** (10 new tests in `TakeawayCard.test.tsx`: digest extraction, chips, sparkline series, code-fence handling, prose rejection, short/no-structure → no card, plus MessageList integration: card shown for committed long answers, hidden while streaming, hidden for short answers).
- `npm run typecheck` — clean (web + node tsconfigs).

## Voice note

All user-facing strings are warm and jargon-free ("Quick recap", not "AI-generated summary" or "extracted digest"). No dev terminology appears in the UI.
