### PR TITLE
release(alpha.6): bump app version to 0.1.0-alpha.6

### DIFF
--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Your personal AI. With a dog.",
   "main": "./out/main/index.js",
   "author": "Collie",


### PR DESCRIPTION
One-line version bump so the alpha.6 tag ships alpha.6-labeled installers (the current draft build is labeled alpha.5). After merge, the tag v0.1.0-alpha.6 moves to the merge commit and the release pipeline rebuilds.