### PR TITLE
fix(ui): honest API-key card copy — provider pick is a step

### DIFF
--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
@@ -505,7 +505,7 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
             <div>
               <div className="font-medium">I have an API key</div>
               <div className="text-sm" style={{ color: 'var(--collie-text-muted)' }}>
-                Paste a key and Collie figures out the rest.
+                Paste a key, pick your provider, and Collie figures out the rest.
               </div>
             </div>
           </button>


### PR DESCRIPTION
## What
QA finding #2 from the 2026-08-20 UX pass: the Welcome card said "Paste a key and Collie figures out the rest", but sk- keys are ambiguous (OpenAI and DeepSeek both use sk- prefixes) — Connect failed by default with a generic "Uh oh. That key didn't work." unless the user picked DeepSeek first.

## Change
- Card copy now sets the expectation: "Paste a key, **pick your provider**, and Collie figures out the rest."
- No behavior change (auto-detection is unreliable for sk- keys); this is the honest-copy fix

## Verification
- WelcomeScreen tests: pass
- typecheck: pass (string-only change)