### PR TITLE
fix(security): decrypted secrets no longer cross into the renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ are welcome too — but the normal path never requires them.
 **🛡️ Safety & reliability**
 
 - **Local-first everything** — memory, settings, and history in local SQLite;
-  no mandatory account, no silent uploads. The optional Collie account is
-  identity only — nothing leaves your machine.
+  no mandatory account, no silent uploads. The optional Collie account only
+  verifies your identity (hosted by Supabase) — chats, files, and history
+  stay on your machine.
 - Permissions engine with a broker → classifier → evaluator → store pipeline
 - **Rollback-safe updates** — a new version must boot healthy, or Collie
   rolls back to the last good one

--- a/collie-core/collie_core/lifecycle.py
+++ b/collie-core/collie_core/lifecycle.py
@@ -37,6 +37,7 @@ _RECLAIM_TIMEOUT_S = 5.0
 
 # -- parent-death watchdog -------------------------------------------------------
 
+
 def _arm_pdeathsig_linux() -> None:
     """Ask the kernel to SIGTERM us the moment our parent dies (Linux only)."""
     if sys.platform != "linux":
@@ -66,9 +67,7 @@ def _parent_still_alive(original: int) -> bool:
             process_query_limited = 0x1000
             still_active = 259
             kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(
-                process_query_limited, False, wintypes.DWORD(original)
-            )
+            handle = kernel32.OpenProcess(process_query_limited, False, wintypes.DWORD(original))
             if not handle:
                 return False
             try:
@@ -106,12 +105,11 @@ def arm_parent_watchdog(interval: float = WATCHDOG_INTERVAL_S) -> None:
             except Exception:
                 os._exit(0)
 
-    threading.Thread(
-        target=_watch, name="collie-parent-watchdog", daemon=True
-    ).start()
+    threading.Thread(target=_watch, name="collie-parent-watchdog", daemon=True).start()
 
 
 # -- stale-core port reclaim -----------------------------------------------------
+
 
 def _port_in_use(port: int) -> bool:
     """True when anything is accepting TCP connections on 127.0.0.1:port."""
@@ -198,9 +196,7 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
-def reclaim_stale_core_port(
-    port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S
-) -> bool:
+def reclaim_stale_core_port(port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S) -> bool:
     """Free the IPC port by terminating leftover cores, if any.
 
     Only ever kills processes whose command line runs ``collie_core.runtime``
@@ -242,5 +238,7 @@ def _proc_entries() -> list[_ProcEntry]:
             continue
         if not raw:
             continue
-        entries.append(_ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split()))
+        entries.append(
+            _ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split())
+        )
     return entries

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -440,9 +440,7 @@ class LocalFilesTool(Tool):
             # approval-free; overwriting or editing an existing file stays an
             # explicit approval because it destroys prior content. The
             # execution path revalidates scope before every change.
-            approval_free=bool(
-                safe_write and (reversible or operation == "mkdir")
-            ),
+            approval_free=bool(safe_write and (reversible or operation == "mkdir")),
             approve_for_me=safe_write,
         )
 
@@ -450,9 +448,7 @@ class LocalFilesTool(Tool):
         errors = super().validate_params(params)
         operation = str(params.get("operation") or "").lower()
         if operation == "mkdir":
-            if not isinstance(params.get("path"), str) or not str(
-                params.get("path") or ""
-            ).strip():
+            if not isinstance(params.get("path"), str) or not str(params.get("path") or "").strip():
                 errors.append("path is required for mkdir")
             return errors
         if operation in {"create", "overwrite", "save"} and not isinstance(
@@ -487,9 +483,7 @@ class LocalFilesTool(Tool):
                 _ensure_parent_dirs(target)
                 target.mkdir(parents=True, exist_ok=False)
                 return ToolResult(
-                    json.dumps(
-                        {"operation": "mkdir", "path": str(target), "local_only": True}
-                    )
+                    json.dumps({"operation": "mkdir", "path": str(target), "local_only": True})
                 )
             _require_text_artifact(target)
             if operation == "read":
@@ -525,9 +519,7 @@ class LocalFilesTool(Tool):
                     return ToolResult(json.dumps(edited_payload))
                 return result
             else:
-                raise _LocalFileError(
-                    "Choose list, read, create, overwrite, edit, save, or mkdir."
-                )
+                raise _LocalFileError("Choose list, read, create, overwrite, edit, save, or mkdir.")
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
             if undo_entry_id and conversation_id:
                 # The write never happened — don't leave an undoable entry

--- a/collie-core/collie_core/tools/reminders.py
+++ b/collie-core/collie_core/tools/reminders.py
@@ -57,9 +57,7 @@ _WEEKDAYS = {
     "saturday": 5,
     "sunday": 6,
 }
-_TIME_RE = re.compile(
-    r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$"
-)
+_TIME_RE = re.compile(r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$")
 _UNIT_SECONDS = {
     "minute": 60,
     "hour": 3600,
@@ -111,18 +109,14 @@ def _parse_due(value: str, label: str) -> datetime:
         lowered,
     )
     if in_match:
-        seconds = int(in_match.group(1)) * _UNIT_SECONDS[
-            in_match.group(2).rstrip("s")
-        ]
+        seconds = int(in_match.group(1)) * _UNIT_SECONDS[in_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
     from_match = re.match(
         r"^(\d+)\s+(minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+from\s+now$",
         lowered,
     )
     if from_match:
-        seconds = int(from_match.group(1)) * _UNIT_SECONDS[
-            from_match.group(2).rstrip("s")
-        ]
+        seconds = int(from_match.group(1)) * _UNIT_SECONDS[from_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
 
     # "tomorrow at 3pm" / "tomorrow 3pm" / "today 6pm" / "tonight"
@@ -138,9 +132,7 @@ def _parse_due(value: str, label: str) -> datetime:
         day_shift = 0
         rest = lowered[len("today") :]
     if day_shift is not None:
-        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
-            days=day_shift
-        )
+        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=day_shift)
         clock = rest.strip().lstrip(",;: ")
         if not clock:
             clock = "20:00" if lowered.startswith("tonight") else "09:00"

--- a/collie-core/tests/collie/test_lifecycle.py
+++ b/collie-core/tests/collie/test_lifecycle.py
@@ -62,9 +62,7 @@ def test_watchdog_exits_when_parent_is_killed(tmp_path: Path) -> None:
         """
     )
     shell_log = tmp_path / "shell.log"
