### PR TITLE
feat(core): save_thing tool + ArtifactEvent — 'Your things' panel backend

### DIFF
--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -39,6 +39,8 @@ from collie_core.permissions.store import PermissionStore
 from collie_core.services.manager import bind_service_manager
 from collie_core.session_identity import desktop_session_key
 from collie_core.subagents.loader import SubagentLoader, bind_subagent_loader
+from collie_core.things.store import ThingStore
+from collie_core.tools.artifacts import bind_things
 from collie_core.tools.life_db import bind_life_db
 from collie_core.tools.memory import bind_profile_store
 from collie_core.tools.model_switch import SetModelTool, bind_model_switcher
@@ -78,6 +80,8 @@ class CollieRuntime:
         bind_plans_db(self.db)
         bind_model_switcher(self._switch_model)
         bind_task_checklists_db(self.db)
+        self.things = ThingStore()
+        bind_things(store=self.things)
         # The connector manager keeps the old ServiceManager-shaped facade for
         # one transition release, so existing life-tool bridges stay bootable.
         self.services = ConnectorManager(self.db)
@@ -175,6 +179,7 @@ class CollieRuntime:
             self.db, mcp_servers=self.services.mcp_servers_for_config()
         )
         bus = CollieBus(on_inbound=self._on_messenger_inbound)
+        bind_things(bus=bus)
         provider_override = self._provider_override()
         telemetry_factories = [create_telemetry_hook_factory(self.db)]
         if provider_override is not None:
@@ -835,10 +840,19 @@ class CollieRuntime:
         loop = self.loop
         if loop is None:
             return
+        from nanobot.bus.outbound_events import (
+            ArtifactEvent,
+            outbound_event_from_message,
+        )
+
         while True:
             outbound = await loop.bus.consume_outbound()
             try:
                 channel = str(getattr(outbound, "channel", "") or "")
+                event = outbound_event_from_message(outbound)
+                if isinstance(event, ArtifactEvent):
+                    await self._deliver_artifact_event(event, outbound)
+                    continue
                 if channel != "collie":
                     await self.messengers.dispatch(outbound)
                     continue
@@ -858,6 +872,35 @@ class CollieRuntime:
                 await self.ipc.send_thinking(conv_id, state)
             except Exception:
                 logger.exception("Failed to deliver background message")
+
+    async def _deliver_artifact_event(self, event: Any, outbound: Any) -> None:
+        """Broadcast a registered "thing" to the desktop panel.
+
+        The ``save_thing`` tool already persisted the record and published the
+        event; this only pushes the desktop payload to IPC clients for the
+        conversation the tool ran in. Messenger channels never reach this
+        branch — they fall back to the message's normie text (``📎 Made: …``)
+        via ``messengers.dispatch``.
+        """
+        conv_id = str(getattr(outbound, "chat_id", "") or "")
+        if not conv_id or self.db.get_conversation(conv_id) is None:
+            return
+        await self.ipc.broadcast(
+            {
+                "type": "artifact",
+                "conversation_id": conv_id,
+                "artifact": {
+                    "id": event.artifact_id,
+                    "title": event.title,
+                    "kind": event.kind,
+                    "path": event.file_path,
+                    "size_bytes": event.size_bytes,
+                    "created_at": event.created_at,
+                    "status": event.status,
+                    "version": event.version,
+                },
+            }
+        )
 
     def _subagents_running(self, conversation_id: str) -> int:
         """How many subagents are still working for a conversation."""

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -849,12 +849,16 @@ class CollieRuntime:
             outbound = await loop.bus.consume_outbound()
             try:
                 channel = str(getattr(outbound, "channel", "") or "")
+                if channel != "collie":
+                    # Messenger-bound replies go to the channel queue even when
+                    # they carry a typed event (e.g. an ArtifactEvent falls
+                    # back to its normie text in channel.send). Intercepting
+                    # here would swallow the fallback for Telegram/Discord/…
+                    await self.messengers.dispatch(outbound)
+                    continue
                 event = outbound_event_from_message(outbound)
                 if isinstance(event, ArtifactEvent):
                     await self._deliver_artifact_event(event, outbound)
-                    continue
-                if channel != "collie":
-                    await self.messengers.dispatch(outbound)
                     continue
                 conv_id = str(getattr(outbound, "chat_id", "") or "")
                 content = str(getattr(outbound, "content", "") or "")

