### PR TITLE
security/hardening: issue #93 checklist — npm audit 0, catalogue URL pin, 0600 secrets, pytest-timeout, README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ No prompt engineering. No forced subscription.
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow" alt="License: MIT"></a>
   <a href="https://github.com/FoxRick/Collie/releases"><img src="https://img.shields.io/badge/Platform-Windows%2011%20x64-0078d6" alt="Platform: Windows 11 x64"></a>
-  <a href="https://github.com/FoxRick/Collie/tree/v0.1.0-alpha.4"><img src="https://img.shields.io/badge/Alpha-v0.1.0--alpha.4-purple" alt="Alpha: v0.1.0-alpha.4"></a>
+  <a href="https://github.com/FoxRick/Collie/tree/v0.1.0-alpha.7.1"><img src="https://img.shields.io/badge/Alpha-v0.1.0--alpha.7.1-purple" alt="Alpha: v0.1.0-alpha.7.1"></a>
   <a href="https://github.com/FoxRick/Collie/actions/workflows/ci.yml"><img src="https://github.com/FoxRick/Collie/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="https://heycollie.com"><img src="https://img.shields.io/badge/Website-heycollie.com-2ea44f" alt="heycollie.com"></a>
   <a href="https://github.com/FoxRick/Collie"><img src="https://img.shields.io/github/stars/FoxRick/Collie" alt="GitHub stars"></a>
@@ -201,6 +201,11 @@ start talking, and Collie figures out the rest.
 The supported alpha platform is **Windows 11 x64** (the app also builds and
 runs from source on Linux for development; macOS is not supported). You need
 Python 3.12, Node.js, and npm:
