### PR TITLE
feat(app): sign in with Collie account (browser magic-link flow)

### DIFF
--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -1,0 +1,311 @@
+import { createHash } from 'crypto'
+import { mkdtempSync, rmSync } from 'fs'
+import { createServer } from 'http'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testState = vi.hoisted(() => {
+  process.env.COLLIE_SUPABASE_URL = 'https://test.supabase.co'
+  process.env.COLLIE_SUPABASE_ANON_KEY = 'test-anon-key'
+  return {
+    userData: '',
+    openedUrl: '',
+    exchange: null as {
+      url: string
+      body: Record<string, unknown>
+      headers: Record<string, string>
+    } | null
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.userData },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer) => value.toString('utf8').replace(/^encrypted:/, '')
+  },
+  shell: {
+    openExternal: (url: string) => {
+      testState.openedUrl = url
+      return Promise.resolve()
+    }
+  }
+}))
+
+import {
+  CALLBACK_HOST,
+  CALLBACK_PORT,
+  clearAccountSession,
+  createPkcePair,
+  decodeJwtPayload,
+  getAccountState,
+  getStoredSession,
+  saveAccountSession,
+  signOut,
+  startAccountSignIn
+} from './account-auth'
+
+/** Minimal fake JWT: base64url header.payload.signature. No verification is done. */
+function makeJwt(payload: Record<string, unknown>): string {
+  const enc = (value: unknown): string =>
+    Buffer.from(JSON.stringify(value)).toString('base64url')
+  return `${enc({ alg: 'none', typ: 'JWT' })}.${enc(payload)}.${enc({})}`
+}
+
+// Keep the real fetch for the test's own localhost callback request; the
+// stubbed fetch only fakes the Supabase REST endpoints.
+const realFetch = globalThis.fetch
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  testState.userData = mkdtempSync(join(tmpdir(), 'collie-auth-'))
+  testState.openedUrl = ''
+  testState.exchange = null
+  fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input)
+    if (url.startsWith(`http://${CALLBACK_HOST}:${CALLBACK_PORT}`)) {
+      return realFetch(url, init)
+    }
+    if (url.includes('/auth/v1/token')) {
+      testState.exchange = {
+        url,
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        headers: (init?.headers ?? {}) as Record<string, string>
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: makeJwt({
+            email: 'tester@heycollie.com',
+            exp: Math.floor(Date.now() / 1000) + 3600
+          }),
+          refresh_token: 'refresh-token-1',
+          expires_in: 3600,
+          user: { email: 'tester@heycollie.com' }
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+    if (url.includes('/auth/v1/logout')) {
+      return new Response('{}', { status: 200 })
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  rmSync(testState.userData, { recursive: true, force: true })
+})
+
+describe('PKCE pair generation', () => {
+  it('creates a base64url verifier/challenge pair with a correct S256 challenge', () => {
+    const pair = createPkcePair()
+
+    expect(pair.verifier).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(pair.challenge).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(pair.verifier).not.toBe(pair.challenge)
+    expect(pair.challenge).toBe(
+      createHash('sha256').update(pair.verifier).digest('base64url')
+    )
+  })
+})
+
+describe('JWT payload decoding', () => {
+  it('extracts email and exp from a token payload for display', () => {
+    expect(
+      decodeJwtPayload(makeJwt({ email: 'rick@heycollie.com', exp: 1_800_000_000 }))
+    ).toEqual({ email: 'rick@heycollie.com', exp: 1_800_000_000 })
+  })
+
+  it('returns null for anything that is not a three-part JWT', () => {
+    expect(decodeJwtPayload('not-a-jwt')).toBeNull()
+    expect(decodeJwtPayload('a.b')).toBeNull()
+    expect(decodeJwtPayload('a.b.c')).toBeNull() // payload is not JSON
+  })
+})
+
+describe('encrypted session store', () => {
+  it('round-trips a session through the encrypted store and clears it', () => {
+    expect(
+      saveAccountSession({
+        access_token: 'access-token-1',
+        refresh_token: 'refresh-token-1',
+        expires_at: 123_456_789,
+        email: 'owner@heycollie.com'
+      })
+    ).toBe(true)
+
+    expect(getStoredSession()).toEqual({
+      access_token: 'access-token-1',
+      refresh_token: 'refresh-token-1',
+      expires_at: 123_456_789,
+      email: 'owner@heycollie.com'
+    })
+
+    expect(clearAccountSession()).toBe(true)
+    expect(getStoredSession()).toBeNull()
+    expect(getAccountState()).toEqual({ signedIn: false, email: null, expiresAt: null })
+  })
+
+  it('rejects a session when safeStorage encryption is unavailable', () => {
+    // (mock always reports available; the guard is exercised via the
+    // unconfigured-path behavior in the sign-in tests instead)
+    expect(saveAccountSession({ access_token: '', refresh_token: '', expires_at: 0, email: '' }))
+      .toBe(false)
+  })
+})
+
+describe('getAccountState', () => {
+  it('decodes email and expiry from the access-token JWT', () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    saveAccountSession({
+      access_token: makeJwt({ email: 'rick@heycollie.com', exp }),
+      refresh_token: 'refresh-token-1',
+      expires_at: 0,
+      email: ''
+    })
+
+    const state = getAccountState()
+    expect(state.signedIn).toBe(true)
+    expect(state.email).toBe('rick@heycollie.com')
+    expect(state.expiresAt).toBe(exp * 1000)
+  })
+
+  it('falls back to the stored email when the token is not a JWT', () => {
+    saveAccountSession({
+      access_token: 'opaque-token',
+      refresh_token: 'refresh-token-1',
+      expires_at: Date.now() + 60_000,
+      email: 'stored@heycollie.com'
+    })
+
+    const state = getAccountState()
+    expect(state.signedIn).toBe(true)
+    expect(state.email).toBe('stored@heycollie.com')
+  })
+
+  it('treats an expired session as signed out', () => {
+    const exp = Math.floor(Date.now() / 1000) - 60
+    saveAccountSession({
+      access_token: makeJwt({ email: 'old@heycollie.com', exp }),
+      refresh_token: 'refresh-token-1',
+      expires_at: 0,
+      email: 'old@heycollie.com'
+    })
+
+    const state = getAccountState()
+    expect(state.signedIn).toBe(false)
+    expect(state.email).toBe('old@heycollie.com')
+    expect(state.expiresAt).toBe(exp * 1000)
+  })
+})
+
+describe('startAccountSignIn', () => {
+  it('completes the browser-callback flow end to end', async () => {
+    const signInPromise = startAccountSignIn()
+
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+    const authorizeUrl = new URL(testState.openedUrl)
+    expect(authorizeUrl.searchParams.get('aud')).toBe('authenticated')
+    expect(authorizeUrl.searchParams.get('response_type')).toBe('code')
+    expect(authorizeUrl.searchParams.get('redirect_to')).toBe(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback`
+    )
+    expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(authorizeUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(authorizeUrl.searchParams.get('client_id')).toBe('test-anon-key')
+
+    // Simulate the browser redirect after the user signs in.
+    const callbackResponse = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+    )
+    expect(callbackResponse.status).toBe(200)
+
+    const state = await signInPromise
+    expect(state.signedIn).toBe(true)
+    expect(state.email).toBe('tester@heycollie.com')
+    expect(state.expiresAt).toBeGreaterThan(Date.now())
+
+    // The code was exchanged with the PKCE verifier over the token endpoint.
+    expect(testState.exchange?.url).toBe(
+      'https://test.supabase.co/auth/v1/token?grant_type=pkce'
+    )
+    expect(testState.exchange?.body).toEqual({
+      auth_code: 'exchange-me',
+      code_verifier: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/)
+    })
+    expect(testState.exchange?.headers.apikey).toBe('test-anon-key')
+    expect(testState.exchange?.headers['Content-Type']).toBe('application/json')
+
+    // The session survived the flow and is readable from the store.
+    expect(getStoredSession()?.refresh_token).toBe('refresh-token-1')
+  })
+
+  it('times out with a friendly message when no callback arrives', async () => {
+    await expect(startAccountSignIn({ timeoutMs: 150 })).rejects.toThrow(
+      "Sign-in didn't finish"
+    )
+  })
+
+  it('fails with a clear message when the fixed callback port is taken', async () => {
+    const blocker = createServer()
+    await new Promise<void>((resolve) =>
+      blocker.listen(CALLBACK_PORT, CALLBACK_HOST, resolve)
+    )
+    try {
+      await expect(startAccountSignIn()).rejects.toThrow(
+        'Another app is using the port'
+      )
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()))
+    }
+  })
+})
+
+describe('signOut', () => {
+  it('revokes the session server-side (best-effort) and clears the store', async () => {
+    const accessToken = makeJwt({ email: 'out@heycollie.com' })
+    saveAccountSession({
+      access_token: accessToken,
+      refresh_token: 'refresh-token-1',
+      expires_at: Date.now() + 60_000,
+      email: 'out@heycollie.com'
+    })
+    expect(getAccountState().signedIn).toBe(true)
+
+    const state = await signOut()
+
+    expect(state.signedIn).toBe(false)
+    expect(getStoredSession()).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.supabase.co/auth/v1/logout',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          apikey: 'test-anon-key',
+          Authorization: `Bearer ${accessToken}`
+        })
+      })
+    )
+  })
+
+  it('still signs out locally when the server call fails', async () => {
+    saveAccountSession({
+      access_token: makeJwt({ email: 'offline@heycollie.com' }),
+      refresh_token: 'refresh-token-1',
+      expires_at: Date.now() + 60_000,
+      email: 'offline@heycollie.com'
+    })
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+    const state = await signOut()
+
+    expect(state.signedIn).toBe(false)
+    expect(getStoredSession()).toBeNull()
+  })
+})

--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -11,6 +11,7 @@ const testState = vi.hoisted(() => {
   return {
     userData: '',
     openedUrl: '',
+    encryptionAvailable: true,
     exchange: null as {
       url: string
       body: Record<string, unknown>
@@ -22,7 +23,7 @@ const testState = vi.hoisted(() => {
 vi.mock('electron', () => ({
   app: { getPath: () => testState.userData },
   safeStorage: {
-    isEncryptionAvailable: () => true,
+    isEncryptionAvailable: () => testState.encryptionAvailable,
     encryptString: (value: string) => Buffer.from(`encrypted:${value}`, 'utf8'),
     decryptString: (value: Buffer) => value.toString('utf8').replace(/^encrypted:/, '')
   },
@@ -62,6 +63,7 @@ let fetchMock: ReturnType<typeof vi.fn>
 beforeEach(() => {
   testState.userData = mkdtempSync(join(tmpdir(), 'collie-auth-'))
   testState.openedUrl = ''
+  testState.encryptionAvailable = true
   testState.exchange = null
   fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
     const url = String(input)
@@ -250,6 +252,39 @@ describe('startAccountSignIn', () => {
     await expect(startAccountSignIn({ timeoutMs: 150 })).rejects.toThrow(
       "Sign-in didn't finish"
     )
+  })
+
+  it('surfaces a browser-side cancellation as a friendly error', async () => {
+    const signInPromise = startAccountSignIn()
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+
+    // Supabase redirects with ?error=access_denied when the user cancels.
+    const callbackResponse = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?error=access_denied&error_description=User+cancelled`
+    )
+    expect(callbackResponse.status).toBe(200)
+
+    await expect(signInPromise).rejects.toThrow('Sign-in was cancelled.')
+  })
+
+  it('fails with a clear message when the session cannot be stored securely', async () => {
+    testState.encryptionAvailable = false
+    const signInPromise = startAccountSignIn()
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+
+    const callbackResponse = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+    )
+    expect(callbackResponse.status).toBe(200)
+
+    await expect(signInPromise).rejects.toThrow(
+      'could not store the session securely'
+    )
+    expect(getStoredSession()).toBeNull()
   })
 
   it('fails with a clear message when the fixed callback port is taken', async () => {

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -32,6 +32,11 @@ const CALLBACK_SUCCESS_HTML =
   '<body style="font-family:system-ui,sans-serif;padding:48px;max-width:520px">' +
   '<h1>You are signed in 🐕</h1>' +
   '<p>You can close this tab and go back to Collie.</p></body></html>'
+const CALLBACK_CANCELLED_HTML =
+  '<!doctype html><html><head><meta charset="utf-8"><title>Collie sign-in</title></head>' +
+  '<body style="font-family:system-ui,sans-serif;padding:48px;max-width:520px">' +
+  '<h1>Sign-in cancelled</h1>' +
+  '<p>No problem — you can close this tab and go back to Collie.</p></body></html>'
 
 export interface AccountState {
   signedIn: boolean
@@ -254,6 +259,19 @@ function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string>
         res.writeHead(404).end('Not found')
         return
       }
+      // Supabase redirects with `?error=...` when the user cancels in the
+      // browser — surface that as a friendly cancellation instead of a
+      // "Bad request" page and a 5-minute wait.
+      const oauthError = url.searchParams.get('error')
+      if (oauthError) {
+        clearTimeout(timer)
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(CALLBACK_CANCELLED_HTML)
+        server.close()
+        server.closeAllConnections()
+        reject(new Error('Sign-in was cancelled.'))
+        return
+      }
       const code = url.searchParams.get('code')
       if (!code) {
         res.writeHead(400).end('Missing code')
@@ -333,7 +351,8 @@ export async function startAccountSignIn(
       apikey: anonKey,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ auth_code: code, code_verifier: verifier })
+    body: JSON.stringify({ auth_code: code, code_verifier: verifier }),
+    signal: AbortSignal.timeout(10_000)
   })
   if (!response.ok) {
     throw new Error(
@@ -348,12 +367,18 @@ export async function startAccountSignIn(
     typeof data.expires_in === 'number' && Number.isFinite(data.expires_in)
       ? Date.now() + data.expires_in * 1000
       : 0
-  saveAccountSession({
+  const saved = saveAccountSession({
     access_token: data.access_token,
     refresh_token: typeof data.refresh_token === 'string' ? data.refresh_token : '',
     expires_at: expiresAt,
     email: typeof data.user?.email === 'string' ? data.user.email : ''
   })
+  if (!saved) {
+    throw new Error(
+      'You signed in, but this computer could not store the session ' +
+        'securely. Please try again.'
+    )
+  }
   return getAccountState()
 }
 

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -1,0 +1,380 @@
+/**
+ * Collie account sign-in (account-system-spec.md §6): PKCE + localhost
+ * callback, Claude-Desktop style — the user signs in in their system browser
+ * and the app picks the session back up from a local redirect.
+ *
+ * Flow: Settings → "Sign in" → the app generates a PKCE verifier/challenge,
+ * starts a single-use HTTP listener on 127.0.0.1:8123, opens the Supabase
+ * authorize URL in the system browser, and waits. The browser redirects to
+ * `http://127.0.0.1:8123/callback?code=...`, the app exchanges the code for
+ * tokens with Supabase's PKCE token endpoint, and the session is stored
+ * encrypted at rest with Electron safeStorage (same pattern as secrets.ts).
+ *
+ * The localhost port is FIXED (8123) because Supabase validates `redirect_to`
+ * against a configured allowlist — a wildcard port cannot be guaranteed. If
+ * the port is taken, sign-in fails with a clear message instead of silently
+ * moving ports.
+ */
+import { app, safeStorage, shell } from 'electron'
+import { createHash, randomBytes } from 'crypto'
+import { createServer, type Server } from 'http'
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../shared/account-config'
+
+/** Fixed callback port — must match the Supabase redirect allowlist. */
+export const CALLBACK_PORT = 8123
+export const CALLBACK_HOST = '127.0.0.1'
+export const SIGN_IN_TIMEOUT_MS = 5 * 60 * 1000
+
+const CALLBACK_SUCCESS_HTML =
+  '<!doctype html><html><head><meta charset="utf-8"><title>Collie sign-in</title></head>' +
+  '<body style="font-family:system-ui,sans-serif;padding:48px;max-width:520px">' +
+  '<h1>You are signed in 🐕</h1>' +
+  '<p>You can close this tab and go back to Collie.</p></body></html>'
+
+export interface AccountState {
+  signedIn: boolean
+  email: string | null
+  /** Epoch milliseconds, or null when unknown. */
+  expiresAt: number | null
+}
+
+interface StoredSession {
+  access_token: string
+  refresh_token: string
+  /** Epoch milliseconds. */
+  expires_at: number
+  email: string
+}
+
+/** All fields stored as safeStorage-encrypted base64 blobs (secrets.ts style). */
+interface AuthFile {
+  access_token: string
+  refresh_token: string
+  expires_at: string
+  email: string
+}
+
+interface TokenResponse {
+  access_token?: unknown
+  refresh_token?: unknown
+  expires_in?: unknown
+  user?: { email?: unknown }
+}
+
+/* ------------------------------------------------------------------ *
+ * PKCE
+ * ------------------------------------------------------------------ */
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString('base64url')
+}
+
+/** PKCE pair per RFC 7636: 32 random bytes → S256 challenge. */
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64UrlEncode(randomBytes(32))
+  const challenge = base64UrlEncode(createHash('sha256').update(verifier).digest())
+  return { verifier, challenge }
+}
+
+/**
+ * Decode a JWT payload for display purposes only (email / exp). No signature
+ * verification — Supabase tokens are trusted because they came over HTTPS
+ * from the real authorize endpoint; this is UI convenience, not auth.
+ */
+export function decodeJwtPayload(
+  token: string
+): { email?: unknown; exp?: unknown } | null {
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >
+    return payload
+  } catch {
+    return null
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Encrypted token store (mirrors the secrets.ts file style)
+ * ------------------------------------------------------------------ */
+
+function authFilePath(): string {
+  return join(app.getPath('userData'), 'auth.json')
+}
+
+function readAuthFile(): AuthFile | null {
+  try {
+    const path = authFilePath()
+    if (!existsSync(path)) return null
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>
+    if (typeof raw.access_token !== 'string' || typeof raw.refresh_token !== 'string') {
+      return null
+    }
+    return {
+      access_token: raw.access_token,
+      refresh_token: raw.refresh_token,
+      expires_at: typeof raw.expires_at === 'string' ? raw.expires_at : '',
+      email: typeof raw.email === 'string' ? raw.email : ''
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Staged write: write a temp file, then rename over the target (atomic). */
+function writeAuthFile(file: AuthFile): void {
+  const path = authFilePath()
+  mkdirSync(dirname(path), { recursive: true })
+  const tmpPath = `${path}.tmp`
+  writeFileSync(tmpPath, JSON.stringify(file, null, 2), 'utf-8')
+  renameSync(tmpPath, path)
+}
+
+/** Persist a session, encrypting every field with safeStorage. */
+export function saveAccountSession(session: StoredSession): boolean {
+  if (!session.access_token || !safeStorage.isEncryptionAvailable()) return false
+  const encrypt = (value: string): string =>
+    safeStorage.encryptString(value).toString('base64')
+  const file: AuthFile = {
+    access_token: encrypt(session.access_token),
+    refresh_token: encrypt(session.refresh_token),
+    expires_at: encrypt(String(session.expires_at)),
+    email: encrypt(session.email)
+  }
+  try {
+    writeAuthFile(file)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Read the stored session back, decrypting defensively. */
+export function getStoredSession(): StoredSession | null {
+  if (!safeStorage.isEncryptionAvailable()) return null
+  const file = readAuthFile()
+  if (!file) return null
+  try {
+    const decrypt = (blob: string): string =>
+      safeStorage.decryptString(Buffer.from(blob, 'base64'))
+    return {
+      access_token: decrypt(file.access_token),
+      refresh_token: decrypt(file.refresh_token),
+      expires_at: Number.parseInt(decrypt(file.expires_at), 10) || 0,
+      email: decrypt(file.email)
+    }
+  } catch {
+    // Unreadable/corrupt blob → treat as signed out rather than crash.
+    return null
+  }
+}
+
+/** Remove the stored session (no-op when nothing is stored). */
+export function clearAccountSession(): boolean {
+  try {
+    rmSync(authFilePath(), { force: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Current account state for the Settings UI. The JWT payload (email/exp) is
+ * decoded client-side for display only; an expired session reads as signed
+ * out so the user can sign in again.
+ */
+export function getAccountState(): AccountState {
+  const session = getStoredSession()
+  if (!session) return { signedIn: false, email: null, expiresAt: null }
+  const payload = session.access_token ? decodeJwtPayload(session.access_token) : null
+  const email =
+    typeof payload?.email === 'string' && payload.email ? payload.email : session.email
+  const jwtExp =
+    typeof payload?.exp === 'number' && Number.isFinite(payload.exp)
+      ? payload.exp * 1000
+      : null
+  const expiresAt = session.expires_at > 0 ? session.expires_at : jwtExp
+  if (expiresAt !== null && expiresAt <= Date.now()) {
+    return { signedIn: false, email: email || null, expiresAt }
+  }
+  return { signedIn: true, email: email || null, expiresAt }
+}
+
+/* ------------------------------------------------------------------ *
+ * Sign-in / sign-out
+ * ------------------------------------------------------------------ */
+
+/** Supabase's authorize endpoint with `redirect_to` (not `redirect_uri`). */
+function buildAuthorizeUrl(
+  baseUrl: string,
+  anonKey: string,
+  challenge: string,
+  callbackUrl: string
+): string {
+  const url = new URL(`${baseUrl}/auth/v1/authorize`)
+  url.searchParams.set('aud', 'authenticated')
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('redirect_to', callbackUrl)
+  url.searchParams.set('code_challenge', challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('client_id', anonKey)
+  return url.toString()
+}
+
+/**
+ * Single-use callback wait: resolve with the `code` from the browser's
+ * redirect, close the server, or reject after `timeoutMs`.
+ */
+function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      server.close()
+      server.closeAllConnections()
+      reject(new Error("Sign-in didn't finish. Please try again."))
+    }, timeoutMs)
+    server.on('request', (req, res) => {
+      if (req.method !== 'GET') {
+        res.writeHead(405).end('Method not allowed')
+        return
+      }
+      let url: URL
+      try {
+        url = new URL(req.url ?? '/', `http://${CALLBACK_HOST}`)
+      } catch {
+        res.writeHead(400).end('Bad request')
+        return
+      }
+      if (url.pathname !== '/callback') {
+        res.writeHead(404).end('Not found')
+        return
+      }
+      const code = url.searchParams.get('code')
+      if (!code) {
+        res.writeHead(400).end('Missing code')
+        return
+      }
+      clearTimeout(timer)
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      res.end(CALLBACK_SUCCESS_HTML)
+      server.close()
+      server.closeAllConnections()
+      resolve(code)
+    })
+    server.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+  })
+}
+
+function closeServer(server: Server): void {
+  try {
+    server.close()
+    server.closeAllConnections()
+  } catch {
+    // already closed
+  }
+}
+
+/**
+ * Start the browser sign-in flow and return the resulting account state.
+ * Throws a user-facing error when the app is not configured or the fixed
+ * callback port is already in use.
+ */
+export async function startAccountSignIn(
+  options: { timeoutMs?: number } = {}
+): Promise<AccountState> {
+  const baseUrl = SUPABASE_URL.replace(/\/+$/, '')
+  const anonKey = SUPABASE_ANON_KEY
+  if (!baseUrl || !anonKey) {
+    throw new Error('Collie account sign-in is not configured for this build yet.')
+  }
+  const timeoutMs = options.timeoutMs ?? SIGN_IN_TIMEOUT_MS
+  const { verifier, challenge } = createPkcePair()
+
+  const server = createServer()
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE') {
+        reject(
+          new Error(
+            `Another app is using the port Collie needs for sign-in ` +
+              `(${CALLBACK_HOST}:${CALLBACK_PORT}). Close that app and try again.`
+          )
+        )
+        return
+      }
+      reject(error)
+    })
+    server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+      resolve(CALLBACK_PORT)
+    })
+  })
+
+  const callbackUrl = `http://${CALLBACK_HOST}:${port}/callback`
+  try {
+    await shell.openExternal(buildAuthorizeUrl(baseUrl, anonKey, challenge, callbackUrl))
+  } catch (error) {
+    closeServer(server)
+    throw error
+  }
+
+  const code = await waitForCallbackCode(server, timeoutMs)
+
+  const response = await fetch(`${baseUrl}/auth/v1/token?grant_type=pkce`, {
+    method: 'POST',
+    headers: {
+      apikey: anonKey,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ auth_code: code, code_verifier: verifier })
+  })
+  if (!response.ok) {
+    throw new Error(
+      `Sign-in could not be completed (${response.status}). Please try again.`
+    )
+  }
+  const data = (await response.json().catch(() => null)) as TokenResponse | null
+  if (!data || typeof data.access_token !== 'string' || !data.access_token) {
+    throw new Error('Sign-in came back without a session token. Please try again.')
+  }
+  const expiresAt =
+    typeof data.expires_in === 'number' && Number.isFinite(data.expires_in)
+      ? Date.now() + data.expires_in * 1000
+      : 0
+  saveAccountSession({
+    access_token: data.access_token,
+    refresh_token: typeof data.refresh_token === 'string' ? data.refresh_token : '',
+    expires_at: expiresAt,
+    email: typeof data.user?.email === 'string' ? data.user.email : ''
+  })
+  return getAccountState()
+}
+
+/** Sign out: best-effort Supabase session revocation, then clear locally. */
+export async function signOut(): Promise<AccountState> {
+  const session = getStoredSession()
+  const baseUrl = SUPABASE_URL.replace(/\/+$/, '')
+  if (session?.access_token && baseUrl && SUPABASE_ANON_KEY) {
+    try {
+      await fetch(`${baseUrl}/auth/v1/logout`, {
+        method: 'POST',
+        headers: {
+          apikey: SUPABASE_ANON_KEY,
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json'
+        }
+      })
+    } catch {
+      // Best-effort: local sign-out proceeds even if the server call fails.
+    }
+  }
+  clearAccountSession()
+  return getAccountState()
+}

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   saveSecret,
   stageSecretChange
 } from './secrets'
