### PR TITLE
fix(ui): account-auth tests — attach rejection handlers before callback requests (CI red on main)

### DIFF
--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -260,13 +260,19 @@ describe('startAccountSignIn', () => {
       expect(testState.openedUrl).toContain('/auth/v1/authorize')
     })
 
+    // Attach the rejection expectation BEFORE firing the callback request:
+    // startAccountSignIn rejects from the server's request handler, which
+    // runs while realFetch is still awaiting the response — a late handler
+    // becomes an unhandled rejection that fails the vitest run (CI exit 1).
+    const rejection = expect(signInPromise).rejects.toThrow('Sign-in was cancelled.')
+
     // Supabase redirects with ?error=access_denied when the user cancels.
     const callbackResponse = await realFetch(
       `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?error=access_denied&error_description=User+cancelled`
     )
     expect(callbackResponse.status).toBe(200)
 
-    await expect(signInPromise).rejects.toThrow('Sign-in was cancelled.')
+    await rejection
   })
 
   it('fails with a clear message when the session cannot be stored securely', async () => {
@@ -276,14 +282,18 @@ describe('startAccountSignIn', () => {
       expect(testState.openedUrl).toContain('/auth/v1/authorize')
     })
 
+    // Same pattern as the cancellation test — handle the rejection before
+    // the callback request can trigger it.
+    const rejection = expect(signInPromise).rejects.toThrow(
+      'could not store the session securely'
+    )
+
     const callbackResponse = await realFetch(
       `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
     )
     expect(callbackResponse.status).toBe(200)
 
-    await expect(signInPromise).rejects.toThrow(
-      'could not store the session securely'
-    )
+    await rejection
     expect(getStoredSession()).toBeNull()
   })
 


### PR DESCRIPTION
## What & why

The merge of #45 (feat/account-signin) is **red on Linux CI** — and the merge-commit run is the first one to carry the failure.

Root cause: review-round-1 commit `34cebf3` added two new error-path tests (`surfaces a browser-side cancellation` and `fails with a clear message when the session cannot be stored securely`). Both let `startAccountSignIn()` reject **from the server's HTTP request handler** — i.e. while the test is still awaiting `realFetch()` on the callback — so the `.rejects` expectation attaches *after* the rejection fires. Node flags the promise as unhandled; vitest reports `Unhandled Errors` and the CI step exits 1. All 338 tests pass locally, but the run is racy: on the VM it happened to exit 0, on GitHub's Linux runner it exits 1 (verified: `collie-ui (Node 22)` job on `34cebf3` failed with exactly these two errors; the NSIS/Windows failures on the same run are the unrelated pre-existing `things-files.test.ts` 8.3-short-path flake).

## Fix

Attach the rejection expectation **before** firing the callback request in both tests (standard `const rejection = expect(...).rejects...; await rejection` pattern). No runtime behavior change — test-only.

## Verification (Linux VM, branch worktree)

- `npm run typecheck` ✅
- `npx vitest run` — **338 passed / 53 files** ✅ (exit 0; the failing job's exact invocation `npx vitest run` re-run 3× on the target file: exit 0 every time, zero unhandled errors)
- No `collie-core` / Python changes.

## Files

- `collie-ui/src/main/account-auth.test.ts` — 2 tests, +14/−4
