### PR TITLE
feat(permissions): folder grant covers in-scope file work; cron always asks

### DIFF
--- a/collie-core/collie_core/permissions/evaluator.py
+++ b/collie-core/collie_core/permissions/evaluator.py
@@ -164,8 +164,10 @@ class PermissionEvaluator:
             )
             if redacted.get("unrestricted_local_files") is True:
                 # Full local-file access is selected: no project-boundary ask
-                # for local file tools (reads that disclose content still hit
-                # their own hard-approval gate above).
+                # for local file tools. In-scope content reads are covered by
+                # the folder/file-access consent itself (local_files declares
+                # them READ rather than hard-gated); any other operation still
+                # hits its own gates above and below.
                 return PermissionDecision(
                     Effect.ALLOW, "Full local file access is selected."
                 )

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -359,7 +359,7 @@ class LocalFilesTool(Tool):
             return PermissionRequest(
                 action="local_file.read",
                 resource=resource,
-                risk=Risk.SENSITIVE,
+                risk=Risk.READ,
                 summary=f"Read {resource} and send its text to {provider}",
                 reversible=True,
                 data_leaving_device=(provider,),
@@ -372,9 +372,16 @@ class LocalFilesTool(Tool):
                     "allowed_local_roots": allowed_roots,
                     "unrestricted_local_files": unrestricted,
                 },
-                # Selecting a Files scope limits where the tool may look; it
-                # is not consent to disclose this file's contents externally.
-                hard_approval=True,
+                # Selecting a Files scope (project folder, chosen folders, or
+                # full file access) is explicit consent for the content inside
+                # it — including that a read may send the file's text to the
+                # configured model provider, which the summary and
+                # data_leaving_device above still disclose honestly. In-scope
+                # reads therefore need no per-file approval card; targets
+                # outside the granted scope were already refused above (no
+                # dead-end approvals). Irreversible writes and external
+                # actions keep their own gates.
+                hard_approval=False,
             )
         return PermissionRequest(
             action="local_file.write" if is_write else "local_file.read",
@@ -391,11 +398,12 @@ class LocalFilesTool(Tool):
                 "allowed_local_roots": allowed_roots,
                 "unrestricted_local_files": unrestricted,
             },
-            # A folder selection defines where files may be touched, not an
-            # automatic consent to edit them.  Workstream A can offer an
-            # explicit "approve for me" run rule for these bounded writes.
-            # The execution path revalidates scope before every change.
-            approval_free=False,
+            # A folder selection defines where files may be touched. Reversible
+            # bounded work inside it (create, save of a new file) is
+            # approval-free; overwriting or editing an existing file stays an
+            # explicit approval because it destroys prior content. The
+            # execution path revalidates scope before every change.
+            approval_free=bool(safe_write and reversible),
             approve_for_me=safe_write,
         )
 

--- a/collie-core/collie_core/tools/open_file.py
+++ b/collie-core/collie_core/tools/open_file.py
@@ -22,8 +22,13 @@ from collie_core.permissions.models import PermissionRequest, Risk, Scope
 # Reuse the same canonical scope + path-safety resolution as ``local_files``
 # (workspace roots, symlink/junction refusal, UNC/device refusal) so the two
 # tools can never disagree about what a safe local target is.
-from collie_core.tools.local_files import _LocalFileError, _resolve_local_path
+from collie_core.tools.local_files import (
+    _LocalFileError,
+    _resolve_local_path,
+    _scope_roots,
+)
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
+from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.security.workspace_policy import WorkspaceBoundaryError
 
 __all__ = ["OpenFileTool"]
@@ -141,6 +146,8 @@ class OpenFileTool(Tool):
             resource = str(target)
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError):
             resource = str(params.get("path") or "local file")
+        roots, unrestricted = _scope_roots(current_tool_workspace(None))
+        allowed_roots = [str(root) for root in roots] if roots else []
         kind = "folder" if (target is not None and target.is_dir()) else "file"
         label = target.name if target is not None else Path(resource).name or resource
         return PermissionRequest(
@@ -155,6 +162,11 @@ class OpenFileTool(Tool):
                 "path": resource,
                 "local_only": True,
                 "default_app": True,
+                # Same scope metadata as local_files, so a target inside a
+                # user-granted folder is recognized as granted by the
+                # evaluator's read-allow path instead of asking.
+                "allowed_local_roots": allowed_roots,
+                "unrestricted_local_files": unrestricted,
             },
             # Read-only and bounded to allowlisted types inside the approved
             # folders: no data leaves the device, nothing is written.  The

