### PR TITLE
fix(tools): mkdir in granted folder is approval-free (reversible flag)

### DIFF
--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -376,8 +376,11 @@ class LocalFilesTool(Tool):
         safe_write = bool(is_write and in_scope)
         reversible = bool(
             is_write
-            and operation == "create"
-            or (operation == "save" and target is not None and not target.exists())
+            and (
+                operation == "create"
+                or operation == "mkdir"
+                or (operation == "save" and target is not None and not target.exists())
+            )
         )
         verb = {
             "list": "List",

--- a/collie-core/tests/tools/test_local_files_tool.py
+++ b/collie-core/tests/tools/test_local_files_tool.py
@@ -260,6 +260,46 @@ async def test_local_file_read_inside_granted_scope_is_authorized_silently(
 
 
 @pytest.mark.asyncio
+async def test_local_files_mkdir_auto_allowed_inside_granted_folder(scoped_tool) -> None:
+    """mkdir in-scope is reversible bounded work: the broker auto-approves it.
+
+    Regression for the launch sweep finding: the permission_request set
+    approval_free=True for mkdir but left reversible=False, so the evaluator's
+    _ordinary_safe() gate fell through to an approval card despite the
+    documented intent. Both flags must be true for the auto-allow path.
+    """
+    tool, root = scoped_tool
+    db = CollieDB(root / "collie.db")
+    events: list[dict] = []
+
+    async def broadcaster(payload: dict) -> None:
+        events.append(payload)
+
+    broker = ApprovalBroker(
+        db,
+        PermissionEvaluator(PermissionStore(db)),
+        broadcaster=broadcaster,
+        timeout_seconds=1,
+    )
+    with request_context(
+        RequestContext(
+            channel="test",
+            chat_id="test",
+            metadata={"permission_context": {"model_provider": "ChatGPT"}},
+        )
+    ):
+        await broker.authorize(
+            ExecutionContext(run_id="run-mkdir"),
+            SimpleNamespace(id="call-1", name="local_files"),
+            tool,
+            {"operation": "mkdir", "path": "docs/2026"},
+        )
+    assert events == []
+    assert broker.db.list_pending_approvals() == []
+    db.close()
+
+
+@pytest.mark.asyncio
 async def test_live_file_access_override_applies_mid_turn(tmp_path: Path) -> None:
     """A scope change while the turn runs applies to the very next tool call."""
     root = tmp_path / "project"
@@ -466,6 +506,7 @@ def test_local_files_mkdir_permission_metadata(scoped_tool) -> None:
     assert made.action == "local_file.write"
     assert made.resource == str((root / "docs" / "2026").resolve())
     assert made.risk.value == "local_write"
+    assert made.reversible is True
     assert made.approval_free is True
     assert made.approve_for_me is True
     assert made.data_leaving_device == ()


### PR DESCRIPTION
## What & why

Found live by the launch UX sweep (2026-08-18): asking Collie to **create a folder** popped an approval card, even though `local_files.py`'s own comment documents mkdir as approval-free "reversible bounded work".

**Root cause:** the permission request for `mkdir` set `approval_free=True` but left `reversible=False`. The evaluator's `_ordinary_safe()` auto-allow gate requires **both** flags, so in-scope `mkdir` fell through to `Effect.ASK` → an approval card for a trivial, fully reversible action (a brand-new empty folder inside the granted workspace).

For non-coder users this is exactly the kind of surprise approval that breaks flow ("I just asked to make a folder").

## Fix

- `collie_core/tools/local_files.py` — include `operation == "mkdir"` in the `reversible` computation (a new empty folder inside the granted scope is trivially reversible), matching the documented intent.
- Tests:
  - `test_local_files_mkdir_permission_metadata` now asserts `made.reversible is True` (previously only checked `approval_free`, which is why the gap shipped).
  - New `test_local_files_mkdir_auto_allowed_inside_granted_folder` — end-to-end through the `ApprovalBroker`: in-scope `mkdir` produces **no approval event and no pending approval** (auto-allowed).

## Gates

- `pytest tests/tools/test_local_files_tool.py` → **19 passed** (18 + new broker test)
- Full core suite → running (expected green)
- `ruff check` → clean
- Repository snapshot → current
