### PR TITLE
fix(memory): Dream proposes before writing — approve to apply

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1338,6 +1338,35 @@ class CollieIPCServer:
         )
         return {"versions": versions}
 
+    async def _cmd_get_dream_pending(self, connection: ServerConnection, frame: dict) -> dict:
+        """Pending Dream proposal state (Settings → Memory self-review)."""
+        from collie_core.memory.dream import get_dream_pending
+
+        return await asyncio.to_thread(
+            get_dream_pending,
+            workspace=collie_home() / "workspace",
+        )
+
+    async def _cmd_apply_dream_proposal(self, connection: ServerConnection, frame: dict) -> dict:
+        """Approve the pending Dream proposal: re-validate, write, version."""
+        from collie_core.memory.dream import apply_dream_proposal
+        from collie_core.versions import VersionStore
+
+        return await asyncio.to_thread(
+            apply_dream_proposal,
+            workspace=collie_home() / "workspace",
+            version_store=VersionStore(self.db),
+        )
+
+    async def _cmd_dismiss_dream_proposal(self, connection: ServerConnection, frame: dict) -> dict:
+        """Dismiss the pending Dream proposal without applying it."""
+        from collie_core.memory.dream import dismiss_dream_proposal
+
+        return await asyncio.to_thread(
+            dismiss_dream_proposal,
+            workspace=collie_home() / "workspace",
+        )
+
     async def _cmd_run_gardener(self, connection: ServerConnection, frame: dict) -> dict:
         """Manual trigger: run one Gardener pass (evidence → suggestions)."""
         if self._gardener_runner is None:

--- a/collie-core/collie_core/memory/dream.py
+++ b/collie-core/collie_core/memory/dream.py
@@ -10,12 +10,21 @@ session keys, pruning) into Collie:
    approvals, read-only posture). Collie has no file-editing tools, so the
    model outputs the full proposed new ``memory/MEMORY.md`` as its final
    response.
-3. If the proposed content differs from the current file, write it and
-   snapshot it via the version store (``artifact_type="memory_dream"``) so
-   the change is reviewable and undoable in Settings → Memory.
-4. Advance the dream cursor **only on success** (a completed turn — even
-   one that produced no change — so history is never re-processed).
+3. If the proposed content differs from the current file, store it as a
+   **pending proposal** (``memory/.dream-proposal.json``) — ``MEMORY.md``
+   itself is NOT touched. The user reviews the diff in Settings → Memory
+   and explicitly applies or dismisses it (``apply_dream_proposal`` /
+   ``dismiss_dream_proposal``).
+4. Advance the dream cursor **only on success** (a completed turn — even one
+   that produced no change — so history is never re-processed). The cursor
+   advances when the proposal is created; applying or dismissing never
+   re-runs the model.
 5. Prune old Dream sessions (keep 10) after each run.
+
+On apply, the proposal is re-validated against the current file before the
+write (a manual edit in between invalidates it), written atomically, and
+snapshotted via the version store (``artifact_type="memory_dream"``) so the
+change stays reviewable and undoable in Settings → Memory.
 
 Never touches ProfileStore (the structured profile memory) — Dream
 consolidates nanobot's long-term ``memory/MEMORY.md`` only.
@@ -23,9 +32,11 @@ consolidates nanobot's long-term ``memory/MEMORY.md`` only.
 
 from __future__ import annotations
 
+import json
 import re
 import tempfile
 from contextlib import suppress
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -36,7 +47,12 @@ from nanobot.agent.runner import AgentRunSpec
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.turn_hooks import AgentTurnHookContext
 
-__all__ = ["run_dream"]
+__all__ = [
+    "apply_dream_proposal",
+    "dismiss_dream_proposal",
+    "get_dream_pending",
+    "run_dream",
+]
 
 # Collie has no file-editing tools; the Dream model must return the file
 # content directly instead of editing on disk.
@@ -57,6 +73,26 @@ _DREAM_SYSTEM_PROMPT = (
 )
 
 _FENCE_RE = re.compile(r"```[a-zA-Z0-9_-]*\s*\n(.*?)```", re.DOTALL)
