### PR TITLE
fix(ui): friendly remember-pill copy for preference/note writes

### DIFF
--- a/collie-ui/src/renderer/src/components/RememberPill.test.tsx
+++ b/collie-ui/src/renderer/src/components/RememberPill.test.tsx
@@ -167,6 +167,45 @@ describe('RememberPill', () => {
     act(() => root.unmount())
   })
 
+  it('shows friendly copy when a write lands under preferences', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    hooks.journal.entries = [
+      entry({ id: 1, subject: 'preferences', value: 'prefer short answers' })
+    ]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+
+    const pill = container.querySelector('.remember-pill')
+    expect(pill?.textContent).toContain("I've saved your preference")
+    expect(pill?.textContent).not.toContain('preferences is')
+    act(() => root.unmount())
+  })
+
+  it('shows friendly copy when a write lands under notes', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    act(() => root.render(<RememberPill conversationId="c1" />))
+    await flush()
+
+    hooks.journal.entries = [
+      entry({ id: 1, subject: 'notes', value: 'prefers short answers' })
+    ]
+    await act(async () => {
+      hooks.emit(assistantMessage('c1'))
+    })
+    await flush()
+
+    const pill = container.querySelector('.remember-pill')
+    expect(pill?.textContent).toContain("I've made a note of that")
+    act(() => root.unmount())
+  })
+
   it('stays visible while the user keeps typing (consistent duration)', async () => {
     const container = document.createElement('div')
     const root = createRoot(container)

--- a/collie-ui/src/renderer/src/lib/rememberPill.ts
+++ b/collie-ui/src/renderer/src/lib/rememberPill.ts
@@ -20,7 +20,9 @@ const SEEN_KEYS_KEY = 'collie.rememberPill.seen'
 /**
  * Warm one-line acknowledgement of a fresh memory write. Uses the detail
  * variant only for short, single-line facts where it reads naturally
- * ("I'll remember your name is Rick."); everything else gets the plain line.
+ * ("I'll remember your name is Rick."); preference/note writes get their own
+ * friendly lines (the raw value is a sentence fragment that would not fit
+ * the "your X is Y" template); everything else gets the plain line.
  */
 export function rememberPillText(entry: MemoryJournalEntry): string {
   const value = typeof entry.value === 'string' ? entry.value.trim() : null
@@ -31,6 +33,12 @@ export function rememberPillText(entry: MemoryJournalEntry): string {
     value.length <= 24 &&
     !value.includes('\n')
   if (isShortFact) {
+    if (entry.subject === 'preferences') {
+      return "Got it — I've saved your preference."
+    }
+    if (entry.subject === 'notes') {
+      return "Got it — I've made a note of that."
+    }
     return `Got it — I'll remember your ${entry.subject} is ${value}.`
   }
   return "Got it — I'll remember that."


### PR DESCRIPTION
## What
Companion UI fix to #81 (memory name-sentence guard): sentence-like remembers now journal under `preferences`/`notes` instead of `name`. The pill's short-fact template would have rendered broken grammar for those keys:

> "Got it — I'll remember your **preferences is** prefer short answers."

## Changes
- `preferences` writes → "Got it — I've saved your preference."
- `notes` writes → "Got it — I've made a note of that."
- Legit name writes unchanged ("Got it — I'll remember your name is Rick.")
- Raw value stays out of the pill for these keys (it's a sentence fragment that doesn't fit the name template)

## Verification
- RememberPill tests: 12/12 (2 new copy tests)
- typecheck: pass
- Full UI suite: 359/359