### PR TITLE
test: allow patch-level alpha versions (alpha.7.1) in updater gate

### DIFF
--- a/collie-ui/src/main/updater-publish-config.test.ts
+++ b/collie-ui/src/main/updater-publish-config.test.ts
@@ -6,7 +6,11 @@ describe('alpha updater publish configuration', () => {
   it('targets GitHub prereleases and the alpha metadata channel', () => {
     const config = readFileSync(new URL('../../electron-builder.yml', import.meta.url), 'utf8')
 
-    expect(packageJson.version).toMatch(/-alpha\.\d+$/)
+    // Version scheme: 0.1.0-alpha.<n> with an OPTIONAL patch level (alpha.7.1).
+    // The patch level exists for the 2026-08-21 OTA update test (alpha.7 → alpha.7.1);
+    // semver handles it fine (alpha.7.1 > alpha.7) and electron-updater compares
+    // versions with semver, so the dotted form is safe for the alpha feed.
+    expect(packageJson.version).toMatch(/-alpha\.\d+(\.\d+)*$/)
     expect(config).toMatch(
       /publish:\s+provider: github\s+owner: FoxRick\s+repo: Collie\s+channel: alpha\s+releaseType: prerelease/
     )


### PR DESCRIPTION
The release pipeline's qualify job rejected the alpha.7.1 bump: `updater-publish-config.test.ts` asserts `packageJson.version` matches `/-alpha\.\d+$/` (integer alphas only), and `0.1.0-alpha.7.1` ends in a dotted patch level.

The alpha.7.1 version is the user's explicit choice for the OTA update test (installed alpha.7 must see a newer version in the alpha feed). Following the documented guardrail precedent (user decision overrides the gate — relaxed in the same PR, stated openly): the regex now allows an optional dotted patch level: `/-alpha\.\d+(\.\d+)*$/`. Semver orders alpha.7.1 > alpha.7, and electron-updater compares with semver, so the alpha feed stays correct.

Verified locally: `npx vitest run src/main/updater-publish-config.test.ts` → 1 passed.