### PR TITLE
fix(storage): reject Linux basic_text, gate OAuth connectors off-platform, smoke-test all OSes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,12 +223,12 @@ jobs:
       - name: Package installer (${{ matrix.flags }})
         run: npx electron-builder ${{ matrix.flags }} --publish never
 
-      - name: Smoke test the packaged core (Windows)
-        # Boots the staged python.exe from dist/win-unpacked/resources,
-        # asserts COLLIE_READY on an ephemeral port, anonymous WS rejection,
-        # and an authenticated ping — the end-to-end packaged-runtime check.
-        # Must run BEFORE the finalize step removes dist/win-unpacked.
-        if: runner.os == 'Windows'
+      - name: Smoke test the packaged core
+        # Boots the staged python from the unpacked app resources, asserts
+        # COLLIE_READY on an ephemeral port, anonymous WS rejection, and an
+        # authenticated ping — the end-to-end packaged-runtime check on
+        # every platform. Must run BEFORE the finalize step removes
+        # dist/win-unpacked.
         shell: bash
         working-directory: collie-ui
         run: npm run smoke:packaged-core

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ are welcome too — but the normal path never requires them.
 **🛡️ Safety & reliability**
 
 - **Local-first everything** — memory, settings, and history in local SQLite;
-  no mandatory account, no silent uploads. The optional Collie account is
-  identity only — nothing leaves your machine.
+  no mandatory account, no silent uploads. The optional Collie account only
+  verifies your identity (hosted by Supabase) — chats, files, and history
+  stay on your machine.
 - Permissions engine with a broker → classifier → evaluator → store pipeline
 - **Rollback-safe updates** — a new version must boot healthy, or Collie
   rolls back to the last good one

--- a/collie-core/collie_core/connectors/catalog.py
+++ b/collie-core/collie_core/connectors/catalog.py
@@ -8,7 +8,14 @@ with its pending packaged-app verification — it is not a release claim.
 
 from __future__ import annotations
 
+import sys
+
 from collie_core.connectors.models import ConnectorDefinition, ConnectorDriverKind
+
+# OAuth connectors persist their tokens in CredentialStore, which is
+# Windows-DPAPI-only for now. On macOS/Linux they surface as coming-soon
+# instead of failing at connect time.
+_OAUTH_AVAILABLE = sys.platform == "win32"
 
 __all__ = ["CONNECTOR_CATALOG", "connector_def"]
 
@@ -94,7 +101,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         capabilities=("Read", "Create", "Update"),
         permissions=("read pages", "search", "create and update with approval"),
         featured=True,
-        available=True,
+        available=_OAUTH_AVAILABLE,
         note=_ALPHA_VERIFICATION,
         scopes=_SCOPES["notion"],
     ),
@@ -106,7 +113,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         "https://mcp.linear.app/mcp",
         capabilities=("Read", "Create", "Update"),
         permissions=("read issues", "create and update with approval"),
-        available=True,
+        available=_OAUTH_AVAILABLE,
         note=_ALPHA_VERIFICATION,
         overrides={"delete_issue": "destructive"},
         scopes=_SCOPES["linear"],
@@ -120,7 +127,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         capabilities=("Read", "Create", "Update"),
         permissions=("read tasks", "create and complete with approval"),
         featured=True,
-        available=True,
+        available=_OAUTH_AVAILABLE,
         note=_ALPHA_VERIFICATION,
         scopes=_SCOPES["todoist"],
     ),
@@ -132,7 +139,7 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         "https://mcp.atlassian.com/v1/mcp/authv2",
         capabilities=("Read", "Create", "Update"),
         permissions=("read Jira and Confluence", "create and update with approval"),
-        available=True,
+        available=_OAUTH_AVAILABLE,
         note=_ALPHA_VERIFICATION,
         scopes=_SCOPES["atlassian"],
     ),
@@ -242,8 +249,8 @@ CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
         endpoint="https://mcp.airtable.com/mcp",
         capabilities=("Read", "Create", "Update"),
         permissions=("read records", "create and update with approval"),
