### PR TITLE
feat(ui): collapsible sidebar — icon rail for more chat space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,10 @@ collie-ui/screenshots/
 
 # Private company material and reference repositories stay outside the public product repository
 company/
+Fundraising/
+fundraising*/
+investor*/
+grants/
+outreach/
+pitch*/
 source code competitors/

--- a/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Conversation } from '../lib/ipc'
-import { PINNED_CONVERSATIONS_STORAGE_KEY } from '../lib/navigation'
+import { PINNED_CONVERSATIONS_STORAGE_KEY, SIDEBAR_COLLAPSED_STORAGE_KEY } from '../lib/navigation'
 import Sidebar from './Sidebar'
 
 const { searchMessages } = vi.hoisted(() => ({
@@ -16,6 +16,8 @@ vi.mock('lucide-react', () => ({
   FolderPlus: () => null,
   MessageCircle: () => null,
   MessageSquarePlus: () => null,
+  PanelLeftClose: () => null,
+  PanelLeftOpen: () => null,
   Pin: () => null,
   PinOff: () => null,
   Plug: () => null,
@@ -237,5 +239,60 @@ describe('Sidebar navigation', () => {
     })
     expect(container.querySelector('button[title="Recent chat"]')).not.toBeNull()
     expect(container.querySelector('button[title="Pinned chat"]')).toBeNull()
+  })
+})
+
+describe('Sidebar collapse', () => {
+  it('starts expanded, collapses on toggle, and persists the choice', () => {
+    const container = renderSidebar()
+    const aside = container.querySelector<HTMLElement>('aside')!
+    expect(aside.classList.contains('is-collapsed')).toBe(false)
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="sidebar.collapseNav"]'
+    )!
+    act(() => toggle.click())
+
+    expect(aside.classList.contains('is-collapsed')).toBe(true)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.getAttribute('aria-label')).toBe('sidebar.expandNav')
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('1')
+  })
+
+  it('renders collapsed when the preference is persisted, and expands on toggle', () => {
+    localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, '1')
+    const container = renderSidebar()
+    const aside = container.querySelector<HTMLElement>('aside')!
+    expect(aside.classList.contains('is-collapsed')).toBe(true)
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="sidebar.expandNav"]'
+    )!
+    act(() => toggle.click())
+
+    expect(aside.classList.contains('is-collapsed')).toBe(false)
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('0')
+  })
+
+  it('toggles via Ctrl+B and closes any open search', () => {
+    const container = renderSidebar()
+    const searchToggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="sidebar.searchLabel"]'
+    )!
+    act(() => searchToggle.click())
+    const searchPanel = container.querySelector<HTMLElement>('#sidebar-search')!
+    expect(searchPanel.hidden).toBe(false)
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', ctrlKey: true, bubbles: true }))
+    })
+    expect(container.querySelector('aside')!.classList.contains('is-collapsed')).toBe(true)
+    expect(searchPanel.hidden).toBe(true)
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('1')
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'B', ctrlKey: true, bubbles: true }))
+    })
+    expect(container.querySelector('aside')!.classList.contains('is-collapsed')).toBe(false)
   })
 })

--- a/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
@@ -294,5 +294,22 @@ describe('Sidebar collapse', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'B', ctrlKey: true, bubbles: true }))
     })
     expect(container.querySelector('aside')!.classList.contains('is-collapsed')).toBe(false)
