### PR TITLE
feat(ui): remember pill on learning

### DIFF
--- a/collie-ui/src/renderer/src/components/RememberPill.test.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.test.tsx
@@ -282,6 +282,24 @@ describe('RememberPill', () => {
     act(() => root.unmount())
   })
 
+  it('follows conversation switches after mount (activeId starts null in ChatScreen)', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId={null} />))
+    await flush() // baseline established (empty journal -> 0)
+
+    // ChatScreen opens the starter conversation after mount.
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+    act(() => root.unmount())
+  })
+
   it('re-baselines after a core restart without replaying history', async () => {
     const container = document.createElement('div')
     const root = createRoot(container)

--- a/collie-ui/src/renderer/src/components/RememberPill.test.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.test.tsx
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CollieEvent, MemoryJournalEntry } from '../lib/ipc'
+
+const hooks = vi.hoisted(() => {
+  const listeners = new Set<(event: CollieEvent) => void>()
+  const client = {
+    on: vi.fn((listener: (event: CollieEvent) => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }),
+    getMemoryJournal: vi.fn()
+  }
+  return {
+    journal: { entries: [] as MemoryJournalEntry[] },
+    emit: (event: CollieEvent): void => {
+      for (const listener of [...listeners]) listener(event)
+    },
+    client
+  }
+})
+
+vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+
+import RememberPill from './RememberPill'
+
+function entry(overrides: Partial<MemoryJournalEntry> = {}): MemoryJournalEntry {
+  return {
+    id: 1,
+    kind: 'fact',
+    subject: 'name',
+    action: 'add',
+    value: 'Rick',
+    created_at: '2026-08-08T10:00:00Z',
+    ...overrides
+  }
+}
+
+function assistantMessage(conversationId: string): CollieEvent {
+  return {
+    type: 'message',
+    conversation_id: conversationId,
+    message: {
+      id: 'm-1',
+      conversation_id: conversationId,
+      role: 'assistant',
+      content: 'Done!',
+      created_at: '2026-08-08T10:00:01Z'
+    }
+  }
+}
+
+function userMessage(conversationId: string): CollieEvent {
+  return {
+    type: 'message',
+    conversation_id: conversationId,
+    message: {
+      id: 'm-0',
+      conversation_id: conversationId,
+      role: 'user',
+      content: 'remember my name',
+      created_at: '2026-08-08T10:00:00Z'
+    }
+  }
+}
+
+/** Flush the mock's promise chains (baseline fetch, journal poll). */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+beforeEach(() => {
+  hooks.journal.entries = []
+  hooks.client.getMemoryJournal.mockImplementation(async () => ({
+    entries: hooks.journal.entries
+  }))
+  sessionStorage.clear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('RememberPill', () => {
+  it('whispers about a new fact after the assistant completes a turn', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush() // baseline established (empty journal -> 0)
+
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+
+    const pill = container.querySelector('.remember-pill')
+    expect(pill).not.toBeNull()
+    expect(pill?.getAttribute('role')).toBe('status')
+    expect(pill?.textContent).toContain("Got it — I'll remember your name is Rick.")
+
+    act(() => root.unmount())
+  })
+
+  it('never replays entries that existed before this session', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    hooks.journal.entries = [entry({ id: 7 })]
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush() // baseline = 7
+
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+
+    expect(container.querySelector('.remember-pill')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('stays silent when the only journal activity is a delete', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    hooks.journal.entries = [entry({ id: 1, action: 'delete', value: 'Rick' })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+
+    expect(container.querySelector('.remember-pill')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('ignores assistant turns in other conversations', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('other-conversation'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).toBeNull()
+
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('dismisses on the next user send', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+
+    await act(async () => {
+      hooks.emit(userMessage('c1'))
+    })
+    expect(container.querySelector('.remember-pill')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('auto-dismisses after four seconds', async () => {
+    vi.useFakeTimers()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+    expect(container.querySelector('.remember-pill')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('caps at two whispers per session, then stays silent', async () => {
+    vi.useFakeTimers()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    // First learning -> pill.
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    // Second learning -> pill again.
+    hooks.journal.entries = [entry({ id: 2, subject: 'city', value: 'Lisbon' })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    // Third learning -> silent.
+    hooks.journal.entries = [entry({ id: 3, subject: 'job', value: 'designer' })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('de-duplicates identical journal entries', async () => {
+    vi.useFakeTimers()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    // First sight of "name = Rick" -> pill.
+    hooks.journal.entries = [entry({ id: 1 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    // The same fact re-learned (new journal id, identical content) -> silent.
+    hooks.journal.entries = [entry({ id: 2 })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).toBeNull()
+
+    // A genuinely new fact -> pill.
+    hooks.journal.entries = [entry({ id: 3, subject: 'city', value: 'Lisbon' })]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('re-baselines after a core restart without replaying history', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    // Old entries exist before the restart.
+    hooks.journal.entries = [entry({ id: 10 })]
+    await act(async () => {
+      hooks.emit({ type: 'ready', protocol: 1, phrase: 'Hi' })
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).toBeNull()
+
+    // Nothing new after the restart -> still silent.
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+    expect(container.querySelector('.remember-pill')).toBeNull()
+    act(() => root.unmount())
+  })
+})

--- a/collie-ui/src/renderer/src/components/RememberPill.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.tsx
@@ -42,6 +42,14 @@ export default function RememberPill({ conversationId }: Props): React.JSX.Eleme
   // would clobber ChatScreen's own collieClient listener (ordering tests).
   const conversationIdRef = useRef(conversationId)
 
+  // ...but the ref *value* must track the active conversation. ChatScreen
+  // mounts this component before the starter conversation is opened
+  // (activeId starts null), so without this sync the assistant-turn gate
+  // below would never pass in the real app.
+  useEffect(() => {
+    conversationIdRef.current = conversationId
+  }, [conversationId])
+
   const dismiss = useCallback(() => {
     if (timerRef.current !== null) {
       clearTimeout(timerRef.current)

--- a/collie-ui/src/renderer/src/components/RememberPill.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.tsx
@@ -1,0 +1,152 @@
+/**
+ * RememberPill — the quiet "I'll remember that." whisper.
+ *
+ * Watches the core's append-only memory journal. When an assistant turn in
+ * the current conversation completes and the journal shows a brand-new memory
+ * write (kind fact/person/date, action add/update), a small warm pill appears
+ * near the message list for a few seconds. It never fires for context usage
+ * (reads are not journaled), never replays entries that existed before this
+ * session, de-duplicates identical entries, and goes silent after two shows.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { collieClient, type CollieEvent, type MemoryJournalEntry } from '../lib/ipc'
+import {
+  journalEntryKey,
+  loadPillShownCount,
+  loadSeenPillKeys,
+  REMEMBER_PILL_CAP,
+  REMEMBER_PILL_DURATION_MS,
+  rememberPillText,
+  savePillShownCount,
+  saveSeenPillKeys
+} from '../lib/rememberPill'
+
+interface Props {
+  /** Only completed turns in this conversation count as "learning during chat". */
+  conversationId: string | null
+}
+
+interface PillState {
+  entry: MemoryJournalEntry
+}
+
+export default function RememberPill({ conversationId }: Props): React.JSX.Element | null {
+  const [pill, setPill] = useState<PillState | null>(null)
+  const shownRef = useRef(loadPillShownCount())
+  const seenKeysRef = useRef(loadSeenPillKeys())
+  const baselineRef = useRef<number | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Read the conversation id from a ref so the event subscription can be
+  // registered exactly once — re-subscribing on every conversation adoption
+  // would clobber ChatScreen's own collieClient listener (ordering tests).
+  const conversationIdRef = useRef(conversationId)
+
+  const dismiss = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setPill(null)
+  }, [])
+
+  const show = useCallback(
+    (entry: MemoryJournalEntry) => {
+      const key = journalEntryKey(entry)
+      if (seenKeysRef.current.has(key)) return
+      if (shownRef.current >= REMEMBER_PILL_CAP) return
+      seenKeysRef.current.add(key)
+      saveSeenPillKeys(seenKeysRef.current)
+      shownRef.current += 1
+      savePillShownCount(shownRef.current)
+      setPill({ entry })
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(dismiss, REMEMBER_PILL_DURATION_MS)
+    },
+    [dismiss]
+  )
+
+  /**
+   * Ask the core for recent journal entries and whisper about anything new.
+   * The first sight of the journal in a session only establishes the baseline
+   * — old entries must never replay as if they were just learned.
+   */
+  const checkForLearning = useCallback(async () => {
+    try {
+      const { entries } = await collieClient.getMemoryJournal(5)
+      if (entries.length === 0) return
+      const newestId = entries[0].id
+      const baseline = baselineRef.current
+      if (baseline === null) {
+        baselineRef.current = newestId
+        return
+      }
+      baselineRef.current = Math.max(baseline, newestId)
+      const fresh = entries.find(
+        (entry) =>
+          entry.id > baseline && (entry.action === 'add' || entry.action === 'update')
+      )
+      if (fresh) show(fresh)
+    } catch {
+      // Core unreachable — the next completed turn retries.
+    }
+  }, [show])
+
+  /** Re-anchor the baseline without showing anything (app start / core restart). */
+  const establishBaseline = useCallback(async () => {
+    try {
+      const { entries } = await collieClient.getMemoryJournal(1)
+      baselineRef.current = entries.length > 0 ? entries[0].id : 0
+    } catch {
+      // Keep the current baseline; the next completed turn retries.
+    }
+  }, [])
+
+  useEffect(() => {
+    void establishBaseline()
+  }, [establishBaseline])
+
+  useEffect(() => {
+    const off = collieClient.on((event: CollieEvent) => {
+      switch (event.type) {
+        case 'ready':
+          // The core (re)started: clear the stale whisper and re-anchor so
+          // nothing written before the restart is treated as new learning.
+          dismiss()
+          void establishBaseline()
+          break
+        case 'message':
+          if (event.message.role === 'user') {
+            // Any user send clears the whisper, per the quiet-whisper rule.
+            dismiss()
+          } else if (
+            event.message.role === 'assistant' &&
+            conversationIdRef.current !== null &&
+            event.message.conversation_id === conversationIdRef.current
+          ) {
+            // The turn is committed — memory writes happened, check the journal.
+            void checkForLearning()
+          }
+          break
+        default:
+          break
+      }
+    })
+    return off
+  }, [checkForLearning, dismiss, establishBaseline])
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+    },
+    []
+  )
+
+  if (!pill) return null
+  return (
+    <div className="remember-pill" role="status" aria-live="polite" onClick={dismiss}>
+      <span aria-hidden="true">🧠</span>
+      <span>{rememberPillText(pill.entry)}</span>
+    </div>
+  )
+}

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -377,6 +377,16 @@ export interface GardenerSuggestion {
   evidence_ids: string[]
 }
 
+/** One append-only memory write (ProfileStore mutation), newest first. */
+export interface MemoryJournalEntry {
+  id: number
+  kind: 'fact' | 'person' | 'date' | string
+  subject: string
+  action: 'add' | 'update' | 'delete' | string
+  value?: unknown
+  created_at: string
+}
+
 /** A user-facing progress snapshot. It deliberately excludes tool traffic and model reasoning. */
 export interface TaskStep {
   key: string
@@ -724,6 +734,11 @@ export class CollieClient {
   /** Past Dream consolidations (memory_dream versions), newest first. */
   getDreamHistory(): Promise<{ versions: ArtifactVersion[] }> {
     return this.command('get_dream_history', {})
+  }
+
+  /** Recent memory writes (kind/subject/action/value), newest first. */
+  getMemoryJournal(limit = 50): Promise<{ entries: MemoryJournalEntry[] }> {
+    return this.command('get_memory_journal', { limit })
   }
 
   /** Manual trigger: run one Gardener pass (evidence -> suggestions). */

--- a/collie-ui/src/renderer/src/lib/rememberPill.test.ts
+++ b/collie-ui/src/renderer/src/lib/rememberPill.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { MemoryJournalEntry } from './ipc'
+import {
+  journalEntryKey,
+  loadPillShownCount,
+  loadSeenPillKeys,
+  rememberPillText,
+  savePillShownCount,
+  saveSeenPillKeys
+} from './rememberPill'
+
+function entry(overrides: Partial<MemoryJournalEntry> = {}): MemoryJournalEntry {
+  return {
+    id: 1,
+    kind: 'fact',
+    subject: 'name',
+    action: 'add',
+    value: 'Rick',
+    created_at: '2026-08-08T10:00:00Z',
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+})
+
+describe('rememberPillText', () => {
+  it('names a short fact naturally', () => {
+    expect(rememberPillText(entry())).toBe("Got it — I'll remember your name is Rick.")
+  })
+
+  it('trims whitespace around a short fact value', () => {
+    expect(rememberPillText(entry({ value: '  Rick  ' }))).toBe(
+      "Got it — I'll remember your name is Rick."
+    )
+  })
+
+  it('falls back to the plain line for long facts', () => {
+    expect(rememberPillText(entry({ value: 'a very long detail that exceeds the whisper limit' }))).toBe(
+      "Got it — I'll remember that."
+    )
+  })
+
+  it('falls back to the plain line for multi-line facts', () => {
+    expect(rememberPillText(entry({ value: 'first line\nsecond line' }))).toBe(
+      "Got it — I'll remember that."
+    )
+  })
+
+  it('falls back to the plain line for empty values', () => {
+    expect(rememberPillText(entry({ value: '' }))).toBe("Got it — I'll remember that.")
+  })
+
+  it('falls back to the plain line for structured values', () => {
+    expect(rememberPillText(entry({ value: { city: 'Lisbon' } }))).toBe(
+      "Got it — I'll remember that."
+    )
+  })
+
+  it('falls back to the plain line for people and dates', () => {
+    expect(rememberPillText(entry({ kind: 'person', subject: 'Mom' }))).toBe(
+      "Got it — I'll remember that."
+    )
+    expect(rememberPillText(entry({ kind: 'date', subject: 'birthday' }))).toBe(
+      "Got it — I'll remember that."
+    )
+  })
+})
+
+describe('journalEntryKey', () => {
+  it('is stable for identical entries', () => {
+    expect(journalEntryKey(entry({ id: 1 }))).toBe(journalEntryKey(entry({ id: 99 })))
+  })
+
+  it('distinguishes different values', () => {
+    expect(journalEntryKey(entry({ value: 'Rick' }))).not.toBe(
+      journalEntryKey(entry({ value: 'Alex' }))
+    )
+  })
+
+  it('distinguishes deletes from adds of the same subject', () => {
+    expect(journalEntryKey(entry({ action: 'add' }))).not.toBe(
+      journalEntryKey(entry({ action: 'delete' }))
+    )
+  })
+
+  it('serializes structured values deterministically', () => {
+    expect(journalEntryKey(entry({ value: { city: 'Lisbon' } }))).toBe(
+      journalEntryKey(entry({ value: { city: 'Lisbon' } }))
+    )
+  })
+})
+
+describe('session cap storage', () => {
+  it('starts at zero and persists the shown count', () => {
+    expect(loadPillShownCount()).toBe(0)
+    savePillShownCount(2)
+    expect(loadPillShownCount()).toBe(2)
+  })
+
+  it('ignores corrupted counts', () => {
+    sessionStorage.setItem('collie.rememberPill.shown', 'not-a-number')
+    expect(loadPillShownCount()).toBe(0)
+  })
+
+  it('round-trips the seen-key set', () => {
+    expect(loadSeenPillKeys().size).toBe(0)
+    saveSeenPillKeys(new Set(['fact|name|add|Rick']))
+    expect(loadSeenPillKeys()).toEqual(new Set(['fact|name|add|Rick']))
+  })
+
+  it('ignores corrupted seen keys', () => {
+    sessionStorage.setItem('collie.rememberPill.seen', '{oops')
+    expect(loadSeenPillKeys().size).toBe(0)
+  })
+})

--- a/collie-ui/src/renderer/src/lib/rememberPill.ts
+++ b/collie-ui/src/renderer/src/lib/rememberPill.ts
@@ -1,0 +1,84 @@
+/**
+ * Remember pill — the quiet "I'll remember that." whisper.
+ *
+ * Pure helpers shared by the RememberPill component and its tests: the warm
+ * one-line copy, the de-duplication key for identical journal entries, and
+ * the per-session cap + seen-set persisted in sessionStorage (so the whisper
+ * survives a renderer reload but resets when the app closes).
+ */
+
+import type { MemoryJournalEntry } from './ipc'
+
+/** How many times the whisper may appear per app session (then silent). */
+export const REMEMBER_PILL_CAP = 2
+/** How long the whisper stays visible before dismissing itself. */
+export const REMEMBER_PILL_DURATION_MS = 4000
+
+const SHOWN_COUNT_KEY = 'collie.rememberPill.shown'
+const SEEN_KEYS_KEY = 'collie.rememberPill.seen'
+
+/**
+ * Warm one-line acknowledgement of a fresh memory write. Uses the detail
+ * variant only for short, single-line facts where it reads naturally
+ * ("I'll remember your name is Rick."); everything else gets the plain line.
+ */
+export function rememberPillText(entry: MemoryJournalEntry): string {
+  const value = typeof entry.value === 'string' ? entry.value.trim() : null
+  const isShortFact =
+    entry.kind === 'fact' &&
+    value !== null &&
+    value.length > 0 &&
+    value.length <= 24 &&
+    !value.includes('\n')
+  if (isShortFact) {
+    return `Got it — I'll remember your ${entry.subject} is ${value}.`
+  }
+  return "Got it — I'll remember that."
+}
+
+/** Identity of a journal entry for de-duplication (kind + subject + action + value). */
+export function journalEntryKey(entry: MemoryJournalEntry): string {
+  const value =
+    typeof entry.value === 'string' ? entry.value : JSON.stringify(entry.value ?? null)
+  return `${entry.kind}|${entry.subject}|${entry.action}|${value}`
+}
+
+export function loadPillShownCount(): number {
+  try {
+    const raw = sessionStorage.getItem(SHOWN_COUNT_KEY)
+    if (raw === null) return 0
+    const count = Number.parseInt(raw, 10)
+    return Number.isFinite(count) && count > 0 ? count : 0
+  } catch {
+    return 0
+  }
+}
+
+export function savePillShownCount(count: number): void {
+  try {
+    sessionStorage.setItem(SHOWN_COUNT_KEY, String(count))
+  } catch {
+    // Storage unavailable — the in-memory cap still applies this session.
+  }
+}
+
+export function loadSeenPillKeys(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(SEEN_KEYS_KEY)
+    if (raw === null) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((item): item is string => typeof item === 'string'))
+      : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+export function saveSeenPillKeys(keys: Set<string>): void {
+  try {
+    sessionStorage.setItem(SEEN_KEYS_KEY, JSON.stringify([...keys]))
+  } catch {
+    // Best effort only.
+  }
+}

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -16,6 +16,7 @@ import {
 } from '../lib/ipc'
 import Sidebar from '../components/Sidebar'
 import MessageList from '../components/MessageList'
+import RememberPill from '../components/RememberPill'
 import ChatInput from '../components/ChatInput'
 import CollieFace from '../components/CollieFace'
 import InteractiveColliePortrait from '../components/InteractiveColliePortrait'
@@ -989,6 +990,7 @@ export default function ChatScreen({
         </header>
         <div className="conversation-panel">
           <MessageList messages={messages} streamText={streamText} cardPreview={cardPreview} />
+          <RememberPill conversationId={activeId} />
         {errorText && (
           <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             style={{ borderColor: 'var(--collie-snoot)' }}>

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1647,6 +1647,7 @@ button {
 .collie-dog--watching { animation: dog-happy 1.8s ease-in-out infinite; }
 
 .conversation-panel {
+  position: relative;
   display: flex;
   min-height: 0;
   flex: 1;
@@ -1657,6 +1658,48 @@ button {
   border-radius: 0 0 16px 16px;
   background: var(--card);
   box-shadow: var(--shadow-md);
+}
+
+/* Remember pill — the quiet "I'll remember that." whisper. Sits above the
+   composer, overlaying the bottom edge of the message list without moving
+   layout, and never intercepts clicks. */
+.remember-pill {
+  position: absolute;
+  bottom: 104px;
+  left: 50%;
+  z-index: 20;
+  transform: translateX(-50%);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(88%, 440px);
+  padding: 7px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  box-shadow: var(--shadow-md);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 550;
+  animation: remember-pill-in var(--motion-smooth) ease-out;
+}
+
+@keyframes remember-pill-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 6px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .remember-pill {
+    animation: none;
+  }
 }
 
 .empty-chat {


### PR DESCRIPTION
## What

Adds the **Remember Pill** — a small, warm whisper in chat when Collie *learns something new* during a conversation (your name, a preference, a fact): 🧠 "Got it — I'll remember that." (or the short-fact variant, e.g. "I'll remember your name is Rick.")

The pill shows on **learning only, never on context usage** (user direction, 2026-08-08 — mirrors the Hermes "brain memory log" concept but as a quiet whisper, not a notification). It auto-dismisses after 4s or on the next user send, never replays entries that existed before the session, de-duplicates, and goes **silent after 2 shows per session** (persisted in `sessionStorage`).

## Why

For normies, memory is invisible — the pill makes it *felt*: "Collie remembers me" in one glance. The cap keeps it magical instead of noisy. The rules are constructed so context usage (reads are never journaled), deletions, other conversations, and core restarts can never trigger it.

## IPC wiring map

`ProfileStore` mutations → `db.log_memory_journal(kind, subject, action, value)` (append-only `memory_journal`, schema V13, PR #17) → existing `get_memory_journal` IPC handler (`ipc/server.py`) → **new** `CollieClient.getMemoryJournal(limit)` in `lib/ipc.ts` (renderer↔core WebSocket IPC; preload untouched) → `RememberPill` hook (baseline-on-mount, poll on current-conversation assistant-turn completion, `add`/`update` actions only) → pill UI.

## Voice

Warm person, zero jargon: "I'll remember that." — never "memory journal written" or any dev phrasing.

## What changed

- **New** `lib/rememberPill.ts` — pure logic: copy variants, dedupe key, session cap (2) + seen-set in `sessionStorage`
- **New** `components/RememberPill.tsx` — hook + pill (absolute, centered above the composer, `pointer-events: none`, pill-shaped, theme tokens light/dark, `collie-reveal` fade-up, `prefers-reduced-motion` guard, `role="status"` + `aria-live="polite"`)
- **New** `lib/rememberPill.test.ts` (15 tests) + `components/RememberPill.test.tsx` (9 tests)
- **Modified** `lib/ipc.ts` (MemoryJournalEntry + getMemoryJournal), `screens/ChatScreen.tsx` (mount after MessageList), `styles/globals.css` (pill + conversation-panel positioning)

The event subscription registers exactly once (conversation id read from a ref) so it can never clobber ChatScreen's own listener.

## Tests

- 24 new vitest tests (all pass): whisper on learning, no replay of pre-session entries, delete-silent, other-conversation ignored, user-send dismiss, 4s auto-dismiss, 2-cap, dedupe, core-restart re-baseline
- Full UI suite + `npm run typecheck` — see final run in PR conversation
