### PR TITLE
fix(ci): unblock release qualification (ruff, Windows trusted-ID tests, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ are welcome too — but the normal path never requires them.
 **🛡️ Safety & reliability**
 
 - **Local-first everything** — memory, settings, and history in local SQLite;
-  no mandatory account, no silent uploads. The optional Collie account is
-  identity only — nothing leaves your machine.
+  no mandatory account, no silent uploads. The optional Collie account only
+  verifies your identity (hosted by Supabase) — chats, files, and history
+  stay on your machine.
 - Permissions engine with a broker → classifier → evaluator → store pipeline
 - **Rollback-safe updates** — a new version must boot healthy, or Collie
   rolls back to the last good one

--- a/collie-core/collie_core/lifecycle.py
+++ b/collie-core/collie_core/lifecycle.py
@@ -37,6 +37,7 @@ _RECLAIM_TIMEOUT_S = 5.0
 
 # -- parent-death watchdog -------------------------------------------------------
 
+
 def _arm_pdeathsig_linux() -> None:
     """Ask the kernel to SIGTERM us the moment our parent dies (Linux only)."""
     if sys.platform != "linux":
@@ -66,9 +67,7 @@ def _parent_still_alive(original: int) -> bool:
             process_query_limited = 0x1000
             still_active = 259
             kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(
-                process_query_limited, False, wintypes.DWORD(original)
-            )
+            handle = kernel32.OpenProcess(process_query_limited, False, wintypes.DWORD(original))
             if not handle:
                 return False
             try:
@@ -106,12 +105,11 @@ def arm_parent_watchdog(interval: float = WATCHDOG_INTERVAL_S) -> None:
             except Exception:
                 os._exit(0)
 
-    threading.Thread(
-        target=_watch, name="collie-parent-watchdog", daemon=True
-    ).start()
+    threading.Thread(target=_watch, name="collie-parent-watchdog", daemon=True).start()
 
 
 # -- stale-core port reclaim -----------------------------------------------------
+
 
 def _port_in_use(port: int) -> bool:
     """True when anything is accepting TCP connections on 127.0.0.1:port."""
@@ -198,9 +196,7 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
-def reclaim_stale_core_port(
-    port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S
-) -> bool:
+def reclaim_stale_core_port(port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S) -> bool:
     """Free the IPC port by terminating leftover cores, if any.
 
     Only ever kills processes whose command line runs ``collie_core.runtime``
@@ -242,5 +238,7 @@ def _proc_entries() -> list[_ProcEntry]:
             continue
         if not raw:
             continue
-        entries.append(_ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split()))
+        entries.append(
+            _ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split())
+        )
     return entries

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -440,9 +440,7 @@ class LocalFilesTool(Tool):
             # approval-free; overwriting or editing an existing file stays an
             # explicit approval because it destroys prior content. The
             # execution path revalidates scope before every change.
-            approval_free=bool(
-                safe_write and (reversible or operation == "mkdir")
-            ),
+            approval_free=bool(safe_write and (reversible or operation == "mkdir")),
             approve_for_me=safe_write,
         )
 
@@ -450,9 +448,7 @@ class LocalFilesTool(Tool):
         errors = super().validate_params(params)
         operation = str(params.get("operation") or "").lower()
         if operation == "mkdir":
-            if not isinstance(params.get("path"), str) or not str(
-                params.get("path") or ""
-            ).strip():
+            if not isinstance(params.get("path"), str) or not str(params.get("path") or "").strip():
                 errors.append("path is required for mkdir")
             return errors
         if operation in {"create", "overwrite", "save"} and not isinstance(
@@ -487,9 +483,7 @@ class LocalFilesTool(Tool):
                 _ensure_parent_dirs(target)
                 target.mkdir(parents=True, exist_ok=False)
                 return ToolResult(
-                    json.dumps(
-                        {"operation": "mkdir", "path": str(target), "local_only": True}
-                    )
+                    json.dumps({"operation": "mkdir", "path": str(target), "local_only": True})
                 )
             _require_text_artifact(target)
             if operation == "read":
@@ -525,9 +519,7 @@ class LocalFilesTool(Tool):
                     return ToolResult(json.dumps(edited_payload))
                 return result
             else:
-                raise _LocalFileError(
-                    "Choose list, read, create, overwrite, edit, save, or mkdir."
-                )
+                raise _LocalFileError("Choose list, read, create, overwrite, edit, save, or mkdir.")
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
             if undo_entry_id and conversation_id:
                 # The write never happened — don't leave an undoable entry

--- a/collie-core/collie_core/tools/reminders.py
+++ b/collie-core/collie_core/tools/reminders.py
@@ -57,9 +57,7 @@ _WEEKDAYS = {
     "saturday": 5,
     "sunday": 6,
 }
-_TIME_RE = re.compile(
-    r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$"
-)
+_TIME_RE = re.compile(r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$")
 _UNIT_SECONDS = {
     "minute": 60,
     "hour": 3600,
@@ -111,18 +109,14 @@ def _parse_due(value: str, label: str) -> datetime:
         lowered,
     )
     if in_match:
-        seconds = int(in_match.group(1)) * _UNIT_SECONDS[
-            in_match.group(2).rstrip("s")
-        ]
+        seconds = int(in_match.group(1)) * _UNIT_SECONDS[in_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
     from_match = re.match(
         r"^(\d+)\s+(minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+from\s+now$",
         lowered,
     )
     if from_match:
-        seconds = int(from_match.group(1)) * _UNIT_SECONDS[
-            from_match.group(2).rstrip("s")
-        ]
+        seconds = int(from_match.group(1)) * _UNIT_SECONDS[from_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
 
     # "tomorrow at 3pm" / "tomorrow 3pm" / "today 6pm" / "tonight"
@@ -138,9 +132,7 @@ def _parse_due(value: str, label: str) -> datetime:
         day_shift = 0
         rest = lowered[len("today") :]
     if day_shift is not None:
-        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
-            days=day_shift
-        )
+        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=day_shift)
         clock = rest.strip().lstrip(",;: ")
         if not clock:
             clock = "20:00" if lowered.startswith("tonight") else "09:00"

--- a/collie-core/tests/collie/test_lifecycle.py
+++ b/collie-core/tests/collie/test_lifecycle.py
@@ -62,9 +62,7 @@ def test_watchdog_exits_when_parent_is_killed(tmp_path: Path) -> None:
         """
     )
     shell_log = tmp_path / "shell.log"
