### PR TITLE
feat: one-tap undo for local file changes

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1598,11 +1598,15 @@ class CollieIPCServer:
 
         conversation_id = str(frame.get("conversation_id") or "")
         raw_ids = frame.get("entry_ids")
-        entry_ids = (
-            [str(entry_id) for entry_id in raw_ids if str(entry_id)]
-            if isinstance(raw_ids, list) and raw_ids
-            else None
-        )
+        if raw_ids is None:
+            # Field omitted: undo every journaled entry for this conversation.
+            entry_ids = None
+        elif isinstance(raw_ids, list):
+            # Explicit list (even empty) selects exactly those entries — an
+            # empty list is a deliberate no-op, never a blanket undo.
+            entry_ids = [str(entry_id) for entry_id in raw_ids if str(entry_id)]
+        else:
+            entry_ids = None
         return undo_entries(conversation_id, entry_ids)
 
     async def _cmd_write_file(self, connection: ServerConnection, frame: dict) -> dict:

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1587,6 +1587,24 @@ class CollieIPCServer:
             return {"content": ""}
         return {"content": file_path.read_text(encoding="utf-8")}
 
+    async def _cmd_undo_file_changes(self, connection: ServerConnection, frame: dict) -> dict:
+        """One-tap undo: restore files Collie changed in a conversation.
+
+        Restores the pre-write bytes (or removes created files) from the
+        shadow journal. Scope is strictly the entries recorded for this
+        conversation; ``entry_ids`` narrows to a subset (all when omitted).
+        """
+        from collie_core.undo.journal import undo_entries
+
+        conversation_id = str(frame.get("conversation_id") or "")
+        raw_ids = frame.get("entry_ids")
+        entry_ids = (
+            [str(entry_id) for entry_id in raw_ids if str(entry_id)]
+            if isinstance(raw_ids, list) and raw_ids
+            else None
+        )
+        return undo_entries(conversation_id, entry_ids)
+
     async def _cmd_write_file(self, connection: ServerConnection, frame: dict) -> dict:
         file_path = self._resolve_workspace_path(str(frame.get("path") or ""))
         content = str(frame.get("content") or "")
@@ -3311,6 +3329,11 @@ class CollieIPCServer:
                 await self.send_thinking(conv_id, "idle")
                 return
             card_type, card_data = self._extract_card(tool_results)
