### PR TITLE
fix(oauth): Claude sign-in 'Invalid request format' — mirror current Claude Code OAuth flow

### DIFF
--- a/collie-core/collie_core/providers/auth.py
+++ b/collie-core/collie_core/providers/auth.py
@@ -127,12 +127,6 @@ class OAuthLoginAttempt:
         self._storage.discard()
 
 
-def _cancel_aware_prompt(cancelled: Event | None) -> str:
-    if cancelled is not None and cancelled.is_set():
-        raise OAuthLoginCancelledError("Sign-in cancelled.")
-    return ""
-
-
 def _login_oauth_cancellable(config: Any, storage: Any, cancelled: Event) -> Any:
     """Run oauth_cli_kit's browser flow with prompt listener cancellation.
 
@@ -152,6 +146,8 @@ def _login_oauth_cancellable(config: Any, storage: Any, cancelled: Event) -> Any
             raise OAuthLoginCancelledError("Sign-in cancelled.")
 
     async def run() -> Any:
+        from collie_core.providers.callback_server import start_callback_server
+
         verifier, challenge = oauth_flow._generate_pkce()
         state = oauth_flow._create_state()
         params = {
@@ -162,10 +158,13 @@ def _login_oauth_cancellable(config: Any, storage: Any, cancelled: Event) -> Any
             "code_challenge": challenge,
             "code_challenge_method": "S256",
             "state": state,
-            "id_token_add_organizations": "true",
-            "codex_cli_simplified_flow": "true",
-            "originator": config.default_originator,
         }
+        # Codex-only parameters: the Claude endpoint rejects requests that
+        # carry them, so only the OpenAI flow sends originator/codex params.
+        if config.authorize_url.startswith("https://auth.openai.com/"):
+            params["id_token_add_organizations"] = "true"
+            params["codex_cli_simplified_flow"] = "true"
+            params["originator"] = config.default_originator
         url = f"{config.authorize_url}?{urllib.parse.urlencode(params)}"
         loop = asyncio.get_running_loop()
         code_future: asyncio.Future[str] = loop.create_future()
@@ -174,7 +173,7 @@ def _login_oauth_cancellable(config: Any, storage: Any, cancelled: Event) -> Any
             if not code_future.done():
                 loop.call_soon_threadsafe(code_future.set_result, code)
 
-        server, server_error = oauth_flow._start_local_server(state, on_code=notify)
+        server, server_error = start_callback_server(config.redirect_uri, state, on_code=notify)
         try:
             await check_cancelled()
             should_open = oauth_flow._should_open_browser()
@@ -226,7 +225,7 @@ def _login_with_storage(
     cancelled: Event | None = None,
 ) -> dict[str, Any]:
     try:
-        from oauth_cli_kit import get_token, login_oauth_interactive  # noqa: F811
+        from oauth_cli_kit import get_token
     except ImportError as e:
         raise ValueError(
             "The OAuth sign-in helper library is not installed. "
@@ -243,17 +242,14 @@ def _login_with_storage(
         token = get_token(provider=config, storage=storage)
     check_cancelled()
     if not (token and token.access):
-        messages: list[str] = []
         try:
-            if cancelled is not None:
-                token = _login_oauth_cancellable(config, storage, cancelled)
-            else:
-                token = login_oauth_interactive(
-                    print_fn=lambda message: messages.append(str(message)),
-                    prompt_fn=lambda _prompt: _cancel_aware_prompt(cancelled),
-                    provider=config,
-                    storage=storage,
-                )
+            # One flow for every caller: the cancellable path owns the
+            # callback server derived from the provider's redirect_uri.
+            token = _login_oauth_cancellable(
+                config,
+                storage,
+                cancelled if cancelled is not None else Event(),
+            )
         except OAuthLoginCancelledError:
             raise
         except Exception as e:

--- a/collie-core/collie_core/providers/callback_server.py
+++ b/collie-core/collie_core/providers/callback_server.py
@@ -1,0 +1,139 @@
+"""Local OAuth callback server derived from a provider's redirect_uri.
+
+``oauth_cli_kit``'s built-in callback server is hardcoded to the Codex
+callback (``localhost:1455/auth/callback``). Collie's Claude flow uses the
+public Claude Code OAuth client, whose registered redirect is
+``http://localhost:54545/callback``, so the local server must follow the
+provider's ``redirect_uri`` instead of a fixed port and path.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import urllib.parse
+from collections.abc import Callable
+from contextlib import suppress
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from oauth_cli_kit.constants import SUCCESS_HTML
+
+
+class _OAuthHandler(BaseHTTPRequestHandler):
+    """Callback handler that accepts only the redirect path + expected state."""
+
+    server_version = "CollieOAuth/1.0"
+    protocol_version = "HTTP/1.1"
+
+    def _send_body(
+        self, status: int, body: bytes, content_type: str = "text/plain; charset=utf-8"
+    ) -> None:
+        self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        with suppress(Exception):
+            self.wfile.flush()
+
+    def do_GET(self) -> None:  # noqa: N802
+        try:
+            url = urllib.parse.urlparse(self.path)
+            if url.path != self.server.callback_path:
+                self._send_body(404, b"Not found")
+                return
+
+            qs = urllib.parse.parse_qs(url.query)
+            code = qs.get("code", [None])[0]
+            state = qs.get("state", [None])[0]
+
+            if state != self.server.expected_state:
+                self._send_body(400, b"State mismatch")
+                return
+            if not code:
+                self._send_body(400, b"Missing code")
+                return
+
+            self.server.code = code
+            try:
+                if getattr(self.server, "on_code", None):
+                    self.server.on_code(code)
+            except Exception:
+                pass
+            self._send_body(200, SUCCESS_HTML.encode("utf-8"), "text/html; charset=utf-8")
+        except Exception:
+            self._send_body(500, b"Internal error")
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        # Suppress default logs to avoid noisy output.
+        return
+
+
+class _OAuthServer(ThreadingHTTPServer):
+    """Callback server bound to one address family with expected-state checks."""
+
+    daemon_threads = True
+    block_on_close = False
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        expected_state: str,
+        callback_path: str,
+        on_code: Callable[[str], None] | None = None,
+    ) -> None:
+        super().__init__(server_address, _OAuthHandler)
+        self.expected_state = expected_state
+        self.callback_path = callback_path
+        self.code: str | None = None
+        self.on_code = on_code
+
+
+def start_callback_server(
+    redirect_uri: str,
+    state: str,
+    on_code: Callable[[str], None] | None = None,
+) -> tuple[_OAuthServer | None, str | None]:
+    """Start a localhost callback server matching ``redirect_uri``.
+
+    The port and path are taken from the redirect URI so both the Codex
+    (``localhost:1455/auth/callback``) and Claude (``localhost:54545/callback``)
+    flows work. Returns ``(server, None)`` on success or ``(None, message)``.
+    """
+    parsed = urllib.parse.urlsplit(redirect_uri)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        return None, f"Invalid redirect_uri port: {exc}"
+    if not port:
+        return None, f"redirect_uri has no port: {redirect_uri}"
+
+    host = parsed.hostname or "localhost"
+    callback_path = parsed.path or "/auth/callback"
+
+    try:
+        addrinfos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        return None, f"Failed to resolve {host}: {exc}"
+
+    last_error: OSError | None = None
+    for family, _socktype, _proto, _canonname, sockaddr in addrinfos:
+        try:
+            # Support IPv4/IPv6 to avoid missing callbacks when localhost
+            # resolves to ::1.
+            class _AddrOAuthServer(_OAuthServer):
+                address_family = family
+
+            server = _AddrOAuthServer(sockaddr, state, callback_path, on_code=on_code)
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+            return server, None
+        except OSError as exc:
+            last_error = exc
+            continue
+
+    if last_error:
+        return None, f"Local callback server failed to start: {last_error}"
+    return None, "Local callback server failed to start: unknown error"

