### PR TITLE
release(alpha.5): bump app version + fix packaged smoke on macOS

### DIFF
--- a/collie-ui/package-lock.json
+++ b/collie-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Your personal AI. With a dog.",
   "main": "./out/main/index.js",
   "author": "Collie",

--- a/collie-ui/scripts/smoke-packaged-core.cjs
+++ b/collie-ui/scripts/smoke-packaged-core.cjs
@@ -1,4 +1,4 @@
-const { existsSync } = require('fs')
+const { existsSync, readdirSync } = require('fs')
 const { spawn } = require('child_process')
 const { randomBytes } = require('crypto')
 const net = require('net')
@@ -11,16 +11,32 @@ const repositoryRoot = resolve(uiRoot, '..')
 // Auto-detect the electron-builder unpacked output (win-unpacked on Windows,
 // linux-unpacked on Linux, mac/mac-arm64 on macOS) so the same smoke runs on
 // every platform. COLLIE_PACKAGED_RESOURCES overrides for odd layouts.
-const defaultUnpackedResources = [
-  'win-unpacked',
-  'linux-unpacked',
-  'mac',
-  'mac-arm64',
-  'mac-x64',
-  'mac-universal'
-]
-  .map((dir) => resolve(uiRoot, 'dist', dir, 'resources'))
-  .find((candidate) => existsSync(candidate))
+function findMacBundleResources() {
+  // macOS: electron-builder emits dist/mac[--arch]/<App>.app/Contents/Resources
+  // — a bundle layout, NOT a flat dist/<dir>/resources like win/linux-unpacked.
+  const macDirs = ['mac', 'mac-arm64', 'mac-x64', 'mac-universal'].map((dir) =>
+    resolve(uiRoot, 'dist', dir)
+  )
+  for (const dir of macDirs) {
+    if (!existsSync(dir)) continue
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.endsWith('.app')) continue
+      const candidate = resolve(dir, entry.name, 'Contents', 'Resources')
+      if (existsSync(candidate)) return candidate
+    }
+  }
+  return undefined
+}
+const defaultUnpackedResources =
+  ['win-unpacked', 'linux-unpacked', 'mac', 'mac-arm64', 'mac-x64', 'mac-universal']
+    .map((dir) => resolve(uiRoot, 'dist', dir, 'resources'))
+    .find((candidate) => existsSync(candidate)) ?? findMacBundleResources()
 const resources = process.env.COLLIE_PACKAGED_RESOURCES
   ? resolve(process.env.COLLIE_PACKAGED_RESOURCES)
   : (defaultUnpackedResources ?? resolve(uiRoot, 'dist', 'win-unpacked', 'resources'))


### PR DESCRIPTION
## Why (two release-blocking finds from run 32208947848)

1. **Artifacts were built as 0.1.0-alpha.4** — the app version in `collie-ui/package.json` was never bumped for alpha.5. The tag was `v0.1.0-alpha.5` but every installer/dmg/AppImage said alpha.4. That would break the alpha.4 → alpha.5 auto-update path (electron-updater treats same-version as no update) and mislabel the release.
2. **macOS build failed its packaged smoke** — `smoke-packaged-core` only auto-detected flat `dist/<dir>/resources` layouts (win-unpacked/linux-unpacked) and fell back to `win-unpacked` on macOS, where electron-builder emits `dist/mac-arm64/<App>.app/Contents/Resources`. The 3-OS smoke (#54) did its job: it caught the mac packaging hole before any draft was created.

## Changes

- `collie-ui/package.json` + lockfile root: `0.1.0-alpha.4` → `0.1.0-alpha.5` (updater-controller tests already fixture the alpha.4→alpha.5 path — untouched)
- `scripts/smoke-packaged-core.cjs`: scan `dist/mac*` for a `.app` bundle and use its `Contents/Resources` when the flat candidates don't exist

## Verification

- Mac layout detection: with linux-unpacked hidden + a fake `dist/mac-arm64/Collie.app/Contents/Resources`, the smoke resolves the bundle path (was win-unpacked fallback)
- Linux regression: real packaged-core smoke **passes** end-to-end (port + anonymous-reject + authenticated ping)
- vitest: 352/352 · typecheck clean