+            files_card_type, files_card_data = self._files_changed_card(tool_results, conv_id)
+            if files_card_type:
+                # The undo surface wins: a turn that changed files shows the
+                # files_changed card (with its one-tap undo) over any info card.
+                card_type, card_data = files_card_type, files_card_data
             failure_message = self.db.add_message(
                 conv_id,
                 "assistant",
@@ -3388,6 +3411,11 @@ class CollieIPCServer:
                 terminal_task = turn_task_snapshot
 
         card_type, card_data = self._extract_card(tool_results)
+        files_card_type, files_card_data = self._files_changed_card(tool_results, conv_id)
+        if files_card_type:
+            # The undo surface wins: a turn that changed files shows the
+            # files_changed card (with its one-tap undo) over any info card.
+            card_type, card_data = files_card_type, files_card_data
         final = getattr(outbound, "content", None) or "".join(parts)
         message_task = terminal_task
         if run_id:
@@ -3423,3 +3451,42 @@ class CollieIPCServer:
                 data.pop("plan_change_terminal_message", None)
                 return card_type, data
         return None, None
+
+    @staticmethod
+    def _files_changed_card(
+        tool_results: list[str], conversation_id: str
+    ) -> tuple[str | None, Any]:
+        """Build a ``files_changed`` card from this turn's undo journal entries.
+
+        LocalFilesTool writes carry ``undo_entry_id`` in their result JSON;
+        each becomes one card row the UI can take back with a single tap.
+        Returns ``(None, None)`` when the turn changed no local files.
+        """
+        import json as _json
+
+        write_operations = frozenset({"create", "overwrite", "edit", "save"})
+        files: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for raw in tool_results:
+            try:
+                data = _json.loads(raw)
+            except (TypeError, _json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            entry_id = data.get("undo_entry_id")
+            operation = str(data.get("operation") or "")
+            path = str(data.get("path") or "")
+            if not entry_id or operation not in write_operations or not path:
+                continue
+            if entry_id in seen:
+                continue
+            seen.add(str(entry_id))
+            files.append({
+                "path": path,
+                "status": "added" if operation == "create" else "modified",
+                "undo_entry_id": str(entry_id),
+            })
+        if not files:
+            return None, None
+        return "files_changed", {"files": files, "conversation_id": conversation_id}

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from collie_core.permissions.broker import PermissionDeniedError
 from collie_core.permissions.models import PermissionRequest, Risk, Scope
-from collie_core.undo.journal import record_write
+from collie_core.undo.journal import discard_write, record_write
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.context import current_request_context
 from nanobot.security.workspace_access import (
@@ -414,6 +414,8 @@ class LocalFilesTool(Tool):
 
     async def execute(self, **kwargs: Any) -> ToolResult:
         operation = str(kwargs.get("operation") or "").lower()
+        undo_entry_id: str | None = None
+        conversation_id: str | None = None
         try:
             target, _in_scope = _resolve_local_path(
                 str(kwargs.get("path") or ""), allow_directory=operation == "list"
@@ -426,9 +428,8 @@ class LocalFilesTool(Tool):
             # Snapshot the pre-write state so the user can take the change
             # back with one tap. Skipped (returns None) when no conversation
             # id is in scope or the file is too large to copy.
-            undo_entry_id = record_write(
-                _current_conversation_id(), target, operation
-            )
+            conversation_id = _current_conversation_id()
+            undo_entry_id = record_write(conversation_id, target, operation)
             if operation == "create":
                 if not target.parent.is_dir():
                     raise _LocalFileError("The destination folder does not exist.")
@@ -459,6 +460,11 @@ class LocalFilesTool(Tool):
             else:
                 raise _LocalFileError("Choose list, read, create, overwrite, edit, or save.")
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
+            if undo_entry_id and conversation_id:
+                # The write never happened — don't leave an undoable entry
+                # for a file that was not changed (a later undo would be a
+                # confusing no-op).
+                discard_write(conversation_id, undo_entry_id)
             return ToolResult.error(f"I couldn't work with that local file: {exc}")
         result_payload: dict[str, Any] = {
             "operation": operation,

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from collie_core.permissions.broker import PermissionDeniedError
 from collie_core.permissions.models import PermissionRequest, Risk, Scope
+from collie_core.undo.journal import record_write
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.context import current_request_context
 from nanobot.security.workspace_access import (
@@ -422,6 +423,12 @@ class LocalFilesTool(Tool):
             _require_text_artifact(target)
             if operation == "read":
                 return self._read(target, int(kwargs.get("max_chars") or 12_000))
+            # Snapshot the pre-write state so the user can take the change
+            # back with one tap. Skipped (returns None) when no conversation
+            # id is in scope or the file is too large to copy.
+            undo_entry_id = record_write(
+                _current_conversation_id(), target, operation
+            )
             if operation == "create":
                 if not target.parent.is_dir():
                     raise _LocalFileError("The destination folder does not exist.")
@@ -441,12 +448,26 @@ class LocalFilesTool(Tool):
                 else:
                     _atomic_create(target, payload)
             elif operation == "edit":
-                return self._edit(target, str(kwargs.get("old_text")), str(kwargs.get("new_text")))
+                result = self._edit(
+                    target, str(kwargs.get("old_text")), str(kwargs.get("new_text"))
+                )
+                if not result.is_error and undo_entry_id:
+                    edited_payload = json.loads(result)
+                    edited_payload["undo_entry_id"] = undo_entry_id
+                    return ToolResult(json.dumps(edited_payload))
+                return result
             else:
                 raise _LocalFileError("Choose list, read, create, overwrite, edit, or save.")
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
             return ToolResult.error(f"I couldn't work with that local file: {exc}")
-        return ToolResult(json.dumps({"operation": operation, "path": str(target), "local_only": True}))
+        result_payload: dict[str, Any] = {
+            "operation": operation,
+            "path": str(target),
+            "local_only": True,
+        }
+        if undo_entry_id:
+            result_payload["undo_entry_id"] = undo_entry_id
+        return ToolResult(json.dumps(result_payload))
 
     @staticmethod
     def _list(path: Path, max_entries: int) -> ToolResult:

--- a/collie-core/collie_core/undo/__init__.py
+++ b/collie-core/collie_core/undo/__init__.py
@@ -1,0 +1,1 @@
+"""Undo journal — shadow-copy snapshots behind Collie's one-tap file undo."""

--- a/collie-core/collie_core/undo/journal.py
+++ b/collie-core/collie_core/undo/journal.py
@@ -144,6 +144,27 @@ def record_write(conversation_id: str, path: str | Path, operation: str) -> str 
         return entry_id
 
 
+def discard_write(conversation_id: str, entry_id: str) -> None:
+    """Drop a journal entry that must not be undoable (e.g. the write failed).
+
+    Removes the entry from the manifest and deletes its shadow copy. Safe to
+    call for unknown entry ids — it is a no-op then.
+    """
+    safe_id = _safe_conversation_id(conversation_id)
+    if safe_id is None or not isinstance(entry_id, str) or not entry_id:
+        return
+    conversation_dir = _conversation_dir(safe_id)
+    with _LOCK:
+        entries = _load_manifest(conversation_dir)
+        kept = [entry for entry in entries if entry.get("id") != entry_id]
+        if len(kept) == len(entries):
+            return
+        (conversation_dir / f"{entry_id}.orig").unlink(missing_ok=True)
+        _save_manifest(conversation_dir, kept)
+        if not kept and not any(conversation_dir.iterdir()):
+            shutil.rmtree(conversation_dir, ignore_errors=True)
+
+
 def pending_entries(conversation_id: str) -> list[dict[str, Any]]:
     """Return not-yet-undone journal entries for a conversation, newest first."""
     safe_id = _safe_conversation_id(conversation_id)

--- a/collie-core/collie_core/undo/journal.py
+++ b/collie-core/collie_core/undo/journal.py
@@ -1,0 +1,206 @@
+"""Shadow-copy undo journal for Collie's local file writes.
+
+Before any write, ``LocalFilesTool`` snapshots the file's current bytes into a
+per-conversation journal under the Collie home directory. A one-tap undo
+restores those bytes (or removes a created file) — strictly scoped to files
+Collie itself changed in that conversation.
+
+Storage layout (``COLLIE_HOME`` or ``~/.collie``)::
+
+    undo/<conversation_id>/manifest.json   — entries, newest first
+    undo/<conversation_id>/<entry_id>.orig — pre-write snapshot bytes
+
+Entries are append-only until undone; the journal sweeps entries older than
+``_RETENTION_DAYS`` lazily on the next write.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from collie_core.db import collie_home
+
+_UNDO_DIR_NAME = "undo"
+_MAX_ENTRY_BYTES = 1_000_000  # mirrors LocalFilesTool._MAX_FILE_BYTES
+_RETENTION_DAYS = 7
+_LOCK = threading.Lock()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _safe_conversation_id(conversation_id: str) -> str | None:
+    """Return a filesystem-safe conversation id, or None when untrusted."""
+    if not isinstance(conversation_id, str) or not conversation_id.strip():
+        return None
+    if "/" in conversation_id or "\\" in conversation_id or conversation_id in {".", ".."}:
+        return None
+    return conversation_id
+
+
+def _conversation_dir(conversation_id: str) -> Path:
+    return collie_home() / _UNDO_DIR_NAME / _safe_conversation_id(conversation_id)  # type: ignore[arg-type]
+
+
+def _manifest_path(conversation_dir: Path) -> Path:
+    return conversation_dir / "manifest.json"
+
+
+def _load_manifest(conversation_dir: Path) -> list[dict[str, Any]]:
+    try:
+        raw = _manifest_path(conversation_dir).read_text(encoding="utf-8")
+        entries = json.loads(raw)
+    except (OSError, ValueError, TypeError):
+        return []
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _save_manifest(conversation_dir: Path, entries: list[dict[str, Any]]) -> None:
+    conversation_dir.mkdir(parents=True, exist_ok=True)
+    path = _manifest_path(conversation_dir)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(entries, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _sweep() -> None:
+    """Drop entries older than the retention window (lazy, on write)."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=_RETENTION_DAYS)
+    root = collie_home() / _UNDO_DIR_NAME
+    if not root.is_dir():
+        return
+    for conversation_dir in root.iterdir():
+        if not conversation_dir.is_dir():
+            continue
+        entries = _load_manifest(conversation_dir)
+        kept: list[dict[str, Any]] = []
+        for entry in entries:
+            ts = entry.get("ts")
+            try:
+                timestamp = datetime.fromisoformat(str(ts))
+            except (TypeError, ValueError):
+                timestamp = None
+            if timestamp is not None and timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            if timestamp is not None and timestamp < cutoff:
+                shadow = conversation_dir / f"{entry.get('id')}.orig"
+                shadow.unlink(missing_ok=True)
+                continue
+            kept.append(entry)
+        if len(kept) != len(entries):
+            _save_manifest(conversation_dir, kept)
+        if not kept and not any(conversation_dir.iterdir()):
+            shutil.rmtree(conversation_dir, ignore_errors=True)
+
+
+def record_write(conversation_id: str, path: str | Path, operation: str) -> str | None:
+    """Snapshot ``path`` before a write and return the entry id.
+
+    Returns ``None`` when there is no trusted conversation id or the file is
+    too large to snapshot (writes then simply have no undo entry). ``create``
+    operations record a ``existed=False`` entry — undo removes the created
+    file instead of restoring bytes.
+    """
+    safe_id = _safe_conversation_id(conversation_id)
+    if safe_id is None:
+        return None
+    target = Path(path)
+    if not isinstance(operation, str) or not operation:
+        return None
+
+    with _LOCK:
+        _sweep()
+        conversation_dir = _conversation_dir(safe_id)
+        conversation_dir.mkdir(parents=True, exist_ok=True)
+        existed = target.is_file()
+        entry_id = uuid.uuid4().hex
+        if existed:
+            try:
+                if target.stat().st_size > _MAX_ENTRY_BYTES:
+                    return None
+                shutil.copyfile(target, conversation_dir / f"{entry_id}.orig")
+            except OSError:
+                return None
+        entry: dict[str, Any] = {
+            "id": entry_id,
+            "ts": _now_iso(),
+            "path": str(target),
+            "operation": operation,
+            "existed": existed,
+        }
+        entries = _load_manifest(conversation_dir)
+        entries.insert(0, entry)
+        _save_manifest(conversation_dir, entries)
+        return entry_id
+
+
+def pending_entries(conversation_id: str) -> list[dict[str, Any]]:
+    """Return not-yet-undone journal entries for a conversation, newest first."""
+    safe_id = _safe_conversation_id(conversation_id)
+    if safe_id is None:
+        return []
+    return _load_manifest(_conversation_dir(safe_id))
+
+
+def undo_entries(
+    conversation_id: str, entry_ids: list[str] | None = None
+) -> dict[str, list[dict[str, str]]]:
+    """Restore journaled files for a conversation.
+
+    ``entry_ids`` selects a subset (all entries when None). Restores the
+    pre-write bytes for edited/overwritten files and removes created files.
+    Consumed entries are dropped from the manifest. Returns ``undone`` and
+    ``errors`` lists keyed by entry id.
+    """
+    safe_id = _safe_conversation_id(conversation_id)
+    if safe_id is None:
+        return {"undone": [], "errors": []}
+    conversation_dir = _conversation_dir(safe_id)
+
+    with _LOCK:
+        entries = _load_manifest(conversation_dir)
+        if entry_ids is not None:
+            wanted = set(entry_ids)
+            selected = [entry for entry in entries if entry.get("id") in wanted]
+            remaining = [entry for entry in entries if entry.get("id") not in wanted]
+        else:
+            selected = entries
+            remaining = []
+
+        undone: list[dict[str, str]] = []
+        errors: list[dict[str, str]] = []
+        for entry in selected:
+            entry_id = str(entry.get("id") or "")
+            target = Path(str(entry.get("path") or ""))
+            existed = bool(entry.get("existed"))
+            shadow = conversation_dir / f"{entry_id}.orig"
+            try:
+                if existed:
+                    if not shadow.is_file():
+                        raise OSError("The safety copy is missing.")
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    temporary = target.with_name(f".collie-undo-{entry_id}{target.suffix}")
+                    temporary.write_bytes(shadow.read_bytes())
+                    os.replace(temporary, target)
+                else:
+                    target.unlink(missing_ok=True)
+                shadow.unlink(missing_ok=True)
+                undone.append({"id": entry_id, "path": str(target)})
+            except OSError as exc:
+                errors.append({"id": entry_id, "path": str(target), "message": str(exc)})
+                remaining.append(entry)
+
+        _save_manifest(conversation_dir, remaining)
+        if not remaining and not any(conversation_dir.iterdir()):
+            shutil.rmtree(conversation_dir, ignore_errors=True)
+        return {"undone": undone, "errors": errors}

--- a/collie-core/tests/collie/test_undo_file_changes_ipc.py
+++ b/collie-core/tests/collie/test_undo_file_changes_ipc.py
@@ -34,10 +34,31 @@ async def test_undo_file_changes_restores_all_entries(
     entry = record_write("conv-1", edited, "overwrite")
     edited.write_text("after", encoding="utf-8")
 
-    result = await _call(server, {"conversation_id": "conv-1", "entry_ids": []})
+    result = await _call(server, {"conversation_id": "conv-1"})
     assert [item["id"] for item in result["undone"]] == [entry]
     assert result["errors"] == []
     assert edited.read_text(encoding="utf-8") == "before"
+
+
+@pytest.mark.asyncio
+async def test_undo_file_changes_empty_entry_ids_is_a_noop(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An explicit empty list undoes nothing — never a blanket undo."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    server = _server(tmp_path)
+
+    edited = home / "notes.md"
+    edited.write_text("before", encoding="utf-8")
+    record_write("conv-1", edited, "overwrite")
+    edited.write_text("after", encoding="utf-8")
+
+    result = await _call(server, {"conversation_id": "conv-1", "entry_ids": []})
+    assert result["undone"] == []
+    assert result["errors"] == []
+    assert edited.read_text(encoding="utf-8") == "after"
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_undo_file_changes_ipc.py
+++ b/collie-core/tests/collie/test_undo_file_changes_ipc.py
@@ -1,0 +1,77 @@
+"""IPC undo_file_changes command: one-tap restore of journaled file writes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.undo.journal import record_write
+
+
+def _server(tmp_path: Path) -> CollieIPCServer:
+    return CollieIPCServer(CollieDB(tmp_path / "collie.db"))
+
+
+def _call(server: CollieIPCServer, frame: dict):
+    return server._cmd_undo_file_changes(cast(Any, None), frame)
+
+
+@pytest.mark.asyncio
+async def test_undo_file_changes_restores_all_entries(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    server = _server(tmp_path)
+
+    edited = home / "notes.md"
+    edited.write_text("before", encoding="utf-8")
+    entry = record_write("conv-1", edited, "overwrite")
+    edited.write_text("after", encoding="utf-8")
+
+    result = await _call(server, {"conversation_id": "conv-1", "entry_ids": []})
+    assert [item["id"] for item in result["undone"]] == [entry]
+    assert result["errors"] == []
+    assert edited.read_text(encoding="utf-8") == "before"
+
+
+@pytest.mark.asyncio
+async def test_undo_file_changes_removes_created_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    server = _server(tmp_path)
+
+    created = home / "fresh.md"
+    entry = record_write("conv-1", created, "create")
+    created.write_text("made", encoding="utf-8")
+
+    result = await _call(server, {"conversation_id": "conv-1", "entry_ids": [str(entry)]})
+    assert len(result["undone"]) == 1
+    assert not created.exists()
+
+
+@pytest.mark.asyncio
+async def test_undo_file_changes_is_scoped_to_conversation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    server = _server(tmp_path)
+
+    other = home / "other.md"
+    other.write_text("other", encoding="utf-8")
+    record_write("conv-2", other, "overwrite")
+    other.write_text("other2", encoding="utf-8")
+
+    result = await _call(server, {"conversation_id": "conv-1", "entry_ids": []})
+    assert result["undone"] == []
+    assert other.read_text(encoding="utf-8") == "other2"

--- a/collie-core/tests/collie/test_undo_journal.py
+++ b/collie-core/tests/collie/test_undo_journal.py
@@ -134,3 +134,36 @@ def test_undo_restores_paths_with_missing_parent(undo_home: Path) -> None:
     result = journal.undo_entries("conv-1")
     assert [item["id"] for item in result["undone"]] == [entry]
     assert target.read_text(encoding="utf-8") == "orig"
+
+
+def test_discard_write_removes_entry_and_shadow(undo_home: Path) -> None:
+    target = undo_home / "notes.md"
+    target.write_text("original", encoding="utf-8")
+    entry = journal.record_write("conv-1", target, "overwrite")
+
+    journal.discard_write("conv-1", str(entry))
+    assert journal.pending_entries("conv-1") == []
+    conversation_dir = undo_home / "undo" / "conv-1"
+    assert not (conversation_dir / f"{entry}.orig").exists()
+
+
+def test_discard_write_keeps_other_entries(undo_home: Path) -> None:
+    first = undo_home / "a.md"
+    first.write_text("a", encoding="utf-8")
+    first_entry = journal.record_write("conv-1", first, "overwrite")
+    second = undo_home / "b.md"
+    second.write_text("b", encoding="utf-8")
+    second_entry = journal.record_write("conv-1", second, "overwrite")
+
+    journal.discard_write("conv-1", str(first_entry))
+    remaining = journal.pending_entries("conv-1")
+    assert [item["id"] for item in remaining] == [second_entry]
+
+
+def test_discard_write_unknown_entry_is_noop(undo_home: Path) -> None:
+    target = undo_home / "notes.md"
+    target.write_text("original", encoding="utf-8")
+    entry = journal.record_write("conv-1", target, "overwrite")
+
+    journal.discard_write("conv-1", "does-not-exist")
+    assert [item["id"] for item in journal.pending_entries("conv-1")] == [entry]

--- a/collie-core/tests/collie/test_undo_journal.py
+++ b/collie-core/tests/collie/test_undo_journal.py
@@ -1,0 +1,136 @@
+"""Undo journal: shadow-copy snapshots + one-tap restore for local file writes."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import collie_core.undo.journal as journal
+from collie_core.db import collie_home
+
+
+@pytest.fixture
+def undo_home(tmp_path: Path, monkeypatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    return home
+
+
+def test_record_and_undo_restores_original_bytes(undo_home: Path) -> None:
+    target = undo_home / "notes.md"
+    target.write_text("original", encoding="utf-8")
+
+    entry = journal.record_write("conv-1", target, "overwrite")
+    assert entry is not None
+    target.write_text("changed by collie", encoding="utf-8")
+
+    result = journal.undo_entries("conv-1")
+    assert [item["id"] for item in result["undone"]] == [entry]
+    assert result["errors"] == []
+    assert target.read_text(encoding="utf-8") == "original"
+    assert journal.pending_entries("conv-1") == []
+
+
+def test_create_undo_removes_created_file(undo_home: Path) -> None:
+    target = undo_home / "new.md"
+    entry = journal.record_write("conv-1", target, "create")
+    assert entry is not None
+    target.write_text("created by collie", encoding="utf-8")
+
+    result = journal.undo_entries("conv-1")
+    assert len(result["undone"]) == 1
+    assert not target.exists()
+
+
+def test_undo_subset_then_rest(undo_home: Path) -> None:
+    first = undo_home / "a.txt"
+    second = undo_home / "b.txt"
+    first.write_text("A", encoding="utf-8")
+    second.write_text("B", encoding="utf-8")
+    journal.record_write("conv-1", first, "overwrite")
+    entry_b = journal.record_write("conv-1", second, "overwrite")
+    first.write_text("A2", encoding="utf-8")
+    second.write_text("B2", encoding="utf-8")
+
+    result = journal.undo_entries("conv-1", [str(entry_b)])
+    assert [item["id"] for item in result["undone"]] == [entry_b]
+    assert second.read_text(encoding="utf-8") == "B"
+    assert first.read_text(encoding="utf-8") == "A2"
+
+    journal.undo_entries("conv-1")
+    assert first.read_text(encoding="utf-8") == "A"
+    assert journal.pending_entries("conv-1") == []
+
+
+def test_unknown_entry_ids_are_ignored(undo_home: Path) -> None:
+    target = undo_home / "a.txt"
+    target.write_text("A", encoding="utf-8")
+    journal.record_write("conv-1", target, "overwrite")
+    target.write_text("A2", encoding="utf-8")
+
+    result = journal.undo_entries("conv-1", ["does-not-exist"])
+    assert result["undone"] == []
+    assert target.read_text(encoding="utf-8") == "A2"
+
+
+def test_missing_conversation_id_skips_journaling(undo_home: Path) -> None:
+    target = undo_home / "x.txt"
+    target.write_text("x", encoding="utf-8")
+    assert journal.record_write("", target, "overwrite") is None
+    assert journal.record_write("../evil", target, "overwrite") is None
+    assert journal.record_write("..", target, "overwrite") is None
+    assert journal.pending_entries("") == []
+
+
+def test_missing_shadow_reports_error_and_keeps_entry(undo_home: Path) -> None:
+    target = undo_home / "m.txt"
+    target.write_text("orig", encoding="utf-8")
+    entry = journal.record_write("conv-1", target, "overwrite")
+    (collie_home() / "undo" / "conv-1" / f"{entry}.orig").unlink()
+    target.write_text("changed", encoding="utf-8")
+
+    result = journal.undo_entries("conv-1")
+    assert result["undone"] == []
+    assert len(result["errors"]) == 1
+    assert result["errors"][0]["id"] == entry
+    # Entry survives so a later repair attempt stays possible.
+    assert [item["id"] for item in journal.pending_entries("conv-1")] == [entry]
+
+
+def test_retention_sweep_drops_expired_entries(undo_home: Path) -> None:
+    target = undo_home / "old.txt"
+    target.write_text("old", encoding="utf-8")
+    old_entry = journal.record_write("conv-1", target, "overwrite")
+
+    conversation_dir = collie_home() / "undo" / "conv-1"
+    manifest_path = conversation_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    expired = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+    manifest[0]["ts"] = expired
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    keeper = undo_home / "keep.txt"
+    keeper.write_text("keep", encoding="utf-8")
+    keeper_entry = journal.record_write("conv-1", keeper, "overwrite")
+
+    remaining = journal.pending_entries("conv-1")
+    assert [item["id"] for item in remaining] == [keeper_entry]
+    assert not (conversation_dir / f"{old_entry}.orig").exists()
+
+
+def test_undo_restores_paths_with_missing_parent(undo_home: Path) -> None:
+    target = undo_home / "sub" / "nested.md"
+    target.parent.mkdir()
+    target.write_text("orig", encoding="utf-8")
+    entry = journal.record_write("conv-1", target, "overwrite")
+    target.write_text("changed", encoding="utf-8")
+    target.unlink()
+    target.parent.rmdir()
+
+    result = journal.undo_entries("conv-1")
+    assert [item["id"] for item in result["undone"]] == [entry]
+    assert target.read_text(encoding="utf-8") == "orig"

--- a/collie-core/tests/tools/test_local_files_tool.py
+++ b/collie-core/tests/tools/test_local_files_tool.py
@@ -12,6 +12,7 @@ from collie_core.permissions.evaluator import PermissionEvaluator
 from collie_core.permissions.models import ExecutionContext, Risk
 from collie_core.permissions.store import PermissionStore
 from collie_core.tools.local_files import LocalFilesTool
+from collie_core.undo.journal import undo_entries
 from nanobot.agent.tools.context import RequestContext, request_context
 from nanobot.security.workspace_access import (
     bind_workspace_scope,
@@ -320,3 +321,52 @@ def test_live_file_access_override_is_conversation_scoped(tmp_path: Path) -> Non
     finally:
         clear_live_local_file_scope("conv-a")
         reset_workspace_scope(token)
+
+
+@pytest.mark.asyncio
+async def test_local_files_writes_journal_undoable_entries(
+    scoped_tool, tmp_path: Path, monkeypatch
+) -> None:
+    """Writes inside a conversation snapshot the pre-write state; undo restores."""
+    tool, root = scoped_tool
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path / "home"))
+
+    with request_context(
+        RequestContext(
+            channel="collie",
+            chat_id="conv-undo",
+            metadata={"permission_context": {"conversation_id": "conv-undo"}},
+        )
+    ):
+        created = await tool.execute(operation="create", path="notes.md", content="draft")
+        assert not created.is_error
+        created_id = json.loads(created).get("undo_entry_id")
+        assert created_id
+
+        edited = await tool.execute(
+            operation="edit", path="notes.md", old_text="draft", new_text="final"
+        )
+        assert not edited.is_error
+        edited_id = json.loads(edited).get("undo_entry_id")
+        assert edited_id
+        assert (root / "notes.md").read_text(encoding="utf-8") == "final"
+
+        undone = undo_entries("conv-undo")
+        assert {item["id"] for item in undone["undone"]} == {created_id, edited_id}
+        # Undo order is newest-first: the edit restores "draft", then the
+        # create entry removes the file entirely.
+        assert not (root / "notes.md").exists()
+        assert undone["errors"] == []
+
+
+@pytest.mark.asyncio
+async def test_local_files_writes_without_conversation_skip_journaling(
+    scoped_tool, tmp_path: Path, monkeypatch
+) -> None:
+    """No conversation id in scope -> write still works, no undo entry."""
+    tool, root = scoped_tool
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path / "home"))
+
+    created = await tool.execute(operation="create", path="notes.md", content="draft")
+    assert not created.is_error
+    assert "undo_entry_id" not in json.loads(created)

--- a/collie-core/tests/tools/test_local_files_tool.py
+++ b/collie-core/tests/tools/test_local_files_tool.py
@@ -370,3 +370,35 @@ async def test_local_files_writes_without_conversation_skip_journaling(
     created = await tool.execute(operation="create", path="notes.md", content="draft")
     assert not created.is_error
     assert "undo_entry_id" not in json.loads(created)
+
+
+@pytest.mark.asyncio
+async def test_local_files_failed_write_discards_phantom_entry(
+    scoped_tool, tmp_path: Path, monkeypatch
+) -> None:
+    """A write that fails must not leave an undoable journal entry behind."""
+    tool, root = scoped_tool
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path / "home"))
+
+    with request_context(
+        RequestContext(
+            channel="collie",
+            chat_id="conv-undo",
+            metadata={"permission_context": {"conversation_id": "conv-undo"}},
+        )
+    ):
+        created = await tool.execute(operation="create", path="notes.md", content="draft")
+        assert not created.is_error
+        created_id = json.loads(created).get("undo_entry_id")
+        assert created_id
+
+        # old_text does not match -> the edit fails after record_write ran.
+        failed = await tool.execute(
+            operation="edit", path="notes.md", old_text="missing", new_text="nope"
+        )
+        assert failed.is_error
+        # The phantom entry from the failed edit was discarded; the create
+        # entry remains the only undoable one, and undoing it removes the file.
+        entries = undo_entries("conv-undo")
+        assert [item["id"] for item in entries["undone"]] == [created_id]
+        assert not (root / "notes.md").exists()

--- a/collie-ui/src/renderer/src/components/cards/FilesChangedCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/FilesChangedCard.test.tsx
@@ -1,9 +1,18 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { collieClient } from '../../lib/ipc'
 import CardRenderer from './CardRenderer'
 import FilesChangedCard, { parseFilesChangedCardData } from './FilesChangedCard'
+
+vi.mock('../../lib/ipc', () => ({
+  collieClient: {
+    undoFileChanges: vi.fn()
+  }
+}))
+
+const mockedUndo = vi.mocked(collieClient.undoFileChanges)
 
 const roots: Root[] = []
 
@@ -23,6 +32,7 @@ beforeAll(() => {
 afterEach(() => {
   for (const root of roots.splice(0)) act(() => root.unmount())
   document.body.replaceChildren()
+  vi.clearAllMocks()
 })
 
 describe('FilesChangedCard', () => {
@@ -56,5 +66,65 @@ describe('FilesChangedCard', () => {
     const container = render(<CardRenderer cardType="files_changed" cardData={{ files: 'not a list' }} />)
     expect(container.querySelector('[aria-label="Files changed"]')).toBeNull()
     expect(container.textContent).toBe('')
+  })
+
+  it('parses undo entry ids and conversation id defensively', () => {
+    expect(parseFilesChangedCardData({
+      conversation_id: 'conv-1',
+      files: [
+        { path: 'notes.md', status: 'added', undo_entry_id: 'abc123' },
+        { path: 'x.md', status: 'modified', undo_entry_id: 42 },
+        { path: 'y.md', status: 'modified' }
+      ]
+    })).toEqual({
+      conversationId: 'conv-1',
+      files: [
+        { path: 'notes.md', additions: 0, deletions: 0, status: 'added', undoEntryId: 'abc123' },
+        { path: 'x.md', additions: 0, deletions: 0, status: 'modified' },
+        { path: 'y.md', additions: 0, deletions: 0, status: 'modified' }
+      ]
+    })
+  })
+
+  it('offers one-tap undo and confirms when restored', async () => {
+    mockedUndo.mockResolvedValue({ undone: [{ id: 'abc123', path: 'notes.md' }], errors: [] })
+    const container = render(<FilesChangedCard data={{
+      conversation_id: 'conv-1',
+      files: [{ path: 'notes.md', status: 'modified', undo_entry_id: 'abc123' }]
+    }} />)
+
+    const button = container.querySelector('button')
+    expect(button?.textContent).toContain('Take it back')
+
+    await act(async () => { button?.click() })
+    expect(mockedUndo).toHaveBeenCalledWith('conv-1', ['abc123'])
+    expect(container.querySelector('[aria-label="Undo changes"]')?.textContent).toContain('Undone')
+    expect(container.textContent).toContain('back the way they were')
+  })
+
+  it('surfaces a notice when undo fails', async () => {
+    mockedUndo.mockResolvedValue({
+      undone: [],
+      errors: [{ id: 'abc123', path: 'notes.md', message: 'missing' }]
+    })
+    const container = render(<FilesChangedCard data={{
+      conversation_id: 'conv-1',
+      files: [{ path: 'notes.md', status: 'modified', undo_entry_id: 'abc123' }]
+    }} />)
+
+    await act(async () => { container.querySelector('button')?.click() })
+    expect(container.querySelector('[aria-label="Undo changes"]')?.textContent).toContain('could not be restored')
+  })
+
+  it('hides the undo button without journal entries or a conversation id', () => {
+    const noIds = render(<FilesChangedCard data={{
+      files: [{ path: 'notes.md', status: 'modified' }]
+    }} />)
+    expect(noIds.querySelector('button')).toBeNull()
+
+    const noConv = render(<FilesChangedCard data={{
+      files: [{ path: 'notes.md', status: 'modified', undo_entry_id: 'abc' }]
+    }} />)
+    expect(noConv.querySelector('button')).toBeNull()
   })
 })

--- a/collie-ui/src/renderer/src/components/cards/FilesChangedCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/FilesChangedCard.tsx
@@ -1,4 +1,6 @@
-import { ChevronDown, FileDiff } from 'lucide-react'
+import { useState } from 'react'
+import { ChevronDown, FileDiff, Undo2 } from 'lucide-react'
+import { collieClient } from '../../lib/ipc'
 
 export type ChangedFileStatus = 'added' | 'modified' | 'deleted' | 'renamed'
 
@@ -7,10 +9,14 @@ export interface ChangedFile {
   additions: number
   deletions: number
   status: ChangedFileStatus
+  /** Shadow-journal entry id; present when this change can be undone. */
+  undoEntryId?: string
 }
 
-interface FilesChangedCardData {
+export interface FilesChangedCardData {
   files: ChangedFile[]
+  /** Conversation owning the undo journal; required for the undo button. */
+  conversationId?: string
 }
 
 const supportedStatuses = new Set<ChangedFileStatus>(['added', 'modified', 'deleted', 'renamed'])
@@ -25,12 +31,18 @@ function asStatus(value: unknown): ChangedFileStatus {
     : 'modified'
 }
 
+function asOptionalId(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
 /**
  * Cards arrive from a streamed runtime boundary, so accept only the small
  * declared shape. Invalid file entries are ignored; invalid counts become 0.
  */
 export function parseFilesChangedCardData(data: Record<string, unknown>): FilesChangedCardData {
-  if (!Array.isArray(data.files)) return { files: [] }
+  const conversationId = asOptionalId(data.conversation_id)
+
+  if (!Array.isArray(data.files)) return { files: [], conversationId }
 
   const files = data.files.flatMap((entry): ChangedFile[] => {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return []
@@ -42,11 +54,12 @@ export function parseFilesChangedCardData(data: Record<string, unknown>): FilesC
       path,
       additions: asSafeCount(candidate.additions),
       deletions: asSafeCount(candidate.deletions),
-      status: asStatus(candidate.status)
+      status: asStatus(candidate.status),
+      undoEntryId: asOptionalId(candidate.undo_entry_id)
     }]
   })
 
-  return { files }
+  return { files, conversationId }
 }
 
 function statusLabel(status: ChangedFileStatus): string {
@@ -56,13 +69,42 @@ function statusLabel(status: ChangedFileStatus): string {
         : 'Modified'
 }
 
+type UndoState = 'idle' | 'undoing' | 'undone' | 'error'
+
 export default function FilesChangedCard({ data }: { data: Record<string, unknown> }): React.JSX.Element | null {
-  const { files } = parseFilesChangedCardData(data)
+  const { files, conversationId } = parseFilesChangedCardData(data)
+  const [undoState, setUndoState] = useState<UndoState>('idle')
+  const [notice, setNotice] = useState('')
+
   if (files.length === 0) return null
 
   const additions = files.reduce((total, file) => total + file.additions, 0)
   const deletions = files.reduce((total, file) => total + file.deletions, 0)
   const fileLabel = `${files.length} changed file${files.length === 1 ? '' : 's'}`
+  const undoable = files.some((file) => file.undoEntryId !== undefined) && conversationId !== undefined
+  const busy = undoState === 'undoing'
+
+  const handleUndo = async (): Promise<void> => {
+    if (!conversationId || busy || undoState === 'undone') return
+    setUndoState('undoing')
+    setNotice('')
+    try {
+      const result = await collieClient.undoFileChanges(
+        conversationId,
+        files.flatMap((file) => (file.undoEntryId ? [file.undoEntryId] : []))
+      )
+      if (result.errors.length > 0) {
+        setNotice('Some files could not be restored. They may have been moved or deleted since.')
+        setUndoState('error')
+        return
+      }
+      setUndoState('undone')
+      setNotice('Undone — the files are back the way they were.')
+    } catch {
+      setNotice('I could not undo that change. Try again?')
+      setUndoState('error')
+    }
+  }
 
   return (
     <section aria-label="Files changed" className="my-2 max-w-2xl rounded-xl border border-stone-200 bg-white text-stone-900 shadow-sm">
@@ -89,6 +131,25 @@ export default function FilesChangedCard({ data }: { data: Record<string, unknow
               </li>
             ))}
           </ul>
+          {undoable && (
+            <div className="mt-2 border-t border-stone-100 pt-2" aria-label="Undo changes">
+              {undoState === 'undone' ? (
+                <p className="text-xs font-medium text-emerald-700">✓ {notice}</p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void handleUndo()}
+                  disabled={busy}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-stone-900 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-stone-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Undo2 size={13} /> {busy ? 'Taking it back…' : 'Take it back'}
+                </button>
+              )}
+              {notice && undoState !== 'undone' && (
+                <p className="mt-1.5 text-xs text-rose-700">{notice}</p>
+              )}
+            </div>
+          )}
         </div>
       </details>
     </section>

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -719,6 +719,20 @@ export class CollieClient {
     return this.command('rollback_artifact', { version_id: versionId })
   }
 
+  /** One-tap undo of local file changes made in a conversation. */
+  undoFileChanges(
+    conversationId: string,
+    entryIds?: string[]
+  ): Promise<{
+    undone: Array<{ id: string; path: string }>
+    errors: Array<{ id: string; path: string; message: string }>
+  }> {
+    return this.command('undo_file_changes', {
+      conversation_id: conversationId,
+      entry_ids: entryIds ?? []
+    })
+  }
+
   /** Manual trigger: run one Dream consolidation pass (Settings -> Memory). */
   runDream(): Promise<{
     changed: boolean

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,16 +11,16 @@
 
 ## Source inventory
 
-- Core Python files: **502**
-- Core Python test files: **226**
-- Desktop TypeScript/TSX files: **125**
-- Desktop test files: **38**
-- Active Markdown docs: **25**
+- Core Python files: **507**
+- Core Python test files: **229**
+- Desktop TypeScript/TSX files: **147**
+- Desktop test files: **51**
+- Active Markdown docs: **27**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups
 
-`automations`, `catalog`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
+`automations`, `catalog`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`, `undo`
 
 ## Required orientation files
 

--- a/docs/product/features/undo-file-changes.md
+++ b/docs/product/features/undo-file-changes.md
@@ -1,0 +1,64 @@
+# Undo file changes
+
+**Status:** shipped (alpha, 2026-08-10) — one-tap undo for local file changes
+**Date:** 2026-08-10
+**Applies to:** Chat file work (LocalFilesTool writes)
+
+## Outcome
+
+When Collie changes a local file for you, you can take it back with one tap.
+Every write in a conversation is journaled first: a safety copy of the
+pre-write state is stored under the Collie home directory, and the assistant
+message for that turn carries a **files changed** card with a "Take it back"
+button. Pressing it restores the previous bytes — or removes a file Collie
+created. Strictly scoped to files Collie itself changed; nothing external
+(emails, calendar invites, posts) is ever presented as one-tap undoable.
+
+This extends the approval story: *plan → approve → act → review → undo*.
+The undo surface supersedes the earlier parked "undo pill" idea (user
+re-requested 2026-08-10, scoped to file changes only).
+
+## How it works
+
+1. **Journal before write** — `LocalFilesTool` snapshots the target file
+   (copy-before-write) via `collie_core/undo/journal.py` before every
+   `create` / `overwrite` / `edit` / `save`. Created files record a
+   no-bytes entry (`existed=False`); undo removes them.
+2. **Card per turn** — tool results carrying `undo_entry_id` are collected
+   in `CollieIPCServer._run_chat_turn`; at turn end a `files_changed` card
+   (files + `conversation_id`) is attached to the assistant message. It takes
+   precedence over info cards when the turn changed files.
+3. **One-tap restore** — `FilesChangedCard` renders the list with a "Take it
+   back" button → IPC `undo_file_changes` → `undo_entries()` restores the
+   shadow bytes (atomic replace) or unlinks created files, and consumes the
+   entries.
+
+## Storage
+
+```
+~/.collie/undo/<conversation_id>/manifest.json   # entries, newest first
+~/.collie/undo/<conversation_id>/<id>.orig       # pre-write snapshot bytes
+```
+
+- Entries expire after 7 days (lazy sweep on the next write).
+- Files over 1 MB are not journaled (writes still work; no undo entry).
+- No conversation id in scope (non-chat contexts) → writes work, no journal.
+
+## Scope boundaries
+
+- **Undoable:** local text artifacts changed via `LocalFilesTool`.
+- **Not undoable (by design):** anything with external side effects (sent
+  messages, calendar events, connector writes) — no fake undo buttons.
+- UI-side workspace writes (`_cmd_write_file`, the user's own editor) are the
+  user's edits, not journaled.
+
+## Design decisions
+
+- **Files only** (user direction 2026-08-10): the one-tap undo promise must
+  be 100% honest; external actions can't be reliably taken back.
+- **No confirmation dialog:** undo is the safe action — instant, reversible
+  (the restored state is itself journaled as the new "current" state going
+  forward only if the user edits again).
+- **Approval-free IPC:** restoring files Collie itself changed is
+  reversible + low blast radius, matching the approval philosophy
+  (gate by blast radius + reversibility, not category).


### PR DESCRIPTION
## Summary

**One-tap undo for local file changes** — "Collie makes a safety copy before it touches anything. You can always go back."

Extends the approval story to *plan → approve → act → review → undo*:

- **Journal before write** — `LocalFilesTool` snapshots the pre-write state into a shadow journal (`~/.collie/undo/<conversation_id>/manifest.json` + `.orig` copies) before every `create` / `overwrite` / `edit` / `save`. Writes return an `undo_entry_id`.
- **Card per turn** — the runtime collects write results and attaches a `files_changed` card to the assistant message: the changed files + a **"Take it back"** button. (The `files_changed` cardType was renderer-ready but never emitted — this PR completes the pipeline.)
- **One-tap restore** — new IPC `undo_file_changes` restores the previous bytes (atomic replace) or removes created files. Strictly scoped to files Collie itself changed in that conversation; approval-free (reversible + low blast radius, per the approval philosophy).

**Scope decision (user direction 2026-08-10):** undo is **files only**. Anything with external side effects (emails sent, calendar invites, posts) is never presented as undoable — a fake undo button would kill trust.

## Files

| Area | Change |
|---|---|
| `collie_core/undo/journal.py` | new — shadow journal: `record_write` / `undo_entries` / `pending_entries`, 7-day retention sweep, 1 MB cap, per-conversation scope |
| `collie_core/tools/local_files.py` | journal-before-write; `undo_entry_id` in write results |
| `collie_core/ipc/server.py` | `_cmd_undo_file_changes` + `_files_changed_card()` at turn end (success + failure paths; files card takes precedence over info cards when files changed) |
| `collie-ui/.../lib/ipc.ts` | `collieClient.undoFileChanges()` |
| `collie-ui/.../cards/FilesChangedCard.tsx` | "Take it back" button with undone / error states (button only when journal entries + conversation id present) |
| tests | journal unit tests (restore / create-removal / subset / retention / missing-shadow), IPC command tests, LocalFilesTool integration, UI card tests |
| `docs/product/features/undo-file-changes.md` | feature spec |

## Notes

- Supersedes the previously **parked "undo pill"** idea (user re-requested 2026-08-10, scoped to file changes).
- Files > 1 MB or writes outside a conversation are not journaled (writes still work, no undo entry).
- Non-goal: undo for cloud docs (native version history is the mechanism there, future work).

## Test plan

- Core: `pytest tests/collie/test_undo_journal.py tests/collie/test_undo_file_changes_ipc.py tests/tools/test_local_files_tool.py` → **24 passed**; full `tests/collie + tests/tools` → **940 passed**, 7 failed = documented baseline (3 Windows DPAPI, 1 flaky IPC escape-path, 2 pre-existing gardener failures verified on pristine origin/main).
- UI: `npm test` → **310 passed**; `npm run typecheck` clean; ruff clean.