--- a/collie-core/collie_core/providers/claude_oauth.py
+++ b/collie-core/collie_core/providers/claude_oauth.py
@@ -24,14 +24,18 @@ __all__ = [
 ]
 
 # Public OAuth client used by Claude Code and compatible harnesses.
+# Matches Claude Code's current flow: console.anthropic.com authorize
+# endpoint and the registered localhost:54545/callback redirect. The legacy
+# claude.ai/oauth/authorize surface rejects this request shape ("Invalid
+# request format") for signed-in users, so do not regress these values.
 ANTHROPIC_OAUTH_PROVIDER = OAuthProviderConfig(
     client_id="9d1c250a-e61b-44d9-88ed-5944d1962f5e",
-    authorize_url="https://claude.ai/oauth/authorize",
+    authorize_url="https://console.anthropic.com/oauth/authorize",
     token_url="https://console.anthropic.com/v1/oauth/token",
-    # oauth_cli_kit's callback server uses this fixed endpoint.
-    redirect_uri="http://localhost:1455/auth/callback",
-    scope="org:create_api_key user:profile user:inference",
-    default_originator="collie",
+    # oauth_cli_kit's callback server is hardcoded to the Codex endpoint, so
+    # collie_core.providers.callback_server derives port/path from this value.
+    redirect_uri="http://localhost:54545/callback",
+    scope="org:create_api_key user:profile",
     token_filename="claude.json",
 )
 