--- a/collie-core/nanobot/agent/tools/cron.py
+++ b/collie-core/nanobot/agent/tools/cron.py
@@ -6,6 +6,7 @@ from contextvars import ContextVar
 from datetime import datetime
 from typing import Any
 
+from collie_core.permissions.models import PermissionRequest, Risk
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.context import current_request_context
 from nanobot.agent.tools.schema import (
@@ -117,6 +118,38 @@ class CronTool(Tool):
         return (
             "Schedule reminders and recurring tasks. Actions: add, list, remove. "
             f"If tz is omitted, cron expressions and naive ISO times default to {self._default_timezone}."
+        )
+
+    def permission_request(self, params: dict[str, Any]) -> PermissionRequest:
+        action = str(params.get("action") or "").strip().lower()
+        if action == "remove":
+            return PermissionRequest(
+                action="delete.destructive",
+                resource=str(params.get("job_id") or "scheduled job"),
+                risk=Risk.DESTRUCTIVE,
+                summary="Delete this scheduled job",
+                reversible=False,
+                hard_approval=True,
+            )
+        if action == "add":
+            return PermissionRequest(
+                action="cron.add",
+                resource="cron",
+                risk=Risk.LOCAL_WRITE,
+                summary="Schedule a recurring task",
+                reversible=False,
+                # Recurring authority is never automatic or run-approvable:
+                # a scheduled job keeps acting for the user. The ``cron.``
+                # prefix also excludes it from any future automatic-local
+                # eligibility (see permissions.defaults).
+                hard_approval=True,
+            )
+        return PermissionRequest(
+            action="cron.list",
+            resource="cron",
+            risk=Risk.LOCAL_WRITE,
+            summary="List scheduled tasks",
+            reversible=True,
         )
 
     def validate_params(self, params: dict[str, Any]) -> list[str]:

--- a/collie-core/tests/cron/test_cron_tool_permission.py
+++ b/collie-core/tests/cron/test_cron_tool_permission.py
@@ -1,0 +1,53 @@
+"""Cron scheduling is recurring authority: add/remove always hard-ask.
+
+A scheduled job keeps acting for the user after creation, so creating or
+removing one is never automatic and never run-approvable (see
+``collie_core/permissions/defaults.py`` for the ``cron.`` ineligible
+prefix). Listing stays an ordinary ask.
+"""
+
+from pathlib import Path
+
+from collie_core.permissions.evaluator import PermissionEvaluator
+from collie_core.permissions.models import Effect, ExecutionContext, Risk
+from nanobot.agent.tools.cron import CronTool
+from nanobot.cron.service import CronService
+
+
+def _tool(tmp_path: Path) -> CronTool:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    return CronTool(service)
+
+
+def test_cron_add_is_hard_approval_and_always_asks(tmp_path: Path) -> None:
+    request = _tool(tmp_path).permission_request({"action": "add", "message": "daily standup"})
+
+    assert request.action == "cron.add"
+    assert request.hard_approval is True
+    assert request.approval_free is False
+    assert request.approve_for_me is False
+    # Even a run-wide "approve everything" never covers a new schedule.
+    decision = PermissionEvaluator().evaluate(
+        ExecutionContext(run_id="run-1", approve_all_for_run=True), request
+    )
+    assert decision.effect == Effect.ASK
+
+
+def test_cron_remove_is_hard_destructive(tmp_path: Path) -> None:
+    request = _tool(tmp_path).permission_request({"action": "remove", "job_id": "job-1"})
+
+    assert request.action == "delete.destructive"
+    assert request.risk == Risk.DESTRUCTIVE
+    assert request.hard_approval is True
+    assert request.approval_free is False
+
+
+def test_cron_list_asks_and_is_never_run_approvable(tmp_path: Path) -> None:
+    request = _tool(tmp_path).permission_request({"action": "list"})
+
+    assert request.action == "cron.list"
+    assert request.hard_approval is False
+    assert request.approval_free is False
+    assert request.approve_for_me is False
+    decision = PermissionEvaluator().evaluate(ExecutionContext(run_id="run-1"), request)
+    assert decision.effect == Effect.ASK

--- a/collie-core/tests/tools/test_local_files_tool.py
+++ b/collie-core/tests/tools/test_local_files_tool.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -163,7 +162,9 @@ def test_local_files_permission_metadata_is_local_and_in_scope(scoped_tool) -> N
     assert write.action == "local_file.write"
     assert write.resource == str((root / "draft.txt").resolve())
     assert write.risk.value == "local_write"
-    assert write.approval_free is False
+    # A brand-new file inside the granted folder is reversible bounded work:
+    # the folder grant covers it without a card.
+    assert write.approval_free is True
     assert write.approve_for_me is True
     assert write.data_leaving_device == ()
     assert write.redacted_parameters["allowed_local_roots"] == [str(root.resolve())]
@@ -176,11 +177,13 @@ def test_local_files_permission_metadata_is_local_and_in_scope(scoped_tool) -> N
         )
     ):
         read = tool.permission_request({"operation": "read", "path": "draft.txt"})
