### PR TITLE
release: bump version to 0.1.0-alpha.7.1

### DIFF
--- a/collie-ui/package-lock.json
+++ b/collie-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collie",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.7.1",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.7.1",
   "description": "Your personal AI. With a dog.",
   "main": "./out/main/index.js",
   "author": "Collie",


### PR DESCRIPTION
Version bump for the OTA update test:

- `collie-ui/package.json` → 0.1.0-alpha.7.1 (also syncs both root entries in package-lock.json, which had drifted at alpha.5/alpha.4)

Purpose: the installed alpha.7 app must see a NEWER version in the alpha channel feed for electron-updater to offer the update. After merge, tag `v0.1.0-alpha.7.1` at the merge commit to trigger the release pipeline.