### PR TITLE
fix(mac): ad-hoc sign the .app so Gatekeeper stops reporting 'damaged'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ name: Release
 # Signing notes (alpha):
 #  - Windows: the installer is unsigned (no code-signing cert); SmartScreen
 #    may warn. Signing with an EV/OV cert is a follow-up.
-#  - macOS: codesign + notarization are SKIPPED for alpha — there is no Apple
-#    Developer certificate yet (CSC_IDENTITY_AUTO_DISCOVERY=false below).
-#    The unsigned dmg is acceptable for alpha but Gatekeeper will show
-#    "Apple cannot check it for malicious software" — users must
-#    right-click → Open. A $99/yr Apple Developer account + notarytool
-#    secrets (APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID) are the
-#    follow-up.
+#  - macOS: Developer ID codesign + notarization are SKIPPED for alpha — no
+#    Apple Developer certificate yet (CSC_IDENTITY_AUTO_DISCOVERY=false
+#    below). The app is ad-hoc signed (scripts/adhoc-sign-mac.cjs) so it
+#    launches, but Gatekeeper will show "cannot be opened because the
+#    developer cannot be verified" — users must right-click → Open. A
+#    $99/yr Apple Developer account + notarytool secrets (APPLE_ID /
+#    APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID) are the follow-up.
 #
 # Secrets: only the automatic secrets.GITHUB_TOKEN is used. No real secrets
 # are referenced or committed; APPLE_* / signing certs are placeholders for

--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -42,14 +42,17 @@ linux:
   artifactName: Collie-${version}.${ext}
   category: Utility
   maintainer: Collie <hello@heycollie.com>
-# macOS: unsigned alpha builds (no Apple certificate yet — the CI workflow
-# disables identity discovery). build/icon.icns is generated on the mac
+# macOS: ad-hoc signed alpha builds (no Apple Developer certificate yet — the
+# CI workflow disables identity discovery, and scripts/adhoc-sign-mac.cjs
+# applies codesign --force --deep --sign - after packing so Gatekeeper does
+# not report the app as "damaged"). build/icon.icns is generated on the mac
 # runner from build/icon.png (iconutil) so the branded portrait ships.
 # arch: arm64 only — the CI macos runner stages a native-arm64 Python
 # runtime, and an x64 .app carrying arm64 python/site-packages would not
 # run on Intel Macs. x64/universal2 needs per-arch staged runtimes
 # (follow-up, tracked in docs/operations/release).
 mac:
+  afterPack: ./scripts/adhoc-sign-mac.cjs
   target:
     - target: dmg
       arch:

--- a/collie-ui/scripts/adhoc-sign-mac.cjs
+++ b/collie-ui/scripts/adhoc-sign-mac.cjs
@@ -1,0 +1,18 @@
+const { execSync } = require('child_process')
+
+// macOS alpha builds have no Apple Developer certificate, but shipping the
+// .app with signing fully disabled leaves Electron's stale embedded
+// signature in place — the repackaged bundle's seal no longer matches, so
+// Gatekeeper rejects it with "Collie is damaged and can't be opened" (an
+// error with no right-click → Open bypass). Ad-hoc signing
+// (`codesign --force --deep --sign -`) replaces every stale signature with
+// a fresh valid one: macOS launches the app, and users only hit the normal
+// "unidentified developer" prompt, bypassable via right-click → Open.
+// Real Developer ID signing + notarization remains the $99/yr follow-up.
+exports.default = async function afterPack(context) {
+  const appPath = context.appOutDir
+  console.log(`Ad-hoc codesigning ${appPath}`)
+  execSync(`codesign --force --deep --sign - "${appPath}"`, {
+    stdio: 'inherit',
+  })
+}

