### PR TITLE
test(core): fix watchdog lifecycle test startup race (release qualify flake)

### DIFF
--- a/collie-core/tests/collie/test_lifecycle.py
+++ b/collie-core/tests/collie/test_lifecycle.py
@@ -67,6 +67,20 @@ def test_watchdog_exits_when_parent_is_killed(tmp_path: Path) -> None:
     core_pid = _child_pid(shell.pid)
     assert core_pid is not None, "core process not found under the shell"
 
+    # The core arms its watchdog during startup. Killing the shell before
+    # that arms it tests the startup race, not the watchdog: a still-booting
+    # core sees the dead shell as "already daemonized" (ppid == init) and
+    # skips arming entirely. Coverage-instrumented runs widen the window
+    # (slower subprocess imports) and flake deterministically. Wait for the
+    # arm marker — the core's stdout lands in the same inherited log.
+    armed_deadline = time.monotonic() + 30
+    while time.monotonic() < armed_deadline:
+        if "CORE_ARMED" in shell_log.read_text(encoding="utf-8", errors="replace"):
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("core never armed its watchdog (CORE_ARMED not seen)")
+
     # Simulate a crash: SIGKILL, no cleanup, no signal to the child.
     os.kill(shell.pid, signal.SIGKILL)
 


### PR DESCRIPTION
## Why

The alpha.5 release pipeline (run 32208440301) failed at **Qualify**:
`test_watchdog_exits_when_parent_is_killed` — "core survived its dead parent (watchdog did not fire)". The same failure reproduced **5/5 locally with `--cov`** and passed in isolation without it.

## Root cause (test race, not a product bug)

The test SIGKILLed the shell the moment `shell up` printed, but the grandchild core arms its watchdog during **its own** startup. Killing the shell in that window makes a still-booting core see `ppid == init` and skip arming entirely (`arm_parent_watchdog` treats it as already-daemonized). Coverage instrumentation slows subprocess imports, widening the window — hence deterministic failure under the full `--cov` suite on slow runners.

Production is unaffected: the core's startup window is covered by `reclaim_stale_core_port` on the next boot.

## Fix

Wait for the core's `CORE_ARMED` marker (same inherited log) before killing the shell. The watchdog must then reap the core within the existing 8s assertion.

## Verification

- `pytest test_watchdog... --cov`: **5/5 pass** (was 5/5 fail)
- Full `tests/collie/test_lifecycle.py`: **4/4 pass** with `--cov`
- ruff check + format: clean