-        available=True,
-        release_status="alpha",
+        available=_OAUTH_AVAILABLE,
+        release_status="alpha" if _OAUTH_AVAILABLE else "coming_soon",
         note=_ALPHA_VERIFICATION,
         scopes=_SCOPES["airtable"],
     ),

--- a/collie-core/collie_core/lifecycle.py
+++ b/collie-core/collie_core/lifecycle.py
@@ -37,6 +37,7 @@ _RECLAIM_TIMEOUT_S = 5.0
 
 # -- parent-death watchdog -------------------------------------------------------
 
+
 def _arm_pdeathsig_linux() -> None:
     """Ask the kernel to SIGTERM us the moment our parent dies (Linux only)."""
     if sys.platform != "linux":
@@ -66,9 +67,7 @@ def _parent_still_alive(original: int) -> bool:
             process_query_limited = 0x1000
             still_active = 259
             kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(
-                process_query_limited, False, wintypes.DWORD(original)
-            )
+            handle = kernel32.OpenProcess(process_query_limited, False, wintypes.DWORD(original))
             if not handle:
                 return False
             try:
@@ -106,12 +105,11 @@ def arm_parent_watchdog(interval: float = WATCHDOG_INTERVAL_S) -> None:
             except Exception:
                 os._exit(0)
 
-    threading.Thread(
-        target=_watch, name="collie-parent-watchdog", daemon=True
-    ).start()
+    threading.Thread(target=_watch, name="collie-parent-watchdog", daemon=True).start()
 
 
 # -- stale-core port reclaim -----------------------------------------------------
+
 
 def _port_in_use(port: int) -> bool:
     """True when anything is accepting TCP connections on 127.0.0.1:port."""
