### PR TITLE
fix: P2 findings from Codex review of c3898c7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Lint (ruff)
         run: python -m ruff check nanobot collie_core tests
 
-      - name: Test (tests/collie, with the coverage gate)
+      - name: Test (full backend suite, with the coverage gate)
         run: |
           set -o pipefail
           PET=""
@@ -60,11 +60,17 @@ jobs:
           #    Windows-shaped and flaky on Linux (documented in
           #    docs + repo testing notes).
           # These tests are NOT deselected on Windows — the
-          # collie-core-windows job runs the full suite (see below).
+          # collie-core-windows job runs them for real (see below).
+          #
+          # The full suite (tests/ — not just tests/collie) gates merges so
+          # tests/tools, tests/providers and the rest cannot regress silently.
           #
           # --cov activates the pyproject floor (coverage.report.fail_under
-          # = 70); without it the gate is inert.
-          python -m pytest tests/collie -q $PET \
+          # = 42 — a deliberate headroom floor; the full suite measures ~76%
+          # on the Linux dev VM, so raising the floor is safe whenever the
+          # team wants a tighter gate). The old "70" note predated the
+          # full-suite run and was stale.
+          python -m pytest tests -q $PET \
             --cov=nanobot --cov=collie_core --cov-report=term-missing \
             --deselect tests/collie/test_services.py::test_credential_store_roundtrip \
             --deselect tests/collie/test_services.py::test_connect_api_key_service \
@@ -98,7 +104,7 @@ jobs:
       - name: Lint (ruff)
         run: python -m ruff check nanobot collie_core tests
 
-      - name: Test (tests/collie — full suite, no deselection)
+      - name: Test (full backend suite, no deselection)
         # Windows is the supported runtime: the DPAPI/service credential
         # tests and the ipc escape-path test that are deselected on Linux
         # must actually pass here. tkinter ships with the setup-python
@@ -106,7 +112,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          python -m pytest tests/collie -q
+          python -m pytest tests -q
 
   collie-ui:
     name: collie-ui (Node 22)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Lint (ruff)
         run: python -m ruff check nanobot collie_core tests
 
-      - name: Test (tests/collie, with the coverage gate)
+      - name: Test (full backend suite, with the coverage gate)
         run: |
           set -o pipefail
           PET=""
@@ -66,7 +66,9 @@ jobs:
           else
             PET="--ignore=tests/collie/test_pet_status.py"
           fi
-          python -m pytest tests/collie -q $PET \
+          # Full suite (tests/), not just tests/collie — the coverage floor in
+          # pyproject.toml (fail_under = 42) is measured across everything.
+          python -m pytest tests -q $PET \
             --cov=nanobot --cov=collie_core --cov-report=term-missing \
             --deselect tests/collie/test_services.py::test_credential_store_roundtrip \
             --deselect tests/collie/test_services.py::test_connect_api_key_service \
@@ -182,13 +184,14 @@ jobs:
       - name: Core tests (Python 3.12, Windows — full suite, no deselection)
         # The Windows job stages the real supported runtime (CPython 3.12 +
         # DPAPI-backed CredentialStore), so the tests that are deselected on
-        # Linux must pass here before anything is packaged.
+        # Linux must pass here before anything is packaged. Full suite: the
+        # whole tests/ tree gates the release, not just tests/collie.
         if: runner.os == 'Windows'
         shell: bash
         working-directory: collie-core
         run: |
           set -o pipefail
-          .venv/Scripts/python -m pytest tests/collie -q
+          .venv/Scripts/python -m pytest tests -q
 
       - name: Write build provenance (requires a clean tree)
         run: npm run provenance:write

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -754,6 +754,16 @@ class CollieIPCServer:
             except Exception:
                 logger.exception("Failed to delete session files for {}", conv_id)
         self._prune_conversation_media(conv_id)
+        # Drop the "Your things" index for this conversation (metadata only —
+        # user deliverables stay on disk). Mirrors the _cmd_list_things fallback
+        # so a server without an injected store still cleans up.
+        try:
+            from collie_core.things.store import ThingStore
+
+            store = self._thing_store if self._thing_store is not None else ThingStore()
+            store.delete(conv_id)
+        except Exception:
+            logger.exception("Failed to delete thing index for {}", conv_id)
         self.db.delete_conversation(conv_id)
         return {"deleted": True}
 

--- a/collie-core/collie_core/things/store.py
+++ b/collie-core/collie_core/things/store.py
@@ -85,6 +85,32 @@ class ThingStore:
         """All things for a conversation, newest first (empty for unknown)."""
         return self._load(conversation_id)
 
+    def get(
+        self, conversation_id: str, thing_id: str
+    ) -> ThingRecord | None:
+        """One registered thing by id, or ``None``. Safe for unknown ids."""
+        for record in self._load(conversation_id):
+            if record.get("id") == thing_id:
+                return record
+        return None
+
+    def delete(self, conversation_id: str) -> bool:
+        """Drop the whole thing index for a conversation.
+
+        Metadata-only: the deliverables themselves stay on disk (they are
+        the user's files — Collie never deletes them), and deleting a
+        conversation must not make them unreachable by path. Returns True
+        when an index file existed and was removed.
+        """
+        path = self._index_path(conversation_id)
+        if not path.exists():
+            return False
+        try:
+            path.unlink()
+        except OSError:
+            return False
+        return True
+
     # -- internals ---------------------------------------------------------
 
     def _index_path(self, conversation_id: str) -> Path:

