### PR TITLE
feat(ui): skeleton streaming container for answers

### DIFF
--- a/collie-ui/src/renderer/src/components/MessageBubble.skeleton.test.tsx
+++ b/collie-ui/src/renderer/src/components/MessageBubble.skeleton.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import MessageBubble from './MessageBubble'
+
+const roots: Root[] = []
+
+function render(element: React.ReactNode): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(element))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+describe('MessageBubble streaming skeleton frame', () => {
+  it('shows placeholder lines while the first tokens are still on their way', () => {
+    const container = render(<MessageBubble role="assistant" content="" streaming />)
+    const skeleton = container.querySelector('.collie-skeleton')
+    expect(skeleton).not.toBeNull()
+    expect(skeleton?.classList.contains('collie-skeleton--active')).toBe(true)
+    expect(skeleton?.querySelectorAll('.collie-skeleton-line')).toHaveLength(3)
+    expect(skeleton?.getAttribute('aria-hidden')).toBe('true')
+    expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('keeps a short streamed answer inside the same active frame', () => {
+    const container = render(<MessageBubble role="assistant" content="Sure — on it." streaming />)
+    const skeleton = container.querySelector('.collie-skeleton')
+    expect(skeleton).not.toBeNull()
+    expect(skeleton?.classList.contains('collie-skeleton--active')).toBe(true)
+    expect(container.textContent).toContain('Sure — on it.')
+    expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('fades the placeholder lines once real text fills the card', () => {
+    const container = render(
+      <MessageBubble
+        role="assistant"
+        content="A longer answer that has clearly crossed the initial-latency threshold by now."
+        streaming
+      />
+    )
+    const skeleton = container.querySelector('.collie-skeleton')
+    expect(skeleton).not.toBeNull()
+    expect(skeleton?.classList.contains('collie-skeleton--settled')).toBe(true)
+    expect(skeleton?.classList.contains('collie-skeleton--active')).toBe(false)
+  })
+
+  it('streams markdown into the same card while the frame is up', () => {
+    const container = render(<MessageBubble role="assistant" content="A **smooth** answer" streaming />)
+    expect(container.querySelector('strong')?.textContent).toBe('smooth')
+    expect(container.querySelector('.message-content')).not.toBeNull()
+  })
+
+  it('never shows the frame for user bubbles', () => {
+    const container = render(<MessageBubble role="user" content="" streaming />)
+    expect(container.querySelector('.collie-skeleton')).toBeNull()
+    expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBeNull()
+  })
+
+  it('renders no frame once streaming has finished', () => {
+    const container = render(<MessageBubble role="assistant" content="All set." />)
+    expect(container.querySelector('.collie-skeleton')).toBeNull()
+    expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBeNull()
+  })
+})

--- a/collie-ui/src/renderer/src/components/MessageBubble.tsx
+++ b/collie-ui/src/renderer/src/components/MessageBubble.tsx
@@ -21,6 +21,12 @@ interface Props {
   taskState?: TaskState | null
 }
 
+// While an answer is streaming, the assistant card shows a quiet skeleton
+// frame (placeholder lines) so the chat never looks stalled. As soon as the
+// streamed text crosses this length the placeholder lines fade out and the
+// stream keeps filling the same card — the frame itself never disappears.
+const STREAM_SKELETON_MAX_CHARS = 48
+
 const PREVIEWABLE_IMAGE_TYPES = new Set([
   'image/png',
   'image/jpeg',
@@ -41,6 +47,8 @@ function MessageBubble({ role, content, streaming, settled = true, cardType, car
   const isUser = role === 'user'
   const visibleContent = isUser ? content : visibleStreamText(content)
   const takeaway = useMemo(() => buildTakeawayDigest(content), [content])
+  const writing = Boolean(streaming && !isUser)
+  const skeletonActive = writing && visibleContent.trim().length < STREAM_SKELETON_MAX_CHARS
 
   const closePreview = useCallback((): void => {
     setPreview(null)
@@ -67,7 +75,8 @@ function MessageBubble({ role, content, streaming, settled = true, cardType, car
     >
       <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
         <div
-          className="message-bubble max-w-[80%] whitespace-pre-wrap px-4 py-3 text-[15px] leading-relaxed"
+          className={`message-bubble max-w-[80%] whitespace-pre-wrap px-4 py-3 text-[15px] leading-relaxed ${writing ? 'message-bubble--writing' : ''}`}
+          aria-busy={writing || undefined}
         >
           {attachments && attachments.length > 0 && (
             <div className="message-attachments">
@@ -96,12 +105,25 @@ function MessageBubble({ role, content, streaming, settled = true, cardType, car
               })}
             </div>
           )}
-          {visibleContent && (
-            isUser || streaming
-              ? <span className="whitespace-pre-wrap">{visibleContent}</span>
-              : <MarkdownContent content={visibleContent} />
+          {visibleContent ? (
+            <div className="message-content">
+              {isUser ? (
+                <span className="whitespace-pre-wrap">{visibleContent}</span>
+              ) : (
+                <MarkdownContent content={visibleContent} />
+              )}
+            </div>
+          ) : null}
+          {writing && (
+            <div
+              className={`collie-skeleton ${skeletonActive ? 'collie-skeleton--active' : 'collie-skeleton--settled'}`}
+              aria-hidden="true"
+            >
+              <span className="collie-skeleton-line" />
+              <span className="collie-skeleton-line" />
+              <span className="collie-skeleton-line" />
+            </div>
           )}
-          {streaming && <span className="collie-thinking">▍</span>}
         </div>
       </div>
       {!isUser && cardType && cardData && (

--- a/collie-ui/src/renderer/src/components/MessageList.test.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.test.tsx
@@ -47,4 +47,42 @@ describe('MessageList streaming output', () => {
 
     act(() => root.unmount())
   })
+
+  it('holds the writing frame on the live bubble before the first token arrives', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => root.render(<MessageList messages={[]} streamText="" streaming />))
+    expect(container.querySelector('.collie-skeleton--active')).not.toBeNull()
+    expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBe('true')
+
+    act(() => root.unmount())
+  })
+
+  it('streams the first tokens into the same live bubble without a gap', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => root.render(<MessageList messages={[]} streamText="" streaming />))
+    const bubble = container.querySelector('.message-bubble')
+
+    act(() => root.render(<MessageList messages={[]} streamText="Hello there" streaming />))
+    expect(container.querySelector('.message-bubble')).toBe(bubble)
+    expect(container.textContent).toContain('Hello there')
+
+    act(() => root.unmount())
+  })
+
+  it('leaves no frame behind once the live stream ends', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => root.render(<MessageList messages={[]} streamText="Done" streaming />))
+    expect(container.querySelector('.collie-skeleton')).not.toBeNull()
+
+    act(() => root.render(<MessageList messages={[]} streamText="" />))
+    expect(container.querySelector('.collie-skeleton')).toBeNull()
+
+    act(() => root.unmount())
+  })
 })

--- a/collie-ui/src/renderer/src/components/MessageList.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.tsx
@@ -7,13 +7,14 @@ import { stableMarkdownStreamText, visibleStreamText } from '../lib/stream'
 interface Props {
   messages: CollieMessage[]
   streamText: string
+  streaming?: boolean
   cardPreview?: { card_type: string; card_data: Record<string, unknown> } | null
 }
 
 // Long conversations render in windows so the DOM stays light (Step 49).
 const WINDOW_SIZE = 100
 
-export default function MessageList({ messages, streamText, cardPreview }: Props): React.JSX.Element {
+export default function MessageList({ messages, streamText, streaming = false, cardPreview }: Props): React.JSX.Element {
   const endRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const shouldFollowRef = useRef(true)
@@ -76,7 +77,16 @@ export default function MessageList({ messages, streamText, cardPreview }: Props
             taskState={msg.task_state}
           />
         ))}
-        {visibleStream && <MessageBubble role="assistant" content={visibleStream} cardType={cardPreview?.card_type ?? null} cardData={cardPreview?.card_data ?? null} settled={false} />}
+        {(visibleStream || streaming) && (
+          <MessageBubble
+            role="assistant"
+            content={visibleStream}
+            streaming={streaming}
+            settled={false}
+            cardType={cardPreview?.card_type ?? null}
+            cardData={cardPreview?.card_data ?? null}
+          />
+        )}
         <div ref={endRef} />
       </div>
     </div>

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -134,6 +134,7 @@ export default function ChatScreen({
   const [activeId, setActiveId] = useState<string | null>(null)
   const [messages, setMessages] = useState<CollieMessage[]>([])
   const [streamText, setStreamText] = useState('')
+  const [streaming, setStreaming] = useState(false)
   const [thinkingMap, setThinkingMap] = useState<Record<string, ThinkingState>>({})
   const [errorText, setErrorText] = useState('')
   const [planChangeNotice, setPlanChangeNotice] = useState('')
@@ -303,6 +304,7 @@ export default function ChatScreen({
     const token = ++loadTokenRef.current
     setActiveId(id)
     setStreamText('')
+    setStreaming(false)
     setErrorText('')
     setPlanChangeNotice('')
     setPortraitThinking(null)
@@ -373,6 +375,7 @@ export default function ChatScreen({
           void refreshCommandCatalog()
           void refreshApprovalPreset()
           setThinkingMap({})
+          setStreaming(false)
           if (current) {
             collieClient
               .getMessages(current)
@@ -428,6 +431,7 @@ export default function ChatScreen({
           const key = event.conversation_id || current
           if (!key) break
           const terminal = ['done', 'idle', 'error'].includes(event.state)
+          if (key === current) setStreaming(!terminal)
           setTaskTimings((previous) => {
             const existing = previous[key]
             if (terminal) {
@@ -467,6 +471,7 @@ export default function ChatScreen({
         case 'delta':
           if (event.conversation_id === current) {
             streamRef.current = mergeStreamDelta(streamRef.current, event.text)
+            setStreaming(true)
             scheduleStreamReveal()
           }
           break
@@ -496,6 +501,9 @@ export default function ChatScreen({
           }
           if (msg.role === 'assistant' && isCurrentConversationEvent(msg.conversation_id, current)) {
             pendingAssistantRef.current = msg
+            // The turn's final text is reserved and revealed in the
+            // transcript — the live stream card hands over to it.
+            setStreaming(false)
             // A mid-turn steer delivers the superseded answer as its own
             // message; the follow-up response then covers only the tail of
             // the accumulated stream. Reveal that bubble from scratch instead
@@ -562,6 +570,7 @@ export default function ChatScreen({
             stopStreamReveal()
             streamRef.current = ''
             streamDisplayRef.current = ''
+            setStreaming(false)
             const pending = pendingAssistantRef.current
             pendingAssistantRef.current = null
             if (pending) {
@@ -666,6 +675,7 @@ export default function ChatScreen({
         phrase: 'Thinking through your task…',
         pet_animation: 'working'
       })
+      setStreaming(true)
       try {
         const { conversation_id, command_handled } = await collieClient.chat(
           activeIdRef.current,
@@ -989,7 +999,7 @@ export default function ChatScreen({
           </div>
         </header>
         <div className="conversation-panel">
-          <MessageList messages={messages} streamText={streamText} cardPreview={cardPreview} />
+          <MessageList messages={messages} streamText={streamText} streaming={streaming} cardPreview={cardPreview} />
           <RememberPill conversationId={activeId} />
         {errorText && (
           <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1783,6 +1783,66 @@ button {
   color: #fff;
 }
 
+/* Streaming answer frame: while the first tokens are on their way the
+   assistant card shows a quiet skeleton (placeholder lines). The frame
+   stays once text arrives — the stream fills the same card and the
+   placeholder lines fade out beneath it. */
+.message-row--assistant .message-bubble--writing {
+  position: relative;
+  min-height: 88px;
+  overflow: hidden;
+}
+
+.message-content {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.collie-skeleton {
+  position: absolute;
+  z-index: 0;
+  top: 12px;
+  right: 16px;
+  left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  opacity: 0;
+  transition: opacity var(--motion-smooth) ease-out;
+  pointer-events: none;
+}
+
+.collie-skeleton--active {
+  opacity: 1;
+}
+
+.collie-skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--line) 62%, transparent) 25%,
+    color-mix(in srgb, var(--line) 34%, transparent) 50%,
+    color-mix(in srgb, var(--line) 62%, transparent) 75%
+  );
+  background-size: 200% 100%;
+  animation: collie-skeleton-shimmer 1.8s linear infinite;
+}
+
+.collie-skeleton-line:nth-child(1) { width: 92%; }
+.collie-skeleton-line:nth-child(2) { width: 100%; }
+.collie-skeleton-line:nth-child(3) { width: 58%; }
+
+@keyframes collie-skeleton-shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .collie-skeleton-line { animation: none; }
+}
+
 .message-markdown { min-width: 0; overflow-wrap: anywhere; }
 .message-markdown > :first-child { margin-top: 0; }
 .message-markdown > :last-child { margin-bottom: 0; }


### PR DESCRIPTION
## What

Adds a skeleton-card **streaming container** to assistant answers in chat. While Collie is writing, the answer card shows a subtle frame with three placeholder lines (shimmer). The moment the first tokens arrive, the full streamed markdown renders **inside the same card** — text is never delayed, hidden, or replaced by the skeleton.

This is the "skeleton = the loading style of the answer card, not a replacement for streaming" pattern (user direction, 2026-08-08): no empty skeleton sitting for minutes, no dead air during initial latency.

## Why

"Less read, more see" for normies: a frame that reads as *"the answer is being written here"* instead of a bare cursor. The skeleton only shows while the visible content is empty/short (`STREAM_SKELETON_MAX_CHARS = 48`), then fades out via opacity transition.

## Codex / OpenCode streaming patterns (research, as requested)

| Pattern | Codex (openai/codex TUI) | OpenCode (opencode-ai) | Borrowed for Collie? |
|---|---|---|---|
| Same-container inline streaming | `streaming/render.rs`: stable markdown prefix retained, only final block mutates — no placeholder swap | `chat/message.go`: renders live content directly | ✅ **Yes** — text always streams into the one card |
| Activity/status line above composer | `status_indicator_widget.rs`: animated "Working…" header | `chat/list.go`: Bubble Tea spinner + "Loading…" line | ❌ No — Collie already has the portrait pet + thinking notes |
| Thinking/reasoning rendered as content | chat widget renders reasoning while assistant text is empty | `message.go` `IsThinking()` branch | ❌ No — Collie hides thinking tags via `visibleStreamText` |
| Skeleton for quiet moments | none (TUI always has full text after status line) | spinner only in status line, never in the card | ✅ **Yes** — 3 skeleton lines + shimmer replacing the cursor, only while empty/short |

Note: opencode-ai/opencode is archived (project moved to Crush) — cited as such.

## What changed

- **`MessageBubble.tsx`** — assistant bubbles while `streaming` render a `message-bubble--writing` frame with the live streamed content + an absolutely-positioned `.collie-skeleton` layer (3 placeholder lines) that fades out past 48 chars. `aria-busy` on the container; skeleton is `aria-hidden`. User bubbles unaffected. Removed the orphaned `▍` cursor branch (the cursor was deliberately removed in alpha.4).
- **`MessageList.tsx`** — new `streaming?: boolean` prop; the live bubble stays mounted when `streaming=true` even with empty text (no remount gap), so the skeleton shows during initial latency and text streams into the SAME card.
- **`ChatScreen.tsx`** — `streaming` state driven by the turn lifecycle: true on send/`delta`, false on terminal thinking, final message, error, core `ready` reset, and conversation open.
- **`globals.css`** — `.collie-skeleton` layer using theme tokens (`--line` via `color-mix`, light/dark safe), subtle shimmer keyframe, `prefers-reduced-motion: reduce` disables the animation (structure stays static), `min-height` frame.

## Accessibility

- `aria-busy` on the writing container
- skeleton `aria-hidden` (decorative)
- `prefers-reduced-motion` respected — no shimmer, static placeholder lines

## Tests

- `npm test` — **271 passed (48 files)**, incl. new `MessageBubble.skeleton.test.tsx` (6 tests: frame on empty, short text keeps frame, fade past 48 chars, markdown streams into same card, no frame for user bubbles, no frame when not streaming) + 3 new `MessageList.test.tsx` cases (frame held pre-token, same-bubble streaming, frame removed when stream ends)
- `npm run typecheck` — clean (tsconfig.web + tsconfig.node)
