### PR TITLE
fix(renderer): harden CSP with base-uri, object-src, form-action

### DIFF
--- a/collie-ui/src/renderer/index.html
+++ b/collie-ui/src/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ws://127.0.0.1:* http://127.0.0.1:* ws://localhost:* http://localhost:*; img-src 'self' data: https:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ws://127.0.0.1:* http://127.0.0.1:* ws://localhost:* http://localhost:*; img-src 'self' data: https:; base-uri 'self'; object-src 'none'; form-action 'self'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Collie</title>


### PR DESCRIPTION
## What
Adds the missing hardening directives to the renderer CSP meta:
- `base-uri 'self'` — no base-tag hijack
- `object-src 'none'` — no plugin/embed content
- `form-action 'self'` — no cross-origin form submission

`img-src 'self' data: https:` intentionally kept: NewsCard and markdown render remote article images. A host allowlist / image proxy is the tracked follow-up (issue already flags it as low severity, no script exec).

## Why
Verified finding from #63.

## Test plan
- `npm run build` ✅ (renderer builds; CSP lands in packaged index.html)

Closes #63