### PR TITLE
feat(account): sign-in works in installers + sessions auto-refresh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,13 @@ jobs:
         run: npm run provenance:write
 
       - name: Build renderer + main bundles
+        # Public Supabase client config for the optional Collie account
+        # sign-in (same values shipped in the website bundle — the anon key
+        # is designed to live in clients). Without these the packaged app
+        # reports "sign-in is not configured" (account-config.ts).
+        env:
+          COLLIE_SUPABASE_URL: https://uavxtllbzwygytbkrpwd.supabase.co
+          COLLIE_SUPABASE_ANON_KEY: sb_publishable_S9I3uB67XI93xhJ3OKM6Rw_Ejyc6aci
         run: npm run build
 
       - name: Stage the bundled Python core + MCP runtime

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ are welcome too — but the normal path never requires them.
 **🛡️ Safety & reliability**
 
 - **Local-first everything** — memory, settings, and history in local SQLite;
-  no mandatory account, no silent uploads. The optional Collie account is
-  identity only — nothing leaves your machine.
+  no mandatory account, no silent uploads. The optional Collie account only
+  verifies your identity (hosted by Supabase) — chats, files, and history
+  stay on your machine.
 - Permissions engine with a broker → classifier → evaluator → store pipeline
 - **Rollback-safe updates** — a new version must boot healthy, or Collie
   rolls back to the last good one

--- a/collie-core/collie_core/lifecycle.py
+++ b/collie-core/collie_core/lifecycle.py
@@ -37,6 +37,7 @@ _RECLAIM_TIMEOUT_S = 5.0
 
 # -- parent-death watchdog -------------------------------------------------------
 
+
 def _arm_pdeathsig_linux() -> None:
     """Ask the kernel to SIGTERM us the moment our parent dies (Linux only)."""
     if sys.platform != "linux":
@@ -66,9 +67,7 @@ def _parent_still_alive(original: int) -> bool:
             process_query_limited = 0x1000
             still_active = 259
             kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(
-                process_query_limited, False, wintypes.DWORD(original)
-            )
+            handle = kernel32.OpenProcess(process_query_limited, False, wintypes.DWORD(original))
             if not handle:
                 return False
             try:
@@ -106,12 +105,11 @@ def arm_parent_watchdog(interval: float = WATCHDOG_INTERVAL_S) -> None:
             except Exception:
                 os._exit(0)
 
-    threading.Thread(
-        target=_watch, name="collie-parent-watchdog", daemon=True
-    ).start()
+    threading.Thread(target=_watch, name="collie-parent-watchdog", daemon=True).start()
 
 
 # -- stale-core port reclaim -----------------------------------------------------
+
 
 def _port_in_use(port: int) -> bool:
     """True when anything is accepting TCP connections on 127.0.0.1:port."""
@@ -198,9 +196,7 @@ def _pid_alive(pid: int) -> bool:
         return False
 
 
-def reclaim_stale_core_port(
-    port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S
-) -> bool:
+def reclaim_stale_core_port(port: int, *, timeout_s: float = _RECLAIM_TIMEOUT_S) -> bool:
     """Free the IPC port by terminating leftover cores, if any.
 
     Only ever kills processes whose command line runs ``collie_core.runtime``
@@ -242,5 +238,7 @@ def _proc_entries() -> list[_ProcEntry]:
             continue
         if not raw:
             continue
-        entries.append(_ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split()))
+        entries.append(
+            _ProcEntry(int(name), raw.replace(b"\x00", b" ").decode("utf-8", "replace").split())
+        )
     return entries

--- a/collie-core/collie_core/providers/validation.py
+++ b/collie-core/collie_core/providers/validation.py
@@ -224,11 +224,14 @@ async def detect_provider_for_key(
     api_key: str,
     catalogue: CatalogueStore | None = None,
 ) -> dict[str, Any]:
-    """Resolve a pasted key to a provider, probing ambiguous prefixes.
+    """Resolve a pasted key to a provider using prefix hints only.
 
-    Unambiguous prefixes (``gsk_``, ``sk-ant-``, …) resolve instantly;
-    ``sk-`` (OpenAI vs DeepSeek) is resolved by probing each candidate's
-    model-list endpoint — the first one that accepts the key wins.
+    Unambiguous prefixes (``gsk_``, ``sk-ant-``, …) resolve instantly.
+    Ambiguous prefixes (``sk-`` matches OpenAI and DeepSeek) NEVER probe the
+    candidate endpoints with the user's key — that would ship the key to
+    providers that don't own it. The candidates are returned instead and the
+    UI asks the user to pick; the key then only travels to the provider they
+    chose.
     """
     catalogue = catalogue or CatalogueStore()
     candidates = catalogue.detect_provider_for_key(api_key)