+
+# The pending proposal lives next to MEMORY.md. It is the only artifact a
+# Dream run may write — MEMORY.md itself changes only on explicit apply.
+_DREAM_PROPOSAL_FILE = ".dream-proposal.json"
+
+
+def _proposal_path(workspace: Path) -> Path:
+    return Path(workspace) / "memory" / _DREAM_PROPOSAL_FILE
+
+
+def read_dream_proposal(workspace: Path) -> dict[str, Any] | None:
+    """The pending Dream proposal, or None when nothing awaits review."""
+    path = _proposal_path(workspace)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.warning("Unreadable dream proposal at {}", path)
+        return None
 
 
 def _extract_file_content(response: str) -> str:
@@ -114,8 +150,19 @@ async def run_dream(
     version_store: Any = None,
     session_key: str | None = None,
 ) -> dict[str, Any]:
-    """Run one Dream consolidation pass; returns a result summary dict."""
+    """Run one Dream consolidation pass; returns a result summary dict.
+
+    Never writes ``MEMORY.md``: a changed proposal is stored as pending for
+    the user to review and apply (or dismiss) in Settings → Memory.
+    """
     from collie_core.versions import make_diff
+
+    if _proposal_path(workspace).exists():
+        return {
+            "changed": False,
+            "reason": "pending_exists",
+            "message": "You already have a memory review waiting — open Settings → Memory to review it.",
+        }
 
     store: MemoryStore = loop.context.memory
     built = store.build_dream_prompt()
@@ -187,32 +234,98 @@ async def run_dream(
             "message": "Memory review done — everything was already tidy.",
         }
 
-    _atomic_write(memory_file, new_text)
+    _atomic_write(
+        _proposal_path(workspace),
+        json.dumps(
+            {
+                "before": before,
+                "proposed": new_text,
+                "cursor": cursor,
+                "session_key": dream_key,
+                "created_at": datetime.now(UTC).isoformat(timespec="seconds"),
+            },
+            indent=2,
+        ),
+    )
+
+    # Success path only: the proposal is durable, so the processed history
+    # is marked done. MEMORY.md itself stays untouched until the user
+    # approves the proposal (apply_dream_proposal).
+    store.set_last_dream_cursor(cursor)
+    _prune(workspace)
+
+    return {
+        "changed": True,
+        "pending": True,
+        "diff": make_diff(before, proposed, "memory/MEMORY.md"),
+        "message": "Memory review done — I have changes ready for you to review.",
+    }
+
+
+def apply_dream_proposal(*, workspace: Path, version_store: Any) -> dict[str, Any]:
+    """Approve the pending Dream proposal: re-validate, write, version.
+
+    The proposal is only applied while ``MEMORY.md`` still matches the
+    content the review started from — a manual edit in between invalidates
+    it and the caller must run a fresh review.
+    """
+    from collie_core.versions import make_diff
+
+    proposal = read_dream_proposal(workspace)
+    if proposal is None:
+        return {"applied": False, "reason": "no_pending"}
+
+    memory_file = Path(workspace) / "memory" / "MEMORY.md"
+    current = memory_file.read_text(encoding="utf-8") if memory_file.exists() else ""
+    if current != proposal["before"]:
+        raise ValueError("Your memory changed since the review — run a new review to refresh it.")
+
+    proposed = proposal["proposed"]
+    _atomic_write(memory_file, proposed)
     version_id = None
     if version_store is not None:
         try:
             version_id = version_store.snapshot(
                 "memory_dream",
                 "MEMORY.md",
-                before,
-                new_text,
-                evidence={"cursor": cursor, "session_key": dream_key},
+                proposal["before"],
+                proposed,
+                evidence={
+                    "cursor": proposal.get("cursor"),
+                    "session_key": proposal.get("session_key"),
+                },
                 source="collie",
             )
         except Exception:
             logger.exception("dream version snapshot failed (swallowed)")
 
