### PR TITLE
feat(ui): gate desktop pet off for release — 'coming soon' in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ underneath:
   Collie account, no forced monthly fee.
 - **It remembers — on your machine.** Collie keeps its notes, settings, and
   history locally. Nothing is silently shipped off your device.
-- **It has a dog.** A little Border Collie lives in your corner of the
-  screen, with moods and reactions of its own. (Friendly, but never in
-  charge — the permissions always are.)
+- **It has a dog.** A little Border Collie is on the way — she'll live in
+  your corner of the screen, with moods and reactions of its own. (Friendly,
+  but never in charge — the permissions always are.)
 
 Collie is built for people who want the leverage of agentic AI *without* the
 terminals, API keys, MCP servers, or prompt-engineering vocabulary. Experts
@@ -118,8 +118,8 @@ are welcome too — but the normal path never requires them.
 
 **🎨 Made for humans**
 
-- A **Border Collie companion** in the corner of your screen, with moods and
-  reactions (friendly, never in charge)
+- A **Border Collie companion** for your desktop — coming soon (moods and
+  reactions; friendly, never in charge)
 - **Collapsible sidebar** — an icon rail that gives chat more room
 - Fast, calm desktop app — Electron + React
 - **Voice input/output** on the way

--- a/collie-ui/src/main/pet.ts
+++ b/collie-ui/src/main/pet.ts
@@ -5,7 +5,15 @@
  * (`python -m collie_core.pet`). The Electron main process owns it:
  * spawned at app start (unless disabled in pet_settings.json), revived by
  * "show", respawned after crashes, and put to bed when the app quits.
+ *
+ * Release gate: the desktop pet is NOT shipping yet (F070/F078 are built and
+ * tested, but not needed in the alpha release). All pet code and assets stay
+ * in the repo — flip PET_AVAILABLE to true to re-enable the whole feature
+ * (spawn, IPC, and the Settings tab render it again). pet_settings.json
+ * overrides still apply once the gate is open.
  */
+
+const PET_AVAILABLE = false
 
 import { ChildProcess, spawn } from 'child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