--- a/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
@@ -12,6 +12,7 @@ const { searchMessages } = vi.hoisted(() => ({
 
 vi.mock('lucide-react', () => ({
   Bot: () => null,
+  ChevronDown: () => null,
   Folder: () => null,
   FolderPlus: () => null,
   MessageCircle: () => null,
@@ -53,12 +54,36 @@ const conversations: Conversation[] = [
     created_at: '2026-08-01T00:00:00Z',
     updated_at: '2026-08-01T00:00:00Z',
     archived: 0
+  },
+  {
+    id: 'project-chat',
+    title: 'Project chat',
+    project_path: '/home/rick/proj-a',
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z',
+    archived: 0
+  },
+  {
+    id: 'project-chat-b',
+    title: 'Project chat B',
+    project_path: '/home/rick/proj-b',
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z',
+    archived: 0
   }
 ]
 
 const roots: Root[] = []
 
-function renderSidebar(onDelete = vi.fn()): HTMLElement {
+interface SidebarTestOptions {
+  onDelete?: (id: string) => void
+  projects?: string[]
+  workspace?: string
+  onProjectChange?: (path: string) => void
+}
+
+function renderSidebar(options: SidebarTestOptions = {}): HTMLElement {
+  const { onDelete = vi.fn(), projects = [], workspace, onProjectChange = vi.fn() } = options
   const container = document.createElement('div')
   document.body.append(container)
   const root = createRoot(container)
@@ -73,7 +98,9 @@ function renderSidebar(onDelete = vi.fn()): HTMLElement {
         onSelect={vi.fn()}
         onNewChat={vi.fn()}
         onDelete={onDelete}
-        onProjectChange={vi.fn()}
+        workspace={workspace}
+        projects={projects}
+        onProjectChange={onProjectChange}
         onAddProject={vi.fn()}
       />
     )
@@ -167,7 +194,7 @@ describe('Sidebar navigation', () => {
   it('shows persisted pins above recent chats and removes a pin when deleting', () => {
     localStorage.setItem(PINNED_CONVERSATIONS_STORAGE_KEY, JSON.stringify(['pinned']))
     const onDelete = vi.fn()
-    const container = renderSidebar(onDelete)
+    const container = renderSidebar({ onDelete })
     const labels = Array.from(container.querySelectorAll('.sidebar-nested-label'))
     expect(labels.map((label) => label.textContent)).toEqual(['Pinned', 'Recent chats'])
     expect(labels[0]?.parentElement?.textContent).toContain('Pinned chat')
@@ -239,6 +266,64 @@ describe('Sidebar navigation', () => {
     })
     expect(container.querySelector('button[title="Recent chat"]')).not.toBeNull()
     expect(container.querySelector('button[title="Pinned chat"]')).toBeNull()
+  })
+})
+
+describe('Sidebar layout', () => {
+  it('keeps General Chat outside the scrolling conversation list', () => {
+    const container = renderSidebar()
+    const conversationNav = container.querySelector<HTMLElement>(
+      'nav[aria-label="Conversations"]'
+    )!
+    const generalChat = container.querySelector<HTMLButtonElement>(
+      '.sidebar-context-wrap button'
+    )!
+    expect(generalChat.textContent).toBe('General Chat')
+    expect(conversationNav.contains(generalChat)).toBe(false)
+  })
+
+  it('shows project chats collapsed behind a toggle and expands on click', () => {
+    const container = renderSidebar({
+      projects: ['/home/rick/proj-a', '/home/rick/proj-b'],
+      workspace: '/home/rick/proj-a'
+    })
+    const projectGroups = container.querySelectorAll<HTMLElement>('.sidebar-project-group')
+    expect(projectGroups.length).toBe(2)
+
+    const activeToggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse proj-a"]'
+    )!
+    expect(activeToggle.getAttribute('aria-expanded')).toBe('true')
+    const collapsedToggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Expand proj-b"]'
+    )!
+    expect(collapsedToggle.getAttribute('aria-expanded')).toBe('false')
+
+    // Only the active project's chats are visible; the other stays folded.
+    expect(container.querySelector('button[title="Project chat"]')).not.toBeNull()
+
+    act(() => collapsedToggle.click())
+    expect(collapsedToggle.getAttribute('aria-expanded')).toBe('true')
+
+    act(() => collapsedToggle.click())
+    expect(collapsedToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('button[title="Project chat"]')).not.toBeNull()
+  })
+
+  it('selecting a project navigates and expands its chats', () => {
+    const onProjectChange = vi.fn()
+    const container = renderSidebar({
+      projects: ['/home/rick/proj-b'],
+      workspace: '/home/rick/proj-a',
+      onProjectChange
+    })
+    const row = container.querySelector<HTMLButtonElement>('button[title="/home/rick/proj-b"]')!
+    act(() => row.click())
+    expect(onProjectChange).toHaveBeenCalledWith('/home/rick/proj-b')
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse proj-b"]'
+    )!
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
   })
 })
 

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   Bot,
+  ChevronDown,
   Folder,
   FolderPlus,
   MessageCircle,
@@ -65,6 +66,11 @@ export default function Sidebar({
   const [pinnedIds, setPinnedIds] = useState<string[]>(() =>
     typeof localStorage === 'undefined' ? [] : readPinnedConversationIds(localStorage)
   )
+  // Projects collapse to their folder row so the list never dominates the
+  // sidebar; the active project stays expanded so its chats are one tap away.
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() =>
+    workspace ? new Set([workspace]) : new Set()
+  )
   const [contentMatches, setContentMatches] = useState<Set<string> | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const searchToggleRef = useRef<HTMLButtonElement>(null)
@@ -114,6 +120,13 @@ export default function Sidebar({
   useEffect(() => {
     if (searchOpen) searchInputRef.current?.focus()
   }, [searchOpen])
+
+  // Keep the active project expanded whenever it changes (e.g. switched from
+  // the composer dropdown), without forcing other projects open.
+  useEffect(() => {
+    if (!workspace) return
+    setExpandedProjects((prev) => (prev.has(workspace) ? prev : new Set(prev).add(workspace)))
+  }, [workspace])
 
   useEffect(() => {
     const generation = ++searchGenerationRef.current
@@ -172,6 +185,20 @@ export default function Sidebar({
     persistPinnedIds(
       pinnedIdSet.has(id) ? pinnedIds.filter((pinnedId) => pinnedId !== id) : [...pinnedIds, id]
     )
+  }
+
+  const toggleProject = (path: string): void => {
+    setExpandedProjects((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  const selectProject = (path: string): void => {
+    setExpandedProjects((prev) => (prev.has(path) ? prev : new Set(prev).add(path)))
+    onProjectChange(path)
   }
 
   const deleteConversation = (id: string): void => {
@@ -299,6 +326,20 @@ export default function Sidebar({
         ))}
       </nav>
 
+      {/* Fixed context row: General Chat anchors the chat area and must not
+          scroll away with the conversation list below it. */}
+      <div className="sidebar-context-wrap px-3">
+        <button
+          type="button"
+          className={`sidebar-context-row ${!workspace && activeView === 'chat' ? 'is-active' : ''}`}
+          onClick={() => onProjectChange('')}
+          aria-current={!workspace && activeView === 'chat' ? 'page' : undefined}
+        >
+          <MessageCircle size={15} />
+          <span>General Chat</span>
+        </button>
+      </div>
+
       <nav className="sidebar-conversation-nav flex-1 overflow-y-auto px-3" aria-label="Conversations">
         {conversations.length > 0 && visible.length === 0 && (
           <p className="px-2 py-6 text-center text-xs" style={{ color: 'var(--collie-text-sidebar-muted)' }}>
@@ -314,15 +355,6 @@ export default function Sidebar({
           </section>
         ) : null}
         <section className="sidebar-chat-group">
-          <button
-            type="button"
-            className={`sidebar-context-row ${!workspace && activeView === 'chat' ? 'is-active' : ''}`}
-            onClick={() => onProjectChange('')}
-            aria-current={!workspace && activeView === 'chat' ? 'page' : undefined}
-          >
-            <MessageCircle size={15} />
-            <span>General Chat</span>
-          </button>
           <div className="sidebar-nested-label">Recent chats</div>
           <div className="sidebar-nested-conversations">
             {conversationRows(generalConversations)}
@@ -342,21 +374,36 @@ export default function Sidebar({
           <div className="sidebar-project-list">
             {projects.map((path) => {
               const recent = projectConversations(path)
+              const expanded = expandedProjects.has(path)
               return (
                 <div className="sidebar-project-group" key={path}>
-                  <button
-                    type="button"
-                    className={`project-row ${path === workspace ? 'is-active' : ''}`}
-                    title={path}
-                    onClick={() => onProjectChange(path)}
-                  >
-                    <Folder size={13} />
-                    <span>
-                      <b>{path.split(/[\\/]/).filter(Boolean).at(-1) || path}</b>
-                      <small>{path}</small>
-                    </span>
-                  </button>
-                  {recent.length > 0 ? (
+                  <div className="sidebar-project-header">
+                    <button
+                      type="button"
+                      className={`project-row ${path === workspace ? 'is-active' : ''}`}
+                      title={path}
+                      onClick={() => selectProject(path)}
+                    >
+                      <Folder size={13} />
+                      <span>
+                        <b>{path.split(/[\\/]/).filter(Boolean).at(-1) || path}</b>
+                        <small>{path}</small>
+                      </span>
+                    </button>
+                    {recent.length > 0 ? (
+                      <button
+                        type="button"
+                        className={`project-toggle ${expanded ? 'is-expanded' : ''}`}
+                        onClick={() => toggleProject(path)}
+                        aria-expanded={expanded}
+                        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${path.split(/[\\/]/).filter(Boolean).at(-1) || path}`}
+                        title={expanded ? 'Collapse project chats' : 'Show project chats'}
+                      >
+                        <ChevronDown size={14} />
+                      </button>
+                    ) : null}
+                  </div>
+                  {expanded && recent.length > 0 ? (
                     <div className="sidebar-nested-conversations">
                       {conversationRows(recent)}
                     </div>

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -2868,6 +2868,42 @@ button {
   overflow-y: auto;
 }
 
+.sidebar-project-header {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.sidebar-project-header .project-row {
+  flex: 1;
+  min-width: 0;
+}
+
+.project-toggle {
+  display: grid;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  margin-right: 2px;
+  place-items: center;
+  border-radius: 7px;
+  color: #8f938d;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.project-toggle:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.project-toggle svg {
+  transition: transform 150ms ease;
+}
+
+.project-toggle.is-expanded svg {
+  transform: rotate(180deg);
+}
+
 .sidebar-project-list .project-row {
   display: grid;
   width: 100%;
@@ -2890,6 +2926,10 @@ button {
 
 .sidebar-chat-group {
   padding-top: 1px;
+}
+
+.sidebar-context-wrap {
+  margin: 10px 0 4px;
 }
 
 .sidebar-context-row {

--- a/docs/product/features/chat-experience.md
+++ b/docs/product/features/chat-experience.md
@@ -24,7 +24,11 @@ arrive, and the sidebar should prioritize starting and returning to chats.
 - Markdown is rendered continuously while a response streams. Users do not see
   raw formatting markers such as `**` or `__` before styled text appears.
 - The sidebar order is: **New Chat**, **Agents**, **Skills**, **Routines**,
-  **Connectors**, pinned chats, then recent chats.
+  **Connectors**, then **General Chat** as a fixed row that never scrolls away,
+  followed by pinned chats and recent chats in the scrolling area.
+- Project groups sit below recent chats in the scrolling area. Each project
+  collapses to its folder row; the active project stays expanded, and clicking
+  a project row opens the project and expands its recent chats.
 - The sidebar can be collapsed to a 64px icon-only rail (chevron button or
   Ctrl/Cmd+B) to free up chat space. Labels become tooltips; the choice
   survives restarts. Expanding restores the full navigation.


### PR DESCRIPTION
## Problem
The macOS download (v0.1.0-alpha.6) fails on Macs with:
> "Collie is damaged and can't be opened. You should move it to the Trash."

Root cause: the mac build runs with `CSC_IDENTITY_AUTO_DISCOVERY=false` (no Apple cert), which makes electron-builder skip signing entirely. The repackaged .app then still carries Electron's **stale embedded Developer-ID signature**, whose bundle seal no longer matches. Gatekeeper sees an invalid signature → "damaged" (no right-click → Open bypass — worse than the "unidentified developer" prompt the release notes anticipated).

## Fix
New `afterPack` hook `collie-ui/scripts/adhoc-sign-mac.cjs` runs `codesign --force --deep --sign -` (ad-hoc) after packing, before dmg/zip creation. Result:
- App launches on macOS (incl. Apple Silicon, which refuses unsigned arm64 binaries).
- Users hit only the standard "developer cannot be verified" prompt → right-click → Open.
- Developer ID signing + notarization stays the $99/yr follow-up (unchanged scope).

## Test plan
- Re-run the mac build job on this branch; verify the .app inside the dmg/zip passes `codesign --verify --deep` and `spctl -a -vv` reports ad-hoc signature (still not notarized).
- Manual: download from heycollie.com after release, right-click → Open works.