-    # Success path only: the content is durable and versioned, so the
-    # processed history is marked done.
-    store.set_last_dream_cursor(cursor)
-    _prune(workspace)
-
+    _proposal_path(workspace).unlink(missing_ok=True)
     return {
-        "changed": True,
+        "applied": True,
         "version_id": version_id,
-        "cursor": cursor,
-        "diff": make_diff(before, proposed, "memory/MEMORY.md"),
-        "message": "Memory review done — I tidied up my long-term memory.",
+        "diff_text": make_diff(proposal["before"], proposed, "memory/MEMORY.md"),
+    }
+
+
+def dismiss_dream_proposal(*, workspace: Path) -> dict[str, Any]:
+    """Dismiss the pending Dream proposal without applying it."""
+    path = _proposal_path(workspace)
+    if path.exists():
+        path.unlink()
+    return {"dismissed": True}
+
+
+def get_dream_pending(*, workspace: Path) -> dict[str, Any]:
+    """Current pending Dream proposal state (Settings → Memory)."""
+    from collie_core.versions import make_diff
+
+    proposal = read_dream_proposal(workspace)
+    if proposal is None:
+        return {"pending": False}
+    return {
+        "pending": True,
+        "diff_text": make_diff(proposal["before"], proposal["proposed"], "memory/MEMORY.md"),
+        "created_at": proposal.get("created_at"),
     }
 
 

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -1066,7 +1066,7 @@ class CollieRuntime:
         return await self._run_gardener(auto) or {}
 
     async def _run_memory_maintenance(self, auto: dict[str, Any]) -> None:
-        """Weekly Dream pass: consolidate long-term memory, versioned + undoable."""
+        """Weekly Dream pass: propose a consolidation, pending for review."""
         if self.loop is None:
             result = await self._configure()
             if not result.get("configured"):
@@ -1084,8 +1084,8 @@ class CollieRuntime:
         content = str(outcome.get("message") or "Memory maintenance ran.")
         if outcome.get("changed"):
             content += (
-                "\n\nChanged my long-term memory file. You can review the diff "
-                "and undo it in Settings → Memory → History."
+                "\n\nOpen Settings → Memory to review and apply the changes, "
+                "or dismiss them — nothing is written until you approve."
             )
         await self._announce_automation_result(auto, conv_id, content)
 

--- a/collie-core/tests/collie/test_dream_collie.py
+++ b/collie-core/tests/collie/test_dream_collie.py
@@ -1,13 +1,17 @@
-"""Dream wiring tests (Gardener Foundations PR 3).
+"""Dream wiring tests (Gardener Foundations PR 3, two-phase review).
 
 Covers ``collie_core/memory/dream.py`` against a fake loop/provider:
-memory consolidation updates ``memory/MEMORY.md``, the cursor advances only
-on success, a no-change run is a no-op, rollback restores the prior file,
-dream sessions are pruned, and the built-in automation seeds correctly.
+a Dream run stores a **pending proposal** instead of writing
+``memory/MEMORY.md``, the cursor advances only on a completed run, the
+proposal is applied only on explicit approval (with re-validation) and can
+be dismissed, no-change/error runs are no-ops, rollback restores the prior
+file, dream sessions are pruned, and the built-in automation seeds
+correctly.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -21,7 +25,12 @@ from collie_core.automations.scheduler import (
 )
 from collie_core.db import CollieDB
 from collie_core.ipc.server import CollieIPCServer
-from collie_core.memory.dream import run_dream
+from collie_core.memory.dream import (
+    apply_dream_proposal,
+    dismiss_dream_proposal,
+    get_dream_pending,
+    run_dream,
+)
 from collie_core.versions import VersionStore
 from nanobot.agent.memory import MemoryStore
 from nanobot.session.manager import SessionManager
@@ -87,7 +96,11 @@ def db(tmp_path: Path) -> CollieDB:
     d.close()
 
 
-async def test_dream_updates_memory_and_advances_cursor(tmp_path: Path, db: CollieDB) -> None:
+def _proposal_path(workspace: Path) -> Path:
+    return workspace / "memory" / ".dream-proposal.json"
+
+
+async def test_dream_proposes_pending_and_advances_cursor(tmp_path: Path, db: CollieDB) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
     loop = FakeLoop(workspace)
