### PR TITLE
fix(main): open external URLs https-only via shared policy

### DIFF
--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -33,6 +33,7 @@ import {
 } from './updater-controller'
 import {
   guardIpcHandler,
+  isSafeExternalUrl,
   isTrustedIpcSender,
   isTrustedRendererUrl,
   shouldAllowAudioPermission
@@ -279,7 +280,8 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith('https://') || url.startsWith('http://')) {
+    // Aligned with `collie:open-external`: https only, no credentials.
+    if (isSafeExternalUrl(url)) {
       shell.openExternal(url)
     }
     return { action: 'deny' }
@@ -454,7 +456,7 @@ function registerIpc(): void {
     return folders
   })
   handle('collie:open-external', (url: string) => {
-    if (url.startsWith('https://')) shell.openExternal(url)
+    if (isSafeExternalUrl(url)) shell.openExternal(url)
   })
   handle('collie:show-window', () => {
     if (!mainWindow) return

--- a/collie-ui/src/main/renderer-security.test.ts
+++ b/collie-ui/src/main/renderer-security.test.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'url'
 import { describe, expect, it, vi } from 'vitest'
 import {
   guardIpcHandler,
+  isSafeExternalUrl,
   isTrustedIpcSender,
   isTrustedRendererUrl,
   shouldAllowAudioPermission
@@ -28,6 +29,26 @@ describe('renderer URL trust', () => {
     expect(isTrustedRendererUrl(rendererUrl.replace('index.html', 'settings.html'), rendererUrl)).toBe(false)
     expect(isTrustedRendererUrl(`${rendererUrl}?preview=1`, rendererUrl)).toBe(false)
     expect(isTrustedRendererUrl('file:///C:/Windows/System32/calc.exe', rendererUrl)).toBe(false)
+  })
+})
+
+describe('external URL trust', () => {
+  it('allows only plain https URLs', () => {
+    expect(isSafeExternalUrl('https://example.com/page')).toBe(true)
+    expect(isSafeExternalUrl('https://example.com/page?q=1#frag')).toBe(true)
+    expect(isSafeExternalUrl('http://example.com/page')).toBe(false)
+    expect(isSafeExternalUrl('http://localhost:5173/')).toBe(false)
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeExternalUrl('data:text/html,hi')).toBe(false)
+    expect(isSafeExternalUrl('file:///C:/Windows/calc.exe')).toBe(false)
+    expect(isSafeExternalUrl('not a url')).toBe(false)
+    expect(isSafeExternalUrl('')).toBe(false)
+  })
+
+  it('rejects URLs with embedded credentials', () => {
+    expect(isSafeExternalUrl('https://user:password@example.com/')).toBe(false)
+    expect(isSafeExternalUrl('https://user@example.com/')).toBe(false)
+    expect(isSafeExternalUrl('https://example.com@evil.test/')).toBe(false)
   })
 })
 

--- a/collie-ui/src/main/renderer-security.ts
+++ b/collie-ui/src/main/renderer-security.ts
@@ -31,6 +31,25 @@ export function isTrustedRendererUrl(candidate: string, trustedRendererUrl: stri
   }
 }
 
+/**
+ * Only https URLs without embedded credentials may leave the app.
+ *
+ * Shared by the new-window handler and the `collie:open-external` IPC so
+ * both external-open paths enforce the same policy: https only, no
+ * `http://` fallback, no credentials smuggled in the authority.
+ */
+export function isSafeExternalUrl(raw: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:') return false
+  if (parsed.username || parsed.password) return false
+  return true
+}
+
 export function isTrustedIpcSender(
   senderFrame: RendererFrameLike | null,
   mainFrame: RendererFrameLike | null,


### PR DESCRIPTION
## What
Aligns `setWindowOpenHandler` with the `collie:open-external` IPC handler so both external-open paths enforce the same policy: **https only, no embedded credentials** (parsed with `URL`, not `startsWith`).

Shared `isSafeExternalUrl` helper lives in `renderer-security.ts` (unit-tested).

## Why
Verified finding from #60: markdown `target="_blank"` / middle-click could hand `http://` URLs to the system browser while the IPC path was already https-only.

## Test plan
- `npm run typecheck` ✅
- `vitest run` — 354/354 ✅ (incl. 5 new `isSafeExternalUrl` cases)

Closes #60