@@ -236,14 +239,10 @@ async def detect_provider_for_key(
         return {"detected": False, "provider_id": None, "reason": "no_prefix_match"}
     if len(candidates) == 1:
         return {"detected": True, "provider_id": candidates[0], "reason": "prefix"}
-    for provider_id in candidates:
-        result = await probe_api_key(provider_id=provider_id, api_key=api_key, catalogue=catalogue)
-        if result.get("ok"):
-            return {"detected": True, "provider_id": provider_id, "reason": "probe"}
     return {
         "detected": False,
         "provider_id": None,
-        "reason": "probe_failed",
+        "reason": "ambiguous",
         "candidates": candidates,
     }
 

--- a/collie-core/collie_core/tools/local_files.py
+++ b/collie-core/collie_core/tools/local_files.py
@@ -440,9 +440,7 @@ class LocalFilesTool(Tool):
             # approval-free; overwriting or editing an existing file stays an
             # explicit approval because it destroys prior content. The
             # execution path revalidates scope before every change.
-            approval_free=bool(
-                safe_write and (reversible or operation == "mkdir")
-            ),
+            approval_free=bool(safe_write and (reversible or operation == "mkdir")),
             approve_for_me=safe_write,
         )
 
@@ -450,9 +448,7 @@ class LocalFilesTool(Tool):
         errors = super().validate_params(params)
         operation = str(params.get("operation") or "").lower()
         if operation == "mkdir":
-            if not isinstance(params.get("path"), str) or not str(
-                params.get("path") or ""
-            ).strip():
+            if not isinstance(params.get("path"), str) or not str(params.get("path") or "").strip():
                 errors.append("path is required for mkdir")
             return errors
         if operation in {"create", "overwrite", "save"} and not isinstance(
@@ -487,9 +483,7 @@ class LocalFilesTool(Tool):
                 _ensure_parent_dirs(target)
                 target.mkdir(parents=True, exist_ok=False)
                 return ToolResult(
-                    json.dumps(
-                        {"operation": "mkdir", "path": str(target), "local_only": True}
-                    )
+                    json.dumps({"operation": "mkdir", "path": str(target), "local_only": True})
                 )
             _require_text_artifact(target)
             if operation == "read":
@@ -525,9 +519,7 @@ class LocalFilesTool(Tool):
                     return ToolResult(json.dumps(edited_payload))
                 return result
             else:
-                raise _LocalFileError(
-                    "Choose list, read, create, overwrite, edit, save, or mkdir."
-                )
+                raise _LocalFileError("Choose list, read, create, overwrite, edit, save, or mkdir.")
         except (OSError, UnicodeError, WorkspaceBoundaryError, _LocalFileError) as exc:
             if undo_entry_id and conversation_id:
                 # The write never happened — don't leave an undoable entry

--- a/collie-core/collie_core/tools/reminders.py
+++ b/collie-core/collie_core/tools/reminders.py
@@ -57,9 +57,7 @@ _WEEKDAYS = {
     "saturday": 5,
     "sunday": 6,
 }
-_TIME_RE = re.compile(
-    r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$"
-)
+_TIME_RE = re.compile(r"^(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$|^(noon|midnight)$")
 _UNIT_SECONDS = {
     "minute": 60,
     "hour": 3600,
@@ -111,18 +109,14 @@ def _parse_due(value: str, label: str) -> datetime:
         lowered,
     )
     if in_match:
-        seconds = int(in_match.group(1)) * _UNIT_SECONDS[
-            in_match.group(2).rstrip("s")
-        ]
+        seconds = int(in_match.group(1)) * _UNIT_SECONDS[in_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
     from_match = re.match(
         r"^(\d+)\s+(minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+from\s+now$",
         lowered,
     )
     if from_match:
-        seconds = int(from_match.group(1)) * _UNIT_SECONDS[
-            from_match.group(2).rstrip("s")
-        ]
+        seconds = int(from_match.group(1)) * _UNIT_SECONDS[from_match.group(2).rstrip("s")]
         return now + timedelta(seconds=seconds)
 
     # "tomorrow at 3pm" / "tomorrow 3pm" / "today 6pm" / "tonight"
@@ -138,9 +132,7 @@ def _parse_due(value: str, label: str) -> datetime:
         day_shift = 0
         rest = lowered[len("today") :]
     if day_shift is not None:
-        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
-            days=day_shift
-        )
+        base = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=day_shift)
         clock = rest.strip().lstrip(",;: ")
         if not clock:
             clock = "20:00" if lowered.startswith("tonight") else "09:00"