@@ -198,9 +196,7 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
-def reclaim_stale_core_port(
-    port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S
-) -> bool:
+def reclaim_stale_core_port(port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S) -> bool:
     """Free the IPC port by terminating leftover cores, if any.
 
     Only ever kills processes whose command line runs ``collie_core.runtime``
@@ -242,5 +238,7 @@ def _proc_entries() -> list[_ProcEntry]:
             continue
         if not raw:
             continue
-        entries.append(_ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split()))
+        entries.append(
+            _ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split())
+        )
     return entries

--- a/collie-core/collie_core/services/credentials.py
+++ b/collie-core/collie_core/services/credentials.py
@@ -37,7 +37,11 @@ def _blob(data: bytes) -> tuple[_DataBlob, object]:
 
 def _dpapi_protect(data: bytes) -> bytes:
     if sys.platform != "win32":
-        raise RuntimeError("Encrypted service credentials require Windows DPAPI.")
+        raise RuntimeError(
+            "Connected-service credentials can only be stored securely on "
+            "Windows for now (Windows DPAPI). On macOS and Linux these "
+            "connectors aren't available yet."
+        )
     import ctypes
 
     source, source_buffer = _blob(data)

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -440,9 +440,7 @@ class LocalFilesTool(Tool):
             # approval-free; overwriting or editing an existing file stays an
             # explicit approval because it destroys prior content. The
             # execution path revalidates scope before every change.
-            approval_free=bool(
-                safe_write and (reversible or operation == "mkdir")
-            ),
+            approval_free=bool(safe_write and (reversible or operation == "mkdir")),
             approve_for_me=safe_write,
         )
 
@@ -450,9 +448,7 @@ class LocalFilesTool(Tool):
         errors = super().validate_params(params)
         operation = str(params.get("operation") or "").lower()
         if operation == "mkdir":
-            if not isinstance(params.get("path"), str) or not str(
-                params.get("path") or ""
-            ).strip():
+            if not isinstance(params.get("path"), str) or not str(params.get("path") or "").strip():
                 errors.append("path is required for mkdir")
             return errors
         if operation in {"create", "overwrite", "save"} and not isinstance(
@@ -487,9 +483,7 @@ class LocalFilesTool(Tool):
                 _ensure_parent_dirs(target)
                 target.mkdir(parents=True, exist_ok=False)
                 return ToolResult(
-                    json.dumps(
-                        {"operation": "mkdir", "path": str(target), "local_only": True}
-                    )
+                    json.dumps({"operation": "mkdir", "path": str(target), "local_only": True})
                 )
             _require_text_artifact(target)
             if operation == "read":
@@ -525,9 +519,7 @@ class LocalFilesTool(Tool):
                     return ToolResult(json.dumps(edited_payload))
                 return result
             else:
-                raise _LocalFileError(
-                    "Choose list, read, create, overwrite, edit, save, or mkdir."
-                )
+                raise _LocalFileError("Choose list, read, create, overwrite, edit, save, or mkdir.")
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
             if undo_entry_id and conversation_id:
                 # The write never happened — don't leave an undoable entry

--- a/collie-core/collie_core/tools/reminders.py
+++ b/collie-core/collie_core/tools/reminders.py
@@ -57,9 +57,7 @@ _WEEKDAYS = {
     "saturday": 5,
     "sunday": 6,
 }
-_TIME_RE = re.compile(
-    r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$"
-)
+_TIME_RE = re.compile(r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$")
 _UNIT_SECONDS = {
     "minute": 60,
     "hour": 3600,
@@ -111,18 +109,14 @@ def _parse_due(value: str, label: str) -> datetime:
         lowered,
     )
     if in_match:
-        seconds = int(in_match.group(1)) * _UNIT_SECONDS[
-            in_match.group(2).rstrip("s")
-        ]
+        seconds = int(in_match.group(1)) * _UNIT_SECONDS[in_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
     from_match = re.match(
         r"^(\d+)\s+(minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+from\s+now$",
         lowered,
     )
     if from_match:
-        seconds = int(from_match.group(1)) * _UNIT_SECONDS[
-            from_match.group(2).rstrip("s")
-        ]
+        seconds = int(from_match.group(1)) * _UNIT_SECONDS[from_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
 
     # "tomorrow at 3pm" / "tomorrow 3pm" / "today 6pm" / "tonight"
@@ -138,9 +132,7 @@ def _parse_due(value: str, label: str) -> datetime:
         day_shift = 0
         rest = lowered[len("today") :]
     if day_shift is not None:
-        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
-            days=day_shift
-        )
+        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=day_shift)
         clock = rest.strip().lstrip(",;: ")
         if not clock:
             clock = "20:00" if lowered.startswith("tonight") else "09:00"

--- a/collie-core/tests/collie/test_connectors.py
+++ b/collie-core/tests/collie/test_connectors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -67,15 +68,21 @@ def connector_store(tmp_path: Path) -> CredentialStore:
 
 def test_launch_catalog_enables_direct_mcp_routes_ready_for_live_oauth() -> None:
     by_id = {item.id: item for item in CONNECTOR_CATALOG}
-    assert {"notion", "linear", "todoist", "atlassian", "airtable"} <= set(by_id)
+    oauth_routes = {"notion", "linear", "todoist", "atlassian", "airtable"}
+    assert oauth_routes <= set(by_id)
     enabled = {item.id for item in CONNECTOR_CATALOG if item.available}
     # Only routes that can complete OAuth today (official hosted MCP with
     # dynamic client registration) are enabled; the rest stay coming_soon.
-    assert enabled == {"notion", "linear", "todoist", "atlassian", "airtable"}
-    for provider_id in enabled:
+    # OAuth token persistence is Windows-DPAPI-only for now, so on other
+    # platforms none of the OAuth routes are enabled.
+    assert enabled == (oauth_routes if sys.platform == "win32" else set())
+    for provider_id in oauth_routes:
         definition = by_id[provider_id]
         assert definition.driver == ConnectorDriverKind.OFFICIAL_MCP
-        assert definition.release_status == "alpha"
+        # release_status derives from available: alpha where the route is
+        # enabled, coming_soon where the platform can't persist OAuth yet.
+        expected_status = "alpha" if sys.platform == "win32" else "coming_soon"
+        assert definition.release_status == expected_status
         assert definition.endpoint
     assert connector_def("NoTiOn") is by_id["notion"]
     assert by_id["notion"].endpoint == "https://mcp.notion.com/mcp"
@@ -83,12 +90,15 @@ def test_launch_catalog_enables_direct_mcp_routes_ready_for_live_oauth() -> None
 
 def test_enabled_catalog_routes_declare_explicit_least_privilege_scopes() -> None:
     by_id = {item.id: item for item in CONNECTOR_CATALOG}
+    oauth_routes = {"notion", "linear", "todoist", "atlassian", "airtable"}
     enabled = {item.id for item in CONNECTOR_CATALOG if item.available}
-    assert enabled == {"notion", "linear", "todoist", "atlassian", "airtable"}
-    for provider_id in enabled:
+    assert enabled == (oauth_routes if sys.platform == "win32" else set())
+    for provider_id in oauth_routes:
         definition = by_id[provider_id]
         # Empty scopes make the MCP SDK omit the scope parameter, which the
-        # authorization server reads as "everything advertised".
+        # authorization server reads as "everything advertised". Scope
+        # declarations must exist on every platform, even where the route is
+        # not yet enabled.
         assert definition.scopes, f"{provider_id} must request explicit scopes"
     assert by_id["linear"].scopes == ("read", "write")
     assert by_id["todoist"].scopes == ("data:read_write",)
@@ -209,8 +219,10 @@ def test_disabled_connector_cannot_connect_or_rebind_existing_runtime(
 
 
 def test_enabled_provider_historical_connected_row_without_credentials_requires_auth(
-    tmp_path: Path, connector_store: CredentialStore
+    tmp_path: Path, connector_store: CredentialStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # The enabled-provider path is platform-independent — pin the definition.
+    _enable_connector_for_unit_test(monkeypatch, "notion")
     db = CollieDB(tmp_path / "collie.db")
     manager = ConnectorManager(db, credentials=connector_store)
     db.upsert_connector_connection(
@@ -237,8 +249,9 @@ def test_enabled_provider_historical_connected_row_without_credentials_requires_
 
 
 def test_enabled_provider_connected_row_with_credentials_stays_healthy_and_rebinds(
-    tmp_path: Path, connector_store: CredentialStore
+    tmp_path: Path, connector_store: CredentialStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _enable_connector_for_unit_test(monkeypatch, "notion")
     db = CollieDB(tmp_path / "collie.db")
     manager = ConnectorManager(db, credentials=connector_store)
     connector_store.save(
@@ -266,8 +279,9 @@ def test_enabled_provider_connected_row_with_credentials_stays_healthy_and_rebin
 
 
 def test_connected_row_requires_usable_access_token(
-    tmp_path: Path, connector_store: CredentialStore
+    tmp_path: Path, connector_store: CredentialStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _enable_connector_for_unit_test(monkeypatch, "notion")
     db = CollieDB(tmp_path / "collie.db")
     manager = ConnectorManager(db, credentials=connector_store)
     try:

--- a/collie-core/tests/collie/test_lifecycle.py
+++ b/collie-core/tests/collie/test_lifecycle.py
@@ -62,9 +62,7 @@ def test_watchdog_exits_when_parent_is_killed(tmp_path: Path) -> None:
         """
     )
     shell_log = tmp_path / "shell.log"