@@ -24,6 +32,7 @@ export function petRunning(): boolean {
 }
 
 export function petEnabled(): boolean {
+  if (!PET_AVAILABLE) return false
   // Respect an "enabled": false flag in the Collie home dir
   // (COLLIE_HOME-consistent; matches index.ts sendPetCommand).
   try {
@@ -59,6 +68,10 @@ function petSettingsDir(): string {
 }
 
 export function spawnPet(isDev: boolean): boolean {
+  if (!PET_AVAILABLE) {
+    console.log('[pet] Desktop pet is gated off for this release (coming soon).')
+    return false
+  }
   if (child) return true
   const python = findPython(isDev)
   if (!python) {

--- a/collie-ui/src/renderer/src/components/settings/PetTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/PetTab.tsx
@@ -1,159 +1,38 @@
-import { useEffect, useRef, useState } from 'react'
-
+/**
+ * Desktop pet settings (F070, F078).
+ *
+ * The desktop Border Collie is not shipping in this release — the feature is
+ * built and tested but gated off (PET_AVAILABLE in src/main/pet.ts). This tab
+ * shows a "coming soon" card instead of live controls, so users know the
+ * companion is on the way. Flip the gate and restore the previous controls
+ * when it ships.
+ */
 interface Props {
+  /** Shared settings-tab notice surface; unused while the pet is gated off. */
   onNotice: (msg: string) => void
 }
 
 export default function PetTab({ onNotice }: Props): React.JSX.Element {
-  const [behavior, setBehavior] = useState<'roam' | 'stay' | 'sleep'>('roam')
-  const [size, setSize] = useState(1.0)
-  const [enabled, setEnabled] = useState(false)
-  const [petReady, setPetReady] = useState(false)
-  const [petBusy, setPetBusy] = useState(false)
-  const sizeTimerRef = useRef(0)
-
-  useEffect(() => {
-    void window.collie?.petStatus?.()
-      .then((status) => setEnabled(status.enabled))
-      .finally(() => setPetReady(true))
-    return () => window.clearTimeout(sizeTimerRef.current)
-  }, [])
-
-  const togglePet = async (): Promise<void> => {
-    if (!window.collie?.setPetEnabled) {
-      onNotice('Desktop pet controls are unavailable.')
-      return
-    }
-    setPetBusy(true)
-    try {
-      const status = await window.collie.setPetEnabled(!enabled)
-      setEnabled(status.enabled)
-      onNotice(status.enabled ? 'Desktop pet is out and ready to play.' : 'Desktop pet is resting.')
-    } catch (error) {
-      onNotice(error instanceof Error ? error.message : 'Could not change the desktop pet.')
-    } finally {
-      setPetBusy(false)
-    }
-  }
-
-  const trigger = (command: string) => {
-    try {
-      void window.collie?.petCommand?.(command)
-      onNotice(`Sent "${command}" to Collie!`)
-    } catch {
-      onNotice('Pet is not running')
-    }
-  }
-
+  void onNotice
   return (
     <div>
-      <h3 className="mb-1 font-semibold">Desktop Pet</h3>
-      <p className="mb-3 text-sm" style={{ color: 'var(--collie-paw)' }}>
-        Your Border Collie lives on your desktop. See how she responds while Collie works.
+      <div className="mb-4 flex items-center gap-2">
+        <h3 className="font-semibold">Desktop Pet</h3>
+        <span className="rounded-full px-2 py-0.5 text-xs font-medium" style={{ background: 'var(--collie-amber)', color: '#fff' }}>
+          Coming soon
+        </span>
+      </div>
+
+      <p className="mb-4 text-sm" style={{ color: 'var(--collie-paw)' }}>
+        Your Border Collie is getting ready to move onto your desktop — with moods and
+        reactions of her own. She&apos;s not here yet, but she&apos;s on the way.
       </p>
 
-      <div className="pet-enable-row">
-        <div>
-          <strong>Show desktop pet</strong>
-          <p>Spawn her now, or close her and keep her tucked away after restart.</p>
-        </div>
-        <button
-          type="button"
-          className={`pet-toggle ${enabled ? 'is-on' : ''}`}
-          role="switch"
-          aria-checked={enabled}
-          aria-label="Show desktop pet"
-          disabled={!petReady || petBusy}
-          onClick={() => void togglePet()}
-        >
-          <span />
-        </button>
-      </div>
-
-      <div className="mb-4">
-        <h4 className="mb-2 text-sm font-medium">Quick actions</h4>
-        <div className="flex gap-2">
-          <button
-            onClick={() => trigger('happy')}
-            disabled={!enabled}
-            className="settings-button is-primary"
-          >
-            Happy
-          </button>
-          <button
-            onClick={() => trigger('working')}
-            disabled={!enabled}
-            className="settings-button"
-          >
-            Focus
-          </button>
-          <button
-            onClick={() => trigger('walk')}
-            disabled={!enabled}
-            className="settings-button"
-          >
-            Walk
-          </button>
-          <button
-            onClick={() => trigger('sleep')}
-            disabled={!enabled}
-            className="settings-button"
-          >
-            Sleep
-          </button>
-        </div>
-      </div>
-
-      <div className="mb-4">
-        <h4 className="mb-2 text-sm font-medium">Behavior</h4>
-        <div className="flex gap-2">
-          {(['roam', 'stay', 'sleep'] as const).map((b) => (
-            <button
-              key={b}
-              onClick={() => {
-                setBehavior(b)
-                trigger(b)
-              }}
-              disabled={!enabled}
-              className={`settings-button ${behavior === b ? 'is-selected' : ''}`}
-            >
-              {b === 'roam' ? 'Roam free' : b === 'stay' ? 'Stay nearby' : 'Sleep when idle'}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <h4 className="mb-2 text-sm font-medium">Size</h4>
-        <div className="flex items-center gap-3">
-          <input
-            type="range"
-            min="0.25"
-            max="3.0"
-            step="0.25"
-            value={size}
-            onChange={(e) => {
-              const v = parseFloat(e.target.value)
-              setSize(v)
-              // Debounce: a drag fires dozens of onChange events — the pet
-              // only needs the final size, not a command per tick.
-              window.clearTimeout(sizeTimerRef.current)
-              sizeTimerRef.current = window.setTimeout(() => {
-                try {
-                  void window.collie?.petCommand?.(`size:${v}`)
-                } catch {
-                  // pet not running — size applies next time it wakes
-                }
-              }, 250)
-            }}
-            disabled={!enabled}
-            className="flex-1"
-            style={{ accentColor: 'var(--collie-amber)' }}
-          />
-          <span className="text-sm font-mono" style={{ color: 'var(--collie-paw)' }}>
-            {size}x
-          </span>
-        </div>
+      <div className="rounded-lg border p-4" style={{ borderColor: 'var(--collie-paw)', background: 'var(--collie-card)' }}>
+        <p className="text-sm">
+          🐾 When she arrives, you&apos;ll be able to switch her on here, choose how she
+          behaves, and keep her company while Collie works.
+        </p>
       </div>
     </div>
   )

--- a/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
@@ -134,7 +134,7 @@ const TAB_COPY: Record<Tab, { title: string; description: string }> = {
   memory: { title: 'Memory', description: 'Review and control the facts Collie remembers.' },
   services: { title: 'Services', description: 'Connect the tools and accounts Collie can work with.' },
   phone: { title: 'Telegram', description: 'Keep Collie within reach when you are away from this app.' },
-  pet: { title: 'Desktop pet', description: 'Control how your Collie companion behaves on the desktop.' },
+  pet: { title: 'Desktop pet', description: 'Your desktop companion is on the way — coming soon.' },
   safety: { title: 'Safety & approvals', description: 'Decide when Collie needs permission before acting.' },
   onboarding: {
     title: 'Onboarding',


### PR DESCRIPTION
## What & why

The desktop Border Collie (F070/F078) is built and tested but **not needed in the alpha release**. Instead of deleting it, the whole feature is gated behind one constant so it can be re-enabled instantly when it ships.

## Changes

- **`collie-ui/src/main/pet.ts`**: new `PET_AVAILABLE = false` gate — `petEnabled()` returns `false` and `spawnPet()` refuses while gated. No pet process is spawned at startup, on 'show', or via `collie:set-pet-enabled`. `pet_settings.json` overrides still apply once the gate opens.
- **`PetTab.tsx`**: live controls (toggle / quick actions / behavior / size) replaced with a warm **'Coming soon'** card — users know the companion is on the way.
- **`SettingsScreen.tsx`**: pet tab description → 'Your desktop companion is on the way — coming soon.'
- **`README.md`**: Border Collie claims softened to 'coming soon' (both feature bullets).

## Preserved

All pet code + assets stay in the repo (3.5MB, mostly sprites): `collie_core/pet/` module, `pet/assets/` PNGs + v2 WebP atlas, IPC handlers, preload bridge, tests. Re-enable = flip `PET_AVAILABLE` to `true`.

## Gates

- `npm run typecheck` ✅
- `npm test` — 352 passed (54 files) ✅
- `npm run build` ✅