-    shell = _run_until_marker(
-        [_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15
-    )
+    shell = _run_until_marker([_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15)
     # Find the grandchild core: the shell's child.
     core_pid = _child_pid(shell.pid)
     assert core_pid is not None, "core process not found under the shell"

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -264,9 +264,9 @@ async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
 
 def test_nl_due_tolerates_sentence_punctuation() -> None:
     """Models wrap due strings in commas/periods — those must not break parsing."""
-    from collie_core.tools.reminders import _normalize_due
-
     import datetime as _dt
+
+    from collie_core.tools.reminders import _normalize_due
 
     today = _dt.datetime.now().astimezone().date()
     tomorrow = today + _dt.timedelta(days=1)

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -143,6 +143,7 @@ async def test_unknown_action(db: CollieDB) -> None:
 
 # -- natural-language due times -------------------------------------------------
 
+
 def _local(month: int, day: int, hour: int = 0, minute: int = 0, year: int = 2026):
     """A local-tz aware datetime (naive input interpreted as local, like the tool)."""
     import datetime as _dt
@@ -256,9 +257,7 @@ async def test_create_reminder_with_natural_language_due(db: CollieDB) -> None:
 async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
     r = db.add_reminder("Nap", "2026-07-20T12:00:00")
     tool = RemindersTool()
-    result = await tool.execute(
-        action="snooze", reminder_id=r["id"], snooze_until="in 1 hour"
-    )
+    result = await tool.execute(action="snooze", reminder_id=r["id"], snooze_until="in 1 hour")
     assert "Snoozed" in str(result)
 
 

--- a/collie-ui/src/main/core-client.test.ts
+++ b/collie-ui/src/main/core-client.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./python', () => ({
+  coreState: vi.fn(() => ({ state: 'running', port: 3818, token: 'test-token', error: '' }))
+}))
+
+const loadSecretsMock = vi.fn()
+vi.mock('./secrets', () => ({
+  loadSecrets: (...args: unknown[]) => loadSecretsMock(...args)
+}))
+
+import { pushStoredSecretsToCore } from './core-client'
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  sent: string[] = []
+  closed = false
+  messageListeners: Array<(event: { data: string }) => void> = []
+
+  constructor(_url: string, _protocols?: string[]) {
+    FakeWebSocket.instances.push(this)
+    // Simulate the connection succeeding on the next tick.
+    queueMicrotask(() => {
+      this.onopen?.()
+    })
+  }
+
+  onopen: (() => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  addEventListener(type: string, listener: (event: { data: string }) => void): void {
+    if (type === 'message') this.messageListeners.push(listener)
+  }
+
+  removeEventListener(): void {
+    // noop
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+    // Auto-ack every command so the push completes.
+    const frame = JSON.parse(data) as { id?: string }
+    queueMicrotask(() => {
+      for (const listener of this.messageListeners) {
+        listener({ data: JSON.stringify({ type: 'ok', id: frame.id, data: {} }) })
+      }
+    })
+  }
+
+  close(): void {
+    this.closed = true
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  FakeWebSocket.instances = []
+  ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
+})
+
+describe('pushStoredSecretsToCore', () => {
+  it('pushes provider keys as set_api_key frames and closes the socket', async () => {
+    loadSecretsMock.mockReturnValue({ deepseek: 'sk-ds-1', openai: 'sk-openai-1' })
+    await pushStoredSecretsToCore()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    const ws = FakeWebSocket.instances[0]
+    const frames = ws.sent.map((raw) => JSON.parse(raw))
+    expect(frames.map((f) => f.type)).toEqual(['set_api_key', 'set_api_key'])
+    expect(frames[0]).toMatchObject({ provider: 'deepseek', key: 'sk-ds-1' })
+    expect(frames[1]).toMatchObject({ provider: 'openai', key: 'sk-openai-1' })
+    expect(ws.closed).toBe(true)
+  })
+
+  it('routes messenger: prefixed entries to set_messenger_secret', async () => {
+    loadSecretsMock.mockReturnValue({ 'messenger:telegram:token': 'bot-123:abc' })
+    await pushStoredSecretsToCore()
+    const ws = FakeWebSocket.instances[0]
+    const frames = ws.sent.map((raw) => JSON.parse(raw))
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toMatchObject({
+      type: 'set_messenger_secret',
+      messenger: 'telegram',
+      key: 'token',
+      value: 'bot-123:abc'
+    })
+  })
+
+  it('opens no socket when there are no stored secrets', async () => {
+    loadSecretsMock.mockReturnValue({})
+    await pushStoredSecretsToCore()
+    expect(FakeWebSocket.instances).toHaveLength(0)
+  })
+
+  it('skips a second push while one is in flight (one-shot guard)', async () => {
+    loadSecretsMock.mockReturnValue({ deepseek: 'sk-ds-1' })
+    const first = pushStoredSecretsToCore()
+    await pushStoredSecretsToCore() // should no-op
+    await first
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('never throws when the core connection fails — degrades gracefully', async () => {
+    loadSecretsMock.mockReturnValue({ deepseek: 'sk-ds-1' })
+    const Original = FakeWebSocket
+    class FailingWebSocket extends Original {
+      override onopen: (() => void) | null = null
+      constructor(url: string, protocols?: string[]) {
+        super(url, protocols)
+        queueMicrotask(() => {
+          this.onerror?.()
+        })
+      }
+    }
+    ;(globalThis as { WebSocket: unknown }).WebSocket = FailingWebSocket
+    await expect(pushStoredSecretsToCore()).resolves.toBeUndefined()
+  })
+})

--- a/collie-ui/src/main/core-client.ts
+++ b/collie-ui/src/main/core-client.ts
@@ -1,0 +1,123 @@
+/**
+ * Main-process core client.
+ *
+ * The ONLY channel over which decrypted stored secrets travel: after the
+ * core reports ready, the main process decrypts the stored secrets once
+ * (secrets.ts loadSecrets) and pushes them over its own WebSocket
+ * connection. The renderer never receives these values — it only learns
+ * how many stored secrets exist (for boot decisions), never their content.
+ *
+ * User-entered keys (typed in Settings) still flow renderer -> main ->
+ * core via the existing saveSecret + renderer WS path; those are fresh
+ * user input, not stored long-lived secrets.
+ */
+import { coreState } from './python'
+import { loadSecrets } from './secrets'
+
+const CONNECT_TIMEOUT_MS = 5000
+const COMMAND_TIMEOUT_MS = 10_000
+
+let pushInFlight = false
+
+function openCoreSocket(timeoutMs = CONNECT_TIMEOUT_MS): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const { port, token } = coreState()
+    let settled = false
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, [`collie-${token}`])
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        ws.close()
+      } catch {
+        // already closed
+      }
+      reject(new Error('Core connection timed out'))
+    }, timeoutMs)
+    ws.onopen = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(ws)
+    }
+    ws.onerror = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      reject(new Error('Could not connect to the core'))
+    }
+  })
+}
+
+function command(
+  ws: WebSocket,
+  type: string,
+  payload: Record<string, unknown>
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+    let settled = false
+    const onMessage = (event: MessageEvent): void => {
+      if (settled) return
+      let frame: { type?: string; id?: string; message?: string; detail?: string; data?: unknown } | null = null
+      try {
+        frame = JSON.parse(String(event.data))
+      } catch {
+        return
+      }
+      if (!frame || frame.id !== id) return
+      settled = true
+      clearTimeout(timer)
+      ws.removeEventListener('message', onMessage)
+      if (frame.type === 'ok') resolve(frame.data)
+      else reject(new Error(frame.message ?? frame.detail ?? `${type} failed`))
+    }
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      ws.removeEventListener('message', onMessage)
+      reject(new Error(`${type} timed out`))
+    }, COMMAND_TIMEOUT_MS)
+    ws.addEventListener('message', onMessage)
+    ws.send(JSON.stringify({ type, id, ...payload }))
+  })
+}
+
+/**
+ * Decrypt every stored secret once and push it to the core over the
+ * main process's own connection. Called once per core spawn, right after
+ * readiness (see python.ts onCoreReady). A failed push degrades to
+ * "re-enter keys in Settings" — it must never crash the app on boot.
+ */
+export async function pushStoredSecretsToCore(): Promise<void> {
+  if (pushInFlight) return
+  pushInFlight = true
+  let ws: WebSocket | null = null
+  try {
+    const secrets = loadSecrets()
+    const entries = Object.entries(secrets)
+    if (entries.length === 0) return
+    ws = await openCoreSocket()
+    for (const [name, key] of entries) {
+      if (name.startsWith('messenger:')) {
+        const [, messenger, secretKey] = name.split(':')
+        if (messenger && secretKey) {
+          await command(ws, 'set_messenger_secret', { messenger, key: secretKey, value: key })
+        }
+      } else {
+        await command(ws, 'set_api_key', { provider: name, key })
+      }
+    }
+  } catch (error) {
+    console.error('[core-client] secret push failed', error)
+  } finally {
+    if (ws) {
+      try {
+        ws.close()
+      } catch {
+        // already closed
+      }
+    }
+    pushInFlight = false
+  }
+}

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'url'
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { readFile as readFileAsync, realpath as realpathAsync, stat as statAsync } from 'fs/promises'
 import { assertLocalWindowsFileAccessFolder } from './local-file-access'