--- a/collie-core/collie_core/things/store.py
+++ b/collie-core/collie_core/things/store.py
@@ -1,0 +1,117 @@
+"""Durable index of the user's "Your things".
+
+One JSON file per conversation under the instance ``things`` directory
+(``~/.collie/things/<conversation_id>.json``), mirroring the sidecar-metadata
+pattern already used for generated media in ``nanobot.utils.artifacts`` — no
+SQLite, no new tables. The renderer hydrates the panel from this index on
+reconnect; live updates arrive as ``ArtifactEvent`` bus messages.
+
+Records are plain dicts so the IPC layer can broadcast them verbatim:
+
+``{"id", "title", "kind", "path", "size_bytes", "created_at", "status", "version"}``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from nanobot.config.paths import get_runtime_subdir
+
+__all__ = ["ThingStore"]
+
+# Conversation ids are Collie-generated keys ("conv_…"); the regex keeps a
+# conversation from ever smuggling path separators into the index filename.
+_SAFE_CONVERSATION_ID = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+ThingRecord = dict[str, Any]
+
+
+class ThingStore:
+    """JSON-per-conversation thing index with atomic writes."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._dir = Path(root) if root is not None else get_runtime_subdir("things")
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def root(self) -> Path:
+        """The directory holding the per-conversation index files."""
+        return self._dir
+
+    def register(
+        self,
+        *,
+        conversation_id: str,
+        artifact_id: str,
+        title: str,
+        kind: str,
+        path: str,
+        size_bytes: int,
+        created_at: float,
+        status: str = "new",
+        version: int = 1,
+    ) -> ThingRecord:
+        """Insert or update one thing record for a conversation.
+
+        A re-registered ``artifact_id`` replaces the existing record in place
+        (the slot keeps its position); a new id is prepended so ``list``
+        returns newest first. The file is written atomically (tmp + rename).
+        """
+        record: ThingRecord = {
+            "id": artifact_id,
+            "title": title,
+            "kind": kind,
+            "path": path,
+            "size_bytes": size_bytes,
+            "created_at": created_at,
+            "status": status,
+            "version": version,
+        }
+        records = self._load(conversation_id)
+        for index, existing in enumerate(records):
+            if existing.get("id") == artifact_id:
+                records[index] = record
+                break
+        else:
+            records.insert(0, record)
+        self._save(conversation_id, records)
+        return record
+
+    def list(self, conversation_id: str) -> list[ThingRecord]:
+        """All things for a conversation, newest first (empty for unknown)."""
+        return self._load(conversation_id)
+
+    # -- internals ---------------------------------------------------------
+
+    def _index_path(self, conversation_id: str) -> Path:
+        if not _SAFE_CONVERSATION_ID.match(conversation_id or ""):
+            raise ValueError(
+                f"conversation_id {conversation_id!r} is not safe for an index file"
+            )
+        return self._dir / f"{conversation_id}.json"
+
+    def _load(self, conversation_id: str) -> list[ThingRecord]:
+        path = self._index_path(conversation_id)
+        if not path.exists():
+            return []
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
+        records = payload.get("things", []) if isinstance(payload, dict) else payload
+        if not isinstance(records, list):
+            return []
+        return [r for r in records if isinstance(r, dict)]
+
+    def _save(self, conversation_id: str, records: list[ThingRecord]) -> None:
+        path = self._index_path(conversation_id)
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(
+            json.dumps({"things": records}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)

--- a/collie-core/collie_core/tools/artifacts.py
+++ b/collie-core/collie_core/tools/artifacts.py
@@ -1,0 +1,286 @@
+"""``save_thing`` tool: register a finished deliverable as one of the user's "things".
+
+The model calls this when it has COMPLETED a deliverable the user asked for
+(a flyer, document, spreadsheet, PDF, image, or web page). The file must
+already exist on disk — the tool only records metadata, publishes an
+:class:`ArtifactEvent` on the bus, and never touches the file's contents.
+The desktop UI renders the event as a card in the "Your things" panel;
+messenger channels (Telegram, Discord, …) fall back to the message text
+(``📎 Made: <title> · Open``), so nothing is ever called an "artifact" to
+the user.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from collie_core.permissions.models import PermissionRequest, Risk, Scope
+from collie_core.things.store import ThingStore
+from collie_core.tools.local_files import _LocalFileError, _resolve_local_path
+from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
+from nanobot.agent.tools.context import current_request_context
+from nanobot.bus.outbound_events import ArtifactEvent, outbound_message_for_event
+from nanobot.bus.queue import MessageBus
+from nanobot.config.paths import get_media_dir
+from nanobot.security.workspace_policy import WorkspaceBoundaryError, is_path_within
+
+__all__ = ["SaveThingTool", "bind_things"]
+
+_MAX_TITLE_CHARS = 120
+_MAX_TITLE_BYTES = 500
+
+# Extension → friendly kind shown in the panel ("Image · 2.1 MB"). Unknown
+# suffixes resolve to "file".
+_KIND_BY_SUFFIX: dict[str, str] = {
+    # images
+    ".png": "image", ".jpg": "image", ".jpeg": "image", ".gif": "image",
+    ".webp": "image", ".bmp": "image", ".svg": "image", ".ico": "image",
+    ".avif": "image", ".tif": "image", ".tiff": "image",
+    # documents
+    ".md": "document", ".txt": "document", ".docx": "document", ".doc": "document",
+    ".rtf": "document", ".odt": "document",
+    # spreadsheets
+    ".xlsx": "sheet", ".csv": "sheet", ".ods": "sheet",
+    # pdf
+    ".pdf": "pdf",
+    # web previews
+    ".html": "web", ".htm": "web",
+}
+
+_thing_store: ThingStore | None = None
+_thing_bus: MessageBus | None = None
+
+
+def bind_things(*, store: ThingStore | None = None, bus: MessageBus | None = None) -> None:
+    """Wire the shared store and/or bus into the tool (called by the runtime).
+
+    The store is bound once at startup; the bus is rebound per agent-loop
+    build (each loop owns its own :class:`MessageBus`). Passing ``None`` for
+    a key leaves that binding untouched.
+    """
+    global _thing_store, _thing_bus
+    if store is not None:
+        _thing_store = store
+    if bus is not None:
+        _thing_bus = bus
+
+
+def _clean_title(raw: str) -> str | None:
+    """Validate + normalize a human title; None means invalid."""
+    if not isinstance(raw, str):
+        return None
+    title = " ".join(raw.split())
+    if not title:
+        return None
+    if len(title) > _MAX_TITLE_CHARS or len(title.encode("utf-8")) > _MAX_TITLE_BYTES:
+        return None
+    if any(ord(char) < 32 for char in title):
+        return None
+    return title
+
+
+def _resolve_thing_path(raw: str) -> tuple[Path | None, str | None]:
+    """Resolve the deliverable path against the workspace scope.
+
+    Returns ``(path, None)`` on success and ``(None, error_message)`` on
+    failure. The normal rules come from :func:`_resolve_local_path`
+    (workspace roots, symlink/junction refusal, UNC/device refusal). One
+    deliberate carve-out: files Collie itself produced in its media directory
+    (e.g. image-generation output) are always registrable even though that
+    directory is outside the task's folder scope — the file was created by
+    the assistant for this exact purpose.
+    """
+    if not isinstance(raw, str) or not raw.strip() or "\x00" in raw:
+        return None, "Please provide a valid file path."
+    try:
+        target, _in_scope = _resolve_local_path(raw, allow_directory=False)
+    except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
+        media = _media_candidate(raw)
+        if media is not None:
+            return media, None
+        return None, str(exc)
+    return target, None
+
+
+def _media_candidate(raw: str) -> Path | None:
+    """Allow an absolute path inside Collie's media root (assistant-made)."""
+    entered = Path(raw).expanduser()
+    if not entered.is_absolute():
+        return None
+    try:
+        media_root = get_media_dir().resolve()
+        if not is_path_within(entered, media_root):
+            return None
+        candidate = entered.resolve(strict=False)
+        if not is_path_within(candidate, media_root):
+            return None
+    except OSError:
+        return None
+    if not candidate.exists() or not candidate.is_file():
+        return None
+    return candidate
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": (
+                    "Short human-friendly title the user will recognize — e.g. "
+                    "\"Dog walk flyer\". No file extension, no path, no technical "
+                    "jargon."
+                ),
+                "minLength": 1,
+                "maxLength": 120,
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "Path to the finished file (relative to an allowed folder, or "
+                    "absolute). The file must already exist."
+                ),
+                "minLength": 1,
+                "maxLength": 4096,
+            },
+            "kind": {
+                "type": "string",
+                "enum": ["image", "document", "sheet", "pdf", "web", "file"],
+                "description": (
+                    "What kind of thing it is: image, document, sheet, pdf, web "
+                    "(a web page), or file (anything else)."
+                ),
+            },
+        },
+        "required": ["title", "path", "kind"],
+        "additionalProperties": False,
+    }
+)
+class SaveThingTool(Tool):
+    """Save a finished deliverable into the user's \"Your things\" panel."""
+
+    @property
+    def name(self) -> str:
+        return "save_thing"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Register a finished deliverable as one of the user's \"things\" so it "
+            "appears in their \"Your things\" panel and can be opened again later. "
+            "Call this when you have COMPLETED a deliverable the user asked for — a "
+            "flyer, document, spreadsheet, PDF, image, or web page you created or "
+            "saved for them — and the file already exists on disk. Pass a short, "
+            "human-friendly title (no extension, no path) and the path to the "
+            "finished file. Only call it for real deliverables the user will want "
+            "to open again — never for temporary working files. After it succeeds, "
+            "tell the user it's ready and mention it's in \"Your things\"."
+        )
+
+    def permission_request(self, params: dict[str, Any]) -> PermissionRequest:
+        title = _clean_title(str(params.get("title") or "")) or "a file"
+        resource = str(params.get("path") or "your file")
+        return PermissionRequest(
+            action="things.save",
+            resource=resource,
+            risk=Risk.LOCAL_WRITE,
+            summary=f"Add “{title}” to your things",
+            reversible=True,
+            data_leaving_device=(),
+            suggested_scope=Scope.ONCE,
+            redacted_parameters={"path": resource, "local_only": True},
+            # Metadata-only: records a path + publishes a UI event; the file's
+            # contents never leave the device and nothing is modified.
+            hard_approval=False,
+            approval_free=True,
+            approve_for_me=False,
+        )
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        title = _clean_title(str(kwargs.get("title") or ""))
+        if title is None:
+            return ToolResult.error(
+                "Please give the thing a short human-friendly title (max 120 characters)."
+            )
+        raw_path = str(kwargs.get("path") or "")
+        declared_kind = str(kwargs.get("kind") or "")
+        if declared_kind not in _KIND_BY_SUFFIX.values() and declared_kind != "file":
+            return ToolResult.error(
+                f"Kind must be one of image, document, sheet, pdf, web, or file (got {declared_kind!r})."
+            )
+
+        target, error = _resolve_thing_path(raw_path)
+        if error is not None:
+            return ToolResult.error(f"I couldn't save that as a thing: {error}")
+        assert target is not None
+        if not target.exists():
+            return ToolResult.error("That file does not exist yet.")
+        if target.is_dir():
+            return ToolResult.error("That path is a folder, not a finished file.")
+        if not target.is_file():
+            return ToolResult.error("That path is not a readable file.")
+
+        actual_kind = _KIND_BY_SUFFIX.get(target.suffix.lower(), "file")
+        if declared_kind != "file" and actual_kind != "file" and declared_kind != actual_kind:
+            return ToolResult.error(
+                f"That file is a {actual_kind}, not a {declared_kind} — "
+                f"call save_thing again with kind={actual_kind!r}."
+            )
+        kind = actual_kind if declared_kind == "file" else declared_kind
+
+        ctx = current_request_context()
+        if ctx is None or not ctx.chat_id:
+            return ToolResult.error("I can't register a thing right now — no active conversation.")
+        conversation_id = str(ctx.chat_id)
+        if _thing_store is None or _thing_bus is None:
+            return ToolResult.error("Things are not available in this session yet.")
+
+        artifact_id = f"th_{uuid.uuid4().hex[:12]}"
+        created_at = time.time()
+        size_bytes = target.stat().st_size
+        record = _thing_store.register(
+            conversation_id=conversation_id,
+            artifact_id=artifact_id,
+            title=title,
+            kind=kind,
+            path=str(target),
+            size_bytes=size_bytes,
+            created_at=created_at,
+            status="new",
+            version=1,
+        )
+
+        await _thing_bus.publish_outbound(
+            outbound_message_for_event(
+                channel=ctx.channel,
+                chat_id=conversation_id,
+                event=ArtifactEvent(
+                    artifact_id=artifact_id,
+                    title=title,
+                    kind=kind,
+                    file_path=str(target),
+                    size_bytes=size_bytes,
+                    created_at=created_at,
+                    status="new",
+                    version=1,
+                ),
+                content=f"📎 Made: {title} · Open",
+            )
+        )
+
+        return ToolResult(
+            json.dumps(
+                {
+                    "thing_id": record["id"],
+                    "title": record["title"],
+                    "kind": record["kind"],
+                    "conversation_id": conversation_id,
+                },
+                ensure_ascii=False,
+            )
+        )