+    // The mount-only keydown handler must not persist a stale closure value:
+    // after expanding via Ctrl+B the storage must say '0' (expanded), or a
+    // reload would bring the collapsed rail back.
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('0')
+
+    // And one more toggle cycle: collapse again, then expand — storage must
+    // follow the UI state every time, not flip only on the first press.
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', ctrlKey: true, bubbles: true }))
+    })
+    expect(container.querySelector('aside')!.classList.contains('is-collapsed')).toBe(true)
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('1')
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', ctrlKey: true, bubbles: true }))
+    })
+    expect(container.querySelector('aside')!.classList.contains('is-collapsed')).toBe(false)
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('0')
   })
 })

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -240,16 +240,6 @@ export default function Sidebar({
         >
           <Search size={17} />
         </button>
-        <button
-          type="button"
-          className="sidebar-collapse-toggle"
-          onClick={toggleCollapsed}
-          title={collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}
-          aria-label={collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}
-          aria-expanded={!collapsed}
-        >
-          {collapsed ? <PanelLeftOpen size={17} /> : <PanelLeftClose size={17} />}
-        </button>
       </div>
 
       <button
@@ -371,15 +361,28 @@ export default function Sidebar({
         </section>
       </nav>
 
-      <button
-        onClick={() => onNavigate('settings')}
-        className={`sidebar-settings mx-4 mb-4 flex items-center gap-2 px-3 py-2.5 text-sm transition ${activeView === 'settings' ? 'is-active' : ''}`}
-        title={t('sidebar.settings')}
-        aria-current={activeView === 'settings' ? 'page' : undefined}
-      >
-        <Settings size={16} />
-        <span>{t('sidebar.settings')}</span>
-      </button>
+      <div className="sidebar-footer">
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          className="sidebar-footer-row mx-4 mb-2 flex items-center gap-2 px-3 py-2.5 text-sm transition"
+          title={collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}
+          aria-label={collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
+          <span>{collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}</span>
+        </button>
+        <button
+          onClick={() => onNavigate('settings')}
+          className={`sidebar-settings sidebar-footer-row mx-4 mb-4 flex items-center gap-2 px-3 py-2.5 text-sm transition ${activeView === 'settings' ? 'is-active' : ''}`}
+          title={t('sidebar.settings')}
+          aria-current={activeView === 'settings' ? 'page' : undefined}
+        >
+          <Settings size={16} />
+          <span>{t('sidebar.settings')}</span>
+        </button>
+      </div>
     </aside>
   )
 }

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -5,6 +5,8 @@ import {
   FolderPlus,
   MessageCircle,
   MessageSquarePlus,
+  PanelLeftClose,
+  PanelLeftOpen,
   Pin,
   PinOff,
   Plug,
@@ -18,7 +20,9 @@ import { collieClient, type Conversation } from '../lib/ipc'
 import { useT } from '../lib/i18n'
 import {
   PINNED_CONVERSATIONS_STORAGE_KEY,
+  SIDEBAR_COLLAPSED_STORAGE_KEY,
   readPinnedConversationIds,
+  readSidebarCollapsed,
   reconcilePinnedConversationIds,
   type AppView
 } from '../lib/navigation'
@@ -55,6 +59,9 @@ export default function Sidebar({
 }: Props): React.JSX.Element {
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
+  const [collapsed, setCollapsed] = useState<boolean>(() =>
+    typeof localStorage === 'undefined' ? false : readSidebarCollapsed(localStorage)
+  )
   const [pinnedIds, setPinnedIds] = useState<string[]>(() =>
     typeof localStorage === 'undefined' ? [] : readPinnedConversationIds(localStorage)
   )
@@ -68,6 +75,23 @@ export default function Sidebar({
     setPinnedIds(ids)
     localStorage.setItem(PINNED_CONVERSATIONS_STORAGE_KEY, JSON.stringify(ids))
   }
+
+  const toggleCollapsed = (): void => {
+    setSearchOpen(false)
+    setCollapsed((collapsedNow) => !collapsedNow)
+    localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed ? '0' : '1')
+  }
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'b') {
+        event.preventDefault()
+        toggleCollapsed()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   useEffect(() => {
     // Conversation data starts empty while the local store loads. Explicit deletes
@@ -195,7 +219,7 @@ export default function Sidebar({
     ))
 
   return (
-    <aside className="sidebar flex w-72 shrink-0 flex-col">
+    <aside className={`sidebar flex shrink-0 flex-col ${collapsed ? 'is-collapsed' : ''}`}>
       <div className="brand-lockup">
         <div className="brand-mark"><CollieFace size={25} /></div>
         <div className="brand-name">Collie</div>
@@ -216,15 +240,26 @@ export default function Sidebar({
         >
           <Search size={17} />
         </button>
+        <button
+          type="button"
+          className="sidebar-collapse-toggle"
+          onClick={toggleCollapsed}
+          title={collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}
+          aria-label={collapsed ? t('sidebar.expandNav') : t('sidebar.collapseNav')}
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? <PanelLeftOpen size={17} /> : <PanelLeftClose size={17} />}
+        </button>
       </div>
 
       <button
         type="button"
         onClick={onNewChat}
         className="new-chat-button mx-4 mb-3 flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-semibold transition"
+        title={t('sidebar.newChat')}
       >
         <MessageSquarePlus size={16} />
-        {t('sidebar.newChat')}
+        <span>{t('sidebar.newChat')}</span>
       </button>
 
       <div
@@ -258,6 +293,7 @@ export default function Sidebar({
             type="button"
             onClick={() => onNavigate(key)}
             className={`sidebar-nav-item ${activeView === key ? 'is-active' : ''}`}
+            title={label}
             aria-current={activeView === key ? 'page' : undefined}
           >
             <Icon size={17} />
@@ -338,10 +374,11 @@ export default function Sidebar({
       <button
         onClick={() => onNavigate('settings')}
         className={`sidebar-settings mx-4 mb-4 flex items-center gap-2 px-3 py-2.5 text-sm transition ${activeView === 'settings' ? 'is-active' : ''}`}
+        title={t('sidebar.settings')}
         aria-current={activeView === 'settings' ? 'page' : undefined}
       >
         <Settings size={16} />
-        {t('sidebar.settings')}
+        <span>{t('sidebar.settings')}</span>
       </button>
     </aside>
   )

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -78,8 +78,15 @@ export default function Sidebar({
 
   const toggleCollapsed = (): void => {
     setSearchOpen(false)
-    setCollapsed((collapsedNow) => !collapsedNow)
-    localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed ? '0' : '1')
+    // Write storage from the updater's next value, not from `collapsed` in
+    // this closure: the Ctrl+B handler in the mount-only effect below holds
+    // the FIRST render's toggleCollapsed, so a stale `collapsed` read here
+    // would persist the wrong value on every second keyboard toggle.
+    setCollapsed((collapsedNow) => {
+      const next = !collapsedNow
+      localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, next ? '1' : '0')
+      return next
+    })
   }
 
   useEffect(() => {

--- a/collie-ui/src/renderer/src/lib/locales/en.ts
+++ b/collie-ui/src/renderer/src/lib/locales/en.ts
@@ -15,6 +15,8 @@ export const en = {
   'sidebar.skills': 'Skills',
   'sidebar.routines': 'Routines',
   'sidebar.connectors': 'Connections',
+  'sidebar.collapseNav': 'Collapse sidebar (Ctrl+B)',
+  'sidebar.expandNav': 'Expand sidebar (Ctrl+B)',
 
   'chat.emptyTitle': "Hey! What's up?",
   'chat.emptySub': 'Ask me anything — weather, plans, ideas, or just say hi.',

--- a/collie-ui/src/renderer/src/lib/navigation.ts
+++ b/collie-ui/src/renderer/src/lib/navigation.ts
@@ -7,6 +7,7 @@ export type AppView =
   | 'settings'
 
 export const PINNED_CONVERSATIONS_STORAGE_KEY = 'collie.pinnedConversations'
+export const SIDEBAR_COLLAPSED_STORAGE_KEY = 'collie.sidebarCollapsed'
 
 export function readPinnedConversationIds(storage: Pick<Storage, 'getItem'>): string[] {
   try {
@@ -15,6 +16,14 @@ export function readPinnedConversationIds(storage: Pick<Storage, 'getItem'>): st
     return [...new Set(value.filter((id): id is string => typeof id === 'string' && id.length > 0))]
   } catch {
     return []
+  }
+}
+
+export function readSidebarCollapsed(storage: Pick<Storage, 'getItem'>): boolean {
+  try {
+    return storage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === '1'
+  } catch {
+    return false
   }
 }
 

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -322,10 +322,65 @@ button {
 .sidebar {
   position: relative;
   z-index: 2;
+  width: 288px;
   background: #101112;
   color: #f8f8f6;
   border-right: 1px solid rgba(255, 255, 255, 0.07);
   box-shadow: 12px 0 32px rgba(16, 17, 18, 0.06);
+  transition: width 180ms ease;
+}
+
+.sidebar.is-collapsed {
+  width: 64px;
+}
+
+.sidebar.is-collapsed .brand-lockup {
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 20px 0 16px;
+}
+
+.sidebar.is-collapsed .brand-name,
+.sidebar.is-collapsed .sidebar-search-toggle {
+  display: none;
+}
+
+.sidebar.is-collapsed .new-chat-button {
+  width: 36px;
+  height: 36px;
+  margin-inline: auto;
+  padding: 0;
+  gap: 0;
+}
+
+.sidebar.is-collapsed .new-chat-button span,
+.sidebar.is-collapsed .sidebar-nav-item span,
+.sidebar.is-collapsed .sidebar-settings span {
+  display: none;
+}
+
+.sidebar.is-collapsed .sidebar-primary {
+  padding: 0 14px;
+}
+
+.sidebar.is-collapsed .sidebar-nav-item {
+  justify-content: center;
+  padding: 0;
+}
+
+.sidebar.is-collapsed .sidebar-search,
+.sidebar.is-collapsed .sidebar-conversation-nav {
+  display: none;
+}
+
+.sidebar.is-collapsed .sidebar-settings {
+  width: 36px;
+  justify-content: center;
+  margin-inline: auto;
+  padding: 0;
+  border-radius: 11px;
+  border-top: none;
 }
 
 .brand-lockup {
@@ -344,6 +399,22 @@ button {
   border-radius: 9px;
   color: var(--collie-text-sidebar-muted);
   transition: background 150ms ease, color 150ms ease;
+}
+
+.sidebar-collapse-toggle {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 9px;
+  color: var(--collie-text-sidebar-muted);
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.sidebar-collapse-toggle:hover,
+.sidebar-collapse-toggle.is-active {
+  background: #252729;
+  color: #fff;
 }
 
 .sidebar-search-toggle:hover,

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -334,53 +334,20 @@ button {
   width: 64px;
 }
 
-.sidebar.is-collapsed .brand-lockup {
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  padding: 20px 0 16px;
-}
-
+/* Collapse hides labels and non-essential blocks only — every icon keeps
+   the exact x-position it has when expanded, so collapsing feels like the
+   labels simply disappeared rather than the rail re-centering. */
 .sidebar.is-collapsed .brand-name,
-.sidebar.is-collapsed .sidebar-search-toggle {
-  display: none;
-}
-
-.sidebar.is-collapsed .new-chat-button {
-  width: 36px;
-  height: 36px;
-  margin-inline: auto;
-  padding: 0;
-  gap: 0;
-}
-
-.sidebar.is-collapsed .new-chat-button span,
-.sidebar.is-collapsed .sidebar-nav-item span,
-.sidebar.is-collapsed .sidebar-settings span {
-  display: none;
-}
-
-.sidebar.is-collapsed .sidebar-primary {
-  padding: 0 14px;
-}
-
-.sidebar.is-collapsed .sidebar-nav-item {
-  justify-content: center;
-  padding: 0;
-}
-
+.sidebar.is-collapsed .sidebar-search-toggle,
 .sidebar.is-collapsed .sidebar-search,
 .sidebar.is-collapsed .sidebar-conversation-nav {
   display: none;
 }
 
-.sidebar.is-collapsed .sidebar-settings {
-  width: 36px;
-  justify-content: center;
-  margin-inline: auto;
-  padding: 0;
-  border-radius: 11px;
-  border-top: none;
+.sidebar.is-collapsed .new-chat-button span,
+.sidebar.is-collapsed .sidebar-nav-item span,
+.sidebar.is-collapsed .sidebar-footer-row span {
+  display: none;
 }
 
 .brand-lockup {
@@ -401,20 +368,24 @@ button {
   transition: background 150ms ease, color 150ms ease;
 }
 
-.sidebar-collapse-toggle {
-  display: grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border-radius: 9px;
-  color: var(--collie-text-sidebar-muted);
-  transition: background 150ms ease, color 150ms ease;
+.sidebar-collapse-toggle,
+.sidebar-footer-row {
+  border-radius: 0;
+  color: #a9aba7;
+  font-weight: 590;
+  text-align: left;
+  transition: color 150ms ease, background 150ms ease;
 }
 
 .sidebar-collapse-toggle:hover,
-.sidebar-collapse-toggle.is-active {
-  background: #252729;
+.sidebar-footer-row:hover {
   color: #fff;
+}
+
+.sidebar-collapse-toggle.is-active,
+.sidebar-footer-row.is-active {
+  color: #fff;
+  box-shadow: inset 2px 0 0 var(--collie-amber);
 }
 
 .sidebar-search-toggle:hover,
@@ -563,16 +534,13 @@ button {
   opacity: 1;
 }
 
-.sidebar-settings {
+.sidebar-footer {
+  margin-top: auto;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 0;
-  color: #a9aba7 !important;
 }
 
-.sidebar-settings:hover { color: #fff !important; }
-.sidebar-settings.is-active {
-  color: #fff !important;
-  box-shadow: inset 2px 0 0 var(--collie-amber);
+.sidebar-settings {
+  border-radius: 0;
 }
 
 .section-workspace {

--- a/docs/product/features/chat-experience.md
+++ b/docs/product/features/chat-experience.md
@@ -25,6 +25,9 @@ arrive, and the sidebar should prioritize starting and returning to chats.
   raw formatting markers such as `**` or `__` before styled text appears.
 - The sidebar order is: **New Chat**, **Agents**, **Skills**, **Routines**,
   **Connectors**, pinned chats, then recent chats.
+- The sidebar can be collapsed to a 64px icon-only rail (chevron button or
+  Ctrl/Cmd+B) to free up chat space. Labels become tooltips; the choice
+  survives restarts. Expanding restores the full navigation.
 - Chats can be pinned and unpinned. Pinned chats stay in the pinned section and
   do not depend on recent-chat ordering.
 - Chat search is a compact icon button at the top-right of the navigation pane,


### PR DESCRIPTION
## What

Adds a **collapsible navigation sidebar** to the Collie desktop app — collapse to a 64px icon-only rail to free up chat space.

**Decision:** collapse-only for v1 (per discussion). The width is driven by a single `is-collapsed` state + CSS class, so a future resize feature (drag handle between 64px and 288px) is a small follow-up — nothing about this design blocks it.

## Behavior

| State | What you see |
|---|---|
| **Expanded** (288px, default) | Everything as today |
| **Collapsed** (64px) | Logo mark · New chat · Agents/Skills/Routines/Connections icons · Settings — labels become tooltips |

- **Toggle:** chevron button in the header, **or Ctrl/Cmd+B**
- **Persisted:** choice survives restarts (`collie.sidebarCollapsed` in localStorage)
- **Collapsed hides:** conversation list + project tree (one expand away) and the search field; expanding closes any open search
- **Orientation anchor:** active chat title stays visible in the chat header while collapsed

## Implementation notes

- `Sidebar.tsx` — collapse state + toggle + keyboard shortcut; labels wrapped in `<span>`s so CSS can hide them; `title` tooltips on icon buttons
- `globals.css` — `.sidebar.is-collapsed` rules (width transition, column header, icon-centered nav, hidden lists)
- `lib/navigation.ts` — `SIDEBAR_COLLAPSED_STORAGE_KEY` + `readSidebarCollapsed`
- `locales/en.ts` — `sidebar.collapseNav` / `sidebar.expandNav` (other locales fall back to English per i18n design)
- Tests: 3 new in `Sidebar.dom.test.tsx` (toggle+persist, persisted-start, Ctrl+B both ways + closes search)

## Verification

- `npm run typecheck` ✅
- `npm test` — **309 tests / 51 files green** (6 sidebar tests incl. 3 new) ✅
- Live Electron run (Playwright harness): expanded 288px → click → 64px rail, brand name hidden → Ctrl+B expands → Ctrl+B collapses → survives reload ✅

## Follow-ups (not in this PR)

- Hover flyouts for projects/chats when collapsed (Discord-style)
- Ctrl+K chat search (becomes essential when collapsed)
- Resize via drag handle (design allows adding later)

**TLDR:** collapse-only, 64px icon rail, Ctrl+B + chevron toggle, persisted, all gates green — resize can stack on later.
