### PR TITLE
fix(tools): drop browser-rendered types from open_file allowlist

### DIFF
--- a/collie-core/collie_core/tools/open_file.py
+++ b/collie-core/collie_core/tools/open_file.py
@@ -36,6 +36,12 @@ __all__ = ["OpenFileTool"]
 # File types that are safe to hand to the OS default handler.  The default
 # app for these (viewer/editor/browser) reads the file locally; nothing is
 # sent to a model provider or anywhere else on the network.
+#
+# Browser-rendered types (.html/.htm/.svg) are deliberately excluded: the
+# default handler for those is a browser or image viewer that can execute
+# scripts and reach the network, so opening them is not a plain document
+# open. They stay off the allowlist unless opening them gains its own
+# approval step (approval-matrix.md).
 _OPENABLE_SUFFIXES = frozenset(
     {
         # documents & data
@@ -47,8 +53,6 @@ _OPENABLE_SUFFIXES = frozenset(
         ".pptx",
         ".csv",
         ".rtf",
-        ".html",
-        ".htm",
         ".json",
         ".xml",
         ".yaml",
@@ -63,7 +67,6 @@ _OPENABLE_SUFFIXES = frozenset(
         ".gif",
         ".webp",
         ".bmp",
-        ".svg",
         ".ico",
         ".avif",
         ".tif",

--- a/collie-core/tests/tools/test_open_file_tool.py
+++ b/collie-core/tests/tools/test_open_file_tool.py
@@ -113,9 +113,7 @@ async def test_rejects_executables_scripts_and_shortcuts(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("name", ["page.html", "page.htm", "logo.svg"])
-async def test_rejects_browser_rendered_types(
-    scoped_tool, fake_launcher, name: str
-) -> None:
+async def test_rejects_browser_rendered_types(scoped_tool, fake_launcher, name: str) -> None:
     """html/svg can execute scripts or reach the network in the default
     handler, so they are refused like executables."""
 

--- a/collie-core/tests/tools/test_open_file_tool.py
+++ b/collie-core/tests/tools/test_open_file_tool.py
@@ -112,6 +112,24 @@ async def test_rejects_executables_scripts_and_shortcuts(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["page.html", "page.htm", "logo.svg"])
+async def test_rejects_browser_rendered_types(
+    scoped_tool, fake_launcher, name: str
+) -> None:
+    """html/svg can execute scripts or reach the network in the default
+    handler, so they are refused like executables."""
+
+    tool, root = scoped_tool
+    (root / name).write_bytes(b"payload")
+
+    result = await tool.execute(path=name)
+
+    assert result.is_error
+    assert "harmless file types" in result
+    assert fake_launcher == []
+
+
+@pytest.mark.asyncio
 async def test_rejects_out_of_scope_path(scoped_tool, tmp_path: Path, fake_launcher) -> None:
     tool, _root = scoped_tool
     outside = tmp_path / "outside.md"

--- a/docs/engineering/security/approval-matrix.md
+++ b/docs/engineering/security/approval-matrix.md
@@ -93,10 +93,14 @@ without shell access or arbitrary app launching.
   UNC/device refusal) is reused, so the two tools can never disagree about what
   a safe local target is.
 - Only an allowlisted set of harmless types can be opened — documents and data
-  (`.md .txt .pdf .docx .xlsx .pptx .csv .rtf .html .json .xml .yaml .log …`),
-  images, audio, and video. A separate denylist (`.exe .bat .cmd .ps1 .vbs
-  .msi .lnk .url .reg .scr .jar …`) is defense in depth so a future allowlist
-  edit can never hand an executable or shortcut to a default handler.
+  (`.md .txt .pdf .docx .xlsx .pptx .csv .rtf .json .xml .yaml .log …`),
+  images, audio, and video. Browser-rendered types (`.html .htm .svg`) are
+  intentionally excluded: their default handler can execute scripts and reach
+  the network, so opening them is not a plain document open and they would
+  need their own approval step to return. A separate denylist (`.exe .bat
+  .cmd .ps1 .vbs .msi .lnk .url .reg .scr .jar …`) is defense in depth so a
+  future allowlist edit can never hand an executable or shortcut to a default
+  handler.
 - It is classified `Risk.READ` with no `data_leaving_device`: the file opens in
   a local app and nothing is sent to any provider. It is reversible (close the
   window), never writes, and can only target files that already exist. Within

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -7,14 +7,14 @@
 | Component | Path | Version |
 | --- | --- | --- |
 | Python core | `collie-core/` | `0.2.2` |
-| Electron desktop | `collie-ui/` | `0.1.0-alpha.4` |
+| Electron desktop | `collie-ui/` | `0.1.0-alpha.6` |
 
 ## Source inventory
 
 - Core Python files: **514**
 - Core Python test files: **234**
-- Desktop TypeScript/TSX files: **157**
-- Desktop test files: **53**
+- Desktop TypeScript/TSX files: **159**
+- Desktop test files: **54**
 - Active Markdown docs: **29**
 - Archived Markdown docs: **0**
 


### PR DESCRIPTION
## What
Removes .html, .htm, .svg from _OPENABLE_SUFFIXES in open_file.py. These get handed to a browser/image viewer that can execute scripts and reach the network - opening them is not a plain document open. They can return only with their own approval step (noted in approval-matrix.md).

Also regenerates docs/generated/REPOSITORY_SNAPSHOT.md (was stale after the alpha6 bump).

## Why
Verified finding from #65 (low severity; local-phishing surface inside approved folders).

## Test plan
- pytest tests/tools/test_open_file_tool.py - 25/25 passed (new parametrized test: html/htm/svg refused like executables)
- ruff clean
- snapshot --check clean

Closes #65