+
+> Versioning note: the repo carries two versions that move independently —
+> the desktop app (`collie-ui/package.json`, e.g. `0.1.0-alpha.7.1`) and the
+> Python core (`collie-core/pyproject.toml`, e.g. `0.2.2`). A release tag
+> tracks the app version.
 
 ```powershell
 cd collie-core

--- a/collie-core/collie_core/catalog/refresh.py
+++ b/collie-core/collie_core/catalog/refresh.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import UTC, datetime
 from typing import Any
@@ -25,12 +26,28 @@ CATALOGUE_REFRESHED_AT_SETTING = "catalogue.refresh.updated_at"
 CATALOGUE_SNAPSHOT_SETTING = "catalogue.snapshot"
 
 MODELS_DEV_URL = "https://models.dev/api.json"
+_ALLOWED_REFRESH_HOSTS = frozenset({"models.dev", "www.models.dev"})
 _FETCH_TIMEOUT_SECONDS = 20
 _MAX_PAYLOAD_BYTES = 8 * 1024 * 1024
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _validate_refresh_url(url: str | None) -> str:
+    """Pin catalogue refresh to the official https models.dev feed.
+
+    The refresh command is reachable over the local IPC surface; constraining
+    the host keeps a buggy or compromised shell from pointing it at an
+    arbitrary URL. Callers may omit the URL (default feed) or pass the
+    canonical one.
+    """
+    effective = url or MODELS_DEV_URL
+    parsed = urllib.parse.urlparse(effective)
+    if parsed.scheme != "https" or parsed.hostname not in _ALLOWED_REFRESH_HOSTS:
+        raise ValueError(f"catalogue refresh only accepts the models.dev feed, got {effective!r}")
+    return effective
 
 
 def _fetch(url: str) -> bytes:
@@ -55,7 +72,16 @@ async def fetch_and_trim_catalogue(
     untouched and a human error is returned.
     """
     try:
-        data = await _fetch_async(url or MODELS_DEV_URL)
+        effective_url = _validate_refresh_url(url)
+    except ValueError as error:
+        return {
+            "refreshed": False,
+            "error": "I can only refresh the catalogue from the official "
+            "models.dev feed, so I kept the bundled one.",
+            "detail": str(error),
+        }
+    try:
+        data = await _fetch_async(effective_url)
         raw = json.loads(data.decode("utf-8"))
     except (urllib.error.URLError, TimeoutError, OSError, ValueError) as error:
         return {

--- a/collie-core/pyproject.toml
+++ b/collie-core/pyproject.toml
@@ -80,6 +80,8 @@ dev = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "aiohttp>=3.9.0,<4.0.0",
     "pytest-cov>=6.0.0,<7.0.0",
+    # Per-test timeout so a wedged async test fails CI instead of hanging it.
+    "pytest-timeout>=2.3.0,<3.0.0",
     # Pinned: the ruff format gate (ci.yml) must be reproducible across
     # machines and CI images — a floating formatter rewrites history.
     "ruff>=0.16,<0.17",
@@ -174,6 +176,11 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Fail a wedged test (default 120s) instead of hanging CI forever. The
+# thread method works with the asyncio suite; override per-test with
+# @pytest.mark.timeout when a test legitimately needs longer.
+timeout = 120
+timeout_method = "thread"
 
 [tool.coverage.run]
 source = ["nanobot", "collie_core"]

--- a/collie-core/tests/collie/test_catalogue.py
+++ b/collie-core/tests/collie/test_catalogue.py
@@ -171,3 +171,55 @@ async def test_refresh_persists_overlay_and_rollback_restores_bundled(tmp_path: 
     rollback = store.rollback()
     assert rollback["rolled_back"] is True
     assert store.providers() == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_non_models_dev_urls(tmp_path: Path) -> None:
+    """The IPC-exposed refresh only fetches the official https models.dev feed."""
+    settings = _FakeSettings()
+    store = CatalogueStore(settings=settings, snapshot_path=tmp_path / "missing.json")
+
+    fetches: list[str] = []
+
+    async def _spy_fetch(url: str) -> bytes:  # pragma: no cover - must not run
+        fetches.append(url)
+        return b"{}"
+
+    from collie_core.catalog import refresh as refresh_module
+
+    original = refresh_module._fetch_async
+    refresh_module._fetch_async = _spy_fetch  # type: ignore[assignment]
+    try:
+        for bad in (
+            "http://models.dev/api.json",  # right host, wrong scheme
+            "https://evil.example.com/api.json",  # arbitrary https host
+            "https://models.dev.evil.example.com/api.json",  # suffix spoof
+            "file:///etc/passwd",  # local file
+        ):
+            result = await store.refresh(url=bad)
+            assert result["refreshed"] is False, bad
+            assert "models.dev feed" in result["error"], bad
+        assert fetches == []  # the fetch layer was never reached
+
+        allowed = await store.refresh(url="https://models.dev/api.json")
+        assert fetches == ["https://models.dev/api.json"]  # allowed URL reached the fetch layer
+        assert (
+            "models.dev feed" not in allowed["error"]
+        )  # rejected for other reasons (empty payload), not the URL gate
+    finally:
+        refresh_module._fetch_async = original  # type: ignore[assignment]
+
+
+def test_validate_refresh_url_defaults_and_normalizes() -> None:
+    from collie_core.catalog.refresh import MODELS_DEV_URL, _validate_refresh_url
+
+    assert _validate_refresh_url(None) == MODELS_DEV_URL
+    assert _validate_refresh_url("https://www.models.dev/api.json") == (
+        "https://www.models.dev/api.json"
+    )
+    for bad in ("http://models.dev/api.json", "https://evil.example.com/x", "not a url"):
+        try:
+            _validate_refresh_url(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected rejection: {bad!r}")

--- a/collie-ui/package-lock.json
+++ b/collie-ui/package-lock.json
@@ -5158,9 +5158,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -6637,9 +6637,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -7025,9 +7025,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7045,7 +7045,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8184,9 +8184,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -47,6 +47,12 @@
     "vite": "^7.1.11",
     "vitest": "^3.2.4"
   },
+  "overrides": {
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.18",
+    "postcss": "8.5.23",
+    "undici": "6.28.0"
+  },
   "allowScripts": {
     "esbuild@0.25.12": true,
     "esbuild@0.28.1": true

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -18,7 +18,7 @@
 import { app, safeStorage, shell } from 'electron'
 import { createHash, randomBytes } from 'crypto'
 import { createServer, type Server } from 'http'
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../shared/account-config'
 import { secureStorageAvailable } from './secrets'
@@ -137,8 +137,16 @@ function writeAuthFile(file: AuthFile): void {
   const path = authFilePath()
   mkdirSync(dirname(path), { recursive: true })
   const tmpPath = `${path}.tmp`
-  writeFileSync(tmpPath, JSON.stringify(file, null, 2), 'utf-8')
+  // Defense-in-depth: fields are safeStorage-encrypted, but keep the session
+  // file owner-only anyway (0600). Windows ignores POSIX modes; DPAPI already
+  // scopes decryption to the user account there.
+  writeFileSync(tmpPath, JSON.stringify(file, null, 2), { encoding: 'utf-8', mode: 0o600 })
   renameSync(tmpPath, path)
+  try {
+    chmodSync(path, 0o600)
+  } catch {
+    // best effort: mode enforcement is defense-in-depth, not correctness
+  }
 }
 
 /** Persist a session, encrypting every field with safeStorage. */

--- a/collie-ui/src/main/secrets.ts
+++ b/collie-ui/src/main/secrets.ts
@@ -12,7 +12,7 @@
  */
 import { app, safeStorage } from 'electron'
 import { randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
 
 type SecretFile = Record<string, string> // provider -> base64(encrypted)
@@ -77,7 +77,16 @@ function readFile(): SecretFile {
 function writeFile(data: SecretFile): void {
   const path = secretsPath()
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(data, null, 2), 'utf-8')
+  // Defense-in-depth: the blobs are safeStorage-encrypted, but keep the file
+  // owner-only anyway (0600). chmod also tightens files written by older
+  // builds with default permissions. Windows ignores POSIX modes; DPAPI
+  // already scopes decryption to the user account there.
+  writeFileSync(path, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600 })
+  try {
+    chmodSync(path, 0o600)
+  } catch {
+    // best effort: mode enforcement is defense-in-depth, not correctness
+  }
 }
 
 export function saveSecret(provider: string, key: string): boolean {

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -7,15 +7,15 @@
 | Component | Path | Version |
 | --- | --- | --- |
 | Python core | `collie-core/` | `0.2.2` |
-| Electron desktop | `collie-ui/` | `0.1.0-alpha.6` |
+| Electron desktop | `collie-ui/` | `0.1.0-alpha.7.1` |
 
 ## Source inventory
 
-- Core Python files: **515**
+- Core Python files: **516**
 - Core Python test files: **234**
 - Desktop TypeScript/TSX files: **159**
 - Desktop test files: **54**
-- Active Markdown docs: **30**
+- Active Markdown docs: **31**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups


### PR DESCRIPTION
Implements all five hardening items from the 2026-08-21 full-repo review checklist.

## Items

- [x] **js-yaml high advisory (GHSA-5p4m-2wfm-xmqj).** npm `overrides` pin `js-yaml@4.3.1`. Note: this is **not dev-only** — `electron-updater` pulls js-yaml at runtime, so the fix covers the shipped app too. electron-builder is already latest (26.15.3, still on js-yaml 4.3.0), so an override was the only path. Cleared the three other `npm audit` findings the same way (nanoid 3.3.18, postcss 8.5.23, undici 6.28.0). **`npm audit`: 4 findings → 0.**
- [x] **Catalogue refresh accepts a client-supplied URL.** `_cmd_refresh_provider_catalogue` now validates through `_validate_refresh_url` (`collie_core/catalog/refresh.py`): https only + host allowlist (`models.dev`, `www.models.dev`). Rejected URLs return a warm error and never reach the network. Two new tests cover scheme/host/suffix-spoof/`file://` rejections plus default and canonical acceptance.
- [x] **README version drift.** Alpha badge → `v0.1.0-alpha.7.1` (tag exists). Added a versioning note in the from-source section: app version (`collie-ui/package.json`) and core version (`collie-core/pyproject.toml`) move independently; release tags track the app.
- [x] **Secrets file mode.** `secrets.json` (`src/main/secrets.ts`) and the account session file (`src/main/account-auth.ts`) are written with mode `0600` plus a best-effort chmod that also tightens files created by older builds. Defense-in-depth on top of safeStorage; Windows unaffected (DPAPI scopes decryption to the user account).
- [x] **pytest-timeout.** `pytest-timeout` added to dev extras; `timeout = 120` / `timeout_method = "thread"` set in `[tool.pytest.ini_options]` — applies to local runs and both CI jobs automatically (no ci.yml change needed).

Also regenerated `docs/generated/REPOSITORY_SNAPSHOT.md` in-branch (absorbed pre-existing drift: UI version alpha.6 → alpha.7.1, +1 core file).

## Gates (fresh, this branch)

- `ruff format --check collie_core tests/collie tests/tools`: 173 files clean
- `ruff check nanobot collie_core tests`: clean
- Full core suite: **3590 passed / 1 skipped** (4 failures = ci.yml's documented Linux DPAPI deselects → green)
- UI: `npm run typecheck` clean · vitest **54 files / 360 tests passed** (secrets + account-auth suites included)
- `npm audit`: **0 vulnerabilities**
- `tools/update_project_snapshot.py --check`: current

Fixes #93
