### PR TITLE
fix(core): keep sentences out of the Name field (remember tool + starter capture)

### DIFF
--- a/collie-core/collie_core/memory/names.py
+++ b/collie-core/collie_core/memory/names.py
@@ -1,0 +1,64 @@
+"""Name-sanity helpers shared by the starter conversation and the remember tool.
+
+A name worth remembering is a single short line. Sentences, instructions, or
+preference statements are not names — they must never land in the profile's
+Name field (wrong memory is worse than none: it resurfaced as the user's
+name in QA). Both writers (``capture_starter_name`` and ``RememberTool``)
+route through these helpers so the rule cannot diverge.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MAX_NAME_LENGTH = 64
+_MAX_NAME_WORDS = 6
+
+# Reply patterns that clearly are not a bare name. Matched anywhere in the
+# candidate so "Remember that I prefer short answers." is caught by
+# "remember", "prefer", and "that i" alike.
+_SENTENCE_MARKERS = re.compile(
+    r"\b(remember|prefer|prefers|preferred|like|likes|dislike|dislikes|"
+    r"want|wants|need|needs|hate|hates|that i|i prefer|i like|i am|i'm|"
+    r"my name is|call me|can you|please|whats|what's)\b",
+    re.IGNORECASE,
+)
+
+# Leading phrasings people use when answering "What's your name?" — strip
+# them, then judge the remainder. ("My name is Rick" → "Rick".)
+_NAME_PREFIX = re.compile(
+    r"^(my name is|i am|i'm|call me|it's|its)\s+", re.IGNORECASE
+)
+
+
+def strip_name_prefix(text: str) -> str:
+    """Drop a leading 'my name is / i'm / call me' phrasing, if present."""
+    return _NAME_PREFIX.sub("", (text or "").strip(), count=1).strip()
+
+
+def is_reasonable_name(text: str) -> bool:
+    """True when ``text`` plausibly names a person.
+
+    Conservative on purpose: when in doubt we refuse and keep the Name field
+    empty rather than store a sentence that later resurfaces as a name.
+    """
+    candidate = strip_name_prefix(text)
+    if not candidate:
+        return False
+    if len(candidate) > _MAX_NAME_LENGTH:
+        return False
+    if "\n" in candidate or "\r" in candidate:
+        return False
+    if candidate[-1] in ".?!":
+        return False
+    if _SENTENCE_MARKERS.search(candidate):
+        return False
+    return len(candidate.split()) <= _MAX_NAME_WORDS
+
+
+def name_candidate(text: str) -> str | None:
+    """Return the cleaned name when ``text`` looks like one, else ``None``."""
+    cleaned = strip_name_prefix(text)
+    if is_reasonable_name(cleaned):
+        return cleaned
+    return None

--- a/collie-core/collie_core/memory/profile.py
+++ b/collie-core/collie_core/memory/profile.py
@@ -52,6 +52,7 @@ PROFILE_KEYS: dict[str, str] = {
     "goals": "Current goals",
     "work": "Work",
     "family": "Family",
+    "preferences": "Preferences",
     "notes": "Other notes",
 }
 

--- a/collie-core/collie_core/onboarding.py
+++ b/collie-core/collie_core/onboarding.py
@@ -15,25 +15,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from collie_core.memory.names import name_candidate
+
 STARTER_CONVERSATION_SETTING = "onboarding.starter_conversation_id"
 
 STARTER_GREETING = (
     "Hey, welcome! I'm Collie — your personal AI. What's your name?\n\n"
     "(P.S. That's me — the little dog on your desktop. Click me to say hi anytime.)"
 )