--- a/collie-core/tests/collie/test_auth.py
+++ b/collie-core/tests/collie/test_auth.py
@@ -59,31 +59,31 @@ def test_login_uses_cached_token(fake_storage, monkeypatch: pytest.MonkeyPatch) 
     def fake_get_token(provider=None, storage=None, **kwargs):
         return FakeToken(access="tok-cached", account_id="acct-1")
 
-    def fake_interactive(**kwargs):
+    def fake_interactive(_config, storage, _cancelled):
         calls["interactive"] += 1
         return FakeToken(access="tok-new", account_id="acct-1")
 
     import oauth_cli_kit
 
     monkeypatch.setattr(oauth_cli_kit, "get_token", fake_get_token)
-    monkeypatch.setattr(oauth_cli_kit, "login_oauth_interactive", fake_interactive)
+    monkeypatch.setattr(collie_auth, "_login_oauth_cancellable", fake_interactive)
 
     result = collie_auth.login_provider("chatgpt")
     assert result == {"provider": "chatgpt", "signed_in": True, "account_id": "acct-1"}
     assert calls["interactive"] == 0
 
 
-def test_login_falls_back_to_interactive(fake_storage, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_login_falls_back_to_oauth_flow(fake_storage, monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get_token(provider=None, storage=None, **kwargs):
         raise RuntimeError("no token")
 
-    def fake_interactive(**kwargs):
+    def fake_interactive(_config, storage, _cancelled):
         return FakeToken(access="tok-new", account_id="acct-2")
 
     import oauth_cli_kit
 
     monkeypatch.setattr(oauth_cli_kit, "get_token", fake_get_token)
-    monkeypatch.setattr(oauth_cli_kit, "login_oauth_interactive", fake_interactive)
+    monkeypatch.setattr(collie_auth, "_login_oauth_cancellable", fake_interactive)
 
     result = collie_auth.login_provider("claude")
     assert result["provider"] == "claude"
@@ -99,9 +99,9 @@ def test_login_failure_is_friendly(fake_storage, monkeypatch: pytest.MonkeyPatch
         lambda **kwargs: None,
     )
     monkeypatch.setattr(
-        oauth_cli_kit,
-        "login_oauth_interactive",
-        lambda **kwargs: FakeToken(access=None),
+        collie_auth,
+        "_login_oauth_cancellable",
+        lambda _config, _storage, _cancelled: FakeToken(access=None),
     )
     with pytest.raises(ValueError, match="another go"):
         collie_auth.login_provider("chatgpt")
@@ -134,10 +134,116 @@ def test_oauth_status(fake_storage, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_claude_oauth_provider_config() -> None:
     from collie_core.providers.claude_oauth import ANTHROPIC_OAUTH_PROVIDER
 
-    assert ANTHROPIC_OAUTH_PROVIDER.authorize_url.startswith("https://claude.ai/")
-    assert "user:inference" in ANTHROPIC_OAUTH_PROVIDER.scope
-    assert ANTHROPIC_OAUTH_PROVIDER.redirect_uri == ("http://localhost:1455/auth/callback")
+    assert ANTHROPIC_OAUTH_PROVIDER.authorize_url.startswith("https://console.anthropic.com/")
+    assert ANTHROPIC_OAUTH_PROVIDER.scope == "org:create_api_key user:profile"
+    assert ANTHROPIC_OAUTH_PROVIDER.redirect_uri == "http://localhost:54545/callback"
     assert ANTHROPIC_OAUTH_PROVIDER.token_filename == "claude.json"
+
+
+def test_callback_server_derives_from_redirect_uri() -> None:
+    import urllib.error
+    import urllib.request
+
+    from collie_core.providers.callback_server import start_callback_server
+
+    received: list[str] = []
+    server, err = start_callback_server(
+        "http://localhost:54545/callback", "st-1", on_code=received.append
+    )
+    assert server is not None and err is None
+    host = str(server.server_address[0])
+    port = int(server.server_address[1])
+    base = f"http://[{host}]:{port}" if ":" in host else f"http://{host}:{port}"
+    try:
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(f"{base}/wrong-path", timeout=5)
+        assert exc.value.code == 404
+
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(f"{base}/callback?code=c1&state=bad-state", timeout=5)
+        assert exc.value.code == 400
+
+        resp = urllib.request.urlopen(f"{base}/callback?code=c1&state=st-1", timeout=5)
+        assert resp.status == 200
+        assert received == ["c1"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_oauth_authorize_url_params_per_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Claude requests carry no Codex-only params; Codex requests keep them."""
+    import webbrowser
+
+    import oauth_cli_kit.flow as oauth_flow
+
+    import collie_core.providers.callback_server as callback_server_mod
+    from collie_core.providers.claude_oauth import ANTHROPIC_OAUTH_PROVIDER
+
+    opened: list[str] = []
+    exchanged: list[str] = []
+    saved: list[FakeToken] = []
+
+    class FakeServer:
+        def __init__(self, redirect_uri, state, on_code=None):
+            self.on_code = on_code
+
+        def shutdown(self):
+            pass
+
+        def server_close(self):
+            pass
+
+    class Storage:
+        def save(self, token) -> None:
+            saved.append(token)
+
+    def fake_start(redirect_uri, state, on_code=None):
+        server = FakeServer(redirect_uri, state, on_code)
+        if on_code is not None:
+            on_code("srv-code")  # complete the flow immediately
+        return server, None
+
+    def fake_exchange(code, verifier, provider):
+        exchanged.append(code)
+
+        async def _run():
+            return FakeToken(access="tok", refresh="ref", expires=1, account_id="a")
+
+        return _run
+
+    monkeypatch.setattr(callback_server_mod, "start_callback_server", fake_start)
+    monkeypatch.setattr(oauth_flow, "_exchange_code_for_token_async", fake_exchange)
+    monkeypatch.setattr(oauth_flow, "_should_open_browser", lambda: True)
+    monkeypatch.setattr(webbrowser, "open", opened.append)
+
+    token = collie_auth._login_oauth_cancellable(
+        ANTHROPIC_OAUTH_PROVIDER, Storage(), threading.Event()
+    )
+    assert token.access == "tok"
+    assert exchanged == ["srv-code"]
+    assert len(opened) == 1
+    claude_url = opened[0]
+    assert claude_url.startswith("https://console.anthropic.com/oauth/authorize?")
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A54545%2Fcallback" in claude_url
+    assert "scope=org%3Acreate_api_key+user%3Aprofile" in claude_url
+    assert "codex_cli_simplified_flow" not in claude_url
+    assert "originator" not in claude_url
+
+    opened.clear()
+    from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
+
+    token = collie_auth._login_oauth_cancellable(
+        OPENAI_CODEX_PROVIDER, Storage(), threading.Event()
+    )
+    assert token.access == "tok"
+    assert len(opened) == 1
+    codex_url = opened[0]
+    assert codex_url.startswith("https://auth.openai.com/oauth/authorize?")
+    assert "originator=nanobot" in codex_url
+    assert "codex_cli_simplified_flow=true" in codex_url
 
 
 def test_oauth_attempt_stages_token_until_commit(
@@ -238,6 +344,8 @@ def test_cancelled_oauth_attempt_closes_callback_server(
     from oauth_cli_kit import flow as oauth_flow
     from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
 
+    import collie_core.providers.callback_server as callback_server_mod
+
     started = threading.Event()
     closed: list[str] = []
 
@@ -258,7 +366,7 @@ def test_cancelled_oauth_attempt_closes_callback_server(
         def server_close(self) -> None:
             closed.append("close")
 
-    def start_server(_state, on_code=None):
+    def start_server(_redirect_uri, _state, on_code=None):
         del on_code
         started.set()
         return Server(), None
@@ -268,7 +376,7 @@ def test_cancelled_oauth_attempt_closes_callback_server(
         "_spec",
         lambda _provider: ("chatgpt", (OPENAI_CODEX_PROVIDER, Storage())),
     )
-    monkeypatch.setattr(oauth_flow, "_start_local_server", start_server)
+    monkeypatch.setattr(callback_server_mod, "start_callback_server", start_server)
     monkeypatch.setattr(oauth_flow, "_should_open_browser", lambda: False)
 
     import oauth_cli_kit

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,11 +11,11 @@
 
 ## Source inventory
 
-- Core Python files: **514**
+- Core Python files: **515**
 - Core Python test files: **234**
 - Desktop TypeScript/TSX files: **159**
 - Desktop test files: **54**
-- Active Markdown docs: **29**
+- Active Markdown docs: **30**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups


### PR DESCRIPTION
## Summary

Fixes Claude sign-in failing with **"Authorization failed / Invalid request format"** for signed-in users.

- **OAuth config** now mirrors the current Claude Code OAuth flow: authorize at `console.anthropic.com/oauth/authorize`, redirect `localhost:54545/callback`, scopes `org:create_api_key user:profile`.
- **New** `collie_core/providers/callback_server.py` — local callback server derived from `redirect_uri`.
- **Gates the Codex-only authorize params** (`codex_cli_simplified_flow`, `id_token_add_organizations`, `originator`) to the OpenAI flow only — they were leaking into the claude.ai authorize URL.
- Updates tests (`tests/collie/test_auth.py`).

## Verification

- 3583 tests passed; ruff clean.
- The 4 `test_services.py` DPAPI failures on Linux are pre-existing and unrelated to this change.

## Note

A real end-to-end sign-in still needs one manual test with a real Claude account once this is in a build.