-    assert read.risk == Risk.SENSITIVE
+    # Reading inside a granted folder is consent for the content there; the
+    # provider is still disclosed honestly in the summary and metadata.
+    assert read.risk == Risk.READ
     assert read.resource == str((root / "draft.txt").resolve())
     assert read.data_leaving_device == ("ChatGPT",)
     assert read.redacted_parameters["model_provider"] == "ChatGPT"
-    assert read.hard_approval is True
+    assert read.hard_approval is False
     assert read.approval_free is False
     assert read.approve_for_me is False
 
@@ -188,6 +191,8 @@ def test_local_files_permission_metadata_is_local_and_in_scope(scoped_tool) -> N
     overwrite = tool.permission_request(
         {"operation": "save", "path": "draft.txt", "content": "replacement"}
     )
+    # Overwriting an existing file destroys prior content: still a card
+    # (or run-approvable), never silently automatic.
     assert overwrite.reversible is False
     assert overwrite.approval_free is False
     assert overwrite.approve_for_me is True
@@ -196,10 +201,19 @@ def test_local_files_permission_metadata_is_local_and_in_scope(scoped_tool) -> N
         tool.permission_request(
             {"operation": "save", "path": "../outside.txt", "content": "no"}
         )
+    with pytest.raises(PermissionDeniedError):
+        tool.permission_request({"operation": "read", "path": "../outside.txt"})
 
 
 @pytest.mark.asyncio
-async def test_local_file_read_broker_discloses_exact_path_and_provider(scoped_tool, tmp_path: Path) -> None:
+async def test_local_file_read_inside_granted_scope_is_authorized_silently(
+    scoped_tool, tmp_path: Path
+) -> None:
+    """Folder selection is consent for in-scope reads: no card is raised.
+
+    The provider is still disclosed honestly on the request itself
+    (summary + data_leaving_device) even though no approval is needed.
+    """
     tool, root = scoped_tool
     target = root / "private.txt"
     target.write_text("private", encoding="utf-8")
@@ -222,33 +236,23 @@ async def test_local_file_read_broker_discloses_exact_path_and_provider(scoped_t
             metadata={"permission_context": {"model_provider": "ChatGPT"}},
         )
     ):