-import { spawnCore, stopCore, coreState } from './python'
+import { spawnCore, stopCore, coreState, onCoreReady } from './python'
 import { petEnabled, petRunning, setPetEnabled, spawnPet, stopPet } from './pet'
 import { isAllowedPetCommand } from './petCommands'
 import {
@@ -18,12 +18,12 @@ import {
   deleteSecret,
   finalizeSecretChange,
   listSecretProviders,
-  loadSecrets,
   rollbackSecretChange,
   saveSecret,
   secureStorageAvailable,
   stageSecretChange
 } from './secrets'
+import { pushStoredSecretsToCore } from './core-client'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
 import { autoUpdater } from 'electron-updater'
 import {
@@ -361,7 +361,9 @@ function registerIpc(): void {
   )
   handle('collie:delete-secret', (provider: string) => deleteSecret(provider))
   handle('collie:list-secrets', () => listSecretProviders())
-  handle('collie:load-secrets', () => loadSecrets())
+  // Count only — the values themselves are pushed to the core by the main
+  // process (core-client.ts); decrypted secrets never cross into the renderer.
+  handle('collie:stored-secret-count', () => listSecretProviders().length)
   handle('account:start-sign-in', () => startAccountSignIn())
   handle('account:get-state', () => getAccountState())
   handle('account:sign-out', () => signOut())
@@ -571,6 +573,11 @@ app.whenReady().then(async () => {
     }
   })
   await spawnCore(isDev)
+  // Push stored secrets to the core over the main process's own connection
+  // (the renderer never sees decrypted values).
+  onCoreReady(() => {
+    void pushStoredSecretsToCore()
+  })
   // If this boot was an update, verify the new version came up healthy
   // before letting the update ledger treat it as last-known-good. Probation
   // (sustained running, not just a ready message) applies only when a

--- a/collie-ui/src/main/python.ts
+++ b/collie-ui/src/main/python.ts
@@ -24,6 +24,16 @@ let readyPort: number | null = null
 let respawnTimer: NodeJS.Timeout | null = null
 let healthyTimer: NodeJS.Timeout | null = null
 
+const coreReadyListeners = new Set<() => void>()
+
+/** Subscribe to the first 'ready' of each core spawn (fires again on respawn). */
+export function onCoreReady(listener: () => void): () => void {
+  coreReadyListeners.add(listener)
+  return () => {
+    coreReadyListeners.delete(listener)
+  }
+}
+
 const MAX_ABNORMAL_EXITS = 3
 const RESPAWN_DELAY_MS = 3000
 const HEALTHY_WINDOW_MS = 5 * 60 * 1000
@@ -146,6 +156,7 @@ export async function spawnCore(isDev: boolean): Promise<void> {
         restartBudget.decayAfterSustainedHealth(Date.now())
       }
     }, HEALTHY_WINDOW_MS)