--- a/collie-core/tests/collie/test_connect_validation.py
+++ b/collie-core/tests/collie/test_connect_validation.py
@@ -174,23 +174,24 @@ async def test_detect_provider_for_key_uses_prefix_for_unambiguous(openai_server
 
 
 @pytest.mark.asyncio
-async def test_detect_provider_for_key_probes_ambiguous_sk(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_detect_provider_for_key_ambiguous_sk_never_probes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from collie_core.providers import validation
 
-    calls: list[str] = []
-
-    async def fake_probe(**kwargs: object) -> dict[str, object]:
-        provider_id = str(kwargs["provider_id"])
-        calls.append(provider_id)
-        if provider_id == "deepseek":
-            return {"ok": True, "model": "deepseek-v4-flash", "model_label": "DeepSeek V4 Flash"}
-        return {"ok": False, "error": "auth"}
+    async def fake_probe(**kwargs: object) -> dict[str, object]:  # pragma: no cover
+        raise AssertionError("ambiguous sk- keys must never be probed")
 
     monkeypatch.setattr(validation, "probe_api_key", fake_probe)
     result = await detect_provider_for_key("sk-abc", catalogue=CatalogueStore())
-    assert result == {"detected": True, "provider_id": "deepseek", "reason": "probe"}
-    # Ambiguous sk- is resolved by probing candidates in order; first accept wins.
-    assert calls == ["openai", "deepseek"]
+    # The key must not be shipped to candidate providers to guess which one
+    # owns it — the candidates come back and the UI asks the user to pick.
+    assert result == {
+        "detected": False,
+        "provider_id": None,
+        "reason": "ambiguous",
+        "candidates": ["openai", "deepseek"],
+    }
 
 
 @pytest.mark.asyncio
@@ -225,3 +226,16 @@ async def test_detect_local_ollama_empty_when_not_running() -> None:
     finally:
         os.environ.pop("OLLAMA_HOST", None)
     assert result == {"available": False, "models": []}
+
+
+@pytest.mark.asyncio
+async def test_detect_provider_for_key_unambiguous_prefix_resolves_instantly() -> None:
+    result = await detect_provider_for_key("gsk_abc123", catalogue=CatalogueStore())
+    assert result == {"detected": True, "provider_id": "groq", "reason": "prefix"}
+
+
+@pytest.mark.asyncio
+async def test_detect_provider_for_key_no_match() -> None:
+    result = await detect_provider_for_key("zzz-unknown-format", catalogue=CatalogueStore())
+    assert result["detected"] is False
+    assert result["reason"] == "no_prefix_match"

--- a/collie-core/tests/collie/test_lifecycle.py
+++ b/collie-core/tests/collie/test_lifecycle.py
@@ -62,9 +62,7 @@ def test_watchdog_exits_when_parent_is_killed(tmp_path: Path) -> None:
         """
     )
     shell_log = tmp_path / "shell.log"
-    shell = _run_until_marker(
-        [_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15
-    )
+    shell = _run_until_marker([_python(), "-c", shell_script], "shell up", shell_log, timeout_s=15)
     # Find the grandchild core: the shell's child.
     core_pid = _child_pid(shell.pid)
     assert core_pid is not None, "core process not found under the shell"

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -264,9 +264,9 @@ async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
 
 def test_nl_due_tolerates_sentence_punctuation() -> None:
     """Models wrap due strings in commas/periods — those must not break parsing."""
-    from collie_core.tools.reminders import _normalize_due
-
     import datetime as _dt
+
+    from collie_core.tools.reminders import _normalize_due
 
     today = _dt.datetime.now().astimezone().date()
     tomorrow = today + _dt.timedelta(days=1)

--- a/collie-core/tests/collie/test_reminders.py
+++ b/collie-core/tests/collie/test_reminders.py
@@ -143,6 +143,7 @@ async def test_unknown_action(db: CollieDB) -> None:
 
 # -- natural-language due times -------------------------------------------------
 
+
 def _local(month: int, day: int, hour: int = 0, minute: int = 0, year: int = 2026):
     """A local-tz aware datetime (naive input interpreted as local, like the tool)."""
     import datetime as _dt
@@ -256,9 +257,7 @@ async def test_create_reminder_with_natural_language_due(db: CollieDB) -> None:
 async def test_snooze_with_natural_language_until(db: CollieDB) -> None:
     r = db.add_reminder("Nap", "2026-07-20T12:00:00")
     tool = RemindersTool()
-    result = await tool.execute(
-        action="snooze", reminder_id=r["id"], snooze_until="in 1 hour"
-    )
+    result = await tool.execute(action="snooze", reminder_id=r["id"], snooze_until="in 1 hour")
     assert "Snoozed" in str(result)
 
 

--- a/collie-ui/electron.vite.config.ts
+++ b/collie-ui/electron.vite.config.ts
@@ -5,6 +5,19 @@ import { resolve } from 'path'
 
 export default defineConfig({
   main: {
+    // Bake the optional account sign-in client config at build time
+    // (account-config.ts reads process.env.COLLIE_SUPABASE_*). These are
+    // PUBLIC Supabase client values — the anon/publishable key is designed
+    // to ship in clients. release.yml sets them on the build step; without
+    // them the packaged app reports "sign-in is not configured".
+    define: {
+      'process.env.COLLIE_SUPABASE_URL': JSON.stringify(
+        process.env.COLLIE_SUPABASE_URL ?? ''
+      ),
+      'process.env.COLLIE_SUPABASE_ANON_KEY': JSON.stringify(
+        process.env.COLLIE_SUPABASE_ANON_KEY ?? ''
+      )
+    },
     build: {
       outDir: 'out/main'
     }

--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -71,10 +71,27 @@ beforeEach(() => {
       return realFetch(url, init)
     }
     if (url.includes('/auth/v1/token')) {
+      const isRefresh =
+        url.includes('grant_type=refresh_token') ||
+        String(init?.body ?? '').includes('grant_type=refresh_token')
       testState.exchange = {
         url,
         body: JSON.parse(String(init?.body)) as Record<string, unknown>,
         headers: (init?.headers ?? {}) as Record<string, string>
+      }
+      if (isRefresh) {
+        return new Response(
+          JSON.stringify({
+            access_token: makeJwt({
+              email: 'tester@heycollie.com',
+              exp: Math.floor(Date.now() / 1000) + 3600
+            }),
+            refresh_token: 'refresh-token-2',
+            expires_in: 3600,
+            user: { email: 'tester@heycollie.com' }
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
       }
       return new Response(
         JSON.stringify({
@@ -130,7 +147,7 @@ describe('JWT payload decoding', () => {
 })
 
 describe('encrypted session store', () => {
-  it('round-trips a session through the encrypted store and clears it', () => {
+  it('round-trips a session through the encrypted store and clears it', async () => {
     expect(
       saveAccountSession({
         access_token: 'access-token-1',
@@ -149,10 +166,10 @@ describe('encrypted session store', () => {
 
     expect(clearAccountSession()).toBe(true)
     expect(getStoredSession()).toBeNull()
-    expect(getAccountState()).toEqual({ signedIn: false, email: null, expiresAt: null })
+    expect(await getAccountState()).toEqual({ signedIn: false, email: null, expiresAt: null })
   })
 
-  it('rejects a session when safeStorage encryption is unavailable', () => {
+  it('rejects a session when safeStorage encryption is unavailable', async () => {
     // (mock always reports available; the guard is exercised via the
     // unconfigured-path behavior in the sign-in tests instead)
     expect(saveAccountSession({ access_token: '', refresh_token: '', expires_at: 0, email: '' }))
@@ -161,7 +178,7 @@ describe('encrypted session store', () => {
 })
 
 describe('getAccountState', () => {
-  it('decodes email and expiry from the access-token JWT', () => {
+  it('decodes email and expiry from the access-token JWT', async () => {
     const exp = Math.floor(Date.now() / 1000) + 3600
     saveAccountSession({
       access_token: makeJwt({ email: 'rick@heycollie.com', exp }),
@@ -170,13 +187,13 @@ describe('getAccountState', () => {
       email: ''
     })
 
-    const state = getAccountState()
+    const state = await getAccountState()
     expect(state.signedIn).toBe(true)
     expect(state.email).toBe('rick@heycollie.com')
     expect(state.expiresAt).toBe(exp * 1000)
   })
 
-  it('falls back to the stored email when the token is not a JWT', () => {
+  it('falls back to the stored email when the token is not a JWT', async () => {
     saveAccountSession({
       access_token: 'opaque-token',
       refresh_token: 'refresh-token-1',
@@ -184,12 +201,27 @@ describe('getAccountState', () => {
       email: 'stored@heycollie.com'
     })
 
-    const state = getAccountState()
+    const state = await getAccountState()
     expect(state.signedIn).toBe(true)
     expect(state.email).toBe('stored@heycollie.com')
   })
 
-  it('treats an expired session as signed out', () => {
+  it('treats an expired session without a refresh token as signed out', async () => {
+    const exp = Math.floor(Date.now() / 1000) - 60
+    saveAccountSession({
+      access_token: makeJwt({ email: 'old@heycollie.com', exp }),
+      refresh_token: '',
+      expires_at: 0,
+      email: 'old@heycollie.com'
+    })
+
+    const state = await getAccountState()
+    expect(state.signedIn).toBe(false)
+    expect(state.email).toBe('old@heycollie.com')
+    expect(state.expiresAt).toBe(exp * 1000)
+  })
+
+  it('silently refreshes an expired session instead of signing out', async () => {
     const exp = Math.floor(Date.now() / 1000) - 60
     saveAccountSession({
       access_token: makeJwt({ email: 'old@heycollie.com', exp }),
@@ -198,10 +230,14 @@ describe('getAccountState', () => {
       email: 'old@heycollie.com'
     })
 
-    const state = getAccountState()
-    expect(state.signedIn).toBe(false)
-    expect(state.email).toBe('old@heycollie.com')
-    expect(state.expiresAt).toBe(exp * 1000)
+    const state = await getAccountState()
+    expect(state.signedIn).toBe(true)
+    expect(state.email).toBe('tester@heycollie.com')
+    // The refreshed session is persisted (new tokens + expiry).
+    const stored = getStoredSession()
+    expect(stored?.access_token).toContain('eyJ')
+    expect(stored?.refresh_token).toBe('refresh-token-2')
+    expect(stored?.expires_at).toBeGreaterThan(Date.now())
   })
 })
 
@@ -321,7 +357,7 @@ describe('signOut', () => {
       expires_at: Date.now() + 60_000,
       email: 'out@heycollie.com'
     })
-    expect(getAccountState().signedIn).toBe(true)
+    expect((await getAccountState()).signedIn).toBe(true)
 
     const state = await signOut()
 

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -189,14 +189,8 @@ export function clearAccountSession(): boolean {
   }
 }
 
-/**
- * Current account state for the Settings UI. The JWT payload (email/exp) is
- * decoded client-side for display only; an expired session reads as signed
- * out so the user can sign in again.
- */
-export function getAccountState(): AccountState {
-  const session = getStoredSession()
-  if (!session) return { signedIn: false, email: null, expiresAt: null }
+/** Derive the user-facing account state from a stored session. */
+function accountStateFromSession(session: StoredSession): AccountState {
   const payload = session.access_token ? decodeJwtPayload(session.access_token) : null
   const email =
     typeof payload?.email === 'string' && payload.email ? payload.email : session.email
@@ -209,6 +203,62 @@ export function getAccountState(): AccountState {
     return { signedIn: false, email: email || null, expiresAt }
   }
   return { signedIn: true, email: email || null, expiresAt }
+}
+
+/**
+ * One silent refresh attempt for an expired session. Supabase access tokens
+ * live ~1h; without this the user would be signed out every hour while the
+ * refresh token sat unused. Returns the refreshed session (already persisted)
+ * or null when there is nothing to refresh or Supabase rejects the token.
+ */
+async function refreshExpiredSession(session: StoredSession): Promise<StoredSession | null> {
+  const baseUrl = SUPABASE_URL.replace(/\/+$/, '')
+  const anonKey = SUPABASE_ANON_KEY
+  if (!baseUrl || !anonKey || !session.refresh_token) return null
+  try {
+    const response = await fetch(`${baseUrl}/auth/v1/token?grant_type=refresh_token`, {
+      method: 'POST',
+      headers: {
+        apikey: anonKey,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ refresh_token: session.refresh_token }),
+      signal: AbortSignal.timeout(10_000)
+    })
+    if (!response.ok) return null
+    const data = (await response.json().catch(() => null)) as TokenResponse | null
+    if (!data || typeof data.access_token !== 'string' || !data.access_token) return null
+    const refreshed: StoredSession = {
+      access_token: data.access_token,
+      refresh_token:
+        typeof data.refresh_token === 'string' && data.refresh_token
+          ? data.refresh_token
+          : session.refresh_token,
+      expires_at:
+        typeof data.expires_in === 'number' && Number.isFinite(data.expires_in)
+          ? Date.now() + data.expires_in * 1000
+          : 0,
+      email: typeof data.user?.email === 'string' ? data.user.email : session.email
+    }
+    return saveAccountSession(refreshed) ? refreshed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Current account state for the Settings UI. The JWT payload (email/exp) is
+ * decoded client-side for display only; an expired session gets one silent
+ * refresh attempt before it reads as signed out.
+ */
+export async function getAccountState(): Promise<AccountState> {
+  const session = getStoredSession()
+  if (!session) return { signedIn: false, email: null, expiresAt: null }
+  const state = accountStateFromSession(session)
+  if (state.signedIn) return state
+  const refreshed = await refreshExpiredSession(session)
+  if (refreshed) return accountStateFromSession(refreshed)
+  return state
 }
 
 /* ------------------------------------------------------------------ *
@@ -380,7 +430,7 @@ export async function startAccountSignIn(
         'or your Windows sign-in on Windows) and try again.'
     )
   }
-  return getAccountState()
+  return await getAccountState()
 }
 
 /** Sign out: best-effort Supabase session revocation, then clear locally. */
@@ -402,5 +452,5 @@ export async function signOut(): Promise<AccountState> {
     }
   }
   clearAccountSession()
-  return getAccountState()
+  return await getAccountState()
 }

--- a/collie-ui/src/main/things-files.test.ts
+++ b/collie-ui/src/main/things-files.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { realpath } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -55,14 +56,19 @@ function record(overrides: Record<string, unknown> = {}): Record<string, unknown
 
 describe('things-files (trusted-ID boundary)', () => {
   let workspaceFile: string
+  let canonicalWorkspaceFile: string
   let projectDir: string
   let projectFile: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     testState.home = mkdtempSync(join(tmpdir(), 'collie-things-'))
     process.env.COLLIE_HOME = testState.home
     writeFileSync(join(testState.home, 'workspace.md'), '# Workspace thing', 'utf-8')
     workspaceFile = join(testState.home, 'workspace.md')
+    // Production resolves the registered path through realpath() before
+    // shell.openPath/showItemInFolder; on Windows that canonicalizes case
+    // and 8.3 short names, so the expected value must be canonical too.
+    canonicalWorkspaceFile = await realpath(workspaceFile)
     // A deliverable in a user-approved project folder, OUTSIDE COLLIE_HOME.
     projectDir = mkdtempSync(join(tmpdir(), 'collie-project-'))
     projectFile = join(projectDir, 'project-notes.md')
@@ -84,7 +90,7 @@ describe('things-files (trusted-ID boundary)', () => {
     // A forged path argument is ignored — the id decides.
     const result = await thingOpen('conv-1', 'th_a')
     expect(result).toBe('')
-    expect(testState.openPathCalls).toEqual([workspaceFile])
+    expect(testState.openPathCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('surfaces OS open errors instead of swallowing them', async () => {
@@ -137,7 +143,7 @@ describe('things-files (trusted-ID boundary)', () => {
   it('shows the registered file in the folder', async () => {
     writeIndex('conv-1', [record({ id: 'th_a', path: workspaceFile })])
     await thingShowInFolder('conv-1', 'th_a')
-    expect(testState.showItemCalls).toEqual([workspaceFile])
+    expect(testState.showItemCalls).toEqual([canonicalWorkspaceFile])
   })
 
   it('save-copy defaults to the record title and copies the registered file', async () => {

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
@@ -236,7 +236,8 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
         return
       }
       if (candidates.length > 1) {
-        // Ambiguous (sk-): let the core probe each candidate endpoint.
+        // Ambiguous (sk-): the core never probes candidate endpoints with
+        // the user's key — ask the user to pick instead.
         setDetectHint('Checking which provider this key belongs to…')
         try {
           const result = await collieClient.detectProviderForKey(key)
@@ -246,6 +247,11 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
             setDetectHint(
               `Looks like this key belongs to ${catalogue.find((item) => item.id === result.provider_id)?.name || result.provider_id}.`
             )
+          } else if (result.reason === 'ambiguous' && result.candidates?.length) {
+            const names = result.candidates
+              .map((id) => catalogue.find((item) => item.id === id)?.name || id)
+              .join(' or ')
+            setDetectHint(`This key format matches ${names} — choose the right provider above.`)
           } else if (result.detected) {
             setDetectHint('')
           } else {


### PR DESCRIPTION
## What
Makes the optional Collie account sign-in actually work in released installers, and keeps users signed in past the 1-hour access-token lifetime.

1. **Supabase config baked into the build** — `electron.vite.config.ts` now `define`s `process.env.COLLIE_SUPABASE_URL` / `ANON_KEY` into the main bundle at build time, fed by `release.yml` (public client values — the same anon-equivalent publishable key already shipped in the website bundle). Before this, every packaged build read empty env at runtime and reported "sign-in is not configured" (`account-config.ts`). **Verified**: both values present in `out/main/index.js` after a build with the env set.
2. **Session auto-refresh** — `getAccountState()` is now async and gives an expired session one silent `refresh_token` grant attempt before reporting signed-out (Supabase access tokens live ~1h). Refreshed tokens are persisted; network/server failures degrade to the existing signed-out state.

## Gates
- vitest: **345 passed / 53 files** (incl. 2 new refresh tests)
- typecheck: clean
- bundle verification: values baked (grep on `out/main/index.js`)

## Merge order note
Base is `fix/alpha5-qualify-unblock` (PR #52) — merge #52 first (or merge this after #52; the diff will clean up automatically).