--- a/collie-core/tests/collie/test_gardener_mvp.py
+++ b/collie-core/tests/collie/test_gardener_mvp.py
@@ -16,6 +16,7 @@ Covers ``collie_core/gardener/`` against seeded telemetry rows:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -56,14 +57,23 @@ def workspace(tmp_path: Path) -> Path:
     return ws
 
 
+def _days_ago(days: int) -> str:
+    """ISO timestamp ``days`` days ago (UTC) — keeps seeds inside Gardener's
+    default 14-day evidence window no matter when the suite is run."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(
+        timespec="seconds"
+    )
+
+
 def _seed_turn(db: CollieDB, turn_id: str, status: str = "ok", **extra: Any) -> None:
+    started_at = extra.pop("started_at", _days_ago(1))
     db.record_turn_event(
         turn_id=turn_id,
         conversation_id=extra.pop("conversation_id", "conv-1"),
         turn_kind="chat",
         status=status,
-        started_at=extra.pop("started_at", "2026-07-25T10:00:00"),
-        finished_at="2026-07-25T10:00:30",
+        started_at=started_at,
+        finished_at=extra.pop("finished_at", started_at),
         **extra,
     )
 
@@ -75,8 +85,9 @@ def _seed_tool(
     tool_name: str,
     status: str = "ok",
     error_message: str | None = None,
-    started_at: str = "2026-07-25T10:00:05",
+    started_at: str | None = None,
 ) -> None:
+    started_at = started_at or _days_ago(1)
     db.record_tool_event(
         tool_id=tool_id,
         turn_id=turn_id,
@@ -84,7 +95,7 @@ def _seed_tool(
         status=status,
         error_message=error_message,
         started_at=started_at,
-        finished_at="2026-07-25T10:00:10",
+        finished_at=started_at,
     )
 
 
@@ -164,8 +175,8 @@ def test_recent_failures_counts_and_samples(db: CollieDB) -> None:
 
 def test_recent_failures_respects_since_window(db: CollieDB) -> None:
     _seed_turn(db, "t1")
-    _seed_tool(db, "old", "t1", "web_fetch", status="error", started_at="2026-06-01T10:00:05")
-    failures = recent_failures(db, since="2026-07-01T00:00:00")
+    _seed_tool(db, "old", "t1", "web_fetch", status="error", started_at=_days_ago(30))
+    failures = recent_failures(db, since=_days_ago(15))
     assert failures == []
 
 

--- a/collie-core/tests/collie/test_ipc.py
+++ b/collie-core/tests/collie/test_ipc.py
@@ -1213,6 +1213,21 @@ async def test_delete_conversation_cancels_turn_and_cleans_related_rows(
         action="web_fetch", resource="http://x", risk="read",
         display={"url": "http://x"}, conversation_id=conv_id,
     )
+    # A "Your things" index exists for this conversation (the default store
+    # resolves under COLLIE_HOME) — deletion must remove it.
+    from collie_core.things.store import ThingStore
+
+    thing_store = ThingStore()
+    thing_store.register(
+        conversation_id=conv_id,
+        artifact_id="th_doomed",
+        title="Doomed flyer",
+        kind="document",
+        path=str(home / "flyer.md"),
+        size_bytes=10,
+        created_at=1720000000.0,
+    )
+    assert (thing_store.root / f"{conv_id}.json").exists()
 
     cancelled: list[str] = []
 
@@ -1246,6 +1261,9 @@ async def test_delete_conversation_cancels_turn_and_cleans_related_rows(
         # The runtime deleter was invoked for the conversation session.
         assert any(f"session:{conv_id}" in item or item == f"collie:{conv_id}"
                    for item in session_files)
+        # The "Your things" index is gone with the conversation (metadata
+        # only — the user's deliverable file stays on disk).
+        assert not (thing_store.root / f"{conv_id}.json").exists()
         # The in-flight task slot was released.
         assert conv_id not in srv._chat_tasks
         await ws.close()

--- a/collie-core/tests/collie/test_things_store.py
+++ b/collie-core/tests/collie/test_things_store.py
@@ -103,3 +103,30 @@ def test_corrupt_index_file_is_treated_as_empty(tmp_path: Path) -> None:
     assert store.list("conv-1") == []
     store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
     assert store.list("conv-1")[0]["id"] == "th_a"
+
+
+def test_get_returns_one_record_or_none(store: ThingStore) -> None:
+    store.register(conversation_id="conv-1", artifact_id="th_a", **RECORD_KW)
+    store.register(conversation_id="conv-1", artifact_id="th_b", **{**RECORD_KW, "title": "Second"})
+
+    second = store.get("conv-1", "th_b")
+    assert second is not None
+    assert second["title"] == "Second"
+    assert store.get("conv-1", "th_ghost") is None
+    assert store.get("conv-other", "th_a") is None
+
+
+def test_delete_removes_index_but_keeps_deliverables(store: ThingStore, tmp_path: Path) -> None:
+    deliverable = tmp_path / "flyer.png"
+    deliverable.write_bytes(b"png")
+    store.register(conversation_id="conv-1", artifact_id="th_a", **{**RECORD_KW, "path": str(deliverable)})
+
+    assert store.delete("conv-1") is True
+    assert store.list("conv-1") == []
+    assert not (store.root / "conv-1.json").exists()
+    # The user's file is untouched.
+    assert deliverable.exists()
+    # Other conversations are unaffected.
+    store.register(conversation_id="conv-2", artifact_id="th_b", **RECORD_KW)
+    assert store.delete("conv-1") is False  # already gone
+    assert store.list("conv-2")[0]["id"] == "th_b"

--- a/collie-ui/scripts/verify-ui-ux.cjs
+++ b/collie-ui/scripts/verify-ui-ux.cjs
@@ -158,11 +158,6 @@ async function main() {
   await command('Log.enable')
   await command('Page.enable')
 
-  if (new URL(page.url).searchParams.has('preview')) {
-    await command('Page.reload', { ignoreCache: true })
-    await waitUntil(`Boolean(document.querySelector('body'))`)
-  }
-
   const { core, ipcProbe } = await evaluate(`(async () => {
     const { token, ...safeCore } = await window.collie.coreState()
     const ipcProbe = await new Promise((resolveProbe) => {
@@ -196,9 +191,13 @@ async function main() {
     `Boolean(document.querySelector('nav[aria-label="Primary navigation"]'))`
   )
   if (!hasApp) {
-    const previewUrl = new URL(page.url)
-    previewUrl.searchParams.set('preview', '1')
-    await command('Page.navigate', { url: previewUrl.toString() })
+    // Seed the preview flag in sessionStorage, then navigate to the SAME URL.
+    // Never a ?preview=1 query string: renderer security treats any
+    // query-string URL as untrusted (renderer-security.test.ts), which would
+    // break IPC auth and strand the app on "Checking Telegram…".
+    // sessionStorage survives navigation and keeps the trusted URL untouched.
+    await evaluate(`sessionStorage.setItem('collie.ui-ux-preview', '1')`)
+    await command('Page.navigate', { url: page.url })
     for (let attempt = 0; attempt < 60; attempt += 1) {
       const ready = await evaluate(
         `Boolean(document.querySelector('nav[aria-label="Primary navigation"]'))`

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -440,12 +440,14 @@ function registerIpc(): void {
     activeWork.update(clampActiveWork(snapshot))
     return true
   })
-  handle('collie:thing-read', (rawPath: string) => thingRead(rawPath))
-  handle('collie:thing-open', (rawPath: string) => thingOpen(rawPath))
-  handle('collie:thing-show-in-folder', (rawPath: string) => thingShowInFolder(rawPath))
-  handle('collie:thing-save-copy', (rawPath: string, title: string) =>
-    thingSaveCopy(rawPath, title)
-  )
+  handle('collie:thing-read', (conversationId: string, thingId: string) =>
+    thingRead(conversationId, thingId))
+  handle('collie:thing-open', (conversationId: string, thingId: string) =>
+    thingOpen(conversationId, thingId))
+  handle('collie:thing-show-in-folder', (conversationId: string, thingId: string) =>
+    thingShowInFolder(conversationId, thingId))
+  handle('collie:thing-save-copy', (conversationId: string, thingId: string) =>
+    thingSaveCopy(conversationId, thingId))
 }
 
 function clampActiveWork(snapshot: ActiveWorkSnapshot): ActiveWorkSnapshot {

--- a/collie-ui/src/main/things-files.test.ts
+++ b/collie-ui/src/main/things-files.test.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testState = vi.hoisted(() => ({
+  home: '',
+  openPathResult: '',
+  openPathCalls: [] as string[],
+  showItemCalls: [] as string[],
+  saveDialogResult: { canceled: true, filePath: '' }
+}))
+
+vi.mock('electron', () => ({
+  dialog: {
+    showSaveDialog: vi.fn(async () => testState.saveDialogResult)
+  },
+  shell: {
+    openPath: vi.fn(async (path: string) => {
+      testState.openPathCalls.push(path)
+      return testState.openPathResult
+    }),
+    showItemInFolder: vi.fn((path: string) => {
+      testState.showItemCalls.push(path)
+    })
+  }
+}))
+
+import {
+  thingOpen,
+  thingRead,
+  thingSaveCopy,
+  thingShowInFolder
+} from './things-files'
+
+function writeIndex(conversationId: string, records: unknown[]): void {
+  const dir = join(testState.home, 'things')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, `${conversationId}.json`), JSON.stringify({ things: records }), 'utf-8')
+}
+
+function record(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'th_a',
+    title: 'Dog walk flyer',
+    kind: 'document',
+    path: '',
+    size_bytes: 2048,
+    created_at: 1_720_000_000,
+    status: 'new',
+    version: 1,
+    ...overrides
+  }
+}
+
+describe('things-files (trusted-ID boundary)', () => {
+  let workspaceFile: string
+  let projectDir: string
+  let projectFile: string
+
+  beforeEach(() => {
+    testState.home = mkdtempSync(join(tmpdir(), 'collie-things-'))
+    process.env.COLLIE_HOME = testState.home
+    writeFileSync(join(testState.home, 'workspace.md'), '# Workspace thing', 'utf-8')
+    workspaceFile = join(testState.home, 'workspace.md')
+    // A deliverable in a user-approved project folder, OUTSIDE COLLIE_HOME.
+    projectDir = mkdtempSync(join(tmpdir(), 'collie-project-'))
+    projectFile = join(projectDir, 'project-notes.md')
+    writeFileSync(projectFile, '# Project notes', 'utf-8')
+    testState.openPathResult = ''
+    testState.openPathCalls = []
+    testState.showItemCalls = []
+    testState.saveDialogResult = { canceled: true, filePath: '' }
+  })
+
+  afterEach(() => {
+    delete process.env.COLLIE_HOME
+    rmSync(testState.home, { recursive: true, force: true })
+    if (projectDir) rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('opens the registered path, not a renderer-supplied one', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
+    // A forged path argument is ignored — the id decides.
+    const result = await thingOpen('conv-1', 'th_a')
+    expect(result).toBe('')
+    expect(testState.openPathCalls).toEqual([workspaceFile])
+  })
+
+  it('surfaces OS open errors instead of swallowing them', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
+    testState.openPathResult = 'The file is in use'
+    const result = await thingOpen('conv-1', 'th_a')
+    expect(result).toBe('The file is in use')
+  })
+
+  it('rejects unknown things and unknown conversations', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
+    await expect(thingOpen('conv-1', 'th_ghost')).rejects.toThrow('no longer registered')
+    await expect(thingOpen('conv-other', 'th_a')).rejects.toThrow('no longer registered')
+  })
+
+  it('rejects unsafe conversation ids (no path traversal)', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
+    await expect(thingOpen('../../etc', 'th_a')).rejects.toThrow('Not a valid conversation')
+  })
+
+  it('rejects a registered thing whose file no longer exists', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', path: join(testState.home, 'gone.md') })])
+    await expect(thingOpen('conv-1', 'th_a')).rejects.toThrow()
+  })
+
+  it('previews text for registered things inside or outside COLLIE_HOME', async () => {
+    writeIndex('conv-1', [
+      record({ id: 'th_ws', path: workspaceFile }),
+      record({ id: 'th_project', path: projectFile })
+    ])
+    const inside = await thingRead('conv-1', 'th_ws')
+    expect(inside.kind).toBe('text')
+    expect(inside.text).toContain('Workspace')
+
+    // Previously blocked: registered project-folder deliverables now preview.
+    const outside = await thingRead('conv-1', 'th_project')
+    expect(outside.kind).toBe('text')
+    expect(outside.text).toContain('Project notes')
+  })
+
+  it('previews images as data URLs', async () => {
+    const png = join(testState.home, 'flyer.png')
+    writeFileSync(png, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    writeIndex('conv-1', [record({ id: 'th_png', path: png, kind: 'image' })])
+    const result = await thingRead('conv-1', 'th_png')
+    expect(result.kind).toBe('image')
+    expect(result.dataUrl).toMatch(/^data:image\/png;base64,/)
+  })
+
+  it('shows the registered file in the folder', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
+    await thingShowInFolder('conv-1', 'th_a')
+    expect(testState.showItemCalls).toEqual([workspaceFile])
+  })
+
+  it('save-copy defaults to the record title and copies the registered file', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', title: 'Walk flyer', path: workspaceFile })])
+    testState.saveDialogResult = { canceled: false, filePath: join(testState.home, 'copied.md') }
+    const result = await thingSaveCopy('conv-1', 'th_a')
+    expect(result.saved).toBe(true)
+    expect(result.path).toBe(join(testState.home, 'copied.md'))
+    expect(testState.showItemCalls).toEqual([])
+  })
+
+  it('save-copy cancel returns saved:false without copying', async () => {
+    writeIndex('conv-1', [record({ id: 'th_a', title: 'Walk flyer', path: workspaceFile })])
+    testState.saveDialogResult = { canceled: true, filePath: '' }
+    const result = await thingSaveCopy('conv-1', 'th_a')
+    expect(result).toEqual({ saved: false })
+  })
+})

--- a/collie-ui/src/main/things-files.ts
+++ b/collie-ui/src/main/things-files.ts
@@ -1,23 +1,30 @@
 /**
  * Main-process file operations for the "Your things" panel.
  *
- * Thing paths travel from the core's ThingStore (validated workspace/media
- * scope at registration time) through the renderer to these handlers —
- * the panel never renders a path, it only asks for Open / Save a copy… /
- * Show in folder / in-panel preview.
+ * Trust boundary: the renderer never supplies a filesystem path. It asks for
+ * a thing by (conversation_id, thing_id); the main process resolves the path
+ * from the persisted ThingStore index under COLLIE_HOME — the same index the
+ * core writes (`~/.collie/things/<conversation_id>.json`). A compromised
+ * renderer can therefore only open / preview / copy files that Collie itself
+ * registered, never arbitrary paths.
  *
- * `read` (preview) is deliberately restricted to files inside the Collie
- * home tree (workspace + media + things indexes) — a compromised renderer
- * must not be able to exfiltrate arbitrary files through the preview API.
- * Open / Show-in-folder are user-initiated OS actions and accept any path
- * the core registered, exactly like the existing `collie:open-external`.
+ * `read` (preview) is authorized purely by the registered record, so things
+ * saved from user-approved project folders preview exactly like
+ * workspace-made ones. Open / Show-in-folder are user-initiated OS actions on
+ * that same registered path, mirroring the existing `collie:open-external`
+ * posture.
  */
 import { dialog, shell } from 'electron'
-import { basename, extname, isAbsolute, join, sep } from 'path'
+import { basename, extname, isAbsolute, join } from 'path'
 import { homedir } from 'os'
+import { readFileSync } from 'fs'
 import { copyFile, readFile, realpath, stat } from 'fs/promises'
 
 const PREVIEW_MAX_BYTES = 8 * 1024 * 1024
+
+// Mirrors the core's ThingStore._SAFE_CONVERSATION_ID — a conversation id can
+// never smuggle path separators into the index filename.
+const SAFE_CONVERSATION_ID = /^[A-Za-z0-9_-]{1,128}$/
 
 const IMAGE_MIME: Record<string, string> = {
   '.png': 'image/png',
@@ -38,19 +45,64 @@ function collieHomeDir(): string {
   return process.env.COLLIE_HOME || join(homedir(), '.collie')
 }
 
-async function resolveThingPath(raw: string): Promise<string> {
-  if (typeof raw !== 'string' || !raw.trim() || !isAbsolute(raw)) {
-    throw new Error('Not a valid file path.')
+/** One record of the on-disk ThingStore index (subset of the core's shape). */
+interface ThingRecord {
+  id?: string
+  title?: string
+  kind?: string
+  path?: string
+  size_bytes?: number
+  created_at?: number | string
+  status?: string
+  version?: number
+}
+
+/**
+ * Resolve a registered thing record from the trusted on-disk index.
+ * Rejects unknown conversations/things, so renderer-supplied ids can only
+ * select from records Collie actually wrote.
+ */
+function loadThingRecord(conversationId: string, thingId: string): ThingRecord {
+  if (typeof conversationId !== 'string' || !SAFE_CONVERSATION_ID.test(conversationId)) {
+    throw new Error('Not a valid conversation.')
+  }
+  if (typeof thingId !== 'string' || !thingId.trim()) {
+    throw new Error('Not a valid thing.')
+  }
+  const indexPath = join(collieHomeDir(), 'things', `${conversationId}.json`)
+  let payload: unknown
+  try {
+    payload = JSON.parse(readFileSync(indexPath, 'utf-8'))
+  } catch {
+    throw new Error('That thing is no longer registered.')
+  }
+  const records =
+    payload && typeof payload === 'object' && Array.isArray((payload as { things?: unknown }).things)
+      ? ((payload as { things: ThingRecord[] }).things)
+      : []
+  const record = records.find((entry) => entry && entry.id === thingId)
+  if (!record || typeof record.path !== 'string' || !record.path.trim()) {
+    throw new Error('That thing is no longer registered.')
+  }
+  return record
+}
+
+/** Resolve a registered thing to a real, existing file on disk. */
+async function resolveRegisteredPath(
+  conversationId: string,
+  thingId: string
+): Promise<string> {
+  const record = loadThingRecord(conversationId, thingId)
+  const raw = record.path as string
+  if (!isAbsolute(raw)) {
+    throw new Error('That thing has an invalid file path.')
   }
   const resolved = await realpath(raw)
   const stats = await stat(resolved)
-  if (!stats.isFile()) throw new Error('Not a file.')
+  if (!stats.isFile()) {
+    throw new Error('That thing is not a file anymore.')
+  }
   return resolved
-}
-
-function insideCollieHome(resolved: string): boolean {
-  const home = join(collieHomeDir()) + sep
-  return resolved.startsWith(home)
 }
 
 export interface ThingReadResult {
@@ -59,11 +111,11 @@ export interface ThingReadResult {
   dataUrl?: string
 }
 
-export async function thingRead(rawPath: string): Promise<ThingReadResult> {
-  const resolved = await resolveThingPath(rawPath)
-  if (!insideCollieHome(resolved)) {
-    throw new Error('Preview is only available for files Collie made in its workspace.')
-  }
+export async function thingRead(
+  conversationId: string,
+  thingId: string
+): Promise<ThingReadResult> {
+  const resolved = await resolveRegisteredPath(conversationId, thingId)
   const stats = await stat(resolved)
   if (stats.size > PREVIEW_MAX_BYTES) {
     throw new Error('That file is too large to preview here — use Open instead.')
@@ -81,14 +133,20 @@ export async function thingRead(rawPath: string): Promise<ThingReadResult> {
   throw new Error('No in-panel preview for this file type — use Open instead.')
 }
 
-export async function thingOpen(rawPath: string): Promise<string> {
-  const resolved = await resolveThingPath(rawPath)
+export async function thingOpen(
+  conversationId: string,
+  thingId: string
+): Promise<string> {
+  const resolved = await resolveRegisteredPath(conversationId, thingId)
   // Returns an error message string on failure, '' on success.
   return shell.openPath(resolved)
 }
 
-export async function thingShowInFolder(rawPath: string): Promise<void> {
-  const resolved = await resolveThingPath(rawPath)
+export async function thingShowInFolder(
+  conversationId: string,
+  thingId: string
+): Promise<void> {
+  const resolved = await resolveRegisteredPath(conversationId, thingId)
   shell.showItemInFolder(resolved)
 }
 
@@ -107,13 +165,14 @@ export interface ThingSaveCopyResult {
 }
 
 export async function thingSaveCopy(
-  rawPath: string,
-  title: string
+  conversationId: string,
+  thingId: string
 ): Promise<ThingSaveCopyResult> {
-  const resolved = await resolveThingPath(rawPath)
+  const record = loadThingRecord(conversationId, thingId)
+  const resolved = await resolveRegisteredPath(conversationId, thingId)
   const options = {
     title: 'Save a copy…',
-    defaultPath: join(homedir(), 'Documents', safeBaseName(resolved, title))
+    defaultPath: join(homedir(), 'Documents', safeBaseName(resolved, record.title || ''))
   }
   const result = await dialog.showSaveDialog(options)
   if (result.canceled || !result.filePath) return { saved: false }

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -63,17 +63,17 @@ const api = {
     ipcRenderer.invoke('collie:pick-file-access-folders'),
   openExternal: (url: string): Promise<void> =>
     ipcRenderer.invoke('collie:open-external', url),
-  thingRead: (path: string): Promise<{ kind: 'text' | 'image'; text?: string; dataUrl?: string }> =>
-    ipcRenderer.invoke('collie:thing-read', path),
-  thingOpen: (path: string): Promise<string> =>
-    ipcRenderer.invoke('collie:thing-open', path),
-  thingShowInFolder: (path: string): Promise<void> =>
-    ipcRenderer.invoke('collie:thing-show-in-folder', path),
+  thingRead: (conversationId: string, thingId: string): Promise<{ kind: 'text' | 'image'; text?: string; dataUrl?: string }> =>
+    ipcRenderer.invoke('collie:thing-read', conversationId, thingId),
+  thingOpen: (conversationId: string, thingId: string): Promise<string> =>
+    ipcRenderer.invoke('collie:thing-open', conversationId, thingId),
+  thingShowInFolder: (conversationId: string, thingId: string): Promise<void> =>
+    ipcRenderer.invoke('collie:thing-show-in-folder', conversationId, thingId),
   thingSaveCopy: (
-    path: string,
-    title: string
+    conversationId: string,
+    thingId: string
   ): Promise<{ saved: boolean; path?: string }> =>
-    ipcRenderer.invoke('collie:thing-save-copy', path, title),
+    ipcRenderer.invoke('collie:thing-save-copy', conversationId, thingId),
   showWindow: (): Promise<void> =>
     ipcRenderer.invoke('collie:show-window'),
   petCommand: (command: string): Promise<boolean> =>

--- a/collie-ui/src/renderer/src/App.tsx
+++ b/collie-ui/src/renderer/src/App.tsx
@@ -80,7 +80,12 @@ export default function App(): React.JSX.Element {
       }
       if (cancelled) return
       collieClient.connect()
-      if (new URLSearchParams(window.location.search).has('preview')) {
+      // The UI-verification preview flag lives in sessionStorage, NOT the URL:
+      // renderer security treats any query-string URL as untrusted (see
+      // renderer-security.test.ts), so a ?preview=1 URL would break IPC auth.
+      // sessionStorage is renderer-side state that survives navigation and
+      // keeps the trusted URL untouched.
+      if (sessionStorage.getItem('collie.ui-ux-preview') === '1') {
         setScreen('app')
         return
       }

--- a/collie-ui/src/renderer/src/components/things/ThingPanel.tsx
+++ b/collie-ui/src/renderer/src/components/things/ThingPanel.tsx
@@ -8,6 +8,7 @@ import ThingPreview from './ThingPreview'
 interface Props {
   things: Thing[]
   unseenIds: Set<string>
+  conversationId: string
   onClose: () => void
   onOpen: (thing: Thing) => void
   onSaveCopy: (thing: Thing) => void
@@ -21,6 +22,7 @@ interface Props {
 export default function ThingPanel({
   things,
   unseenIds,
+  conversationId,
   onClose,
   onOpen,
   onSaveCopy,
@@ -59,7 +61,7 @@ export default function ThingPanel({
       </header>
 
       {selected ? (
-        <ThingPreview thing={selected} onOpen={onOpen} />
+        <ThingPreview conversationId={conversationId} thing={selected} onOpen={onOpen} />
       ) : things.length === 0 ? (
         <div className="things-panel-empty">{t('things.empty')}</div>
       ) : (

--- a/collie-ui/src/renderer/src/components/things/ThingPreview.tsx
+++ b/collie-ui/src/renderer/src/components/things/ThingPreview.tsx
@@ -6,6 +6,7 @@ import MarkdownContent from '../MarkdownContent'
 
 interface Props {
   thing: Thing
+  conversationId: string
   onOpen: (thing: Thing) => void
 }
 
@@ -16,7 +17,7 @@ type PreviewState =
   | { phase: 'image'; dataUrl: string }
 
 /** In-panel preview for a thing: markdown/text or image, else Open fallback. */
-export default function ThingPreview({ thing, onOpen }: Props): React.JSX.Element {
+export default function ThingPreview({ thing, conversationId, onOpen }: Props): React.JSX.Element {
   const t = useT()
   const [state, setState] = useState<PreviewState>({ phase: 'loading' })
 
@@ -24,7 +25,7 @@ export default function ThingPreview({ thing, onOpen }: Props): React.JSX.Elemen
     let cancelled = false
     setState({ phase: 'loading' })
     window.collie
-      .thingRead(thing.path)
+      .thingRead(conversationId, thing.id)
       .then((result) => {
         if (cancelled) return
         if (result.kind === 'image' && result.dataUrl) {

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -373,15 +373,41 @@ export default function ChatScreen({
   }, [])
 
   const handleThingOpen = useCallback((thing: Thing): void => {
-    void window.collie.thingOpen(thing.path)
+    const conversationId = activeIdRef.current
+    if (!conversationId) return
+    window.collie
+      .thingOpen(conversationId, thing.id)
+      .then((errorMessage) => {
+        if (errorMessage) setErrorText(`I could not open "${thing.title}": ${errorMessage}`)
+      })
+      .catch((error: unknown) => {
+        setErrorText(error instanceof Error ? error.message : `I could not open "${thing.title}".`)
+      })
   }, [])
 
   const handleThingShowInFolder = useCallback((thing: Thing): void => {
-    void window.collie.thingShowInFolder(thing.path)
+    const conversationId = activeIdRef.current
+    if (!conversationId) return
+    window.collie
+      .thingShowInFolder(conversationId, thing.id)
+      .catch((error: unknown) => {
+        setErrorText(error instanceof Error ? error.message : `I could not reveal "${thing.title}".`)
+      })
   }, [])
 
   const handleThingSaveCopy = useCallback((thing: Thing): void => {
-    void window.collie.thingSaveCopy(thing.path, thing.title).catch(() => undefined)
+    const conversationId = activeIdRef.current
+    if (!conversationId) return
+    window.collie
+      .thingSaveCopy(conversationId, thing.id)
+      .then((result) => {
+        // { saved: false } means the user cancelled the save dialog — the
+        // dialog itself is the feedback, so only failures need surfacing.
+        if (!result.saved) return
+      })
+      .catch((error: unknown) => {
+        setErrorText(error instanceof Error ? error.message : `I could not save a copy of "${thing.title}".`)
+      })
   }, [])
 
   useEffect(() => () => {
@@ -944,7 +970,7 @@ export default function ChatScreen({
     async (id: string) => {
       const title =
         conversations.find((item) => item.id === id)?.title || 'this conversation'
-      if (!window.confirm(`Delete "${title}"? This removes it and its files.`)) return
+      if (!window.confirm(`Delete "${title}"? The conversation and its things are removed from Collie — the files stay on your computer.`)) return
       try {
         await collieClient.deleteConversation(id)
       } catch {
@@ -1166,6 +1192,7 @@ export default function ChatScreen({
           <ThingPanel
             things={things}
             unseenIds={thingsUnseen}
+            conversationId={activeId ?? ''}
             onClose={closeThingsPanel}
             onOpen={handleThingOpen}
             onSaveCopy={handleThingSaveCopy}

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -13,8 +13,8 @@
 
 - Core Python files: **512**
 - Core Python test files: **232**
-- Desktop TypeScript/TSX files: **147**
-- Desktop test files: **51**
+- Desktop TypeScript/TSX files: **154**
+- Desktop test files: **52**
 - Active Markdown docs: **28**
 - Archived Markdown docs: **0**
 

--- a/docs/product/features/things-panel.md
+++ b/docs/product/features/things-panel.md
@@ -1,7 +1,7 @@
 # Collie "Your things" panel
 
-**Status:** backend shipped (PR #39); desktop UI follow-up
-**Date:** 2026-08-10
+**Status:** shipped (backend PR #39; desktop UI PR #40)
+**Date:** 2026-08-11
 
 ## Objective
 
@@ -13,8 +13,9 @@ stays the timeline; the panel is the home for what Collie makes.
 
 Normie vocabulary is a hard rule: the word "artifact" is internal-only.
 Users see **things** ("it's in Your things"), never file paths, extensions,
-or filenames. Paths travel as data to the Electron main process for
-Open / Save a copy… / Show in folder — never rendered.
+or filenames. The renderer never handles filesystem paths: it sends
+`(conversation_id, thing_id)` over IPC and the Electron main process resolves
+the path from the trusted on-disk index (see Frontend below).
 
 ## UX rules (design sketch, 2026-08-10)
 
@@ -26,8 +27,7 @@ Open / Save a copy… / Show in folder — never rendered.
 - Panel is per-chat: "This chat | All chats" filter (All = later milestone
   with a sidebar "Things" tab).
 - Card: thumbnail/icon · human title · type · size · time · new-dot until
-  viewed · hover Open + ⋮ (Open, Save a copy… → Documents, Show in folder,
-  Add to chat, Remove from your things — soft delete, recoverable in chat).
+  viewed · hover Open + ⋮ (Open, Save a copy… → Documents, Show in folder).
 - Deliverables only: the model declares "this is a deliverable" by calling
   the `save_thing` tool. Temporary working files never appear.
 - Revisions replace the card; version history = later milestone.
@@ -45,20 +45,28 @@ Open / Save a copy… / Show in folder — never rendered.
   nothing leaves the device).
 - `ThingStore` (collie_core/things/store.py) — JSON-per-conversation index
   under `~/.collie/things/<conv>.json`; atomic writes, newest-first,
-  upsert-by-id. No SQLite.
+  upsert-by-id, per-conversation `delete` (metadata only — user files stay).
+  No SQLite.
 - Runtime: `_consume_outbound` routes ArtifactEvent to the desktop as an
   IPC `artifact` broadcast; messengers keep the text fallback.
 
-## Frontend (follow-up PR)
+## Frontend (shipped, PR #40)
 
-ipc `artifact` event in the CollieEvent union, `lib/things.ts` fold,
-`ThingsPanel` / `ThingCard` / `ThingMenu` / `ThingsToggle` /
-`ThingInlineCard` / `ThingPreview` components, ChatScreen `case 'artifact'`,
-main-process handlers (`thing:open`, `thing:showInFolder`,
-`thing:saveCopy`), hydration via a `things.list` IPC read, all copy in
-`lib/locales/en.ts`.
+- `ThingPanel` / `ThingCard` / `ThingPreview` / `ThingsToggle` /
+  `thingMeta` components, ChatScreen `case 'artifact'`, hydration via the
+  `list_things` IPC read, all copy in `lib/locales/en.ts`.
+- Main-process handlers (`collie:thing-open`, `collie:thing-show-in-folder`,
+  `collie:thing-save-copy`, `collie:thing-read`) in
+  `src/main/things-files.ts` — **trusted-ID boundary**: the renderer sends
+  only `(conversation_id, thing_id)`; the main process resolves the path from
+  the ThingStore index under `COLLIE_HOME/things/` and rejects unknown
+  conversations/things. Preview is authorized by the registered record, so
+  deliverables saved from user-approved project folders preview like
+  workspace-made ones. Deleting a conversation removes its index; the
+  deliverables stay on disk.
 
 ## Deferred
 
 File tree · diffs · sidebar Things tab · version history · embedded
-doc/sheet viewers · messenger file attachments (text fallback only).
+doc/sheet viewers · messenger file attachments (text fallback only) ·
+"Add to chat" · recoverable "Remove from your things" (soft delete).


### PR DESCRIPTION
## What

Fixes the P2 findings from the Codex review of `c3898c7` (all claims independently re-verified — see commit history):

1. **Green the core CI (was merged red).** `test_gardener_mvp.py` seeded `2026-07-25` timestamps while Gardener only reads the last 14 days — both failing tests reproduced locally, now derive seeds from the current time.
2. **Thing metadata cleanup on delete.** `ThingStore.delete()` + wiring in `_cmd_delete_conversation`; the confirm copy no longer claims "removes it and its files" (deliverables stay on disk).
3. **Trusted-ID thing-file IPC.** Renderer now sends `(conversation_id, thing_id)`; main resolves from the persisted index, rejects unknown/unsafe ids. `shell.openPath` on arbitrary renderer paths is gone. Preview is authorized by the registered record, so project-folder things preview too. Action errors surfaced, not swallowed.
4. **UI verifier no longer breaks renderer security.** `?preview=1` navigation replaced by a sessionStorage flag + same-URL navigation.
5. **Full backend suite gates CI + release.** All four pytest invocations run `tests/` (was `tests/collie` only). Coverage note reconciled (floor is a deliberate 42; full suite measures ~76%).

## Verification

| Check | Result |
| --- | --- |
| Full backend suite (Linux VM, CI deselections) | ✅ 3546 passed, 1 skipped |
| Coverage with full suite | ✅ 76% (floor 42) |
| Ruff | ✅ passed |
| Vitest | ✅ 323/323 (10 new things-files tests) |
| TypeScript typecheck | ✅ passed |
| Production electron-vite build | ✅ passed |
| ThingStore delete + IPC delete tests | ✅ 11 passed |

## Notes

- The openPath finding was real but *documented as deliberate* in `things-files.ts` (preview locked to COLLIE_HOME; open/folder = OS actions). The ID-based lookup is strictly stricter and fixes the preview inconsistency as a bonus.
- The "snapshot stale by 5 Python files" review claim was **wrong** — Python inventory was in sync; only 6 TS files were stale (fixed).
- Coverage floor deliberately left at 42 (headroom policy documented in pyproject); raising to 70 is safe now that the full suite gates (76% measured) — follow-up decision.