+    for (const listener of coreReadyListeners) listener()
   }
 
   const flushOutput = (): void => {

--- a/collie-ui/src/main/secrets.ts
+++ b/collie-ui/src/main/secrets.ts
@@ -3,10 +3,12 @@
  * (DPAPI on Windows, Keychain on macOS). Never written in plaintext (F020).
  *
  * The encrypted blobs live in userData/secrets.json. Decrypted values are
- * only ever held in memory and handed to the Python core over localhost IPC.
- * `loadSecrets` is one-shot: it decrypts once at the core handshake and then
- * returns nothing until the core process is (re)spawned, so a compromised
- * renderer cannot keep pulling plaintext keys on demand.
+ * only ever held in memory and handed to the Python core over localhost IPC
+ * by the MAIN process (core-client.ts pushStoredSecretsToCore, fired on
+ * core-ready). The renderer never receives decrypted values — the preload
+ * bridge only exposes a count (collie:stored-secret-count). `loadSecrets`
+ * is one-shot: it decrypts once per core spawn and then returns nothing
+ * until the core process is (re)spawned.
  */
 import { app, safeStorage } from 'electron'
 import { randomUUID } from 'crypto'

--- a/collie-ui/src/main/things-files.test.ts
+++ b/collie-ui/src/main/things-files.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { realpath } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -55,14 +56,19 @@ function record(overrides: Record<string, unknown> = {}): Record<string, unknown
 
 describe('things-files (trusted-ID boundary)', () => {
   let workspaceFile: string
+  let canonicalWorkspaceFile: string
   let projectDir: string
   let projectFile: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     testState.home = mkdtempSync(join(tmpdir(), 'collie-things-'))
     process.env.COLLIE_HOME = testState.home
     writeFileSync(join(testState.home, 'workspace.md'), '# Workspace thing', 'utf-8')
     workspaceFile = join(testState.home, 'workspace.md')
+    // Production resolves the registered path through realpath() before
+    // shell.openPath/showItemInFolder; on Windows that canonicalizes case
+    // and 8.3 short names, so the expected value must be canonical too.
+    canonicalWorkspaceFile = await realpath(workspaceFile)
     // A deliverable in a user-approved project folder, OUTSIDE COLLIE_HOME.
     projectDir = mkdtempSync(join(tmpdir(), 'collie-project-'))
     projectFile = join(projectDir, 'project-notes.md')
@@ -84,7 +90,7 @@ describe('things-files (trusted-ID boundary)', () => {
     // A forged path argument is ignored — the id decides.
     const result = await thingOpen('conv-1', 'th_a')
     expect(result).toBe('')
-    expect(testState.openPathCalls).toEqual([workspaceFile])
+    expect(testState.openPathCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('surfaces OS open errors instead of swallowing them', async () => {
@@ -137,7 +143,7 @@ describe('things-files (trusted-ID boundary)', () => {
   it('shows the registered file in the folder', async () => {
     writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
     await thingShowInFolder('conv-1', 'th_a')
-    expect(testState.showItemCalls).toEqual([workspaceFile])
+    expect(testState.showItemCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('save-copy defaults to the record title and copies the registered file', async () => {

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -62,8 +62,8 @@ const api = {
   deleteSecret: (provider: string): Promise<boolean> =>
     ipcRenderer.invoke('collie:delete-secret', provider),
   listSecrets: (): Promise<string[]> => ipcRenderer.invoke('collie:list-secrets'),
-  loadSecrets: (): Promise<Record<string, string>> =>
-    ipcRenderer.invoke('collie:load-secrets'),
+  storedSecretCount: (): Promise<number> =>
+    ipcRenderer.invoke('collie:stored-secret-count'),
   pickAttachments: (): Promise<Array<{ name: string; mime: string; size: number; data_url: string }>> =>
     ipcRenderer.invoke('collie:pick-attachments'),
   pickProjectFolder: (): Promise<string | null> =>

--- a/collie-ui/src/renderer/src/App.tsx
+++ b/collie-ui/src/renderer/src/App.tsx
@@ -27,26 +27,10 @@ export default function App(): React.JSX.Element {
     let cancelled = false
 
     const injectSecrets = async (): Promise<number> => {
-      let providerKeys = 0
-      let messengerSecrets = 0
-      try {
-        const secrets = (await window.collie?.loadSecrets()) ?? {}
-        for (const [name, key] of Object.entries(secrets)) {
-          if (name.startsWith('messenger:')) {
-            const [, messenger, secretKey] = name.split(':')
-            if (messenger && secretKey) {
-              await collieClient.setMessengerSecret(messenger, secretKey, key)
-              messengerSecrets += 1
-            }
-          } else {
-            await collieClient.setApiKey(name, key)
-            providerKeys += 1
-          }
-        }
-      } catch {
-        // fall through — secrets can be re-entered in Settings
-      }
-      return providerKeys + messengerSecrets
+      // Stored secrets are pushed to the core by the main process over its
+      // own connection (core-client.ts). The renderer only learns how many
+      // exist for boot decisions — never the values.
+      return (await window.collie?.storedSecretCount()) ?? 0
     }
 
     const probeController = new BootProbeController({


### PR DESCRIPTION
## What
Closes the renderer trust-boundary violation: decrypted stored secrets no longer cross into the renderer.

**Before:** the renderer pulled ALL stored provider/messenger secrets at boot (`App.tsx` → `collie:load-secrets` → main decrypts → renderer → core WS). The "one-shot" guard in `secrets.ts` was defeated — the renderer was the *only* consumer. A compromised renderer had every stored key.

**After:**
- **`src/main/core-client.ts` (new)** — the main process connects to the core over its own WebSocket and pushes decrypted secrets once per core spawn, right after readiness (`set_api_key` / `set_messenger_secret`). Values stay in the main process.
- **`python.ts`** — new `onCoreReady()` listener, fired on the first `ready` of each spawn (re-armed on respawn).
- **`collie:load-secrets` removed** from IPC + preload; replaced by `collie:stored-secret-count` — a bare count the renderer uses for boot decisions only.
- **`App.tsx`** — `injectSecrets` now reads the count; the injection loop is gone.
- User-entered keys (typed fresh in Settings) keep their existing renderer → main → core path — that's user input, not stored secrets.
- Renderer keeps its direct WS with the per-boot token — the token is ephemeral (new every launch), exists to confine *other local processes*, and the renderer is already the full UI client. Documented rationale in the commit.

## Why this scope
The real leak was stored long-lived secrets reaching untrusted renderer code. Moving the renderer behind a full main-process proxy would be a large refactor that changes chat/streaming paths for no additional security (the renderer is already the UI client); the scoped-token idea doesn't reduce what a compromised renderer can do either (it can already click approve). The secrets removal is the substantive fix.

## Gates
- typecheck ✅ (both tsconfigs)
- vitest: **349 passed / 54 files** (incl. 5 new core-client tests; the 15 account-auth tests needed a stray `python3 -m http.server` killed off port 8123 — pre-existing environment noise, unrelated)
