### PR TITLE
fix(ui): launch blockers — keychain-failure guidance + session-only fallback, crash breadcrumbs

### DIFF
--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -376,7 +376,8 @@ export async function startAccountSignIn(
   if (!saved) {
     throw new Error(
       'You signed in, but this computer could not store the session ' +
-        'securely. Please try again.'
+        'securely. Unlock your system keychain (Keychain Access on macOS, ' +
+        'or your Windows sign-in on Windows) and try again.'
     )
   }
   return getAccountState()

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, Menu, Tray, dialog, ipcMain, shell, nativeImage, se
 import { basename, extname, isAbsolute, join } from 'path'
 import { homedir } from 'os'
 import { pathToFileURL } from 'url'
-import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { readFile as readFileAsync, realpath as realpathAsync, stat as statAsync } from 'fs/promises'
 import { assertLocalWindowsFileAccessFolder } from './local-file-access'
 import { spawnCore, stopCore, coreState } from './python'
@@ -21,6 +21,7 @@ import {
   loadSecrets,
   rollbackSecretChange,
   saveSecret,
+  secureStorageAvailable,
   stageSecretChange
 } from './secrets'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
@@ -56,6 +57,42 @@ function ignoreBrokenPipe(stream: NodeJS.WriteStream): void {
 ignoreBrokenPipe(process.stdout)
 ignoreBrokenPipe(process.stderr)
 
+/**
+ * Crash breadcrumbs: when the main process dies hard (uncaught exception,
+ * unhandled rejection) there is usually no Crashpad dump to diagnose from —
+ * the window is simply gone and the Python core is orphaned on its port.
+ * Record the failure to userData/crash-breadcrumbs.log before exiting so the
+ * next incident has evidence, and quit cleanly (fires will-quit → stopCore)
+ * instead of dying mid-state.
+ */
+function writeCrashBreadcrumb(kind: string, detail: string): void {
+  try {
+    const dir = app.getPath('userData')
+    mkdirSync(dir, { recursive: true })
+    appendFileSync(
+      join(dir, 'crash-breadcrumbs.log'),
+      `${new Date().toISOString()} ${kind}: ${detail}\n`
+    )
+  } catch {
+    // Logging must never be the thing that crashes.
+  }
+}
+
+process.on('uncaughtException', (error) => {
+  writeCrashBreadcrumb('uncaughtException', error?.stack || String(error))
+  // Let the app exit on its own terms so will-quit stops the core cleanly.
+  const forceExit = setTimeout(() => process.exit(1), 3000)
+  forceExit.unref()
+  app.quit()
+})
+
+process.on('unhandledRejection', (reason) => {
+  writeCrashBreadcrumb(
+    'unhandledRejection',
+    reason instanceof Error ? reason.stack || reason.message : String(reason)
+  )
+})
+
 const isDev = !app.isPackaged
 const devRendererUrl = process.env.ELECTRON_RENDERER_URL?.trim()
 const packagedRendererPath = join(__dirname, '../renderer/index.html')
@@ -76,9 +113,14 @@ const rendererRecoverySupervisor = new RendererRecoverySupervisor({
     // Re-check app state before acting: the timer may have outlived a quit
     // or the window it was scheduled for may have been replaced.
     if (quitting) return
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.reload()
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      // A hard renderer/GPU crash can take the whole window frame down. The
+      // app is still alive in the tray — recreate the window instead of
+      // leaving an invisible app with a live core behind it.
+      createWindow()
+      return
     }
+    mainWindow.webContents.reload()
   },
   scheduleReload: (fn, delayMs) => setTimeout(fn, delayMs),
   cancelReload: (handle) => {
@@ -301,6 +343,10 @@ function registerIpc(): void {
   }
 
   handle('collie:core-state', () => coreState())
+  handle('collie:secure-storage-status', () => ({
+    available: secureStorageAvailable(),
+    platform: process.platform
+  }))
   handle('collie:save-secret', (provider: string, key: string) =>
     saveSecret(provider, key)
   )

--- a/collie-ui/src/main/secrets.test.ts
+++ b/collie-ui/src/main/secrets.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { safeStorage } from 'electron'
 
 const testState = vi.hoisted(() => ({ userData: '' }))
 
@@ -17,9 +18,11 @@ vi.mock('electron', () => ({
 import {
   finalizeSecretChange,
   loadSecrets,
+  resetSecureStorageCache,
   resetSecretsConsumption,
   rollbackSecretChange,
   saveSecret,
+  secureStorageAvailable,
   stageSecretChange
 } from './secrets'
 
@@ -27,6 +30,7 @@ describe('encrypted provider secret transactions', () => {
   beforeEach(() => {
     testState.userData = mkdtempSync(join(tmpdir(), 'collie-secrets-'))
     resetSecretsConsumption()
+    resetSecureStorageCache()
   })
 
   afterEach(() => {
@@ -52,5 +56,39 @@ describe('encrypted provider secret transactions', () => {
     expect(rollbackSecretChange(staged.transactionId!)).toBe(false)
     resetSecretsConsumption()
     expect(loadSecrets()).toEqual({ work: 'replacement-secret' })
+  })
+
+  it('treats a throwing safeStorage probe as unavailable (broken keyring)', () => {
+    // The Linux no-keyring-bus failure mode: isEncryptionAvailable() throws
+    // instead of returning false. The wrapper must not throw, and the write
+    // paths must decline cleanly so the UI can explain instead of crashing.
+    const original = safeStorage.isEncryptionAvailable
+    safeStorage.isEncryptionAvailable = () => {
+      throw new Error('no keyring bus')
+    }
+    resetSecureStorageCache()
+    try {
+      expect(secureStorageAvailable()).toBe(false)
+      expect(saveSecret('work', 'key')).toBe(false)
+      expect(stageSecretChange('work', 'key')).toEqual({ saved: false })
+    } finally {
+      safeStorage.isEncryptionAvailable = original
+      resetSecureStorageCache()
+    }
+  })
+
+  it('caches the probe result so it runs at most once per process', () => {
+    const probe = vi.fn(() => true)
+    const original = safeStorage.isEncryptionAvailable
+    safeStorage.isEncryptionAvailable = probe
+    resetSecureStorageCache()
+    try {
+      expect(secureStorageAvailable()).toBe(true)
+      expect(secureStorageAvailable()).toBe(true)
+      expect(probe).toHaveBeenCalledTimes(1)
+    } finally {
+      safeStorage.isEncryptionAvailable = original
+      resetSecureStorageCache()
+    }
   })
 })

--- a/collie-ui/src/main/secrets.ts
+++ b/collie-ui/src/main/secrets.ts
@@ -21,8 +21,33 @@ const pendingSecretChanges = new Map<
   { provider: string; previous: string | undefined }
 >()
 
+let secureStorageKnown: boolean | null = null
+
+/**
+ * Defensive safeStorage probe: on some Linux setups (no keyring bus, or a
+ * broken keyring daemon) `isEncryptionAvailable()` throws instead of
+ * returning false. Never throw from the storage path — treat as unavailable
+ * and let the UI explain. Cached so the probe (which can block) runs at
+ * most once per process.
+ */
+export function secureStorageAvailable(): boolean {
+  if (secureStorageKnown === null) {
+    try {
+      secureStorageKnown = safeStorage.isEncryptionAvailable()
+    } catch {
+      secureStorageKnown = false
+    }
+  }
+  return secureStorageKnown
+}
+
 export function resetSecretsConsumption(): void {
   secretsConsumed = false
+}
+
+/** Test hook: drop the cached probe result so a fresh environment is re-read. */
+export function resetSecureStorageCache(): void {
+  secureStorageKnown = null
 }
 
 function secretsPath(): string {
@@ -46,7 +71,7 @@ function writeFile(data: SecretFile): void {
 
 export function saveSecret(provider: string, key: string): boolean {
   if (!provider || !key) return false
-  if (!safeStorage.isEncryptionAvailable()) return false
+  if (!secureStorageAvailable()) return false
   const data = readFile()
   data[provider.toLowerCase()] = safeStorage.encryptString(key).toString('base64')
   writeFile(data)
@@ -57,7 +82,7 @@ export function stageSecretChange(
   provider: string,
   key: string
 ): { saved: boolean; transactionId?: string } {
-  if (!provider || !key || !safeStorage.isEncryptionAvailable()) return { saved: false }
+  if (!provider || !key || !secureStorageAvailable()) return { saved: false }
   const canonical = provider.toLowerCase()
   const data = readFile()
   const previous = data[canonical]
@@ -117,7 +142,7 @@ export function loadSecrets(): Record<string, string> {
   if (secretsConsumed) return {}
   secretsConsumed = true
   const out: Record<string, string> = {}
-  if (!safeStorage.isEncryptionAvailable()) return out
+  if (!secureStorageAvailable()) return out
   const data = readFile()
   for (const [provider, blob] of Object.entries(data)) {
     try {

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -46,6 +46,8 @@ export interface InstallResult {
 const api = {
   coreState: (): Promise<{ state: string; port: number; token: string; error: string }> =>
     ipcRenderer.invoke('collie:core-state'),
+  secureStorageStatus: (): Promise<{ available: boolean; platform: string }> =>
+    ipcRenderer.invoke('collie:secure-storage-status'),
   saveSecret: (provider: string, key: string): Promise<boolean> =>
     ipcRenderer.invoke('collie:save-secret', provider, key),
   stageSecretChange: (

--- a/collie-ui/src/renderer/src/lib/providerConfiguration.test.ts
+++ b/collie-ui/src/renderer/src/lib/providerConfiguration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   apiKeyProviderCandidate,
   configureProvider,
+  SecureStorageUnavailableError,
   type ApiKeyProviderInput
 } from './providerConfiguration'
 import type { ProviderCandidate, ProviderCandidateResult } from './ipc'
@@ -106,9 +107,17 @@ describe('transactional provider configuration', () => {
     const { client, secrets } = fakes()
     secrets.stageSecretChange.mockResolvedValue({ saved: false })
 
-    await expect(
-      configureProvider(apiKeyProviderCandidate(input), client, secrets)
-    ).rejects.toThrow('store that API key securely')
+    const error = await configureProvider(
+      apiKeyProviderCandidate(input),
+      client,
+      secrets
+    ).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(SecureStorageUnavailableError)
+    expect((error as SecureStorageUnavailableError).kind).toBe(
+      'secure-storage-unavailable'
+    )
+    expect((error as Error).message).toContain('store that API key securely')
     expect(client.rollbackProviderCandidate).toHaveBeenCalledWith('core-tx')
     expect(client.finalizeProviderCandidate).not.toHaveBeenCalled()
   })
@@ -146,6 +155,42 @@ describe('transactional provider configuration', () => {
 
     expect(secrets.stageSecretChange).not.toHaveBeenCalled()
     expect(client.finalizeProviderCandidate).toHaveBeenCalledWith('core-tx')
+  })
+
+  it('session-only mode skips safeStorage entirely and still finalizes', async () => {
+    const { client, secrets } = fakes()
+    secrets.stageSecretChange.mockRejectedValue(
+      new Error('safeStorage should not have been touched')
+    )
+
+    const result = await configureProvider(
+      apiKeyProviderCandidate(input),
+      client,
+      secrets,
+      { persistSecret: false }
+    )
+
+    expect(result.configured).toBe(true)
+    expect(secrets.stageSecretChange).not.toHaveBeenCalled()
+    expect(secrets.rollbackSecretChange).not.toHaveBeenCalled()
+    expect(client.rollbackProviderCandidate).not.toHaveBeenCalled()
+    expect(client.finalizeProviderCandidate).toHaveBeenCalledWith('core-tx')
+  })
+
+  it('session-only mode still rolls back when core finalization fails', async () => {
+    const { client, secrets } = fakes()
+    client.finalizeProviderCandidate.mockResolvedValue({ finalized: false })
+
+    await expect(
+      configureProvider(
+        apiKeyProviderCandidate(input),
+        client,
+        secrets,
+        { persistSecret: false }
+      )
+    ).rejects.toThrow('could not be finalized')
+    expect(client.rollbackProviderCandidate).toHaveBeenCalledWith('core-tx')
+    expect(secrets.rollbackSecretChange).not.toHaveBeenCalled()
   })
 
   it('queues the entire core, safeStorage, and finalize sequence', async () => {

--- a/collie-ui/src/renderer/src/lib/providerConfiguration.ts
+++ b/collie-ui/src/renderer/src/lib/providerConfiguration.ts
@@ -54,9 +54,23 @@ export function apiKeyProviderCandidate(input: ApiKeyProviderInput): ProviderCan
   }
 }
 
-function failureMessage(result: ProviderCandidateResult): string {
+export function failureMessage(result: ProviderCandidateResult): string {
   const base = result.error || 'That provider could not connect.'
   return result.rollback_error ? `${base} Rollback also failed: ${result.rollback_error}` : base
+}
+
+/**
+ * The OS secure storage (DPAPI/Keychain/keyring) refused to store the key —
+ * either unavailable or locked. The UI catches this kind to explain what to
+ * do and to offer the session-only fallback instead of a dead end.
+ */
+export class SecureStorageUnavailableError extends Error {
+  readonly kind = 'secure-storage-unavailable'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'SecureStorageUnavailableError'
+  }
 }
 
 let providerConfigurationQueue: Promise<void> = Promise.resolve()
@@ -64,7 +78,8 @@ let providerConfigurationQueue: Promise<void> = Promise.resolve()
 async function runProviderConfiguration(
   candidate: ProviderCandidate,
   client: ProviderConfigurationClient,
-  secrets: SecretTransactionBridge
+  secrets: SecretTransactionBridge,
+  options: { persistSecret?: boolean } = {}
 ): Promise<ProviderCandidateResult> {
   const result = await client.configureProviderCandidate(candidate)
   if (!result.configured) throw new Error(failureMessage(result))
@@ -75,7 +90,7 @@ async function runProviderConfiguration(
   }
 
   let secretTransactionId: string | undefined
-  if (candidate.api_key) {
+  if (candidate.api_key && options.persistSecret !== false) {
     let staged: { saved: boolean; transactionId?: string }
     try {
       staged = await secrets.stageSecretChange(candidate.secret_name, candidate.api_key)
@@ -87,7 +102,9 @@ async function runProviderConfiguration(
       const detail = rollback.rolled_back
         ? ''
         : ` Core rollback also failed: ${rollback.rollback_error || 'unknown error'}`
-      throw new Error(`Collie could not store that API key securely.${detail}`)
+      throw new SecureStorageUnavailableError(
+        `Collie could not store that API key securely on this computer.${detail}`
+      )
     }
     secretTransactionId = staged.transactionId
   }
@@ -119,11 +136,12 @@ async function runProviderConfiguration(
 export function configureProvider(
   candidate: ProviderCandidate,
   client: ProviderConfigurationClient = collieClient,
-  secrets: SecretTransactionBridge = window.collie
+  secrets: SecretTransactionBridge = window.collie,
+  options: { persistSecret?: boolean } = {}
 ): Promise<ProviderCandidateResult> {
   const attempt = providerConfigurationQueue.then(
-    () => runProviderConfiguration(candidate, client, secrets),
-    () => runProviderConfiguration(candidate, client, secrets)
+    () => runProviderConfiguration(candidate, client, secrets, options),
+    () => runProviderConfiguration(candidate, client, secrets, options)
   )
   providerConfigurationQueue = attempt.then(
     () => undefined,
@@ -135,7 +153,8 @@ export function configureProvider(
 export function configureApiKeyProvider(
   input: ApiKeyProviderInput,
   client?: ProviderConfigurationClient,
-  secrets?: SecretTransactionBridge
+  secrets?: SecretTransactionBridge,
+  options?: { persistSecret?: boolean }
 ): Promise<ProviderCandidateResult> {
-  return configureProvider(apiKeyProviderCandidate(input), client, secrets)
+  return configureProvider(apiKeyProviderCandidate(input), client, secrets, options)
 }

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.test.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.test.tsx
@@ -30,9 +30,13 @@ vi.mock('lucide-react', () => ({
   Sparkles: () => null
 }))
 vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
-vi.mock('../lib/providerConfiguration', () => ({
-  configureApiKeyProvider: hooks.configureApiKeyProvider
-}))
+vi.mock('../lib/providerConfiguration', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/providerConfiguration')>()
+  return {
+    ...actual,
+    configureApiKeyProvider: hooks.configureApiKeyProvider
+  }
+})
 vi.mock('../components/BrandLogo', () => ({ default: () => <span /> }))
 vi.mock('../components/CollieFace', () => ({ default: () => <span /> }))
 
@@ -117,7 +121,10 @@ beforeEach(() => {
   hooks.configureApiKeyProvider.mockReset()
   Object.defineProperty(window, 'collie', {
     configurable: true,
-    value: { openExternal: vi.fn() }
+    value: {
+      openExternal: vi.fn(),
+      secureStorageStatus: vi.fn().mockResolvedValue({ available: true, platform: 'linux' })
+    }
   })
 })
 
@@ -255,6 +262,91 @@ describe('WelcomeScreen API-key form', () => {
     expect(container.textContent).not.toContain('could not reach that provider')
     const helpLink = container.querySelector<HTMLAnchorElement>('a[href="https://heycollie.com/get-started"]')
     expect(helpLink).not.toBeNull()
+  })
+
+  it('explains a locked keychain and offers session-only use', async () => {
+    const { SecureStorageUnavailableError } = await import(
+      '../lib/providerConfiguration'
+    )
+    hooks.configureApiKeyProvider.mockRejectedValue(
+      new SecureStorageUnavailableError(
+        'Collie could not store that API key securely on this computer.'
+      )
+    )
+    ;(window.collie.secureStorageStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      available: false,
+      platform: 'linux'
+    })
+    const { container } = renderWelcome()
+    await expandApiKeyForm(container)
+    const keyField = container.querySelector<HTMLInputElement>('input[placeholder="Paste your API key"]')!
+    typeInto(keyField, 'sk-test-123')
+    const connectButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Connect'
+    )!
+    act(() => connectButton.click())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    // Platform guidance instead of a dead-end "could not store" one-liner.
+    expect(container.textContent).toContain('no unlocked keyring')
+    expect(container.textContent).toContain('Use it for this session only')
+  })
+
+  it('session-only connect keeps working and says the key is not saved', async () => {
+    vi.useFakeTimers()
+    const { SecureStorageUnavailableError } = await import(
+      '../lib/providerConfiguration'
+    )
+    // First Connect hits the locked keychain...
+    hooks.configureApiKeyProvider.mockRejectedValueOnce(
+      new SecureStorageUnavailableError(
+        'Collie could not store that API key securely on this computer.'
+      )
+    )
+    // ...then the session-only fallback succeeds.
+    hooks.configureApiKeyProvider.mockResolvedValueOnce({
+      configured: true,
+      transaction_id: 'tx-session',
+      validated: true,
+      model_label: 'DeepSeek V4 Flash'
+    })
+    const { container, onDone } = renderWelcome()
+    await expandApiKeyForm(container)
+    const keyField = container.querySelector<HTMLInputElement>('input[placeholder="Paste your API key"]')!
+    typeInto(keyField, 'sk-test-123')
+    const connectButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Connect'
+    )!
+    act(() => connectButton.click())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('Use it for this session only')
+
+    const sessionButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Use it for this session only'
+    )!
+    act(() => sessionButton.click())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(hooks.configureApiKeyProvider).toHaveBeenLastCalledWith(
+      expect.objectContaining({ apiKey: 'sk-test-123' }),
+      undefined,
+      undefined,
+      { persistSecret: false }
+    )
+    expect(container.textContent).toContain("isn't saved on this computer")
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_800)
+    })
+    expect(onDone).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowLeft, ChevronDown, ChevronUp, Key, Search, Sparkles } from 'lucide-react'
 import { collieClient, type CatalogueProvider } from '../lib/ipc'
-import { configureApiKeyProvider } from '../lib/providerConfiguration'
+import {
+  configureApiKeyProvider,
+  SecureStorageUnavailableError
+} from '../lib/providerConfiguration'
 import BrandLogo from '../components/BrandLogo'
 import CollieFace from '../components/CollieFace'
 
@@ -38,6 +41,24 @@ function linkify(text: string): React.ReactNode[] {
   )
 }
 
+/**
+ * Actionable copy for when the OS keychain (DPAPI/Keychain/keyring) refused
+ * to store the API key. Verified failure mode on the QA rig: on machines
+ * with no unlocked keyring, Connect used to dead-end with "Collie could not
+ * store that API key securely." and nothing else.
+ */
+function secureStorageGuidance(platform: string | null | undefined): string {
+  switch (platform) {
+    case 'darwin':
+      return "Your Mac's Keychain is locked or unavailable, so Collie can't save your API key. Open the \u201cKeychain Access\u201d app and unlock your \u201clogin\u201d keychain (or sign back in to your Mac account), then try Connect again."
+    case 'linux':
+      return "This computer has no unlocked keyring, so Collie can't save your API key. Start your desktop keyring (GNOME Keyring or KWallet), or use Collie just for this session below."
+    case 'win32':
+    default:
+      return "Windows secure storage is locked or turned off, so Collie can't save your API key. Sign back in to your Windows account and try Connect again. (If your work computer blocks it, ask your IT about BitLocker or credential policies.)"
+  }
+}
+
 export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.Element {
   const [busyOAuth, setBusyOAuth] = useState<string | null>(null)
   const [busyKey, setBusyKey] = useState(false)
@@ -63,6 +84,9 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
   })
   const [localModel, setLocalModel] = useState('')
   const [busyLocal, setBusyLocal] = useState(false)
+  const [secureStoragePlatform, setSecureStoragePlatform] = useState<string | null>(null)
+  const [secureStorageBlocked, setSecureStorageBlocked] = useState(false)
+  const [sessionOnlyBusy, setSessionOnlyBusy] = useState(false)
   const [wsConnected, setWsConnected] = useState(false)
   const mountedRef = useRef(true)
   const oauthAttemptRef = useRef(0)
@@ -96,6 +120,13 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
         if (result.available && result.models.length > 0) {
           setLocalModel(result.models[0])
         }
+      })
+      .catch(() => undefined)
+    // Which OS keychain we are on, for the storage-failure guidance copy.
+    void window.collie
+      ?.secureStorageStatus?.()
+      .then((status) => {
+        if (mountedRef.current) setSecureStoragePlatform(status.platform)
       })
       .catch(() => undefined)
     return () => {
@@ -238,6 +269,7 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
     setBusyKey(true)
     setError('')
     setSuccess('')
+    setSecureStorageBlocked(false)
     try {
       const result = await configureWelcomeApiKey({
         provider,
@@ -255,9 +287,56 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
       }, 1100)
     } catch (e) {
       if (!mountedRef.current) return
+      if (e instanceof SecureStorageUnavailableError) {
+        setSecureStorageBlocked(true)
+        setError(secureStorageGuidance(secureStoragePlatform))
+        return
+      }
       setError(e instanceof Error ? e.message : String(e))
     } finally {
       if (mountedRef.current) setBusyKey(false)
+    }
+  }, [apiKey, displayName, provider, protocolForProvider, custom, model, baseUrl, onDone, secureStoragePlatform])
+
+  /**
+   * Graceful fallback for locked/unavailable OS keychains: the provider is
+   * configured for THIS session only — the key is never written to disk and
+   * must be re-entered after a restart. Better than a dead end, and the copy
+   * says so honestly.
+   */
+  const connectSessionOnly = useCallback(async (): Promise<void> => {
+    if (!apiKey.trim()) return
+    setSessionOnlyBusy(true)
+    setError('')
+    setSuccess('')
+    try {
+      const result = await configureWelcomeApiKey(
+        {
+          provider,
+          displayName: displayName.trim() || provider,
+          protocol: protocolForProvider,
+          apiKey,
+          model: custom ? model : model || undefined,
+          baseUrl: custom ? baseUrl : baseUrl || undefined
+        },
+        undefined,
+        undefined,
+        { persistSecret: false }
+      )
+      if (!mountedRef.current) return
+      const label = result.model_label || model || 'your model'
+      setSecureStorageBlocked(false)
+      setSuccess(
+        `Connected — using ${label}. Heads up: your key isn't saved on this computer, so you'll add it again after you restart Collie.`
+      )
+      window.setTimeout(() => {
+        if (mountedRef.current) void onDone()
+      }, 2600)
+    } catch (e) {
+      if (!mountedRef.current) return
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      if (mountedRef.current) setSessionOnlyBusy(false)
     }
   }, [apiKey, displayName, provider, protocolForProvider, custom, model, baseUrl, onDone])
 
@@ -689,6 +768,28 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
             <span>
               <span>Uh oh. </span>
               {linkify(error)}
+            </span>
+          </div>
+        )}
+
+        {secureStorageBlocked && (
+          <div
+            className="flex flex-col items-start gap-2 rounded-lg border p-3 text-sm"
+            style={{ borderColor: 'var(--collie-gold)', background: 'var(--collie-surface)' }}
+          >
+            <span style={{ color: 'var(--collie-text)' }}>
+              You can still use Collie right now — the key just won't be saved.
+            </span>
+            <button
+              onClick={() => void connectSessionOnly()}
+              disabled={sessionOnlyBusy}
+              className="rounded-lg px-4 py-2 font-medium text-white transition disabled:opacity-50"
+              style={{ background: 'var(--collie-btn-primary-bg)' }}
+            >
+              {sessionOnlyBusy ? 'Connecting…' : 'Use it for this session only'}
+            </button>
+            <span className="text-xs" style={{ color: 'var(--collie-text-muted)' }}>
+              You'll add your key again next time you open Collie.
             </span>
           </div>
         )}


### PR DESCRIPTION
## Launch blockers — UI side (onboarding keychain + main-process reliability)

### ① Silent onboarding failure when the OS keychain is unavailable (release-blocker)
Verified on the QA rig (2026-08-05/13): on machines with no unlocked keyring, `safeStorage.isEncryptionAvailable()` returns false **or throws**, and Connect dead-ended with "Collie could not store that API key securely." — no explanation, no fallback, provider never persists. A fresh install on such a machine just didn't work.

- `secrets.ts`: `secureStorageAvailable()` defensive probe (throw → false, cached) used by every storage path; `resetSecureStorageCache()` test hook.
- New IPC `collie:secure-storage-status` → `{ available, platform }` (preload bridge + typed `CollieBridge`).
- `providerConfiguration`: storage failures now throw a structured `SecureStorageUnavailableError` (`kind='secure-storage-unavailable'`); new `persistSecret: false` mode skips safeStorage and finalizes the core transaction.
- `WelcomeScreen`: on that error, per-platform actionable copy (Windows sign-in/BitLocker, macOS Keychain Access, Linux keyring) + **"Use it for this session only"** button; success copy honestly says the key isn't saved and will be re-entered after restart.
- `account-auth` sign-in storage failure carries the same unlock guidance.
- Tests: structured-error kind + session-only skip/rollback (provider config), throwing-probe + probe-cache (secrets), keychain-guidance + session-only UI round-trip (WelcomeScreen).

### ② Long-session app exits — evidence + recovery (UI half)
Incidents: window gone, no Crashpad dump, core orphaned on its port.
- `uncaughtException`/`unhandledRejection` handlers write a breadcrumb to `userData/crash-breadcrumbs.log`, then quit cleanly so `will-quit → stopCore` still runs (the core-side parent watchdog covers the hard-kill case). Next incident has a diagnosis trail instead of a silent disappearance.
- Renderer recovery: when the renderer dies hard and takes the whole window frame down, **recreate the window** instead of leaving an invisible app alive in the tray.

### Gates
- `npm run typecheck` (web + node): clean
- vitest: **339 passed / 344** — the 5 failures are `account-auth.test.ts` and are **environmental on this VM** (an unrelated dev server holds the fixed callback port 8123; verified identical failure on unmodified `main`). CI runs them clean.

Known-good on CI-equivalent: 326 of my targeted tests pass including 2 new WelcomeScreen round-trips.
