### PR TITLE
fix(mac): move afterPack hook to config root (electron-builder schema)

### DIFF
--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -4,6 +4,7 @@ directories:
   output: dist
   buildResources: build
 beforePack: ./scripts/electron-builder-before-pack.cjs
+afterPack: ./scripts/adhoc-sign-mac.cjs
 files:
   - out/**
 extraResources:
@@ -52,7 +53,6 @@ linux:
 # run on Intel Macs. x64/universal2 needs per-arch staged runtimes
 # (follow-up, tracked in docs/operations/release).
 mac:
-  afterPack: ./scripts/adhoc-sign-mac.cjs
   target:
     - target: dmg
       arch:

--- a/collie-ui/scripts/adhoc-sign-mac.cjs
+++ b/collie-ui/scripts/adhoc-sign-mac.cjs
@@ -9,7 +9,10 @@ const { execSync } = require('child_process')
 // a fresh valid one: macOS launches the app, and users only hit the normal
 // "unidentified developer" prompt, bypassable via right-click → Open.
 // Real Developer ID signing + notarization remains the $99/yr follow-up.
+// afterPack is a TOP-LEVEL electron-builder hook (it fires for every
+// platform), so this script must no-op on non-macOS runners.
 exports.default = async function afterPack(context) {
+  if (process.platform !== 'darwin') return
   const appPath = context.appOutDir
   console.log(`Ad-hoc codesigning ${appPath}`)
   execSync(`codesign --force --deep --sign - "${appPath}"`, {


### PR DESCRIPTION
---
## Why this follow-up
The first rebuild failed: electron-builder rejected the config because `afterPack` is a TOP-LEVEL key, not a `mac:` sub-key — schema validation aborted all 3 platform builds.

Changes:
- Moved `afterPack: ./scripts/adhoc-sign-mac.cjs` to the config root (next to `beforePack`)
- Script now no-ops on non-darwin runners (root hook fires for win/linux too)

Validated locally with electron-builder's own `validateConfiguration` — passes ✅
