### PR TITLE
chore(core): restore the ruff format gate (format 3 files + pin ruff 0.16)

### DIFF
--- a/collie-core/collie_core/memory/names.py
+++ b/collie-core/collie_core/memory/names.py
@@ -26,9 +26,7 @@ _SENTENCE_MARKERS = re.compile(
 
 # Leading phrasings people use when answering "What's your name?" — strip
 # them, then judge the remainder. ("My name is Rick" → "Rick".)
-_NAME_PREFIX = re.compile(
-    r"^(my name is|i am|i'm|call me|it's|its)\s+", re.IGNORECASE
-)
+_NAME_PREFIX = re.compile(r"^(my name is|i am|i'm|call me|it's|its)\s+", re.IGNORECASE)
 
 
 def strip_name_prefix(text: str) -> str:

--- a/collie-core/collie_core/tools/memory.py
+++ b/collie-core/collie_core/tools/memory.py
@@ -188,9 +188,7 @@ class RememberTool(Tool):
                 # Name. Keep the data under a more honest key instead.
                 candidate = name_candidate(value)
                 if candidate is None:
-                    target = (
-                        "preferences" if _PREFERENCE_MARKERS.search(value) else "notes"
-                    )
+                    target = "preferences" if _PREFERENCE_MARKERS.search(value) else "notes"
                     store.set(target, value)
                     return (
                         f"That looked like a preference, not a name — I saved it under "

--- a/collie-core/pyproject.toml
+++ b/collie-core/pyproject.toml
@@ -80,7 +80,9 @@ dev = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "aiohttp>=3.9.0,<4.0.0",
     "pytest-cov>=6.0.0,<7.0.0",
-    "ruff>=0.1.0",
+    # Pinned: the ruff format gate (ci.yml) must be reproducible across
+    # machines and CI images — a floating formatter rewrites history.
+    "ruff>=0.16,<0.17",
     "pymupdf>=1.25.0",
     "pypdf>=5.0.0,<6.0.0",
     "python-docx>=1.1.0,<2.0.0",

--- a/collie-core/tests/collie/test_onboarding.py
+++ b/collie-core/tests/collie/test_onboarding.py
@@ -121,22 +121,17 @@ def test_capture_starter_name_requires_only_greeting_before_reply(
     assert profile.get("name") is None
 
 
-def test_capture_starter_name_rejects_sentence(
-    db: CollieDB, profile: ProfileStore
-) -> None:
+def test_capture_starter_name_rejects_sentence(db: CollieDB, profile: ProfileStore) -> None:
     starter = ensure_starter_conversation(db)
     conv_id = str(starter["conversation"]["id"])
     # QA repro: a preference phrased as an instruction is NOT a name.
     assert (
-        capture_starter_name(db, profile, conv_id, "Remember that I prefer short answers.")
-        is False
+        capture_starter_name(db, profile, conv_id, "Remember that I prefer short answers.") is False
     )
     assert profile.get("name") is None
 
 
-def test_capture_starter_name_strips_name_prefix(
-    db: CollieDB, profile: ProfileStore
-) -> None:
+def test_capture_starter_name_strips_name_prefix(db: CollieDB, profile: ProfileStore) -> None:
     starter = ensure_starter_conversation(db)
     conv_id = str(starter["conversation"]["id"])
     assert capture_starter_name(db, profile, conv_id, "My name is Rick") is True


### PR DESCRIPTION
Two small commits to fix the broken CI format gate:

1. **`chore(core): apply ruff format`** — the three files from #81 (`collie_core/memory/names.py`, `collie_core/tools/memory.py`, `tests/collie/test_onboarding.py`) were merged unformatted; `ruff format --check collie_core tests/collie tests/tools` fails on main with both ruff 0.8.4 and 0.16.4. Format-only diff (no logic changes).
2. **`chore(core): pin ruff 0.16`** — the dev extra declared `ruff>=0.1.0` (fully floating), so the gate's result depended on whichever version CI happened to install. Pin `>=0.16,<0.17`.

**Verified:** format check green (`173 files already formatted`), `ruff check` clean, 44 tests covering the reformatted files pass.

Fixes #92