### PR TITLE
fix(mac): sign the .app bundle, not its parent dir

### DIFF
--- a/collie-ui/scripts/adhoc-sign-mac.cjs
+++ b/collie-ui/scripts/adhoc-sign-mac.cjs
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process')
+const path = require('path')
 
 // macOS alpha builds have no Apple Developer certificate, but shipping the
 // .app with signing fully disabled leaves Electron's stale embedded
@@ -13,9 +14,15 @@ const { execSync } = require('child_process')
 // platform), so this script must no-op on non-macOS runners.
 exports.default = async function afterPack(context) {
   if (process.platform !== 'darwin') return
-  const appPath = context.appOutDir
-  console.log(`Ad-hoc codesigning ${appPath}`)
-  execSync(`codesign --force --deep --sign - "${appPath}"`, {
+  // appOutDir is the PARENT directory (e.g. dist/mac-arm64) — codesign
+  // needs the .app bundle itself. Derive the bundle name from the product
+  // filename so the path stays correct even if productName changes.
+  const appBundle = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`,
+  )
+  console.log(`Ad-hoc codesigning ${appBundle}`)
+  execSync(`codesign --force --deep --sign - "${appBundle}"`, {
     stdio: 'inherit',
   })
 }


### PR DESCRIPTION
## fix(mac): sign the .app bundle, not its parent dir

**Bug hit on the first alpha.7 CI run:** the macOS build fails at the ad-hoc signing step.

- `afterPack`'s `context.appOutDir` is the **parent directory** (`dist/mac-arm64`), not the bundle.
- `codesign` on a directory → `bundle format unrecognized, invalid, or unsuitable` → mac build aborts.
- This hook was added in #74/#75 **after** alpha.6 shipped, so it never ran on CI before — the bug was latent.
- Fix: sign `${appOutDir}/${productFilename}.app` (derived from `packager.appInfo.productFilename`).

Windows + Linux builds passed in the failed run — only mac was affected. After merge, the alpha.7 tag must be re-pushed to rebuild.
