### PR TITLE
fix(ui): remember pill above composer, consistent 6s duration

### DIFF
--- a/collie-ui/src/renderer/src/components/RememberPill.test.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CollieEvent, MemoryJournalEntry } from '../lib/ipc'
+import { REMEMBER_PILL_DURATION_MS } from '../lib/rememberPill'
 
 const hooks = vi.hoisted(() => {
   const listeners = new Set<(event: CollieEvent) => void>()
@@ -166,7 +167,7 @@ describe('RememberPill', () => {
     act(() => root.unmount())
   })
 
-  it('dismisses on the next user send', async () => {
+  it('stays visible while the user keeps typing (consistent duration)', async () => {
     const container = document.createElement('div')
     const root = createRoot(container)
     act(() => root.render(<RememberPill conversationId="c1" />))
@@ -182,11 +183,11 @@ describe('RememberPill', () => {
     await act(async () => {
       hooks.emit(userMessage('c1'))
     })
-    expect(container.querySelector('.remember-pill')).toBeNull()
+    expect(container.querySelector('.remember-pill')).not.toBeNull()
     act(() => root.unmount())
   })
 
-  it('auto-dismisses after four seconds', async () => {
+  it('auto-dismisses after the consistent duration', async () => {
     vi.useFakeTimers()
     const container = document.createElement('div')
     const root = createRoot(container)
@@ -201,7 +202,7 @@ describe('RememberPill', () => {
     expect(container.querySelector('.remember-pill')).not.toBeNull()
 
     act(() => {
-      vi.advanceTimersByTime(4000)
+      vi.advanceTimersByTime(REMEMBER_PILL_DURATION_MS)
     })
     expect(container.querySelector('.remember-pill')).toBeNull()
     act(() => root.unmount())
@@ -222,7 +223,7 @@ describe('RememberPill', () => {
     await flush()
     expect(container.querySelector('.remember-pill')).not.toBeNull()
     act(() => {
-      vi.advanceTimersByTime(4000)
+      vi.advanceTimersByTime(REMEMBER_PILL_DURATION_MS)
     })
 
     // Second learning -> pill again.
@@ -233,7 +234,7 @@ describe('RememberPill', () => {
     await flush()
     expect(container.querySelector('.remember-pill')).not.toBeNull()
     act(() => {
-      vi.advanceTimersByTime(4000)
+      vi.advanceTimersByTime(REMEMBER_PILL_DURATION_MS)
     })
 
     // Third learning -> silent.
@@ -261,7 +262,7 @@ describe('RememberPill', () => {
     await flush()
     expect(container.querySelector('.remember-pill')).not.toBeNull()
     act(() => {
-      vi.advanceTimersByTime(4000)
+      vi.advanceTimersByTime(REMEMBER_PILL_DURATION_MS)
     })
 
     // The same fact re-learned (new journal id, identical content) -> silent.

--- a/collie-ui/src/renderer/src/components/RememberPill.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.tsx
@@ -4,9 +4,11 @@
  * Watches the core's append-only memory journal. When an assistant turn in
  * the current conversation completes and the journal shows a brand-new memory
  * write (kind fact/person/date, action add/update), a small warm pill appears
- * near the message list for a few seconds. It never fires for context usage
- * (reads are not journaled), never replays entries that existed before this
- * session, de-duplicates identical entries, and goes silent after two shows.
+ * above the chat composer for a consistent six seconds. It never fires for
+ * context usage (reads are not journaled), never replays entries that existed
+ * before this session, de-duplicates identical entries, and goes silent after
+ * two shows. Only the auto-dismiss timer and a core restart clear it — the
+ * next user send keeps it visible so the duration never feels clipped.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -124,10 +126,7 @@ export default function RememberPill({ conversationId }: Props): React.JSX.Eleme
           void establishBaseline()
           break
         case 'message':
-          if (event.message.role === 'user') {
-            // Any user send clears the whisper, per the quiet-whisper rule.
-            dismiss()
-          } else if (
+          if (
             event.message.role === 'assistant' &&
             conversationIdRef.current !== null &&
             event.message.conversation_id === conversationIdRef.current
@@ -152,7 +151,7 @@ export default function RememberPill({ conversationId }: Props): React.JSX.Eleme
 
   if (!pill) return null
   return (
-    <div className="remember-pill" role="status" aria-live="polite" onClick={dismiss}>
+    <div className="remember-pill" role="status" aria-live="polite">
       <span aria-hidden="true">🧠</span>
       <span>{rememberPillText(pill.entry)}</span>
     </div>

--- a/collie-ui/src/renderer/src/lib/rememberPill.ts
+++ b/collie-ui/src/renderer/src/lib/rememberPill.ts
@@ -12,7 +12,7 @@ import type { MemoryJournalEntry } from './ipc'
 /** How many times the whisper may appear per app session (then silent). */
 export const REMEMBER_PILL_CAP = 2
 /** How long the whisper stays visible before dismissing itself. */
-export const REMEMBER_PILL_DURATION_MS = 4000
+export const REMEMBER_PILL_DURATION_MS = 6000
 
 const SHOWN_COUNT_KEY = 'collie.rememberPill.shown'
 const SEEN_KEYS_KEY = 'collie.rememberPill.seen'

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -1112,7 +1112,6 @@ export default function ChatScreen({
         <div className={`workspace-body flex min-h-0 flex-1 ${thingsOpen && things.length > 0 ? 'has-things' : ''}`}>
         <div className="conversation-panel">
           <MessageList messages={messages} streamText={streamText} streaming={streaming} cardPreview={cardPreview} />
-          <RememberPill conversationId={activeId} />
         {errorText && (
           <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             style={{ borderColor: 'var(--collie-snoot)' }}>
@@ -1152,6 +1151,7 @@ export default function ChatScreen({
             </div>
           ) : null}
           <div className="portrait-composer-layout">
+            <RememberPill conversationId={activeId} />
             <InteractiveColliePortrait
               thinking={portraitThinking}
               phrase={portraitThinking?.phrase || 'Ready when you are.'}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1705,12 +1705,13 @@ button {
   box-shadow: var(--shadow-md);
 }
 
-/* Remember pill — the quiet "I'll remember that." whisper. Sits above the
-   composer, overlaying the bottom edge of the message list without moving
-   layout, and never intercepts clicks. */
+/* Remember pill — the quiet "I'll remember that." whisper. Anchored to the
+   top of the composer row so it always floats ABOVE the input box — never
+   covering what the user is typing — without moving layout, and never
+   intercepts clicks. */
 .remember-pill {
   position: absolute;
-  bottom: 104px;
+  bottom: calc(100% + 8px);
   left: 50%;
   z-index: 20;
   transform: translateX(-50%);
@@ -3004,6 +3005,7 @@ button {
 
 /* Interactive Collie portrait */
 .portrait-composer-layout {
+  position: relative;
   display: flex;
   width: min(calc(100% - 24px), 920px);
   align-items: flex-start;


### PR DESCRIPTION
## What
Founder bug report: the memory pill rendered inside the chat input area (covering typed text) and its visibility duration was inconsistent.

## Changes
- **Positioning:** pill anchored to the top of the composer row (`bottom: calc(100% + 8px)`) instead of a hardcoded `bottom: 104px` that landed inside the taller composer row — it now always floats above the input box, never covering what the user types
- **Timing:** single consistent 6s auto-dismiss; removed the 'any user send dismisses the pill' rule (only a core restart clears it early)
- Cleaned dead click handler (pill stays click-transparent)

## Files
- `RememberPill.tsx`, `rememberPill.ts` (6000ms), `ChatScreen.tsx` (pill moved into `.portrait-composer-layout`), `globals.css`, `RememberPill.test.tsx`

## Verification
- RememberPill tests: 10/10 pass
- `npm run typecheck`: pass
- Full UI suite: 357/357 pass