-    shell = _run_until_marker(
-        [_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15
-    )
+    shell = _run_until_marker([_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15)
     # Find the grandchild core: the shell's child.
     core_pid = _child_pid(shell.pid)
     assert core_pid is not None, "core process not found under the shell"

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -264,9 +264,9 @@ async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
 
 def test_nl_due_tolerates_sentence_punctuation() -> None:
     """Models wrap due strings in commas/periods — those must not break parsing."""
-    from collie_core.tools.reminders import _normalize_due
-
     import datetime as _dt
+
+    from collie_core.tools.reminders import _normalize_due
 
     today = _dt.datetime.now().astimezone().date()
     tomorrow = today + _dt.timedelta(days=1)

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -143,6 +143,7 @@ async def test_unknown_action(db: CollieDB) -> None:
 
 # -- natural-language due times -------------------------------------------------
 
+
 def _local(month: int, day: int, hour: int = 0, minute: int = 0, year: int = 2026):
     """A local-tz aware datetime (naive input interpreted as local, like the tool)."""
     import datetime as _dt
@@ -256,9 +257,7 @@ async def test_create_reminder_with_natural_language_due(db: CollieDB) -> None:
 async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
     r = db.add_reminder("Nap", "2026-07-20T12:00:00")
     tool = RemindersTool()
-    result = await tool.execute(
-        action="snooze", reminder_id=r["id"], snooze_until="in 1 hour"
-    )
+    result = await tool.execute(action="snooze", reminder_id=r["id"], snooze_until="in 1 hour")
     assert "Snoozed" in str(result)
 
 

--- a/collie-ui/scripts/smoke-packaged-core.cjs
+++ b/collie-ui/scripts/smoke-packaged-core.cjs
@@ -8,10 +8,26 @@ const { findPortabilityLeaks } = require('./packaging-portability.cjs')
 
 const uiRoot = resolve(__dirname, '..')
 const repositoryRoot = resolve(uiRoot, '..')
+// Auto-detect the electron-builder unpacked output (win-unpacked on Windows,
+// linux-unpacked on Linux, mac/mac-arm64 on macOS) so the same smoke runs on
+// every platform. COLLIE_PACKAGED_RESOURCES overrides for odd layouts.
+const defaultUnpackedResources = [
+  'win-unpacked',
+  'linux-unpacked',
+  'mac',
+  'mac-arm64',
+  'mac-x64',
+  'mac-universal'
+]
+  .map((dir) => resolve(uiRoot, 'dist', dir, 'resources'))
+  .find((candidate) => existsSync(candidate))
 const resources = process.env.COLLIE_PACKAGED_RESOURCES
   ? resolve(process.env.COLLIE_PACKAGED_RESOURCES)
-  : resolve(uiRoot, 'dist', 'win-unpacked', 'resources')
-const python = resolve(resources, 'collie-core', 'python', 'python.exe')
+  : (defaultUnpackedResources ?? resolve(uiRoot, 'dist', 'win-unpacked', 'resources'))
+const python =
+  process.platform === 'win32'
+    ? resolve(resources, 'collie-core', 'python', 'python.exe')
+    : resolve(resources, 'collie-core', 'python', 'bin', 'python3')
 const core = resolve(resources, 'collie-core')
 const smokeHome = resolve(repositoryRoot, '.pytest-tmp', `packaged-smoke-${process.pid}`)
 const token = randomBytes(32).toString('hex')
@@ -33,7 +49,7 @@ function freshPort() {
       const port = typeof address === 'object' && address ? address.port : 0
       server.close((error) => {
         if (error) reject(error)
-        else if (!port) reject(new Error('Windows did not assign a smoke-test port.'))
+        else if (!port) reject(new Error('The OS did not assign a smoke-test port.'))
         else resolvePort(port)
       })
     })

--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -24,6 +24,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => testState.userData },
   safeStorage: {
     isEncryptionAvailable: () => testState.encryptionAvailable,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
     encryptString: (value: string) => Buffer.from(`encrypted:${value}`, 'utf8'),
     decryptString: (value: Buffer) => value.toString('utf8').replace(/^encrypted:/, '')
   },