-        task = asyncio.create_task(
-            broker.authorize(
-                ExecutionContext(run_id="run-1"),
-                SimpleNamespace(id="call-1", name="local_files"),
-                tool,
-                {"operation": "read", "path": "private.txt"},
-            )
+        request = tool.permission_request(
+            {"operation": "read", "path": "private.txt"}
         )
-        await asyncio.sleep(0)
-        assert events[-1]["type"] == "approval_requested"
-        approval = broker.db.list_pending_approvals()[0]
-        display = approval["display"]
-        assert display["resource"] == str(target.resolve())
-        assert display["data_leaving_device"] == ["ChatGPT"]
-        assert display["parameters"] == {
-            "operation": "read",
-            "path": str(target.resolve()),
-            "model_provider": "ChatGPT",
-            "local_only": True,
-            "allowed_local_roots": [str(root.resolve())],
-            "unrestricted_local_files": False,
-        }
-        assert display["approve_for_me_eligible"] is False
-        with pytest.raises(ValueError, match="not eligible"):
-            await broker.resolve(str(approval["id"]), "allow_run")
-        await broker.resolve(str(approval["id"]), "allow_once")
-        await task
+        assert request.risk == Risk.READ
+        assert request.hard_approval is False
+        assert request.data_leaving_device == ("ChatGPT",)
+        assert "send its text to ChatGPT" in request.summary
+        assert request.redacted_parameters["allowed_local_roots"] == [str(root.resolve())]
+
+        await broker.authorize(
+            ExecutionContext(run_id="run-1"),
+            SimpleNamespace(id="call-1", name="local_files"),
+            tool,
+            {"operation": "read", "path": "private.txt"},
+        )
+    assert events == []
+    assert broker.db.list_pending_approvals() == []
     db.close()
 
 

--- a/collie-core/tests/tools/test_open_file_tool.py
+++ b/collie-core/tests/tools/test_open_file_tool.py
@@ -228,6 +228,10 @@ def test_permission_request_is_read_only_local_open() -> None:
     assert request.approve_for_me is False
     assert request.redacted_parameters["local_only"] is True
     assert request.redacted_parameters["default_app"] is True
+    # Scope metadata matches local_files so granted-folder opens hit the
+    # evaluator's read-allow path instead of asking.
+    assert request.redacted_parameters["allowed_local_roots"] == []
+    assert request.redacted_parameters["unrestricted_local_files"] is False
 
 
 def test_read_risk_opens_are_allowed_by_default_evaluator() -> None:

--- a/collie-ui/src/renderer/src/components/ChatInput.test.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.test.tsx
@@ -265,6 +265,11 @@ describe('ChatInput compose command listener', () => {
     expect(output).toContain('Project folder only')
     expect(output).toContain('Collie Workspace')
     expect(output).toContain('Local text files anywhere on this computer')
+    // Selecting a Files scope is consent for the content inside it —
+    // including that a read may send the file's text to the model provider.
+    // The disclosure must be visible at grant time, not only in a card that
+    // in-scope reads no longer raise.
+    expect(output).toContain('may be sent to')
 
     hooks.setState(1, [{
       name: 'photo.png',

--- a/collie-ui/src/renderer/src/components/ChatInput.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.tsx
@@ -861,6 +861,10 @@ export default function ChatInput({
                 <div className="context-popover-heading context-popover-heading--section">
                   Access for this chat
                 </div>
+                <p className="context-popover-note">
+                  Files Collie reads inside this scope may be sent to{' '}
+                  {activeProvider?.name || 'your model provider'}.
+                </p>
                 <button
                   type="button"
                   aria-pressed={fileAccessScope.mode === 'selected_folder'}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -2653,6 +2653,13 @@ button {
   padding-top: 12px;
 }
 
+.context-popover-note {
+  padding: 2px 8px 8px;
+  color: var(--muted);
+  font-size: var(--collie-min-font-size);
+  line-height: 1.4;
+}
+
 .context-popover > button {
   display: flex;
   width: 100%;

--- a/docs/engineering/security/approval-matrix.md
+++ b/docs/engineering/security/approval-matrix.md
@@ -10,7 +10,7 @@ This is the current implementation overview. Code and focused tests remain the s
 Collie starts new chats in **Execute** mode. **Plan** remains strictly read-only. In Execute, the permission system makes an explicit per-operation decision immediately before a tool runs:
 
 - Read-only operations are allowed, subject to project and network safety checks.
-- Explicitly classified, reversible local personal actions are prompt-free. This includes ordinary notes, one-time reminders, non-destructive shopping-list work, image creation, local calendar/contact updates, one-time goals, and starting a focused subagent.
+- Explicitly classified, reversible local personal actions are prompt-free. This includes ordinary notes, one-time reminders, non-destructive shopping-list work, image creation, local calendar/contact updates, one-time goals, starting a focused subagent, and bounded file work inside the user-granted scope (reading content, creating files, and saving new files).
 - Other explicitly eligible local work can use the user's **Approve for me** setting or an approved-for-this-task rule. **Ask me** is the conservative default and presents a normal approval card for that work.
 - A broad setting or task rule is never inferred just from `LOCAL_WRITE`. Each operation must opt in, and a task-wide rule is checked again when it is used.
 - Financial transactions, sends, publishing/external writes, destructive actions, sensitive work, credentials/connectors, reusable capabilities, schedules/routines, provider/settings changes, and unknown MCP work still require their own approval path. No saved rule or task-wide approval bypasses a hard action.
@@ -50,7 +50,7 @@ The classifier inspects multi-action wrapper parameters as well as tool names, s
 
 `local_files` is the agent-facing tool for everyday document work. It can list folders; read small UTF-8 text files; and create, save, overwrite, or make one exact edit to supported text artifacts. It does not offer shell access, file deletion, network paths, device paths, symlink/junction hops, Word/PDF binaries, or unrestricted binary handling. Replacements are atomic; read hashes can protect a subsequent overwrite from a stale read.
 
-Reading text may send its contents to the configured model provider to answer the request; the tool says so in its permission metadata. Writing remains local-only. Folder choice is a boundary, not automatic permission to write: in **Ask me** mode an eligible bounded write prompts, while **Approve for me** can continue an explicitly eligible local write.
+Reading text may send its contents to the configured model provider to answer the request; the tool says so in its permission metadata (summary + `data_leaving_device`). **Selecting a Files scope is explicit consent for the content inside it** — including that an in-scope read may send the file's text to the configured model provider — so in-scope reads are prompt-free. Writing stays local-only. Inside the granted scope, reversible writes (create, save of a new file) are prompt-free too; overwriting or editing an existing file still prompts because it destroys prior content (in **Ask me** mode an eligible bounded write prompts, while **Approve for me** can continue an explicitly eligible local write).
 
 The chat composer exposes one compact **Files** selector that combines the
 conversation project folder with the local-file boundary:


### PR DESCRIPTION
## What & why

Implements the permission-review decision from 2026-08-10 (report: `collie-workspace/hermes/reports/permission-review-2026-08-10.md`): **selecting a Files scope is consent for the content inside it — no more per-file approval cards.** Plus cron always asks (recurring authority).

### Per-folder consent (the big one)

| Before | After |
|---|---|
| `local_files` read = `Risk.SENSITIVE` + `hard_approval` → **1 card per file read**, even inside an already-granted folder, even with Full file access (the #1 consent-fatigue source) | In-scope read = `Risk.READ` → **prompt-free**. Summary + `data_leaving_device` still disclose the configured model provider honestly |
| create / save-new inside granted folder → card in Ask-me mode | **prompt-free** (reversible bounded work; the evaluator's `reversible` guard is what keeps this safe) |
| overwrite / edit existing file → card | **still asks** — destroys prior content, never silent (can still use "Approve for this task") |
| `open_file` inside a granted-but-outside-project folder → asked (bug: scope flags missing from its permission metadata, `local_files list` had them) | **prompt-free** — `allowed_local_roots`/`unrestricted_local_files` now carried, so granted-folder opens hit the read-allow path |

Out-of-scope targets are still hard-denied up front (no dead-end approvals), and nothing external (sends, money, connectors, capability create) is touched.

### Cron (recurring authority) always asks

- `cron add` → `cron.add` + `hard_approval` — never automatic, never run-approvable; the `cron.` prefix also fails closed in `defaults.py` against any future automatic-local flag
- `cron remove` → `delete.destructive` + `hard_approval` (explicit now; previously relied on classifier action-param sniffing)
- `cron list` → ordinary ask (`cron.list`)

## Files

- `collie-core/collie_core/tools/local_files.py` — read → READ prompt-free; reversible writes approval-free; irreversible overwrites still ask
- `collie-core/collie_core/tools/open_file.py` — carries granted-root scope metadata
- `collie-core/nanobot/agent/tools/cron.py` — explicit `permission_request` (add/remove hard)
- `collie-core/collie_core/permissions/evaluator.py` — stale comment refreshed (no logic change)
- `docs/engineering/security/approval-matrix.md` — policy updated
- Tests: `test_local_files_tool.py` (metadata + silent in-scope read authorization), `test_open_file_tool.py` (scope keys), new `tests/cron/test_cron_tool_permission.py`

## Test evidence

Full tree (`tests/`): **3501 passed, 7 failed, 1 skipped** — the 7 are the documented Linux-only set (4× `test_services` Windows DPAPI, 1× `test_ipc::test_read_write_file_rejects_escape_paths` flaky, 2× `test_gardener_mvp` verified pre-existing on pristine `origin/main`). Ruff clean on all changed files.

## Note for reviewer

Deliberate trade-off: **irreversible overwrites of existing files still prompt** even inside granted folders (content loss). Reads, creates, and new-file saves are fully covered by the folder grant. If we want overwrites free too, it's a one-flag change (`approval_free=bool(safe_write)` in `local_files.py`).