### PR TITLE
fix(ui): in-content 'Back to chat' button on every settings tab

### DIFF
--- a/collie-ui/src/renderer/src/screens/SettingsScreen.test.ts
+++ b/collie-ui/src/renderer/src/screens/SettingsScreen.test.ts
@@ -1,5 +1,46 @@
-import { describe, expect, it } from 'vitest'
-import { clearAllDataNotice } from './SettingsScreen'
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import SettingsScreen, { clearAllDataNotice } from './SettingsScreen'
+
+const hooks = vi.hoisted(() => {
+  const client = {
+    on: vi.fn(() => () => undefined),
+    getStatus: vi.fn(async () => ({})),
+    getSettings: vi.fn(async () => ({ settings: {} })),
+    authStatus: vi.fn(async () => ({ signed_in: false }))
+  }
+  return { client }
+})
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => null,
+  Brain: () => null,
+  CircleUserRound: () => null,
+  Cloud: () => null,
+  Dog: () => null,
+  KeyRound: () => null,
+  Mic2: () => null,
+  Palette: () => null,
+  RefreshCw: () => null,
+  RotateCcw: () => null,
+  Send: () => null,
+  ShieldCheck: () => null,
+  UserRound: () => null
+}))
+vi.mock('../components/settings/ProviderManager', () => ({ default: () => null }))
+vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+vi.mock('../components/CollieFace', () => ({ default: () => null }))
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('clear-all result reporting', () => {
   it('reports a complete clear only when every phase succeeded', () => {
@@ -50,5 +91,24 @@ describe('clear-all result reporting', () => {
     expect(notice).toContain("couldn't clear Collie's database")
     expect(notice).toContain('left local files in place')
     expect(notice).not.toContain('All clear')
+  })
+})
+
+describe('SettingsScreen back navigation', () => {
+  it('renders a Back to chat button that navigates to chat', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const onNavigate = vi.fn()
+    await act(async () => {
+      root.render(createElement(SettingsScreen, { initialTab: 'onboarding', onNavigate }))
+    })
+    const button = container.querySelector<HTMLButtonElement>('.settings-back')
+    expect(button).not.toBeNull()
+    expect(button?.textContent).toContain('Back to chat')
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onNavigate).toHaveBeenCalledWith('chat')
+    act(() => root.unmount())
   })
 })

--- a/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
+  ArrowLeft,
   Brain,
   CircleUserRound,
   Cloud,
@@ -357,6 +358,14 @@ export default function SettingsScreen({
 
       <div className="settings-content">
         <div className="settings-content-inner">
+          <button
+            type="button"
+            className="settings-back"
+            onClick={() => onNavigate?.('chat')}
+          >
+            <ArrowLeft size={15} />
+            {t('settings.back')}
+          </button>
           {notice && (
             <p className="inline-notice flex items-center gap-2" role="status">
               <CollieFace size={16} />

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1487,6 +1487,28 @@ button {
 .settings-content { overflow-y: auto; }
 .settings-content-inner { width: min(100%, 720px); margin: 0 auto; padding: 34px 30px 50px; }
 
+/* Back-to-chat affordance so non-coders can always leave Settings without
+   hunting for the sidebar row. Visible on every settings tab. */
+.settings-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 20px;
+  padding: 6px 13px 6px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 550;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.settings-back:hover {
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  border-color: var(--collie-border);
+}
+
 @media (max-width: 820px) {
   .settings-layout { grid-template-columns: 178px minmax(0, 1fr); }
   .settings-content-inner { padding: 26px 20px 42px; }


### PR DESCRIPTION
## What
QA finding #1 from the 2026-08-20 UX pass: the `settings.back` locale key existed in all 5 locales but **no component rendered it** — non-coder users hit a dead-end in Settings and had to hunt the sidebar to get back to chat.

## Changes
- Render a `Back to chat` button at the top of the settings content pane (above the per-tab header), wired to the existing `onNavigate` prop
- Lives in the shared settings layout, so it shows on **every** tab (13 tabs), not per-tab
- Uses the existing `settings.back` string (en/de/es/fr/ja all already translated)
- Style: quiet pill button matching the design system tokens

## Files
- `SettingsScreen.tsx` (ArrowLeft import + button), `globals.css` (.settings-back), `SettingsScreen.test.ts` (DOM regression test)

## Verification
- SettingsScreen tests: 4/4 (incl. new back-button navigation test)
- `npm run typecheck`: pass
- Full UI suite: 358/358 pass