### PR TITLE
release: bump version to 0.1.0-alpha.7

### DIFF
--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Your personal AI. With a dog.",
   "main": "./out/main/index.js",
   "author": "Collie",


### PR DESCRIPTION
## Release: bump to 0.1.0-alpha.7

Version bump only (`collie-ui/package.json` — CI reads the version from package.json, not the tag).

Ships the merged fixes since alpha.6:
- **fix(oauth): current Claude Code OAuth config** (console.anthropic.com, localhost:54545) — #77
- **fix(mac): afterPack hook at config root** for ad-hoc signing — #75
- fix(ui): remember pill floats above composer with consistent 6s duration — #78
- fix(memory): Dream proposes before writing — #73
- fix(ui): in-content "Back to chat" button on every settings tab — #80
- fix(core): never store a sentence as the user's name — #81
- ux(account): warm safety-framed copy for secure-storage failures — #82

After merge: tag `v0.1.0-alpha.7` → CI builds win/mac/linux → publish draft → update website downloader.