--- a/collie-core/nanobot/bus/outbound_events.py
+++ b/collie-core/nanobot/bus/outbound_events.py
@@ -81,6 +81,27 @@ class RuntimeModelUpdatedEvent(OutboundEvent):
     model_preset: str | None = None
 
 
+@dataclass(frozen=True)
+class ArtifactEvent(OutboundEvent):
+    """A finished deliverable registered for the user's "Your things" panel.
+
+    Internal name only — user-facing copy never uses the word "artifact"; the
+    desktop UI renders this as a thing card. Carried by
+    :attr:`OutboundMessage.event`; channels that cannot render it (Telegram,
+    Discord, …) fall back to the message ``content``, which the emitter sets
+    to a short normie line like ``📎 Made: Dog walk flyer · Open``.
+    """
+
+    artifact_id: str
+    title: str
+    kind: str
+    file_path: str
+    size_bytes: int
+    created_at: float
+    status: str = "new"
+    version: int = 1
+
+
 def outbound_message_for_event(
     *,
     channel: str,

--- a/collie-core/tests/bus/test_outbound_events.py
+++ b/collie-core/tests/bus/test_outbound_events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import (
+    ArtifactEvent,
     GoalStateSyncEvent,
     GoalStatusEvent,
     ProgressEvent,
@@ -242,3 +243,31 @@ def test_streamed_response_event_keeps_final_content_outside_event_payload() -> 
 
     assert msg.content == "final answer"
     assert isinstance(outbound_event_from_message(msg), StreamedResponseEvent)
+
+
+def test_artifact_event_roundtrip_with_normie_fallback_content() -> None:
+    msg = outbound_message_for_event(
+        channel="collie",
+        chat_id="conv-1",
+        event=ArtifactEvent(
+            artifact_id="th_abc123",
+            title="Dog walk flyer",
+            kind="image",
+            file_path="/tmp/flyer.png",
+            size_bytes=2048,
+            created_at=1_720_000_000.0,
+        ),
+        content="📎 Made: Dog walk flyer · Open",
+    )
+
+    assert msg.content == "📎 Made: Dog walk flyer · Open"
+
+    event = outbound_event_from_message(msg)
+    assert isinstance(event, ArtifactEvent)
+    assert event.artifact_id == "th_abc123"
+    assert event.title == "Dog walk flyer"
+    assert event.kind == "image"
+    assert event.file_path == "/tmp/flyer.png"
+    assert event.size_bytes == 2048
+    assert event.status == "new"
+    assert event.version == 1

--- a/collie-core/tests/collie/test_subagent_visibility.py
+++ b/collie-core/tests/collie/test_subagent_visibility.py
@@ -211,3 +211,97 @@ async def test_shutdown_freezes_intake_before_queued_messenger_dispatch(
     assert runtime._loop_task is None
     assert runtime.loop is None
     db.close()
+
+
+@pytest.mark.asyncio
+async def test_outbound_consumer_artifact_event_reaches_messenger_dispatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """ArtifactEvent on a messenger channel goes to the channel queue, not IPC.
+
+    The normie text fallback (``📎 Made: …``) is the messenger UX for things;
+    intercepting the event before the channel dispatch would swallow it.
+    """
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path / ".collie"))
+    db = CollieDB(tmp_path / ".collie" / "collie.db")
+    runtime = CollieRuntime(port=_free_port(), db=db)
+    bus = MessageBus()
+    runtime.loop = SimpleNamespace(
+        bus=bus,
+        subagents=SimpleNamespace(get_running_count_by_session=lambda key: 0),
+    )
+
+    dispatched: list[Any] = []
+    broadcasts: list[dict[str, Any]] = []
+
+    async def capture_dispatch(msg: Any) -> bool:
+        dispatched.append(msg)
+        return True
+
+    async def capture_broadcast(payload: dict[str, Any]) -> None:
+        broadcasts.append(payload)
+
+    monkeypatch.setattr(runtime.messengers, "dispatch", capture_dispatch)
+    monkeypatch.setattr(runtime.ipc, "broadcast", capture_broadcast)
+
+    from nanobot.bus.outbound_events import ArtifactEvent, outbound_message_for_event
+
+    task = asyncio.create_task(runtime._consume_outbound())
+    try:
+        # Messenger channel: must reach messengers.dispatch (text fallback).
+        await bus.publish_outbound(
+            outbound_message_for_event(
+                channel="telegram",
+                chat_id="12345",
+                event=ArtifactEvent(
+                    artifact_id="th_abc",
+                    title="Dog walk flyer",
+                    kind="image",
+                    file_path="/tmp/flyer.png",
+                    size_bytes=8,
+                    created_at=1.0,
+                ),
+                content="📎 Made: Dog walk flyer · Open",
+            )
+        )
+        # Collie channel: must become an IPC artifact broadcast, never a chat
+        # bubble (the model mentions the thing in its own reply).
+        conv = db.create_conversation("trip")
+        await bus.publish_outbound(
+            outbound_message_for_event(
+                channel="collie",
+                chat_id=conv["id"],
+                event=ArtifactEvent(
+                    artifact_id="th_def",
+                    title="Trip notes",
+                    kind="document",
+                    file_path="/tmp/notes.md",
+                    size_bytes=8,
+                    created_at=1.0,
+                ),
+                content="📎 Made: Trip notes · Open",
+            )
+        )
+        for _ in range(100):
+            if dispatched and any(b.get("type") == "artifact" for b in broadcasts):
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    assert len(dispatched) == 1
+    assert dispatched[0].channel == "telegram"
+    assert dispatched[0].content == "📎 Made: Dog walk flyer · Open"
+
+    artifacts = [b for b in broadcasts if b.get("type") == "artifact"]
+    assert len(artifacts) == 1
+    assert artifacts[0]["conversation_id"] == conv["id"]
+    assert artifacts[0]["artifact"]["title"] == "Trip notes"
+    # No chat bubble for the collie artifact (skip the duplicate).
+    message_events = [b for b in broadcasts if b.get("type") == "message"]
+    assert message_events == []
+    db.close()

--- a/collie-core/tests/collie/test_things_store.py
+++ b/collie-core/tests/collie/test_things_store.py
@@ -1,0 +1,105 @@
+"""Tests for the per-conversation "Your things" index (ThingStore)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from collie_core.things.store import ThingStore
+
+RECORD_KW: dict[str, Any] = dict(
+    title="Dog walk flyer",
+    kind="image",
+    path="/tmp/flyer.png",
+    size_bytes=2048,
+    created_at=1_720_000_000.0,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ThingStore:
+    return ThingStore(root=tmp_path / "things")
+
+
+def test_register_and_list_roundtrip(store: ThingStore) -> None:
+    record = store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+
+    assert record["id"] == "th_a"
+    assert record["title"] == "Dog walk flyer"
+
+    listed = store.list("conv-1")
+    assert len(listed) == 1
+    assert listed[0] == record
+
+
+def test_new_things_are_prepended_newest_first(store: ThingStore) -> None:
+    store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+    store.register(
+        conversation_id="conv-1",
+        artifact_id="th_b",
+        **{**RECORD_KW, "title": "Barcelona trip plan", "kind": "document"},
+    )
+
+    ids = [record["id"] for record in store.list("conv-1")]
+    assert ids == ["th_b", "th_a"]
+
+
+def test_re_registered_id_replaces_in_place(store: ThingStore) -> None:
+    store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+    store.register(conversation_id="conv-1", artifact_id="th_b", **{**RECORD_KW, "title": "Second"})
+    store.register(
+        conversation_id="conv-1",
+        artifact_id="th_a",
+        **{**RECORD_KW, "title": "Flyer v2", "status": "updated", "version": 2},
+    )
+
+    records = store.list("conv-1")
+    assert len(records) == 2
+    assert records[1]["id"] == "th_a"  # slot position kept
+    assert records[1]["title"] == "Flyer v2"
+    assert records[1]["version"] == 2
+
+
+def test_conversations_are_isolated(store: ThingStore) -> None:
+    store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+
+    assert store.list("conv-2") == []
+    assert store.list("conv-1")[0]["id"] == "th_a"
+
+
+def test_unknown_conversation_lists_empty(store: ThingStore) -> None:
+    assert store.list("conv-ghost") == []
+
+
+def test_unsafe_conversation_id_raises(store: ThingStore) -> None:
+    with pytest.raises(ValueError, match="not safe"):
+        store.register(conversation_id="../../etc/passwd", artifact_id="th_a", **RECORD_KW)
+    with pytest.raises(ValueError, match="not safe"):
+        store.list("conv with spaces")
+
+
+def test_index_survives_store_reload(tmp_path: Path) -> None:
+    root = tmp_path / "things"
+    first = ThingStore(root=root)
+    first.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+
+    reloaded = ThingStore(root=root)
+    assert reloaded.list("conv-1")[0]["id"] == "th_a"
+
+    # And the on-disk shape is a {"things": [...]} document.
+    payload = json.loads((root / "conv-1.json").read_text(encoding="utf-8"))
+    assert payload["things"][0]["title"] == "Dog walk flyer"
+
+
+def test_corrupt_index_file_is_treated_as_empty(tmp_path: Path) -> None:
+    root = tmp_path / "things"
+    root.mkdir()
+    (root / "conv-1.json").write_text("{not json", encoding="utf-8")
+
+    store = ThingStore(root=root)
+    assert store.list("conv-1") == []
+    store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+    assert store.list("conv-1")[0]["id"] == "th_a"

--- a/collie-core/tests/tools/test_save_thing_tool.py
+++ b/collie-core/tests/tools/test_save_thing_tool.py
@@ -1,0 +1,247 @@
+"""Tests for the ``save_thing`` tool (the user's "Your things")."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import collie_core.tools.artifacts as artifacts_module
+from collie_core.things.store import ThingStore
+from collie_core.tools.artifacts import SaveThingTool, bind_things
+from nanobot.agent.tools.context import RequestContext, request_context
+from nanobot.agent.tools.loader import ToolLoader
+from nanobot.bus.outbound_events import ArtifactEvent, outbound_event_from_message
+from nanobot.bus.queue import MessageBus
+from nanobot.security.workspace_access import (
+    bind_workspace_scope,
+    build_workspace_scope,
+    reset_workspace_scope,
+)
+
+
+@pytest.fixture
+def scope(tmp_path: Path):
+    root = tmp_path / "project"
+    root.mkdir()
+    token = bind_workspace_scope(build_workspace_scope(root, "restricted", source_channel="websocket"))
+    try:
+        yield root
+    finally:
+        reset_workspace_scope(token)
+
+
+@pytest.fixture
+def wired(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bus = MessageBus()
+    store = ThingStore(root=tmp_path / "things")
+    media = tmp_path / "media"
+    media.mkdir()
+    monkeypatch.setattr(artifacts_module, "get_media_dir", lambda: media)
+    bind_things(store=store, bus=bus)
+    try:
+        yield bus, store, media
+    finally:
+        bind_things(store=None, bus=None)
+
+
+@pytest.fixture
+def chat_ctx():
+    ctx = RequestContext(channel="collie", chat_id="conv-1")
+    with request_context(ctx):
+        yield ctx
+
+
+async def _run_tool(scope: Path, **kwargs: Any) -> Any:
+    return await SaveThingTool().execute(**kwargs)
+
+
+async def _next_outbound(bus: MessageBus) -> Any:
+    return await asyncio.wait_for(bus.consume_outbound(), timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_registers_thing_and_publishes_artifact_event(
+    scope: Path, wired, chat_ctx
+) -> None:
+    bus, store, _media = wired
+    (scope / "flyer.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await _run_tool(
+        scope, title="Dog walk flyer", path="flyer.png", kind="image"
+    )
+
+    assert not result.is_error
+    payload = json.loads(str(result))
+    assert payload["title"] == "Dog walk flyer"
+    assert payload["kind"] == "image"
+    assert payload["conversation_id"] == "conv-1"
+
+    records = store.list("conv-1")
+    assert len(records) == 1
+    assert records[0]["id"] == payload["thing_id"]
+    assert records[0]["path"] == str((scope / "flyer.png").resolve())
+
+    msg = await _next_outbound(bus)
+    event = outbound_event_from_message(msg)
+    assert isinstance(event, ArtifactEvent)
+    assert event.artifact_id == payload["thing_id"]
+    assert event.title == "Dog walk flyer"
+    assert event.kind == "image"
+    assert event.file_path == str((scope / "flyer.png").resolve())
+    assert event.size_bytes == 8
+    assert msg.channel == "collie"
+    assert msg.chat_id == "conv-1"
+    assert msg.content == "📎 Made: Dog walk flyer · Open"
+
+
+async def test_kind_defaults_to_actual_for_unknown_file_kind(
+    scope: Path, wired, chat_ctx
+) -> None:
+    bus, store, _media = wired
+    (scope / "notes.txt").write_text("hello", encoding="utf-8")
+
+    result = await _run_tool(scope, title="Notes", path="notes.txt", kind="file")
+
+    assert not result.is_error
+    assert json.loads(str(result))["kind"] == "document"
+    event = outbound_event_from_message(await _next_outbound(bus))
+    assert isinstance(event, ArtifactEvent) and event.kind == "document"
+
+
+# ---------------------------------------------------------------------------
+# validation failures
+# ---------------------------------------------------------------------------
+
+
+async def test_kind_mismatch_is_rejected(scope: Path, wired, chat_ctx) -> None:
+    bus, store, _media = wired
+    (scope / "flyer.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await _run_tool(
+        scope, title="Dog walk flyer", path="flyer.png", kind="document"
+    )
+
+    assert result.is_error
+    assert "image" in str(result)
+    assert store.list("conv-1") == []
+    with pytest.raises(asyncio.TimeoutError):
+        await _next_outbound(bus)
+
+
+async def test_missing_file_is_rejected(scope: Path, wired, chat_ctx) -> None:
+    bus, store, _media = wired
+
+    result = await _run_tool(
+        scope, title="Ghost", path="ghost.png", kind="image"
+    )
+
+    assert result.is_error
+    assert store.list("conv-1") == []
+    with pytest.raises(asyncio.TimeoutError):
+        await _next_outbound(bus)
+
+
+async def test_directory_is_rejected(scope: Path, wired, chat_ctx) -> None:
+    bus, store, _media = wired
+    (scope / "folder").mkdir()
+
+    result = await _run_tool(scope, title="Folder", path="folder", kind="file")
+
+    assert result.is_error
+    assert store.list("conv-1") == []
+
+
+async def test_path_outside_scope_is_rejected(scope: Path, wired, chat_ctx, tmp_path: Path) -> None:
+    bus, store, _media = wired
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "secret.docx").write_text("x", encoding="utf-8")
+
+    result = await _run_tool(
+        scope, title="Secret", path=str(outside / "secret.docx"), kind="document"
+    )
+
+    assert result.is_error
+    assert "outside" in str(result).lower() or "allowed" in str(result).lower()
+    assert store.list("conv-1") == []
+
+
+async def test_media_dir_carve_out_allows_assistant_made_files(
+    scope: Path, wired, chat_ctx
+) -> None:
+    bus, store, media = wired
+    made = media / "generated" / "img_abc.png"
+    made.parent.mkdir(parents=True)
+    made.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await _run_tool(
+        scope, title="Generated image", path=str(made), kind="image"
+    )
+
+    assert not result.is_error
+    assert store.list("conv-1")[0]["path"] == str(made.resolve())
+
+
+async def test_bad_title_is_rejected(scope: Path, wired, chat_ctx) -> None:
+    bus, store, _media = wired
+    (scope / "flyer.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await _run_tool(scope, title="   ", path="flyer.png", kind="image")
+    assert result.is_error
+
+    result = await _run_tool(scope, title="x" * 200, path="flyer.png", kind="image")
+    assert result.is_error
+
+    assert store.list("conv-1") == []
+
+
+async def test_invalid_kind_value_is_rejected(scope: Path, wired, chat_ctx) -> None:
+    bus, store, _media = wired
+    (scope / "flyer.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await _run_tool(scope, title="Flyer", path="flyer.png", kind="movie")
+
+    assert result.is_error
+    assert store.list("conv-1") == []
+
+
+async def test_no_request_context_is_rejected(scope: Path, wired) -> None:
+    bus, store, _media = wired
+    (scope / "flyer.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await _run_tool(scope, title="Flyer", path="flyer.png", kind="image")
+
+    assert result.is_error
+    assert store.list("conv-1") == []
+
+
+# ---------------------------------------------------------------------------
+# permission + discovery
+# ---------------------------------------------------------------------------
+
+
+def test_permission_request_is_approval_free_and_reversible(scope: Path) -> None:
+    request = SaveThingTool().permission_request(
+        {"title": "Dog walk flyer", "path": "flyer.png", "kind": "image"}
+    )
+
+    assert request.action == "things.save"
+    assert request.approval_free is True
+    assert request.hard_approval is False
+    assert request.reversible is True
+    assert request.data_leaving_device == ()
+
+
+def test_save_thing_tool_is_discoverable_via_loader() -> None:
+    import collie_core.tools as collie_tools
+
+    names = {tool_cls.__name__ for tool_cls in ToolLoader(collie_tools).discover()}
+    assert "SaveThingTool" in names

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,16 +11,16 @@
 
 ## Source inventory
 
-- Core Python files: **502**
-- Core Python test files: **226**
-- Desktop TypeScript/TSX files: **125**
-- Desktop test files: **38**
-- Active Markdown docs: **25**
+- Core Python files: **507**
+- Core Python test files: **229**
+- Desktop TypeScript/TSX files: **147**
+- Desktop test files: **51**
+- Active Markdown docs: **27**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups
 
-`automations`, `catalog`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `tools`
+`automations`, `catalog`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `things`, `tools`, `undo`
 
 ## Required orientation files
 

--- a/docs/product/features/things-panel.md
+++ b/docs/product/features/things-panel.md
@@ -1,0 +1,64 @@
+# Collie "Your things" panel
+
+**Status:** backend shipped (PR #39); desktop UI follow-up
+**Date:** 2026-08-10
+
+## Objective
+
+Non-coders have no file explorer to find what Collie makes for them. When
+Collie finishes a deliverable — a flyer, a document, a spreadsheet, a PDF, a
+web page — it lands in a right-side **"Your things"** panel in the desktop
+app: open it again anytime, save a copy, or show it in the folder. Chat
+stays the timeline; the panel is the home for what Collie makes.
+
+Normie vocabulary is a hard rule: the word "artifact" is internal-only.
+Users see **things** ("it's in Your things"), never file paths, extensions,
+or filenames. Paths travel as data to the Electron main process for
+Open / Save a copy… / Show in folder — never rendered.
+
+## UX rules (design sketch, 2026-08-10)
+
+- Default: panel hidden, no toggle button in a fresh chat (calm default).
+- First thing of a chat auto-opens the panel once; a manual close is
+  respected for the rest of that chat.
+- Toggle: top-right of the chat header; appears only when the chat has
+  things; orange badge count when closed with unseen items.
+- Panel is per-chat: "This chat | All chats" filter (All = later milestone
+  with a sidebar "Things" tab).
+- Card: thumbnail/icon · human title · type · size · time · new-dot until
+  viewed · hover Open + ⋮ (Open, Save a copy… → Documents, Show in folder,
+  Add to chat, Remove from your things — soft delete, recoverable in chat).
+- Deliverables only: the model declares "this is a deliverable" by calling
+  the `save_thing` tool. Temporary working files never appear.
+- Revisions replace the card; version history = later milestone.
+
+## Backend (shipped, PR #39)
+
+- `ArtifactEvent` (nanobot/bus/outbound_events.py) — typed outbound event
+  (id, title, kind, file_path, size_bytes, created_at, status, version)
+  with a normie text fallback (`📎 Made: <title> · Open`) so messenger
+  channels render it with zero channel-specific code.
+- `save_thing` tool (collie_core/tools/artifacts.py) — model registers a
+  finished deliverable. Validates title (≤120 chars), existing file,
+  extension↔kind, workspace scope (local_files resolver) + carve-out for
+  assistant-generated media. approval_free (metadata-only, reversible,
+  nothing leaves the device).
+- `ThingStore` (collie_core/things/store.py) — JSON-per-conversation index
+  under `~/.collie/things/<conv>.json`; atomic writes, newest-first,
+  upsert-by-id. No SQLite.
+- Runtime: `_consume_outbound` routes ArtifactEvent to the desktop as an
+  IPC `artifact` broadcast; messengers keep the text fallback.
+
+## Frontend (follow-up PR)
+
+ipc `artifact` event in the CollieEvent union, `lib/things.ts` fold,
+`ThingsPanel` / `ThingCard` / `ThingMenu` / `ThingsToggle` /
+`ThingInlineCard` / `ThingPreview` components, ChatScreen `case 'artifact'`,
+main-process handlers (`thing:open`, `thing:showInFolder`,
+`thing:saveCopy`), hydration via a `things.list` IPC read, all copy in
+`lib/locales/en.ts`.
+
+## Deferred
+
+File tree · diffs · sidebar Things tab · version history · embedded
+doc/sheet viewers · messenger file attachments (text fallback only).


### PR DESCRIPTION
## Summary

Backend foundation for the right-side **"Your things"** panel (the desktop UI ships in a follow-up PR). The word "artifact" stays internal-only — users never see it; the UI and chat copy say **things**.

- **`ArtifactEvent`** (typed outbound event, `nanobot/bus/outbound_events.py`) — carried on `OutboundMessage.event`, exactly like `ProgressEvent`/`TurnEndEvent`. Emitters set a normie text fallback (`📎 Made: Dog walk flyer · Open`) so Telegram/Discord/Slack render it as plain text with **zero new channel code**.
- **`save_thing` tool** (`collie_core/tools/artifacts.py`) — the model registers a finished deliverable (image / document / sheet / pdf / web / file). Deliverables-only by construction: temporary working files never appear. Validates human title (≤120 chars), existing file, extension↔kind consistency, and resolves paths with the same workspace-scope rules as `local_files` — with one deliberate carve-out: files Collie itself generated in the media dir (image-gen output) are always registrable. `approval_free` (metadata-only, reversible, nothing leaves the device). Tool description coaches the model to tell the user "it's in **Your things**".
- **`ThingStore`** (`collie_core/things/store.py`) — JSON-per-conversation index under `~/.collie/things/<conv>.json`, mirroring the media sidecar-metadata pattern. No SQLite, no migrations. Atomic tmp+rename writes, newest-first, upsert-by-id (slot keeps position), conversation ids filename-escaped, corrupt file → treated as empty.
- **Runtime wiring** (`collie_core/runtime.py`) — store bound at startup, bus bound per loop build (survives model-switch loop rebuilds); `_consume_outbound` routes `ArtifactEvent` to the desktop as an IPC `artifact` broadcast for the conversation it ran in (skips the duplicate chat bubble — the model mentions the thing in its own reply). Messenger channels keep the text fallback.

## Test Plan

- `tests/bus/test_outbound_events.py` — ArtifactEvent roundtrip + normie fallback content (+1)
- `tests/collie/test_things_store.py` — roundtrip, newest-first, upsert-in-place, conversation isolation, unsafe ids, reload persistence, corrupt-file recovery (+8)
- `tests/tools/test_save_thing_tool.py` — happy path (record + event fields + channel/chat routing), kind defaulting, kind mismatch, missing file, directory, out-of-scope, media carve-out, bad title/kind, no request context, permission flags, loader discovery (+13)
- **30 new tests, all passing.** `tests/tools`: 289 passed. `tests/collie`: 658 passed, 7 failed — all pre-existing Linux baselines (3× services DPAPI, 1× flaky ipc escape-path, 2× gardener failures reproduced on pristine `origin/main` via detached worktree). Ruff clean.

## Remaining gaps (follow-ups)

- Desktop panel UI (types, components, toggle/badge, previews) — the phase-2 PR.
- Panel hydration after restart needs a small IPC read endpoint (`things.list`) — the store already supports it.
- Messenger channels get the text fallback but not the attached file (media attachment per-channel is a separate feature).
- Versioning/updates: `status`/`version` fields are plumbed end-to-end but nothing emits `updated` yet.