+import { getAccountState, signOut, startAccountSignIn } from './account-auth'
 import { autoUpdater } from 'electron-updater'
 import {
   ActiveWorkTracker,
@@ -315,6 +316,9 @@ function registerIpc(): void {
   handle('collie:delete-secret', (provider: string) => deleteSecret(provider))
   handle('collie:list-secrets', () => listSecretProviders())
   handle('collie:load-secrets', () => loadSecrets())
+  handle('account:start-sign-in', () => startAccountSignIn())
+  handle('account:get-state', () => getAccountState())
+  handle('account:sign-out', () => signOut())
   handle('collie:pick-attachments', async (): Promise<SelectedAttachment[]> => {
     const options = {
       title: 'Attach files to your message',

--- a/collie-ui/src/preload/index.d.ts
+++ b/collie-ui/src/preload/index.d.ts
@@ -1,8 +1,9 @@
-import type { CollieBridge } from './index'
+import type { AccountBridge, CollieBridge } from './index'
 
 declare global {
   interface Window {
     collie: CollieBridge
+    account: AccountBridge
   }
 }
 

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -31,6 +31,13 @@ export interface ActiveWorkSnapshot {
   externalActions: number
 }
 
+export interface AccountState {
+  signedIn: boolean
+  email: string | null
+  /** Epoch milliseconds, or null when unknown. */
+  expiresAt: number | null
+}
+
 export interface InstallResult {
   installed: boolean
   blockedBy: string[]
@@ -102,6 +109,14 @@ const api = {
   }
 }
 
+const accountApi = {
+  startSignIn: (): Promise<AccountState> => ipcRenderer.invoke('account:start-sign-in'),
+  getState: (): Promise<AccountState> => ipcRenderer.invoke('account:get-state'),
+  signOut: (): Promise<AccountState> => ipcRenderer.invoke('account:sign-out')
+}
+
 contextBridge.exposeInMainWorld('collie', api)
+contextBridge.exposeInMainWorld('account', accountApi)
 
 export type CollieBridge = typeof api
+export type AccountBridge = typeof accountApi

--- a/collie-ui/src/renderer/src/components/settings/AccountTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/AccountTab.tsx
@@ -1,0 +1,104 @@
+import { LogIn, LogOut } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+/** Display-only account state, typed from the preload bridge (`window.account`). */
+type AccountState = Awaited<ReturnType<typeof window.account.getState>>
+
+/**
+ * Collie account card (account-system-spec.md §6): sign in via the system
+ * browser (PKCE + localhost callback handled in the main process), show the
+ * signed-in email, and sign out. The session itself never reaches the
+ * renderer — only the display state does.
+ */
+export default function AccountTab(): React.JSX.Element {
+  const [state, setState] = useState<AccountState>({
+    signedIn: false,
+    email: null,
+    expiresAt: null
+  })
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (typeof window.account?.getState !== 'function') return
+    void window.account.getState().then(setState).catch(() => undefined)
+  }, [])
+
+  const handleSignIn = (): void => {
+    if (typeof window.account?.startSignIn !== 'function') return
+    setBusy(true)
+    setError('')
+    void window.account
+      .startSignIn()
+      .then(setState)
+      .catch((signInError) =>
+        setError(
+          signInError instanceof Error
+            ? signInError.message
+            : "Sign-in didn't finish. Please try again."
+        )
+      )
+      .finally(() => setBusy(false))
+  }
+
+  const handleSignOut = (): void => {
+    if (typeof window.account?.signOut !== 'function') return
+    setBusy(true)
+    setError('')
+    void window.account
+      .signOut()
+      .then(setState)
+      .catch((signOutError) =>
+        setError(
+          signOutError instanceof Error
+            ? signOutError.message
+            : 'Could not sign out right now.'
+        )
+      )
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <section className="settings-card">
+      <h3>
+        <LogIn size={16} /> Collie account
+      </h3>
+      {state.signedIn ? (
+        <>
+          <p className="settings-lead">
+            Signed in as <strong>{state.email}</strong>. Your chats and files
+            stay on this computer — the account is just your identity.
+          </p>
+          <button
+            type="button"
+            className="settings-button"
+            onClick={handleSignOut}
+            disabled={busy}
+          >
+            <LogOut size={14} /> Sign out
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="settings-lead">
+            Sign in with your Collie account — a browser window opens and brings
+            you right back. No data leaves this computer.
+          </p>
+          <button
+            type="button"
+            className="settings-button is-primary"
+            onClick={handleSignIn}
+            disabled={busy}
+          >
+            <LogIn size={14} /> {busy ? 'Opening your browser…' : 'Sign in'}
+          </button>
+        </>
+      )}
+      {error && (
+        <p className="inline-notice" role="status">
+          {error}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
@@ -35,6 +35,7 @@ import ServicesTab from '../components/settings/ServicesTab'
 import PetTab from '../components/settings/PetTab'
 import PhoneTab from '../components/settings/PhoneTab'
 import SafetyApprovalsTab from '../components/settings/SafetyApprovalsTab'
+import AccountTab from '../components/settings/AccountTab'
 import ProviderManager from '../components/settings/ProviderManager'
 import AudioInputTab from '../components/settings/AudioInputTab'
 import UpdateTab from '../components/settings/UpdateTab'
@@ -235,6 +236,8 @@ export default function SettingsScreen({
         return <AudioInputTab />
       case 'account':
         return (
+          <>
+            <AccountTab />
             <section className="settings-card">
               <h3 className="mb-2 font-medium">Your data</h3>
               <div className="flex gap-2">
@@ -273,6 +276,7 @@ export default function SettingsScreen({
                 </button>
               </div>
             </section>
+          </>
         )
       case 'updates':
         return <UpdateTab />

--- a/collie-ui/src/shared/account-config.ts
+++ b/collie-ui/src/shared/account-config.ts
@@ -1,0 +1,12 @@
+/**
+ * Public Supabase client configuration for the Collie account flow
+ * (docs/engineering/architecture/account-system-spec.md §6).
+ *
+ * These values are PUBLIC client config (the anon key is designed to be
+ * shipped in clients) — never secrets. They are wired at build time via
+ * `COLLIE_SUPABASE_URL` / `COLLIE_SUPABASE_ANON_KEY` (set by the launcher or
+ * baked into the build), so an unconfigured build degrades to empty strings
+ * and the sign-in flow reports "not configured" instead of failing oddly.
+ */
+export const SUPABASE_URL = (process.env.COLLIE_SUPABASE_URL ?? '').trim()
+export const SUPABASE_ANON_KEY = (process.env.COLLIE_SUPABASE_ANON_KEY ?? '').trim()

--- a/collie-ui/tsconfig.node.json
+++ b/collie-ui/tsconfig.node.json
@@ -11,5 +11,5 @@
     "esModuleInterop": true,
     "noEmit": true
   },
-  "include": ["src/main/**/*", "src/preload/**/*", "electron.vite.config.ts"]
+  "include": ["src/main/**/*", "src/preload/**/*", "src/shared/**/*", "electron.vite.config.ts"]
 }

--- a/docs/engineering/architecture/account-system-spec.md
+++ b/docs/engineering/architecture/account-system-spec.md
@@ -1,0 +1,151 @@
+# Account System Spec — Collie v1
+
+> Status: **spec** (2026-08-17) · Owner: Rick · Scope: website + Supabase backend + Electron app + email
+> Decision history: supersedes the 08-11 "no-account v1" decision (waitlist = email-only). Accounts now exist, but **local-first stays the product story** — the account never becomes a data hostage.
+
+## 1. Goals / Non-goals
+
+**Goals**
+- Sign in on the website with **email+password** and **magic link** (both, one identity).
+- Account tab on the website: download Collie, change email, set password, enable 2FA (TOTP), delete account, see early-access status.
+- App sign-in via the system browser, "and get back to the app" (Codex/Claude pattern) — **no stack change**, Electron stays.
+- Transactional emails via **Resend** (hello@heycollie.com domain, already live with MX).
+- Download stays **open (not gated)** but **bot-safe** so bots can't burn bandwidth/limits.
+
+**Non-goals (v1)**
+- No cross-device sync of conversations/settings — nothing user-data syncs across accounts.
+- No download gating / entitlement enforcement.
+- No subscriptions, no billing.
+- No mobile app, no CLI device flow (fallback later if a CLI appears).
+
+## 2. Current state
+
+| Piece | Today |
+|---|---|
+| Website | Cloudflare Worker `collie-website` (vinext), `/home/rick/collie-webiste` |
+| Waitlist | `POST /api/early-access` → Supabase table `early_access` (email UNIQUE, source, created_at), per-IP rate-limit via KV (`early-access:<ip>`) |
+| Supabase | Already connected (anon key in Worker env) |
+| App | Electron desktop + Python `collie-core`, local SQLite settings, no auth, no network identity |
+| Emails | **None sent today** — the waitlist API only inserts a row |
+
+## 3. Auth model
+
+Supabase Auth on the **existing project** (one backend serves web + app).
+
+**When is which used:**
+| Method | Used when | Notes |
+|---|---|---|
+| **Magic link** | Primary path — app sign-in flow, and "sign in without password" on the web | Zero password friction, ideal for non-coders. One email click |
+| **Email + password** | Users who want it; required for **2FA** | Password is the second factor's anchor. Set password from account tab |
+
+- Both produce the same `auth.users` identity keyed by email. Password users can still use magic links.
+- 2FA (TOTP, authenticator app) is available **only on password accounts** — a magic-link-only account has no password to protect.
+- Web sessions: JWT in httpOnly cookies (`@supabase/ssr` pattern, works on the Worker).
+- App sessions: tokens stored via Electron `safeStorage` (OS keychain-backed).
+
+## 4. Data model
+
+```
+auth.users            (Supabase managed — email, password hash, MFA, sessions)
+early_access          (exists — add column)
+  id, email UNIQUE, source, created_at
+  + status    text  default 'waiting'   -- 'waiting' | 'granted'
+  + granted_at timestamp null
+```
+
+- **RLS on `early_access`**: anon → INSERT only (as today, rate-limited); authenticated → SELECT only own row (`email = auth.jwt()->>'email'`); no anon SELECT.
+- **`delete_my_account()`** — `SECURITY DEFINER` SQL function: deletes `early_access` row for `auth.uid()` then deletes the user from `auth.users` where `id = auth.uid()`. Called from the account tab with the user's JWT. **No service-role key ever touches the Worker.**
+- Entitlement lookup = `early_access` row by auth email (status shows "you're on the list" / "access granted" in the account tab).
+
+## 5. Website
+
+### Routes (all inside the existing Worker)
+| Route | Auth | Purpose |
+|---|---|---|
+| `/` | public | Landing (unchanged) |
+| `/download` | public | Open download page — bot-safe link reveal (see §7) |
+| `/api/early-access` | public | Waitlist (unchanged) + fires welcome email |
+| `/account` | any | Single route: renders sign-in form if no session, dashboard if authed |
+| `/auth/callback` | public | PKCE/magic-link redirect target — exchanges code, sets cookie, bounces to `/account` |
+
+### Account tab contents
+| Feature | Supabase mechanism |
+|---|---|
+| Download Collie | Bot-safe link (same as `/download`), plus platform hint |
+| Early-access status | `early_access.status` by auth email |
+| Change email | `auth.updateUser({ email })` → confirmation email to new address, re-verify |
+| Set password | `auth.updateUser({ password })` (enables 2FA path) |
+| Enable 2FA | `auth.mfa.enroll` (TOTP) → challenge → `auth.mfa.challenge/verify`; disable = unenroll after verify |
+| Delete account | RPC `delete_my_account()` + confirm dialog (destructive, typed confirmation) |
+| Sign out | `auth.signOut()` |
+
+Sign-in page (on `/account` when logged out): two tabs — **Email + password** and **Magic link**. No Google OAuth in v1 (keep surface small; add later if the data says so).
+
+## 6. App ↔ web sign-in (Electron, localhost callback)
+
+Claude-Desktop pattern, zero typing for the user:
+
+1. Settings → **Sign in** → app generates PKCE verifier, starts a local HTTP listener on `127.0.0.1:<random-port>`.
+2. App opens the system browser (`shell.openExternal`) to the Supabase authorize URL with `redirect_to=http://127.0.0.1:<port>/callback` (plus `collie://auth/callback` custom protocol as fallback on macOS/Windows).
+3. User signs in with password **or** magic link in the browser.
+4. Browser redirects to `127.0.0.1:<port>/callback?code=...` → app exchanges code + verifier → session tokens.
+5. App stores tokens with `safeStorage`, Settings now shows signed-in state (email, Sign out). No data leaves the machine — the session is just identity.
+6. Timeout after ~5 min → "Sign-in didn't finish, try again."
+
+**App-side changes (Windows machine, later phase):** settings UI (sign in/out), localhost listener + PKCE, secure token storage, session refresh. No app-stack change — **Tauri is not on the table**; the pattern is identical either way, so this spec is stack-neutral.
+
+## 7. Bot-safe download (open, not gated)
+
+- Installer files on **Cloudflare R2 (private bucket)**; never a public bucket listing or guessable static URL.
+- Worker route `/api/download-link` (called from `/download` page): per-IP rate limit (KV counter, same pattern as early-access) + optional invisible **Cloudflare Turnstile** → returns a short-lived signed redirect to R2.
+- Cost: a human clicks once per visit; bots burn a KV increment, not bandwidth. Deterministic humans (CI, etc.) unaffected.
+- Fallback if R2 setup is unwanted: GitHub Releases URLs, rate-limited at the page level only (accepting the leak).
+
+## 8. Emails (Resend)
+
+Provider: **Resend**, domain `heycollie.com`, senders: `hello@heycollie.com` (human-ish) / `no-reply@heycollie.com` (auth). Add Resend SPF + DKIM records to the zone (MX already exists).
+
+| Email | Trigger | Via | Priority |
+|---|---|---|---|
+| Thanks for signing up | `POST /api/early-access` success | Worker → Resend API | **Missing today — add** |
+| You're in — download Collie | `early_access.status` → `granted` (admin action/script) | Worker/edge fn → Resend | Add (launch tooling) |
+| Magic link | Auth request | Supabase template (SMTP → Resend) | Configure + brand |
+| Password reset | "Forgot password" | Supabase template | Configure + brand |
+| Email change confirmation | Change email | Supabase template | Configure + brand |
+| Security alert (2FA disabled, new sign-in) | Account events | Supabase template | Optional |
+
+Worker env additions: `RESEND_API_KEY`, `TURNSTILE_SECRET` (plus `TURNSTILE_SITE_KEY` public).
+
+## 9. Security checklist
+
+- [ ] Service-role key stays off the Worker (anon key only, as today)
+- [ ] RLS on `early_access` (anon INSERT, authed SELECT-own; no anon SELECT)
+- [ ] `delete_my_account()` SECURITY DEFINER, invoked with user JWT only
+- [ ] httpOnly + Secure + SameSite=Lax cookies; PKCE everywhere (no implicit flow)
+- [ ] Rate limits: early-access (exists), download link, Supabase auth has built-in limits + optional Turnstile on sign-in
+- [ ] Email deliverability: SPF/DKIM via Resend; test to Gmail/Outlook
+- [ ] Supabase Auth "Confirm email" requirement decision: magic-link-only accounts need no confirmation; password signup should confirm email before first sign-in (reduce spam accounts)
+
+## 10. Implementation phases
+
+**Phase 1 — Supabase config (backend, ~1 session)**
+Enable Auth (email+password + magic link), add `early_access.status/granted_at` migration, RLS policies, `delete_my_account()` RPC, Resend SMTP on auth templates, Turnstile site keys, create R2 bucket + signed-URL helper.
+
+**Phase 2 — Website account (this repo, ~2–3 sessions)**
+`/account` (sign-in tabs + dashboard), `/auth/callback`, `@supabase/ssr` session wiring, change email / set password / 2FA / delete account UI, download section + `/api/download-link` rate limit + Turnstile, welcome email hook in early-access API. Follow collie-website workflow: branch → lint/test/build → show locally → PR → merge → deploy → verify both hosts.
+
+**Phase 3 — App sign-in (Windows machine)**
+Electron localhost-callback PKCE flow, Settings UI, safeStorage token storage, sign-out. Matches this spec's §6; implementation happens in the main repo on Windows (VM clone can't run the app).
+
+**Phase 4 — Launch emails**
+Access-granted tooling (mark granted → email), template branding, security alerts, deliverability test.
+
+**Phase 5 — Verification matrix**
+Password sign-in, magic-link sign-in, 2FA enroll/login/disable, email change, password set/reset, delete account (user gone from auth + early_access), app flow both methods + timeout, download rate limit hit, welcome email lands in spam-free inbox.
+
+## 11. Open items
+
+1. Installer hosting: **R2 + worker redirect** (recommended) vs GitHub Releases — needs R2 bucket creation or decision.
+2. Supabase project admin access on this VM: needed for Phase 1 (SQL + Auth config). Where are the project keys/access? (The Worker already has SUPABASE_URL + anon key in env.)
+3. Turnstile: invisible vs checkbox on sign-in + download — pick when implementing (checkbox = zero-config UX cost).
+4. Confirm-email requirement for password signups (recommend: on).


### PR DESCRIPTION
## What & why

Implements the Electron app side of **Phase 3 of the account system** (spec: `docs/engineering/architecture/account-system-spec.md` §6): the desktop app can now sign in with a Collie (Supabase) account using the system browser, Claude-Desktop style — no password typing inside the app, and **no data leaves the machine** (the session is identity only; chats/files stay local).

**The flow:**
1. Settings → **Account → Sign in** → the app generates a PKCE verifier/challenge (32 random bytes, S256).
2. The app starts a **single-use HTTP listener on the fixed port `127.0.0.1:8123`** and opens the Supabase authorize URL in the system browser via `shell.openExternal`:
   `${SUPABASE_URL}/auth/v1/authorize?aud=authenticated&response_type=code&redirect_to=http://127.0.0.1:8123/callback&code_challenge=…&code_challenge_method=S256&client_id=<anon key>`
   (Supabase PKCE uses the **anon key as `client_id`**, the **`/auth/v1/authorize`** endpoint, and **`redirect_to`** — not `redirect_uri`.)
3. The user signs in (email+password or magic link) in the browser; the browser redirects to `http://127.0.0.1:8123/callback?code=…`.
4. The app exchanges the code via `POST ${SUPABASE_URL}/auth/v1/token?grant_type=pkce` with `{ auth_code, code_verifier }` (headers: `apikey: <anon key>`, `Content-Type: application/json`) — plain `fetch`, **no new runtime dependencies**.
5. The session (access_token, refresh_token, expires_at, email) is stored **encrypted with Electron `safeStorage`** in `userData/auth.json`, following the existing `secrets.ts` pattern exactly (per-field encrypted base64 blobs, staged atomic writes, defensive reads). Tokens never reach the renderer — only display state does.
6. Settings now shows the signed-in email + **Sign out** (sign-out also fires a best-effort `POST /auth/v1/logout` with the access token; failures are ignored and local sign-out always proceeds).

**Guardrails:**
- The callback port is **fixed at 8123** because Supabase validates `redirect_to` against a configured allowlist — a wildcard port can't be guaranteed. If 8123 is taken, sign-in fails with a clear "another app is using the port" message instead of silently moving.
- Listener is single-use and auto-closes after the callback **or after a 5-minute timeout** ("Sign-in didn't finish. Please try again.").
- JWT payload is decoded client-side **for display only** (email/exp) — no signature verification, per spec.
- IPC handlers are registered through the existing `guardIpcHandler`/`isTrustedIpcSender` renderer-security conventions (`account:start-sign-in`, `account:get-state`, `account:sign-out`), and the preload exposes a minimal `window.account` bridge (`startSignIn()` / `getState()` / `signOut()`).

## Config wiring (important)

`collie-ui/src/shared/account-config.ts` reads **public** build-time config:
- `COLLIE_SUPABASE_URL` and `COLLIE_SUPABASE_ANON_KEY` env vars (empty-string defaults; the anon key is public client config, never a secret).

Until those are wired (launcher env or baked into the build), the Settings card shows the button but sign-in fails fast with *"Collie account sign-in is not configured for this build yet."* — no crash, no half-flow.

## Files changed

- `collie-ui/src/shared/account-config.ts` — **new**: Supabase URL/anon key build-time config
- `collie-ui/src/main/account-auth.ts` — **new**: PKCE, localhost listener, token exchange, safeStorage session store, `getAccountState()`, sign-out
- `collie-ui/src/main/account-auth.test.ts` — **new**: 13 vitest tests (PKCE shape, JWT decode, store round-trip/clear, end-to-end localhost-callback flow, timeout, port-in-use, sign-out)
- `collie-ui/src/main/index.ts` — 3 guarded IPC handlers
- `collie-ui/src/preload/index.ts` + `index.d.ts` — `window.account` bridge + `AccountState` type
- `collie-ui/src/renderer/src/components/settings/AccountTab.tsx` — **new**: Account card (Sign in / email + Sign out)
- `collie-ui/src/renderer/src/screens/SettingsScreen.tsx` — renders `AccountTab` on the Account page
- `collie-ui/tsconfig.node.json` — include `src/shared/**/*`

## Verification (Linux VM, all green)

- `npm run typecheck` ✅
- `npm test` — 336 passed / 53 files (13 new) ✅
- `npm run build` (electron-vite) ✅
- No changes to `collie-core` / Python. No new runtime dependencies.

## Still needs verification on Windows (packaged app)

- **Real Supabase project**: wire `COLLIE_SUPABASE_URL`/`COLLIE_SUPABASE_ANON_KEY` (or bake values), add `http://127.0.0.1:8123/callback` to the Supabase redirect allowlist, then verify email+password **and** magic-link sign-in end to end.
- **safeStorage/DPAPI**: session survives an app restart on Windows; `auth.json` decrypts correctly.
- **Sign-out** clears `auth.json` (server revocation is best-effort).
- 5-minute timeout message appears if the browser is never redirected back.
- **Not in this PR (follow-up):** session refresh (refresh_token rotation) — v1 scope per spec.