@@ -104,9 +117,16 @@ async def test_dream_updates_memory_and_advances_cursor(tmp_path: Path, db: Coll
     outcome = await run_dream(workspace=workspace, db=db, loop=loop, version_store=versions)
 
     assert outcome["changed"] is True
-    assert outcome["version_id"] is not None
+    assert outcome["pending"] is True
+
+    # Two-phase review: MEMORY.md is NOT written; the proposal is pending.
     memory_file = workspace / "memory" / "MEMORY.md"
-    assert memory_file.read_text(encoding="utf-8").strip() == proposed.strip()
+    assert not memory_file.exists()
+    assert _proposal_path(workspace).exists()
+    proposal = json.loads(_proposal_path(workspace).read_text(encoding="utf-8"))
+    assert proposal["proposed"].strip() == proposed.strip()
+    assert proposal["before"] == ""
+    assert proposal["cursor"] == cursor
 
     # Bounded, read-only, tool-less turn: exactly one model call.
     spec = loop.subagents.runner.specs[0]
@@ -115,17 +135,125 @@ async def test_dream_updates_memory_and_advances_cursor(tmp_path: Path, db: Coll
     assert spec.session_key.startswith("dream:")
     assert not spec.tools.get_definitions()
 
-    # Cursor advanced only on success.
+    # Cursor advanced on a completed proposal (history never re-processed).
     assert store.get_last_dream_cursor() == cursor
 
-    # Versioned as memory_dream with a diff.
+    # Nothing versioned yet — the version row lands on apply.
+    assert db.list_artifact_versions(artifact_type="memory_dream") == []
+
+
+async def test_apply_dream_proposal_writes_and_versions(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("User prefers concise replies.")
+    proposed = "# Long-term Memory\n- User prefers concise replies."
+    loop.subagents.runner.responses.append(_result(proposed))
+
+    versions = VersionStore(db)
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=versions)
+
+    memory_file = workspace / "memory" / "MEMORY.md"
+    assert not memory_file.exists()
+
+    result = await asyncio.to_thread(
+        apply_dream_proposal, workspace=workspace, version_store=versions
+    )
+    assert result["applied"] is True
+    assert result["version_id"] is not None
+    assert "-" in result["diff_text"] and "+" in result["diff_text"]
+    assert memory_file.read_text(encoding="utf-8").strip() == proposed.strip()
+    assert not _proposal_path(workspace).exists()
+
+    # Versioned as memory_dream with a diff, evidence carries the cursor.
     rows = db.list_artifact_versions(artifact_type="memory_dream")
     assert len(rows) == 1
     assert rows[0]["artifact_key"] == "MEMORY.md"
     assert rows[0]["source"] == "collie"
     assert "-" in rows[0]["diff_text"] and "+" in rows[0]["diff_text"]
     evidence = json.loads(rows[0]["evidence_json"])
-    assert evidence["cursor"] == cursor
+    assert evidence["cursor"] == store.get_last_dream_cursor()
+
+
+async def test_apply_refuses_when_memory_changed_since_proposal(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    proposed = "# Long-term Memory\n- Entry."
+    loop.subagents.runner.responses.append(_result(proposed))
+    versions = VersionStore(db)
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=versions)
+
+    # A manual edit in between invalidates the proposal.
+    memory_file = workspace / "memory" / "MEMORY.md"
+    memory_file.parent.mkdir(parents=True, exist_ok=True)
+    memory_file.write_text("# Long-term Memory\n- Manually edited.\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="changed since the review"):
+        apply_dream_proposal(workspace=workspace, version_store=versions)
+    # Nothing applied, proposal still pending for a fresh decision.
+    assert _proposal_path(workspace).exists()
+    assert db.list_artifact_versions(artifact_type="memory_dream") == []
+
+
+async def test_dismiss_dream_proposal_discards_without_writing(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("# Long-term Memory\n- Entry."))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+
+    result = dismiss_dream_proposal(workspace=workspace)
+    assert result["dismissed"] is True
+    assert not (workspace / "memory" / "MEMORY.md").exists()
+    assert not _proposal_path(workspace).exists()
+    assert db.list_artifact_versions(artifact_type="memory_dream") == []
+
+    assert get_dream_pending(workspace=workspace) == {"pending": False}
+
+
+async def test_run_dream_refuses_when_a_proposal_is_already_pending(
+    tmp_path: Path, db: CollieDB
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("# Long-term Memory\n- Entry."))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+
+    # Second run while a proposal awaits review: no new model call, no
+    # duplicate proposal.
+    outcome = await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+    assert outcome["changed"] is False
+    assert outcome["reason"] == "pending_exists"
+    assert len(loop.subagents.runner.specs) == 1
+    assert len(list((workspace / "memory").glob(".dream-proposal.json"))) == 1
+
+
+async def test_get_dream_pending_reports_diff(tmp_path: Path, db: CollieDB) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    loop = FakeLoop(workspace)
+    store = loop.context.memory
+    store.append_history("Entry.")
+    loop.subagents.runner.responses.append(_result("# Long-term Memory\n- Entry."))
+    await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
+
+    pending = get_dream_pending(workspace=workspace)
+    assert pending["pending"] is True
+    assert "-" in pending["diff_text"] and "+" in pending["diff_text"]
+    assert pending["created_at"]
 
 
 async def test_dream_no_new_history_is_noop(tmp_path: Path, db: CollieDB) -> None:
@@ -136,6 +264,7 @@ async def test_dream_no_new_history_is_noop(tmp_path: Path, db: CollieDB) -> Non
     assert outcome["changed"] is False
     assert outcome["reason"] == "no_new_history"
     assert not (workspace / "memory" / "MEMORY.md").exists()
+    assert not _proposal_path(workspace).exists()
 
 
 async def test_dream_no_change_second_run_advances_cursor(tmp_path: Path, db: CollieDB) -> None:
@@ -150,6 +279,10 @@ async def test_dream_no_change_second_run_advances_cursor(tmp_path: Path, db: Co
     loop.subagents.runner.responses.append(_result(proposed))
     await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
     assert store.get_last_dream_cursor() == cursor1
+    # Apply the pending proposal so memory now matches the proposed content.
+    await asyncio.to_thread(
+        apply_dream_proposal, workspace=workspace, version_store=VersionStore(db)
+    )
 
     # New history arrives, but the model proposes identical content.
     store.append_history("Second entry.")
@@ -162,7 +295,8 @@ async def test_dream_no_change_second_run_advances_cursor(tmp_path: Path, db: Co
     assert outcome["reason"] == "no_content_change"
     # History is processed even when nothing changed — no re-processing loop.
     assert store.get_last_dream_cursor() == cursor2
-    # No extra version rows for a no-op run.
+    # No extra proposal or version rows for a no-op run.
+    assert not _proposal_path(workspace).exists()
     assert len(db.list_artifact_versions(artifact_type="memory_dream")) == 1
 
 
@@ -178,6 +312,7 @@ async def test_dream_error_does_not_advance_cursor_or_write(tmp_path: Path, db: 
     assert outcome["changed"] is False
     assert store.get_last_dream_cursor() == 0
     assert not (workspace / "memory" / "MEMORY.md").exists()
+    assert not _proposal_path(workspace).exists()
     assert db.list_artifact_versions(artifact_type="memory_dream") == []
 
 
@@ -191,6 +326,7 @@ async def test_dream_rollback_restores_prior_memory(tmp_path: Path, db: CollieDB
     loop.subagents.runner.responses.append(_result(proposed))
     versions = VersionStore(db)
     await run_dream(workspace=workspace, db=db, loop=loop, version_store=versions)
+    await asyncio.to_thread(apply_dream_proposal, workspace=workspace, version_store=versions)
 
     memory_file = workspace / "memory" / "MEMORY.md"
     current = memory_file.read_text(encoding="utf-8")
@@ -225,6 +361,9 @@ async def test_dream_fenced_response_is_extracted(tmp_path: Path, db: CollieDB) 
     )
     outcome = await run_dream(workspace=workspace, db=db, loop=loop, version_store=VersionStore(db))
     assert outcome["changed"] is True
+    await asyncio.to_thread(
+        apply_dream_proposal, workspace=workspace, version_store=VersionStore(db)
+    )
     memory_file = workspace / "memory" / "MEMORY.md"
     assert "# Long-term Memory" in memory_file.read_text(encoding="utf-8")
     assert "```" not in memory_file.read_text(encoding="utf-8")
@@ -252,7 +391,9 @@ def test_seed_gardener_automations_once_and_never_resurrects(tmp_path: Path, db:
     }
 
 
-async def test_ipc_run_dream_and_history(tmp_path: Path, db: CollieDB) -> None:
+async def test_ipc_run_dream_and_history(
+    tmp_path: Path, db: CollieDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
     class _FakeConn:
         async def send(self, payload: dict[str, Any]) -> None:
             pass
@@ -260,12 +401,23 @@ async def test_ipc_run_dream_and_history(tmp_path: Path, db: CollieDB) -> None:
     async def fake_dream_runner() -> dict[str, Any]:
         return {"changed": False, "reason": "no_new_history", "message": "All tidy."}
 
+    # Keep the new IPC commands on scratch state, never the real home.
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path / "home"))
+
     srv = CollieIPCServer(db, port=0, dream_runner=fake_dream_runner)
     conn = _FakeConn()
     outcome = await srv._cmd_run_dream(conn, {})
     assert outcome["changed"] is False
     history = await srv._cmd_get_dream_history(conn, {})
     assert history["versions"] == []
+
+    pending = await srv._cmd_get_dream_pending(conn, {})
+    assert pending["pending"] is False
+    applied = await srv._cmd_apply_dream_proposal(conn, {})
+    assert applied["applied"] is False
+    assert applied["reason"] == "no_pending"
+    dismissed = await srv._cmd_dismiss_dream_proposal(conn, {})
+    assert dismissed["dismissed"] is True
 
     unset = CollieIPCServer(db, port=0)
     with pytest.raises(ValueError):

--- a/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/MemoryTab.tsx
@@ -82,6 +82,11 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
   const [undoingId, setUndoingId] = useState<string | null>(null)
   const [reviewBusy, setReviewBusy] = useState<'dream' | 'gardener' | null>(null)
   const [reviewMsg, setReviewMsg] = useState('')
+  const [pendingReview, setPendingReview] = useState<{
+    diff_text?: string | null
+    created_at?: string | null
+  } | null>(null)
+  const [reviewActionBusy, setReviewActionBusy] = useState(false)
 
   const refreshHistory = useCallback(async (): Promise<void> => {
     try {
@@ -99,14 +104,20 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
   }, [])
 
   const refresh = useCallback(async () => {
-    const [pData, ppl, dateData] = await Promise.all([
+    const [pData, ppl, dateData, pending] = await Promise.all([
       collieClient.command<{ profile: ProfileEntry }>('get_profile'),
       collieClient.command<{ people: Person[] }>('get_people'),
-      collieClient.command<{ dates: DateEntry[] }>('get_dates')
+      collieClient.command<{ dates: DateEntry[] }>('get_dates'),
+      collieClient.getDreamPending()
     ])
     setProfile(pData.profile || {})
     setPeople(ppl.people || [])
     setDates(dateData.dates || [])
+    setPendingReview(
+      pending.pending
+        ? { diff_text: pending.diff_text ?? null, created_at: pending.created_at ?? null }
+        : null
+    )
     await refreshHistory()
   }, [refreshHistory])
 
@@ -137,7 +148,13 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
           ? 'Memory review done.'
           : 'Improvement suggestions are ready — check the chat for the review cards.')
       setReviewMsg(message)
-      if (kind === 'dream') await refreshHistory()
+      if (kind === 'dream') {
+        const dreamOutcome = outcome as { pending?: boolean; diff?: string }
+        if (dreamOutcome.pending) {
+          setPendingReview({ diff_text: dreamOutcome.diff ?? null, created_at: null })
+        }
+        await refreshHistory()
+      }
       onNotice(message)
     } catch (error) {
       const message =
@@ -146,6 +163,41 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
       onNotice(message)
     } finally {
       setReviewBusy(null)
+    }
+  }
+
+  const applyDream = async (): Promise<void> => {
+    setReviewActionBusy(true)
+    try {
+      const result = await collieClient.applyDreamProposal()
+      if (result.applied) {
+        setPendingReview(null)
+        await refreshHistory()
+        onNotice('Memory updated — you can undo it in History below.')
+      } else {
+        onNotice(
+          result.reason === 'no_pending'
+            ? 'Nothing is waiting for review.'
+            : 'I could not apply that review.'
+        )
+      }
+    } catch (error) {
+      onNotice(error instanceof Error ? error.message : 'I could not apply that review.')
+    } finally {
+      setReviewActionBusy(false)
+    }
+  }
+
+  const dismissDream = async (): Promise<void> => {
+    setReviewActionBusy(true)
+    try {
+      await collieClient.dismissDreamProposal()
+      setPendingReview(null)
+      onNotice('Review dismissed — your memory stays as it was.')
+    } catch (error) {
+      onNotice(error instanceof Error ? error.message : 'I could not dismiss that review.')
+    } finally {
+      setReviewActionBusy(false)
     }
   }
 
@@ -648,9 +700,10 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
       <section className="memory-section">
         <h3><Sparkles size={14} /> Collie's self-review</h3>
         <p className="memory-note">
-          Run a memory review (tidies long-term memory, undoable) or ask for
-          improvement suggestions from recent run records. Suggestions appear
-          as review cards in the 🔔 conversation.
+          Run a memory review — Collie proposes tidy-ups to long-term memory,
+          and you review and approve them before anything changes (everything
+          stays undoable). Or ask for improvement suggestions from recent run
+          records; those appear as review cards in the 🔔 conversation.
         </p>
         <div className="memory-toolbar">
           <button
@@ -673,6 +726,40 @@ export default function MemoryTab({ onNotice }: Props): React.JSX.Element {
           </button>
         </div>
         {reviewMsg && <p className="memory-note">{reviewMsg}</p>}
+        {pendingReview && (
+          <div className="memory-note review-pending">
+            <b>Memory review waiting for you</b>
+            <span>
+              Collie reviewed your conversations and is proposing tidied-up
+              long-term memory. Nothing is applied until you approve.
+            </span>
+            {pendingReview.diff_text && (
+              <DiffView
+                diff={pendingReview.diff_text}
+                label="Proposed memory changes"
+              />
+            )}
+            <div className="memory-toolbar">
+              <button
+                type="button"
+                className="settings-button"
+                disabled={reviewActionBusy}
+                onClick={() => void applyDream()}
+              >
+                <Check size={13} />{' '}
+                {reviewActionBusy ? 'Working…' : 'Apply changes'}
+              </button>
+              <button
+                type="button"
+                className="settings-button"
+                disabled={reviewActionBusy}
+                onClick={() => void dismissDream()}
+              >
+                <X size={13} /> Not now
+              </button>
+            </div>
+          </div>
+        )}
       </section>
 
       <section className="memory-section">

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -755,6 +755,7 @@ export class CollieClient {
   runDream(): Promise<{
     changed: boolean
     reason?: string
+    pending?: boolean
     version_id?: string | null
     diff?: string
     cursor?: string
@@ -766,6 +767,30 @@ export class CollieClient {
   /** Past Dream consolidations (memory_dream versions), newest first. */
   getDreamHistory(): Promise<{ versions: ArtifactVersion[] }> {
     return this.command('get_dream_history', {})
+  }
+
+  /** Pending Dream proposal state (Settings -> Memory self-review section). */
+  getDreamPending(): Promise<{
+    pending: boolean
+    diff_text?: string | null
+    created_at?: string | null
+  }> {
+    return this.command('get_dream_pending', {})
+  }
+
+  /** Approve the pending Dream proposal: re-validated, applied, versioned. */
+  applyDreamProposal(): Promise<{
+    applied: boolean
+    reason?: string
+    version_id?: string | null
+    diff_text?: string
+  }> {
+    return this.command('apply_dream_proposal', {})
+  }
+
+  /** Dismiss the pending Dream proposal without applying it. */
+  dismissDreamProposal(): Promise<{ dismissed: boolean }> {
+    return this.command('dismiss_dream_proposal', {})
   }
 
   /** Recent memory writes (kind/subject/action/value), newest first. */

--- a/docs/engineering/architecture/gardener-foundations.md
+++ b/docs/engineering/architecture/gardener-foundations.md
@@ -100,11 +100,17 @@ was vendored but dead; Collie had zero references. `run_dream()` wires it:
    read-only by construction), `execution_posture="read_only"`. Collie has
    no file-editing tools, so the output contract asks the model to return
    the full proposed `memory/MEMORY.md` content (fence-tolerant parser).
-3. If the proposed content differs, write it atomically and snapshot via
-   `VersionStore` (`memory_dream` / `MEMORY.md`, `source="collie"`).
+3. If the proposed content differs, store it as a **pending proposal**
+   (`memory/.dream-proposal.json`) — `MEMORY.md` is **not** written.
+   The user reviews the diff in Settings → Memory and explicitly applies
+   or dismisses it. On apply, the proposal is re-validated against the
+   current file, written atomically, and snapshotted via `VersionStore`
+   (`memory_dream` / `MEMORY.md`, `source="collie"`), so the change stays
+   undoable. On dismiss, the proposal is discarded.
 4. Advance the dream cursor **only on success** (a completed turn — even a
    no-change one — so history is never re-processed); failed/incomplete
-   turns leave the cursor put.
+   turns leave the cursor put. The cursor advances when the proposal is
+   created; applying or dismissing never re-runs the model.
 5. `prune_dream_sessions(keep=10)` after each run.
 
 Dream never touches `ProfileStore` — it consolidates nanobot's long-term

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -7,14 +7,14 @@
 | Component | Path | Version |
 | --- | --- | --- |
 | Python core | `collie-core/` | `0.2.2` |
-| Electron desktop | `collie-ui/` | `0.1.0-alpha.4` |
+| Electron desktop | `collie-ui/` | `0.1.0-alpha.6` |
 
 ## Source inventory
 
 - Core Python files: **514**
 - Core Python test files: **234**
-- Desktop TypeScript/TSX files: **157**
-- Desktop test files: **53**
+- Desktop TypeScript/TSX files: **159**
+- Desktop test files: **54**
 - Active Markdown docs: **29**
 - Archived Markdown docs: **0**
 


### PR DESCRIPTION
## What
Dream no longer rewrites `memory/MEMORY.md` directly. A completed run now stores a **pending proposal** (`memory/.dream-proposal.json`) and the user reviews the diff in Settings → Memory, then **applies or dismisses**:

- `run_dream` — propose-only; refuses to run while a proposal is pending
- `apply_dream_proposal` — re-validates the base content (a manual edit in between invalidates it), writes atomically, versions as `memory_dream` (undoable), clears the pending file
- `dismiss_dream_proposal` — discards without writing
- `get_dream_pending` — pending state shown on Settings refresh
- Weekly automation now announces "review in Settings" instead of claiming it changed memory

The dream cursor still advances on a completed run, so history is never re-processed whether the proposal is applied or dismissed. Same review-before-apply pattern Gardener already uses.

## Why
Verified finding from #61: a poisoned conversation could previously persist into MEMORY.md (bootstrap context for every future prompt) with no approval gate — only post-hoc undo.

## Test plan
- `pytest tests/collie/test_dream_collie.py` — 14/14 ✅ (propose-pending, apply+version, re-validation refusal, dismiss, pending-exists refusal, cursor semantics)
- `pytest tests/collie` — 705 passed (4 pre-existing Linux-only services failures, identical on main)
- `ruff check` + `ruff format --check` ✅, snapshot `--check` ✅
- `npm run typecheck` ✅, `vitest run` 352/352 ✅

Closes #61