### PR TITLE
ux(account): warm safety-framed copy for secure-storage failures

### DIFF
--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -325,7 +325,7 @@ describe('startAccountSignIn', () => {
     // Same pattern as the cancellation test — handle the rejection before
     // the callback request can trigger it.
     const rejection = expect(signInPromise).rejects.toThrow(
-      'could not store the session securely'
+      'Your sign-in is secure — Collie never stores it as plain text.'
     )
 
     const callbackResponse = await realFetch(

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -426,10 +426,11 @@ export async function startAccountSignIn(
   })
   if (!saved) {
     throw new Error(
-      'You signed in, but this computer could not store the session ' +
-        'securely. Unlock your system keychain (Keychain Access on macOS, ' +
-        'your Windows sign-in on Windows, or your keyring daemon — e.g. ' +
-        'gnome-keyring / KWallet — on Linux) and try again.'
+      "Your sign-in is secure — Collie never stores it as plain text. This " +
+        "computer couldn't save it, so you'll sign in again next time you open " +
+        "Collie. To make saving work next time: unlock your Mac's Keychain, " +
+        "sign back in to Windows, or restart your computer and sign in " +
+        "normally on Linux."
     )
   }
   return await getAccountState()

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.test.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.test.tsx
@@ -27,6 +27,7 @@ vi.mock('lucide-react', () => ({
   ChevronUp: () => null,
   Key: () => null,
   Search: () => null,
+  ShieldCheck: () => null,
   Sparkles: () => null
 }))
 vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
@@ -290,9 +291,9 @@ describe('WelcomeScreen API-key form', () => {
       await Promise.resolve()
       await Promise.resolve()
     })
-    // Platform guidance instead of a dead-end "could not store" one-liner.
-    expect(container.textContent).toContain('no unlocked keyring')
-    expect(container.textContent).toContain('Use it for this session only')
+    // Safety-framed guidance instead of a dead-end "could not store" one-liner.
+    expect(container.textContent).toContain('Your key stays safe with Collie')
+    expect(container.textContent).toContain('Continue for now')
   })
 
   it('session-only connect keeps working and says the key is not saved', async () => {
@@ -326,10 +327,10 @@ describe('WelcomeScreen API-key form', () => {
       await Promise.resolve()
       await Promise.resolve()
     })
-    expect(container.textContent).toContain('Use it for this session only')
+    expect(container.textContent).toContain('Continue for now')
 
     const sessionButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
-      (button) => button.textContent === 'Use it for this session only'
+      (button) => button.textContent === 'Continue for now'
     )!
     act(() => sessionButton.click())
     await act(async () => {

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, ChevronDown, ChevronUp, Key, Search, Sparkles } from 'lucide-react'
+import { ArrowLeft, ChevronDown, ChevronUp, Key, Search, ShieldCheck, Sparkles } from 'lucide-react'
 import { collieClient, type CatalogueProvider } from '../lib/ipc'
 import {
   configureApiKeyProvider,
@@ -42,20 +42,22 @@ function linkify(text: string): React.ReactNode[] {
 }
 
 /**
- * Actionable copy for when the OS keychain (DPAPI/Keychain/keyring) refused
- * to store the API key. Verified failure mode on the QA rig: on machines
- * with no unlocked keyring, Connect used to dead-end with "Collie could not
- * store that API key securely." and nothing else.
+ * Per-platform "make saving work next time" guidance. Framed as the safety
+ * feature it is — Collie never stores secrets insecurely — not as a bug.
+ * The warm headline leads; platform jargon lives behind "How Collie
+ * protects your key". Verified failure mode on the QA rig: on machines
+ * with no unlocked keyring, Connect used to dead-end with "Collie could
+ * not store that API key securely." and nothing else.
  */
-function secureStorageGuidance(platform: string | null | undefined): string {
+function secureStorageFix(platform: string | null | undefined): string {
   switch (platform) {
     case 'darwin':
-      return "Your Mac's Keychain is locked or unavailable, so Collie can't save your API key. Open the \u201cKeychain Access\u201d app and unlock your \u201clogin\u201d keychain (or sign back in to your Mac account), then try Connect again."
+      return "Open \u201cKeychain Access\u201d (in Applications \u25b8 Utilities), unlock \u201clogin\u201d, then connect again."
     case 'linux':
-      return "This computer has no unlocked keyring, so Collie can't save your API key. Start your desktop keyring (GNOME Keyring or KWallet), or use Collie just for this session below."
+      return "On most computers the secure locker (GNOME Keyring / KWallet) starts automatically when you sign in \u2014 restarting and signing in normally usually fixes it."
     case 'win32':
     default:
-      return "Windows secure storage is locked or turned off, so Collie can't save your API key. Sign back in to your Windows account and try Connect again. (If your work computer blocks it, ask your IT about BitLocker or credential policies.)"
+      return "Saving works when you're signed in to Windows \u2014 sign back in and connect again. (On a work computer that blocks it, ask your IT for help.)"
   }
 }
 
@@ -294,8 +296,10 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
     } catch (e) {
       if (!mountedRef.current) return
       if (e instanceof SecureStorageUnavailableError) {
+        // One warm card replaces the generic error box — the safety framing
+        // leads and "Continue for now" is the only action the user needs.
         setSecureStorageBlocked(true)
-        setError(secureStorageGuidance(secureStoragePlatform))
+        setError('')
         return
       }
       setError(e instanceof Error ? e.message : String(e))
@@ -780,11 +784,22 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
 
         {secureStorageBlocked && (
           <div
-            className="flex flex-col items-start gap-2 rounded-lg border p-3 text-sm"
+            className="flex flex-col items-start gap-2 rounded-xl border p-4 text-sm"
             style={{ borderColor: 'var(--collie-gold)', background: 'var(--collie-surface)' }}
           >
-            <span style={{ color: 'var(--collie-text)' }}>
-              You can still use Collie right now — the key just won't be saved.
+            <span
+              className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide"
+              style={{ color: 'var(--collie-text-link)' }}
+            >
+              <ShieldCheck size={14} /> Security &amp; privacy
+            </span>
+            <span className="text-base font-semibold" style={{ color: 'var(--collie-text)' }}>
+              Your key stays safe with Collie
+            </span>
+            <span style={{ color: 'var(--collie-text-muted)' }}>
+              Collie never writes your key as plain text — it locks it with your
+              computer&apos;s built-in secure storage. This computer&apos;s secure storage
+              isn&apos;t available right now, so your key won&apos;t be saved here.
             </span>
             <button
               onClick={() => void connectSessionOnly()}
@@ -792,11 +807,24 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
               className="rounded-lg px-4 py-2 font-medium text-white transition disabled:opacity-50"
               style={{ background: 'var(--collie-btn-primary-bg)' }}
             >
-              {sessionOnlyBusy ? 'Connecting…' : 'Use it for this session only'}
+              {sessionOnlyBusy ? 'Connecting…' : 'Continue for now'}
             </button>
             <span className="text-xs" style={{ color: 'var(--collie-text-muted)' }}>
-              You'll add your key again next time you open Collie.
+              Your key lives only in memory and is forgotten when you close Collie.
             </span>
+            <details className="w-full">
+              <summary
+                className="cursor-pointer text-xs font-semibold"
+                style={{ color: 'var(--collie-text)' }}
+              >
+                How Collie protects your key
+              </summary>
+              <p className="mt-2 text-xs" style={{ color: 'var(--collie-text-muted)' }}>
+                Collie locks your key with your computer&apos;s own security — Windows
+                sign-in, Mac Keychain, or Linux Keyring. To make saving work next
+                time: {secureStorageFix(secureStoragePlatform)}
+              </p>
+            </details>
           </div>
         )}
 

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -352,6 +352,7 @@ button {
 
 .sidebar.is-collapsed .new-chat-button span,
 .sidebar.is-collapsed .sidebar-nav-item span,
+.sidebar.is-collapsed .sidebar-context-row span,
 .sidebar.is-collapsed .sidebar-footer-row span {
   display: none;
 }


### PR DESCRIPTION
## What
Rescued workstream (was stranded in a worktree stash after a cleanup process stashed the dirty tree). Restores two coordinated UX copy improvements:

## Changes
- **WelcomeScreen:** the secure-storage-blocked card is reframed as the safety feature it is — `Your key stays safe with Collie` headline, `Continue for now` action, and a collapsible `How Collie protects your key` disclosure with short per-platform fix guidance (Keychain Access / Windows sign-in / GNOME Keyring or KWallet)
- **account-auth:** session-store failure message explains itself warmly and plainly instead of keychain jargon (`Your sign-in is secure — Collie never stores it as plain text...`)
- Tests updated to the new copy (WelcomeScreen expectations + account-auth error string)

## Verification
- account-auth + WelcomeScreen tests: 27/27
- `npm run typecheck`: pass
- Full UI suite: 357/357