-
-# A name worth remembering: a single short line. Longer answers, questions,
-# or empty replies are not names — we never force it.
-_MAX_NAME_LENGTH = 64
-
-
-def _is_reasonable_name(reply: str) -> bool:
-    text = (reply or "").strip()
-    if not text:
-        return False
-    if len(text) > _MAX_NAME_LENGTH:
-        return False
-    return not ("\n" in text or "\r" in text)
 
 
 def ensure_starter_conversation(
@@ -86,8 +75,9 @@ def capture_starter_name(
     """Save the first reply in the starter thread as the user's name.
 
     Only fires once (the profile has no name yet and the conversation holds
-    only the greeting). Whatever they said is stored verbatim — or nothing;
-    the name is never forced.
+    only the greeting). The reply is kept only when it plausibly names a
+    person ("Rick", "My name is Rick"); sentences and instructions are
+    refused and the name is never forced.
     """
     if profile_store is None:
         return False
@@ -99,7 +89,8 @@ def capture_starter_name(
     if len(messages) != 1:
         # The greeting is the only message before the first real reply.
         return False
-    if not _is_reasonable_name(reply):
+    candidate = name_candidate(reply)
+    if candidate is None:
         return False
-    profile_store.set("name", reply.strip())
+    profile_store.set("name", candidate)
     return True

--- a/collie-core/collie_core/tools/memory.py
+++ b/collie-core/collie_core/tools/memory.py
@@ -8,14 +8,23 @@ injection on future turns.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
+from collie_core.memory.names import name_candidate
 from collie_core.memory.profile import PROFILE_KEYS, ProfileStore
 from collie_core.permissions.models import PermissionRequest, Risk
 from nanobot.agent.tools.base import Tool, tool_parameters
 
 _PERSON_FIELDS = frozenset(
     {"relationship", "birthday", "allergies", "preferences", "gift_ideas", "notes"}
+)
+
+# When a sentence slips into the name slot, route it to a more honest key.
+_PREFERENCE_MARKERS = re.compile(
+    r"\b(prefer|prefers|preferred|like|likes|dislike|dislikes|"
+    r"enjoy|enjoys|hate|hates|wants?|needs?)\b",
+    re.IGNORECASE,
 )
 
 _profile_store: ProfileStore | None = None
@@ -46,7 +55,9 @@ def _store() -> ProfileStore | None:
             "key": {
                 "type": "string",
                 "description": (
-                    "For kind=fact/forget_fact: which fact. Known keys: "
+                    "For kind=fact/forget_fact: which fact. Use 'name' ONLY for the "
+                    "user's actual name (a short label, e.g. 'Rick'). Likes, dislikes, "
+                    "and communication style belong under 'preferences'. Known keys: "
                     + ", ".join(PROFILE_KEYS)
                     + ". Free-form keys are allowed."
                 ),
@@ -172,6 +183,20 @@ class RememberTool(Tool):
             value = (kwargs.get("value") or "").strip()
             if not key or not value:
                 return self.error("kind=fact needs both 'key' and 'value'.")
+            if key == "name":
+                # A sentence in the name slot must never become the user's
+                # Name. Keep the data under a more honest key instead.
+                candidate = name_candidate(value)
+                if candidate is None:
+                    target = (
+                        "preferences" if _PREFERENCE_MARKERS.search(value) else "notes"
+                    )
+                    store.set(target, value)
+                    return (
+                        f"That looked like a preference, not a name — I saved it under "
+                        f"{target} instead. (Say 'my name is …' to set your name.)"
+                    )
+                value = candidate
             store.set(key, value)
             return f"Remembered: {key} = {value}"
 

--- a/collie-core/tests/collie/test_memory.py
+++ b/collie-core/tests/collie/test_memory.py
@@ -61,6 +61,37 @@ async def test_remember_tool_fact(store: ProfileStore) -> None:
 
 
 @pytest.mark.asyncio
+async def test_remember_tool_never_stores_sentence_as_name(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    result = await tool.execute(
+        kind="fact", key="name", value="Remember that I prefer short answers."
+    )
+    # QA repro: the sentence must not become the user's Name.
+    assert store.get("name") is None
+    # The data survives under a more honest key.
+    assert store.get("preferences") == "Remember that I prefer short answers."
+    assert "preferences" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_remember_tool_strips_name_prefix(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    await tool.execute(kind="fact", key="name", value="My name is Rick")
+    assert store.get("name") == "Rick"
+    assert store.get("preferences") is None
+
+
+@pytest.mark.asyncio
+async def test_remember_tool_plain_name_stored(store: ProfileStore) -> None:
+    bind_profile_store(store)
+    tool = RememberTool()
+    await tool.execute(kind="fact", key="name", value="Rick")
+    assert store.get("name") == "Rick"
+
+
+@pytest.mark.asyncio
 async def test_remember_tool_person_creates_birthday_date(store: ProfileStore) -> None:
     bind_profile_store(store)
     tool = RememberTool()

--- a/collie-core/tests/collie/test_onboarding.py
+++ b/collie-core/tests/collie/test_onboarding.py
@@ -121,6 +121,28 @@ def test_capture_starter_name_requires_only_greeting_before_reply(
     assert profile.get("name") is None
 
 
+def test_capture_starter_name_rejects_sentence(
+    db: CollieDB, profile: ProfileStore
+) -> None:
+    starter = ensure_starter_conversation(db)
+    conv_id = str(starter["conversation"]["id"])
+    # QA repro: a preference phrased as an instruction is NOT a name.
+    assert (
+        capture_starter_name(db, profile, conv_id, "Remember that I prefer short answers.")
+        is False
+    )
+    assert profile.get("name") is None
+
+
+def test_capture_starter_name_strips_name_prefix(
+    db: CollieDB, profile: ProfileStore
+) -> None:
+    starter = ensure_starter_conversation(db)
+    conv_id = str(starter["conversation"]["id"])
+    assert capture_starter_name(db, profile, conv_id, "My name is Rick") is True
+    assert profile.get("name") == "Rick"
+
+
 def test_parse_command_recognizes_get_started() -> None:
     assert parse_command("/get-started") == ("get-started", "")
     assert parse_command("/start") == ("start", "")


### PR DESCRIPTION
## Finding #3 (UX/UI QA pass 2026-08-20, low severity) — fixed

QA repro: chat "Remember that I prefer short answers." → Settings → Memory showed the whole phrase as the profile **Name**.

### Root cause — two write paths could land a sentence in `name`
1. **Starter-thread name capture** (`onboarding.capture_starter_name`, the primary path in a fresh profile — the first reply to "What's your name?" was stored verbatim whenever it was <64 chars and single-line).
2. **`RememberTool`** accepted the LLM's misparse `kind=fact, key=name, value="Remember that I prefer short answers."` with no validation.

### Fix
- **New shared helper `collie_core/memory/names.py`** — `is_reasonable_name()` / `name_candidate()`: strips "my name is / i'm / call me" prefixes, refuses sentences (sentence markers like remember/prefer/that i, trailing `.?!`, >6 words, >64 chars). Both writers route through it so the rule cannot diverge.
- **`onboarding.py`** — `capture_starter_name` stores `name_candidate(reply)`; sentences are refused (name never forced), "My name is Rick" → "Rick".
- **`tools/memory.py`** — a `key="name"` value that isn't a name is **routed** to `preferences`/`notes` (data kept, not dropped) with an explanatory return; the schema description now tells the model `name` = actual name only, likes/dislikes → `preferences`.
- **`memory/profile.py`** — `PROFILE_KEYS` gains `preferences: Preferences` so MEMORY.md + Settings render it with a friendly label and the model sees it as a known key.

### Verification
| Check | Result |
|---|---|
| Repro via starter capture: "Remember that I prefer short answers." | refused — no name stored ✅ |
| Repro via remember tool: `kind=fact,key=name` same phrase | name stays None; saved under `preferences` ✅ |
| "My name is Rick" (both paths) | stored as `Rick` ✅ |
| Plain "Rick" | stored ✅ |
| `pytest tests/collie/test_onboarding.py tests/collie/test_memory.py` | 42 passed (5 new) ✅ |
| `pytest tests/collie` | 712 passed, 1 skipped; 4 pre-existing Linux-only failures in `test_services.py` (DPAPI/Windows-only shim — also fail on origin/main) ✅ |
| `ruff check` (all touched files) | clean ✅ |

Ready for UX/UI tester re-verification: the remember-pill flow should now show a preference, not a name.
