### PR TITLE
test(ui): skip Linux-only basic_text secrets test on other platforms

### DIFF
--- a/collie-ui/src/main/secrets.test.ts
+++ b/collie-ui/src/main/secrets.test.ts
@@ -93,7 +93,9 @@ describe('encrypted provider secret transactions', () => {
     }
   })
 
-  it('rejects the Linux basic_text backend (hardcoded-password "encryption")', () => {
+  it.skipIf(process.platform !== 'linux')(
+    'rejects the Linux basic_text backend (hardcoded-password "encryption")',
+    () => {
     // Without a keyring daemon Electron falls back to basic_text, which
     // "encrypts" with a hardcoded password shipped in the Electron source.
     // isEncryptionAvailable() still reports true — the wrapper must refuse.


### PR DESCRIPTION
## What
The 'rejects the Linux basic_text backend' test mocks `getSelectedStorageBackend` to `basic_text` and expects `secureStorageAvailable()` to be `false`. Prod code only applies that check on Linux (`process.platform === 'linux'`), so on Windows/macOS runners the mock is irrelevant and the assertion fails.

Guarded with `it.skipIf(process.platform !== 'linux')` — the test still runs (and passes) on Linux, and is skipped on Windows/macOS.

## Why
Every open PR's Windows vitest job **and main itself** has been red at `secrets.test.ts:104` for this exact reason — a Linux-only behavior test running unguarded on Windows runners. This unblocks all PR checks.

## Test plan
- `npx vitest run src/main/secrets.test.ts` on Linux: 6/6 pass (test runs, not skipped)