-    shell = _run_until_marker(
-        [_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15
-    )
+    shell = _run_until_marker([_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15)
     # Find the grandchild core: the shell's child.
     core_pid = _child_pid(shell.pid)
     assert core_pid is not None, "core process not found under the shell"

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -264,9 +264,9 @@ async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
 
 def test_nl_due_tolerates_sentence_punctuation() -> None:
     """Models wrap due strings in commas/periods — those must not break parsing."""
-    from collie_core.tools.reminders import _normalize_due
-
     import datetime as _dt
+
+    from collie_core.tools.reminders import _normalize_due
 
     today = _dt.datetime.now().astimezone().date()
     tomorrow = today + _dt.timedelta(days=1)

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -143,6 +143,7 @@ async def test_unknown_action(db: CollieDB) -> None:
 
 # -- natural-language due times -------------------------------------------------
 
+
 def _local(month: int, day: int, hour: int = 0, minute: int = 0, year: int = 2026):
     """A local-tz aware datetime (naive input interpreted as local, like the tool)."""
     import datetime as _dt
@@ -256,9 +257,7 @@ async def test_create_reminder_with_natural_language_due(db: CollieDB) -> None:
 async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
     r = db.add_reminder("Nap", "2026-07-20T12:00:00")
     tool = RemindersTool()
-    result = await tool.execute(
-        action="snooze", reminder_id=r["id"], snooze_until="in 1 hour"
-    )
+    result = await tool.execute(action="snooze", reminder_id=r["id"], snooze_until="in 1 hour")
     assert "Snoozed" in str(result)
 
 

--- a/collie-ui/src/main/things-files.test.ts
+++ b/collie-ui/src/main/things-files.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { realpath } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -55,14 +56,19 @@ function record(overrides: Record<string, unknown> = {}): Record<string, unknown
 
 describe('things-files (trusted-ID boundary)', () => {
   let workspaceFile: string
+  let canonicalWorkspaceFile: string
   let projectDir: string
   let projectFile: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     testState.home = mkdtempSync(join(tmpdir(), 'collie-things-'))
     process.env.COLLIE_HOME = testState.home
     writeFileSync(join(testState.home, 'workspace.md'), '# Workspace thing', 'utf-8')
     workspaceFile = join(testState.home, 'workspace.md')
+    // Production resolves the registered path through realpath() before
+    // shell.openPath/showItemInFolder; on Windows that canonicalizes case
+    // and 8.3 short names, so the expected value must be canonical too.
+    canonicalWorkspaceFile = await realpath(workspaceFile)
     // A deliverable in a user-approved project folder, OUTSIDE COLLIE_HOME.
     projectDir = mkdtempSync(join(tmpdir(), 'collie-project-'))
     projectFile = join(projectDir, 'project-notes.md')
@@ -84,7 +90,7 @@ describe('things-files (trusted-ID boundary)', () => {
     // A forged path argument is ignored — the id decides.
     const result = await thingOpen('conv-1', 'th_a')
     expect(result).toBe('')
-    expect(testState.openPathCalls).toEqual([workspaceFile])
+    expect(testState.openPathCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('surfaces OS open errors instead of swallowing them', async () => {
@@ -137,7 +143,7 @@ describe('things-files (trusted-ID boundary)', () => {
   it('shows the registered file in the folder', async () => {
     writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
     await thingShowInFolder('conv-1', 'th_a')
-    expect(testState.showItemCalls).toEqual([workspaceFile])
+    expect(testState.showItemCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('save-copy defaults to the record title and copies the registered file', async () => {


### PR DESCRIPTION
## What
Three small fixes that unblock the release pipeline (currently **3 of 4 CI jobs red** on main @ 885b38e, and `release.yml` qualify cannot pass).

1. **ruff I001** at `collie-core/tests/collie/test_reminders.py:267` — function-scope imports in the wrong order. This exact error fails the `Lint (ruff)` step in `release.yml` qualify **and** both collie-core CI jobs. Fix: reorder the two imports (verified: `ruff check nanobot collie_core tests` → all checks passed).
2. **Windows UI CI** — 2 `things-files.test.ts` (trusted-ID boundary) tests failed on the Windows runner only. Production resolves registered paths through `realpath()` before `shell.openPath`/`showItemInFolder`; on Windows realpath canonicalizes case / 8.3 short names, so the assertions comparing against the raw mkdtemp path failed. Fix: compare against the canonical path. Verified: 10/10 tests pass locally; will confirm on Windows CI.
3. **README copy** — "the optional Collie account is identity only — nothing leaves your machine" is now inaccurate: identity is verified via Supabase. Reworded: identity verification is hosted by Supabase; chats/files/history stay on your machine.

## Gates
- `ruff check nanobot collie_core tests` ✅ (all checks passed)
- `npx vitest run src/main/things-files.test.ts` ✅ 10/10
- `npm run typecheck` ✅ (both tsconfigs)