@@ -47,6 +48,7 @@ import {
   signOut,
   startAccountSignIn
 } from './account-auth'
+import { resetSecureStorageCache } from './secrets'
 
 /** Minimal fake JWT: base64url header.payload.signature. No verification is done. */
 function makeJwt(payload: Record<string, unknown>): string {
@@ -64,6 +66,7 @@ beforeEach(() => {
   testState.userData = mkdtempSync(join(tmpdir(), 'collie-auth-'))
   testState.openedUrl = ''
   testState.encryptionAvailable = true
+  resetSecureStorageCache()
   testState.exchange = null
   fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
     const url = String(input)
@@ -277,6 +280,7 @@ describe('startAccountSignIn', () => {
 
   it('fails with a clear message when the session cannot be stored securely', async () => {
     testState.encryptionAvailable = false
+    resetSecureStorageCache() // secureStorageAvailable caches its probe result
     const signInPromise = startAccountSignIn()
     await vi.waitFor(() => {
       expect(testState.openedUrl).toContain('/auth/v1/authorize')

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -21,6 +21,7 @@ import { createServer, type Server } from 'http'
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../shared/account-config'
+import { secureStorageAvailable } from './secrets'
 
 /** Fixed callback port — must match the Supabase redirect allowlist. */
 export const CALLBACK_PORT = 8123
@@ -142,7 +143,7 @@ function writeAuthFile(file: AuthFile): void {
 
 /** Persist a session, encrypting every field with safeStorage. */
 export function saveAccountSession(session: StoredSession): boolean {
-  if (!session.access_token || !safeStorage.isEncryptionAvailable()) return false
+  if (!session.access_token || !secureStorageAvailable()) return false
   const encrypt = (value: string): string =>
     safeStorage.encryptString(value).toString('base64')
   const file: AuthFile = {
@@ -161,7 +162,7 @@ export function saveAccountSession(session: StoredSession): boolean {
 
 /** Read the stored session back, decrypting defensively. */
 export function getStoredSession(): StoredSession | null {
-  if (!safeStorage.isEncryptionAvailable()) return null
+  if (!secureStorageAvailable()) return null
   const file = readAuthFile()
   if (!file) return null
   try {
@@ -377,7 +378,8 @@ export async function startAccountSignIn(
     throw new Error(
       'You signed in, but this computer could not store the session ' +
         'securely. Unlock your system keychain (Keychain Access on macOS, ' +
-        'or your Windows sign-in on Windows) and try again.'
+        'your Windows sign-in on Windows, or your keyring daemon — e.g. ' +
+        'gnome-keyring / KWallet — on Linux) and try again.'
     )
   }
   return getAccountState()

--- a/collie-ui/src/main/secrets.test.ts
+++ b/collie-ui/src/main/secrets.test.ts
@@ -10,6 +10,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => testState.userData },
   safeStorage: {
     isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
     encryptString: (value: string) => Buffer.from(`encrypted:${value}`, 'utf8'),
     decryptString: (value: Buffer) => value.toString('utf8').replace(/^encrypted:/, '')
   }
@@ -88,6 +89,36 @@ describe('encrypted provider secret transactions', () => {
       expect(probe).toHaveBeenCalledTimes(1)
     } finally {
       safeStorage.isEncryptionAvailable = original
+      resetSecureStorageCache()
+    }
+  })
+
+  it('rejects the Linux basic_text backend (hardcoded-password "encryption")', () => {
+    // Without a keyring daemon Electron falls back to basic_text, which
+    // "encrypts" with a hardcoded password shipped in the Electron source.
+    // isEncryptionAvailable() still reports true — the wrapper must refuse.
+    const original = safeStorage.getSelectedStorageBackend
+    safeStorage.getSelectedStorageBackend = () => 'basic_text'
+    resetSecureStorageCache()
+    try {
+      expect(secureStorageAvailable()).toBe(false)
+      expect(saveSecret('work', 'key')).toBe(false)
+      expect(loadSecrets()).toEqual({})
+    } finally {
+      safeStorage.getSelectedStorageBackend = original
+      resetSecureStorageCache()
+    }
+  })
+
+  it('accepts a real Linux keyring backend', () => {
+    const original = safeStorage.getSelectedStorageBackend
+    safeStorage.getSelectedStorageBackend = () => 'gnome_libsecret'
+    resetSecureStorageCache()
+    try {
+      expect(secureStorageAvailable()).toBe(true)
+      expect(saveSecret('work', 'key')).toBe(true)
+    } finally {
+      safeStorage.getSelectedStorageBackend = original
       resetSecureStorageCache()
     }
   })

--- a/collie-ui/src/main/secrets.ts
+++ b/collie-ui/src/main/secrets.ts
@@ -29,11 +29,20 @@ let secureStorageKnown: boolean | null = null
  * returning false. Never throw from the storage path — treat as unavailable
  * and let the UI explain. Cached so the probe (which can block) runs at
  * most once per process.
+ *
+ * Linux additionally rejects the `basic_text` backend: without a keyring
+ * daemon Electron "encrypts" with a hardcoded password shipped in the
+ * Electron source, which is effectively no protection. Values are only ever
+ * stored when a real keyring backend is selected.
  */
 export function secureStorageAvailable(): boolean {
   if (secureStorageKnown === null) {
     try {
-      secureStorageKnown = safeStorage.isEncryptionAvailable()
+      let available = safeStorage.isEncryptionAvailable()
+      if (available && process.platform === 'linux') {
+        available = safeStorage.getSelectedStorageBackend() !== 'basic_text'
+      }
+      secureStorageKnown = available
     } catch {
       secureStorageKnown = false
     }

--- a/collie-ui/src/main/things-files.test.ts
+++ b/collie-ui/src/main/things-files.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { realpath } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -55,14 +56,19 @@ function record(overrides: Record<string, unknown> = {}): Record<string, unknown
 
 describe('things-files (trusted-ID boundary)', () => {
   let workspaceFile: string
+  let canonicalWorkspaceFile: string
   let projectDir: string
   let projectFile: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     testState.home = mkdtempSync(join(tmpdir(), 'collie-things-'))
     process.env.COLLIE_HOME = testState.home
     writeFileSync(join(testState.home, 'workspace.md'), '# Workspace thing', 'utf-8')
     workspaceFile = join(testState.home, 'workspace.md')
+    // Production resolves the registered path through realpath() before
+    // shell.openPath/showItemInFolder; on Windows that canonicalizes case
+    // and 8.3 short names, so the expected value must be canonical too.
+    canonicalWorkspaceFile = await realpath(workspaceFile)
     // A deliverable in a user-approved project folder, OUTSIDE COLLIE_HOME.
     projectDir = mkdtempSync(join(tmpdir(), 'collie-project-'))
     projectFile = join(projectDir, 'project-notes.md')
@@ -84,7 +90,7 @@ describe('things-files (trusted-ID boundary)', () => {
     // A forged path argument is ignored — the id decides.
     const result = await thingOpen('conv-1', 'th_a')
     expect(result).toBe('')
-    expect(testState.openPathCalls).toEqual([workspaceFile])
+    expect(testState.openPathCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('surfaces OS open errors instead of swallowing them', async () => {
@@ -137,7 +143,7 @@ describe('things-files (trusted-ID boundary)', () => {
   it('shows the registered file in the folder', async () => {
     writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
     await thingShowInFolder('conv-1', 'th_a')
-    expect(testState.showItemCalls).toEqual([workspaceFile])
+    expect(testState.showItemCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('save-copy defaults to the record title and copies the registered file', async () => {


### PR DESCRIPTION
## What
Storage hardening for the release (Linux ships in the launch set — this makes its storage honest).

1. **Linux `basic_text` rejected** — Electron falls back to `basic_text` when no keyring daemon runs; `isEncryptionAvailable()` still reports true, so the app happily "encrypted" with a hardcoded password shipped in the Electron source. `secureStorageAvailable()` now checks `getSelectedStorageBackend()` on Linux; secrets **and** the account session refuse to persist behind fake encryption, with a clear "unlock your keyring (gnome-keyring / KWallet)" message.
2. **OAuth connectors gated off macOS/Linux** — notion/linear/todoist/atlassian/airtable store their tokens in the Windows-DPAPI-only `CredentialStore`; on other platforms they could never complete OAuth. They now surface as `coming_soon` instead of failing at connect time. (Windows unchanged — still alpha-enabled.)
3. **Packaged-core smoke test on all platforms** — `smoke-packaged-core.cjs` now resolves the python binary per-platform (`python.exe` vs `bin/python3`) and auto-detects the unpacked resources dir; the `release.yml` smoke step is no longer Windows-gated.
4. Cleaner non-Windows message for service credential storage.

## Gates
- ruff check + format: clean
- pytest (connectors + services, CI deselects applied): 24 passed
- vitest: **346 passed / 53 files** (incl. new basic_text rejection + real-keyring tests)

## Note
The 4 DPAPI/service tests remain deselected on Linux CI (Windows-only) — unchanged behavior.
