### PR TITLE
feat(ui): smooth continuous Collie Circle motion (crossfaded gaze, organic blinks, auto-framing)

### DIFF
--- a/collie-ui/src/renderer/src/components/ColliePortraitFrame.tsx
+++ b/collie-ui/src/renderer/src/components/ColliePortraitFrame.tsx
@@ -1,78 +1,514 @@
 import { useEffect, useRef, useState } from 'react'
-import type { PortraitFrame } from './portraitStates'
+import type { PortraitState } from './portraitStates'
+import { FACE_ONLY_ASSET_MANIFEST, PORTRAIT_STILLS } from './portraitStates'
+import { chaseDirection, smoothFactor } from './colliePortraitMotion'
 
 interface Props {
-  frame: PortraitFrame
+  state: PortraitState
+  reducedMotion: boolean
   fallbackSrc: string
   className?: string
 }
 
 /**
- * Draws either one face image or one cell from a face-only source strip.
- * Keeping strip cropping here avoids CSS transforms and keeps full-body atlas
- * geometry out of the composer renderer.
+ * Continuous portrait renderer for the Collie Circle.
+ *
+ * Replaces the old per-frame cell blitter with a single rAF loop that
+ * reproduces the approved motion prototype: continuous blended gaze (no
+ * 16-way snapping), crossfaded sheet walks with irregular blink cadence,
+ * eased state transitions, breathing + micro-sway + head-tilt, and
+ * per-sheet alpha-measured framing so the chest fur always reaches past the
+ * circle's bottom edge.
  */
-export default function ColliePortraitFrame({ frame, fallbackSrc, className }: Props): React.JSX.Element {
+export default function ColliePortraitFrame({
+  state,
+  reducedMotion,
+  fallbackSrc,
+  className
+}: Props): React.JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [failed, setFailed] = useState(false)
-  const [loaded, setLoaded] = useState(false)
+  const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
+  const dprRef = useRef(1)
+  const rafRef = useRef<number | null>(null)
 
+  // ---- assets + per-sheet alpha framing ----
+  const [ready, setReady] = useState(false)
+  const assetsRef = useRef<Assets | null>(null)
+
+  // ---- continuous motion state ----
+  const stateRef = useRef<PortraitState>(state)
+  const prevStateRef = useRef<PortraitState | null>(null)
+  const stateT0Ref = useRef(0)
+  const fromStateRef = useRef<PortraitState | null>(null)
+  const fromT0Ref = useRef(0)
+  const lastRef = useRef(0)
+  const pxRef = useRef(0)
+  const pyRef = useRef(0)
+  const hasPointerRef = useRef(false)
+  const gvXRef = useRef(0)
+  const gvYRef = useRef(0)
+  const contDirRef = useRef(0)
+  const contDirInitRef = useRef(false)
+
+  // Keep the loop reading the freshest state without re-renders.
   useEffect(() => {
-    setFailed(false)
-    const image = new Image()
-    image.onload = () => {
+    const now = performance.now()
+    fromStateRef.current = prevStateRef.current
+    fromT0Ref.current = now
+    stateT0Ref.current = now
+    prevStateRef.current = state
+    stateRef.current = state
+    if (state === 'pointer_look') contDirInitRef.current = false
+  }, [state])
+
+  // Window-wide pointer tracking (the dog follows the cursor anywhere over
+  // the chat window, not just the ring).
+  useEffect(() => {
+    const onMove = (event: PointerEvent): void => {
       const canvas = canvasRef.current
       if (!canvas) return
-      const columns = frame.columns || 1
-      const rows = frame.rows || 1
-      const sourceIndex = frame.sourceIndex || 0
-      const sourceWidth = image.naturalWidth / columns
-      const sourceHeight = image.naturalHeight / rows
-      const outputSize = 384
-      const devicePixelRatio = window.devicePixelRatio || 1
-      const fit = Math.min(outputSize / sourceWidth, outputSize / sourceHeight)
-      const destinationWidth = sourceWidth * fit
-      const destinationHeight = sourceHeight * fit
-      const destinationX = (outputSize - destinationWidth) / 2
-      const destinationY = (outputSize - destinationHeight) / 2
-      canvas.width = outputSize * devicePixelRatio
-      canvas.height = outputSize * devicePixelRatio
-      const context = canvas.getContext('2d')
-      if (!context) return
-      context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0)
-      context.clearRect(0, 0, outputSize, outputSize)
-      context.drawImage(
-        image,
-        (sourceIndex % columns) * sourceWidth,
-        Math.floor(sourceIndex / columns) * sourceHeight,
-        sourceWidth,
-        sourceHeight,
-        destinationX,
-        destinationY,
-        destinationWidth,
-        destinationHeight
-      )
-      setLoaded(true)
+      const rect = canvas.getBoundingClientRect()
+      const cx = rect.left + rect.width / 2
+      const cy = rect.top + rect.height / 2
+      const rad = Math.max(rect.width, rect.height) / 2
+      let nx = (event.clientX - cx) / rad
+      let ny = (event.clientY - cy) / rad
+      const magnitude = Math.hypot(nx, ny)
+      if (magnitude > 1.5) {
+        nx *= 1.5 / magnitude
+        ny *= 1.5 / magnitude
+      }
+      pxRef.current = nx
+      pyRef.current = ny
+      hasPointerRef.current = true
     }
-    image.onerror = () => setFailed(true)
-    image.src = frame.src
+    const onLeave = (): void => {
+      hasPointerRef.current = false
+    }
+    window.addEventListener('pointermove', onMove, { passive: true })
+    document.addEventListener('pointerleave', onLeave)
+    window.addEventListener('blur', onLeave)
     return () => {
-      image.onload = null
-      image.onerror = null
+      window.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerleave', onLeave)
+      window.removeEventListener('blur', onLeave)
     }
-  }, [frame.columns, frame.rows, frame.sourceIndex, frame.src])
+  }, [])
+
+  // Load sheets + stills, measuring each image's alpha bounding box so the
+  // chest fur reaches past the circle's bottom edge (orange-gap fix).
+  useEffect(() => {
+    const sheets = {} as Partial<Record<SheetKey, SheetAsset>>
+    const stills = {} as Partial<Record<StillKey, HTMLImageElement>>
+    let pending = SHEET_KEYS.length + STILL_KEYS.length
+
+    const done = (): void => {
+      pending -= 1
+      if (pending === 0) {
+        assetsRef.current = { sheets, stills }
+        setReady(true)
+      }
+    }
+
+    for (const key of SHEET_KEYS) {
+      const img = new Image()
+      img.onload = () => {
+        sheets[key] = {
+          img,
+          cols: SHEET_DEFS[key].cols,
+          rows: SHEET_DEFS[key].rows,
+          n: SHEET_DEFS[key].n,
+          framing: measureFraming(img, SHEET_DEFS[key].cols, SHEET_DEFS[key].rows)
+        }
+        done()
+      }
+      img.onerror = () => done()
+      img.src = SHEET_DEFS[key].src
+    }
+    for (const key of STILL_KEYS) {
+      const img = new Image()
+      img.onload = () => {
+        stills[key] = img
+        done()
+      }
+      img.onerror = () => done()
+      img.src = PORTRAIT_STILLS[key]
+    }
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const context = canvas.getContext('2d')
+    if (!context) return
+    dprRef.current = window.devicePixelRatio || 1
+    canvas.width = FRAME_SIZE * dprRef.current
+    canvas.height = FRAME_SIZE * dprRef.current
+    ctxRef.current = context
+
+    if (reducedMotion) {
+      drawStaticIdle()
+      return
+    }
+    if (typeof requestAnimationFrame === 'undefined') return
+
+    lastRef.current = performance.now()
+    const frame = (now: number): void => {
+      const dt = Math.min(0.05, (now - lastRef.current) / 1000)
+      lastRef.current = now
+      const t = now / 1000
+      const lt = now - stateT0Ref.current
+      const currentState = stateRef.current
+
+      // Ambient look-around when the pointer is away.
+      if (!hasPointerRef.current) {
+        const wx = Math.sin(t * 0.31) * 0.42 + Math.sin(t * 0.13) * 0.18
+        const wy = Math.cos(t * 0.23) * 0.22
+        const f = 1 - Math.exp(-1.4 * dt)
+        pxRef.current += (wx - pxRef.current) * f
+        pyRef.current += (wy - pyRef.current) * f
+      }
+
+      // Gaze vector: responsive but lagging; damped while working/reviewing,
+      // zeroed while sleepy or in deep-work glasses.
+      let targetX = pxRef.current
+      let targetY = pyRef.current
+      if (currentState === 'working' || currentState === 'review') {
+        targetX *= 0.25
+        targetY *= 0.25
+      }
+      if (currentState === 'sleepy' || currentState === 'deep_work_glasses') {
+        targetX = 0
+        targetY = 0
+      }
+      const gazeFactor = smoothFactor(9, dt)
+      gvXRef.current += (targetX - gvXRef.current) * gazeFactor
+      gvYRef.current += (targetY - gvYRef.current) * gazeFactor
+
+      // One continuously-smoothed look direction; blend two adjacent cells.
+      if (currentState === 'pointer_look') {
+        const degrees = (Math.atan2(gvXRef.current, -gvYRef.current) * 180) / Math.PI
+        const target = ((degrees / 22.5) % LOOK_DIRECTION_COUNT + LOOK_DIRECTION_COUNT) % LOOK_DIRECTION_COUNT
+        if (!contDirInitRef.current) {
+          contDirRef.current = target
+          contDirInitRef.current = true
+        }
+        contDirRef.current = chaseDirection(contDirRef.current, target, 0.16)
+      }
+
+      const context2d = ctxRef.current
+      if (!context2d) return
+      context2d.setTransform(dprRef.current, 0, 0, dprRef.current, 0, 0)
+      context2d.clearRect(0, 0, FRAME_SIZE, FRAME_SIZE)
+
+      // Life at rest: breathing + layered micro-sway + micro head-tilt.
+      const sleepy = currentState === 'sleepy'
+      const breathe = Math.sin(t * (sleepy ? 1.1 : 1.9)) * (sleepy ? 0.01 : 0.006)
+      const sway = currentState === 'deep_work_glasses' || currentState === 'working' ? 0.35 : 1
+      const microX = (Math.sin(t * 0.7) * 1.2 + Math.sin(t * 1.31) * 0.6) * sway
+      const microY = Math.cos(t * 0.61) * 0.8 * sway
+      const scale =
+        1 +
+        breathe +
+        (currentState === 'click_reaction'
+          ? 0.02 * Math.sin(Math.min(1, lt / 900) * Math.PI)
+          : 0)
+      const rotation = gvXRef.current * 0.05 + Math.sin(t * 0.43) * 0.005 * sway
+      const offsetX = gvXRef.current * 6 + microX
+      const offsetY = gvYRef.current * 4.5 + microY + breathe * 8
+
+      // Eased crossfade between states; the old state renders beneath.
+      const sinceTransition = now - fromT0Ref.current
+      let transitionWeight = 1
+      if (fromStateRef.current !== null) {
+        const w = Math.min(1, sinceTransition / STATE_FADE_MS)
+        transitionWeight = w * w * (3 - 2 * w)
+      }
+      if (transitionWeight < 1 && fromStateRef.current !== null) {
+        for (const layer of renderLayers(fromStateRef.current, now - fromT0Ref.current, contDirRef.current)) {
+          drawLayer(layer, layer.alpha * (1 - transitionWeight), offsetX, offsetY, rotation, scale)
+        }
+      }
+      for (const layer of renderLayers(currentState, lt, contDirRef.current)) {
+        drawLayer(layer, layer.alpha * transitionWeight, offsetX, offsetY, rotation, scale)
+      }
+      if (transitionWeight >= 1) fromStateRef.current = null
+
+      rafRef.current = requestAnimationFrame(frame)
+    }
+    rafRef.current = requestAnimationFrame(frame)
+    return () => {
+      if (rafRef.current !== null && typeof cancelAnimationFrame !== 'undefined') {
+        cancelAnimationFrame(rafRef.current)
+      }
+      rafRef.current = null
+    }
+  }, [ready, reducedMotion])
+
+  function drawStaticIdle(): void {
+    const context = ctxRef.current
+    if (!context) return
+    context.setTransform(dprRef.current, 0, 0, dprRef.current, 0, 0)
+    context.clearRect(0, 0, FRAME_SIZE, FRAME_SIZE)
+    drawLayer({ kind: 'still', key: 'idle', alpha: 1 }, 1, 0, 0, 0, 1)
+  }
+
+  function drawLayer(
+    layer: RenderLayer,
+    alpha: number,
+    dx: number,
+    dy: number,
+    rotation: number,
+    scale: number
+  ): void {
+    const context = ctxRef.current
+    const assets = assetsRef.current
+    if (!context || !assets || alpha <= 0.003) return
+    let img: HTMLImageElement
+    let cols = 1
+    let rows = 1
+    let cell = 0
+    let framing: Framing | null = null
+    if (layer.kind === 'sheet') {
+      const sheet = assets.sheets[layer.key]
+      if (!sheet) return
+      img = sheet.img
+      cols = sheet.cols
+      rows = sheet.rows
+      cell = layer.cell
+      framing = sheet.framing
+    } else {
+      const still = assets.stills[layer.key]
+      if (!still) return
+      img = still
+    }
+    if (!img.complete || !img.naturalWidth) return
+    const sw = img.naturalWidth / cols
+    const sh = img.naturalHeight / rows
+    const sx = (cell % cols) * sw
+    const sy = Math.floor(cell / cols) * sh
+    const fit = FRAME_SIZE / Math.max(sw, sh)
+    const dw = sw * fit
+    const dh = sh * fit
+    const scaleFactor = framing ? framing.s : 1
+    const dyOffset = framing ? framing.dy : 0
+    const width = dw * scaleFactor * scale
+    const height = dh * scaleFactor * scale
+    context.save()
+    context.globalAlpha = Math.max(0, Math.min(1, alpha))
+    context.translate(FRAME_SIZE / 2 + dx, FRAME_SIZE / 2 + dy + dyOffset)
+    context.rotate(rotation)
+    context.drawImage(img, sx, sy, sw, sh, -width / 2, -height / 2, width, height)
+    context.restore()
+  }
 
   return (
     <>
-      {(failed || !loaded) && <img className={className} src={fallbackSrc} alt="" draggable={false} />}
-      {!failed && (
-        <canvas
-          ref={canvasRef}
-          className={className}
-          aria-hidden="true"
-          style={{ visibility: loaded ? 'visible' : 'hidden' }}
-        />
-      )}
+      <img className={className} src={fallbackSrc} alt="" draggable={false} aria-hidden="true" />
+      <canvas ref={canvasRef} className={className} aria-hidden="true" />
     </>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Motion primitives ported from the approved prototype
+// (collie-dog-motion-draft.html).
+// ---------------------------------------------------------------------------
+
+const FRAME_SIZE = 384
+const FRAMING_OVERSHOOT = 10
+const FRAMING_TOP_MARGIN = 14
+const STATE_FADE_MS = 300
+const LOOK_DIRECTION_COUNT = 16
+
+type SheetKey = 'idle' | 'pointer' | 'waiting' | 'click' | 'bone' | 'glasses'
+type StillKey = 'idle' | 'sleepy' | 'thinking' | 'concerned' | 'happy'
+
+const SHEET_KEYS: SheetKey[] = ['idle', 'pointer', 'waiting', 'click', 'bone', 'glasses']
+const STILL_KEYS: StillKey[] = ['idle', 'sleepy', 'thinking', 'concerned', 'happy']
+
+const SHEET_DEFS: Record<SheetKey, { src: string; cols: number; rows: number; n: number }> = {
+  idle: { src: FACE_ONLY_ASSET_MANIFEST.idle.src, cols: 3, rows: 2, n: 6 },
+  pointer: { src: FACE_ONLY_ASSET_MANIFEST.pointerLook.src, cols: 4, rows: 4, n: 16 },
+  waiting: { src: FACE_ONLY_ASSET_MANIFEST.waiting.src, cols: 3, rows: 2, n: 6 },
+  click: { src: FACE_ONLY_ASSET_MANIFEST.clickReaction.src, cols: 2, rows: 2, n: 4 },
+  bone: { src: FACE_ONLY_ASSET_MANIFEST.boneCompletion.src, cols: 2, rows: 2, n: 4 },
+  glasses: { src: FACE_ONLY_ASSET_MANIFEST.deepWorkGlasses.src, cols: 3, rows: 2, n: 6 }
+}
+
+interface Framing {
+  s: number
+  dy: number
+}
+
+interface SheetAsset {
+  img: HTMLImageElement
+  cols: number
+  rows: number
+  n: number
+  framing: Framing | null
+}
+
+interface Assets {
+  sheets: Partial<Record<SheetKey, SheetAsset>>
+  stills: Partial<Record<StillKey, HTMLImageElement>>
+}
+
+type RenderLayer =
+  | { kind: 'sheet'; key: SheetKey; cell: number; alpha: number }
+  | { kind: 'still'; key: StillKey; alpha: number }
+
+const framingCache = new WeakMap<HTMLImageElement, Framing | null>()
+
+/**
+ * Measures the alpha bounding box across every cell of a sheet (downscaled to
+ * 72px cells for speed) and returns the scale/offset that frames the fur from
+ * (top + 14px margin) to (bottom + 10px overshoot past the circle edge).
+ * Returns null when the image is not measurable; callers fall back to plain
+ * contain-fit.
+ */
+function measureFraming(img: HTMLImageElement, cols: number, rows: number): Framing | null {
+  const cached = framingCache.get(img)
+  if (cached !== undefined) return cached
+  const framing = computeFraming(img, cols, rows)
+  framingCache.set(img, framing)
+  return framing
+}
+
+function computeFraming(img: HTMLImageElement, cols: number, rows: number): Framing | null {
+  if (!img.complete || !img.naturalWidth) return null
+  const cellSize = 72
+  const canvas = document.createElement('canvas')
+  canvas.width = cellSize
+  canvas.height = cellSize
+  const g = canvas.getContext('2d', { willReadFrequently: true })
+  if (!g) return null
+  const sw = img.naturalWidth / cols
+  const sh = img.naturalHeight / rows
+  let top = cellSize
+  let bottom = -1
+  for (let i = 0; i < cols * rows; i++) {
+    g.clearRect(0, 0, cellSize, cellSize)
+    g.drawImage(img, (i % cols) * sw, Math.floor(i / cols) * sh, sw, sh, 0, 0, cellSize, cellSize)
+    let data: Uint8ClampedArray
+    try {
+      data = g.getImageData(0, 0, cellSize, cellSize).data
+    } catch {
+      return null
+    }
+    for (let y = 0; y < cellSize; y++) {
+      for (let x = 0; x < cellSize; x++) {
+        if (data[(y * cellSize + x) * 4 + 3] > 16) {
+          if (y < top) top = y
+          if (y > bottom) bottom = y
+        }
+      }
+    }
+  }
+  if (bottom < top) return null
+  const topFraction = top / cellSize
+  const bottomFraction = (bottom + 1) / cellSize
+  const fit = FRAME_SIZE / Math.max(sw, sh)
+  const drawHeight = sh * fit
+  // Fur must span from (top edge + margin) to (bottom edge + overshoot).
+  const spanNeeded = FRAME_SIZE - FRAMING_TOP_MARGIN + FRAMING_OVERSHOOT
+  const scale = Math.max(1, spanNeeded / ((bottomFraction - topFraction) * drawHeight))
+  const dy = FRAME_SIZE / 2 + FRAMING_OVERSHOOT - (bottomFraction - 0.5) * drawHeight * scale
+  return { s: scale, dy }
+}
+
+// Deterministic per-cycle hold variation — organic blink cadence.
+const hash01 = (i: number): number => {
+  const s = Math.sin(i * 127.1 + 311.7) * 43758.5453
+  return s - Math.floor(s)
+}
+
+/** Walks a sheet's cells, crossfading between neighbours with irregular holds. */
+function seqPlayer(n: number, holdBase: number, fadeMs: number): (lt: number) => Array<[number, number]> {
+  return (lt) => {
+    let acc = 0
+    let step = 0
+    for (; step < 256; step++) {
+      const hold = holdBase * (0.82 + 0.36 * hash01(step))
+      if (lt < acc + hold + fadeMs) break
+      acc += hold + fadeMs
+    }
+    const hold = holdBase * (0.82 + 0.36 * hash01(step))
+    const into = lt - acc
+    const w = Math.max(0, Math.min(1, (into - hold) / fadeMs))
+    const eased = w * w * (3 - 2 * w)
+    return [
+      [step % n, 1 - eased],
+      [(step + 1) % n, eased]
+    ]
+  }
+}
+
+/** Alternates two stills with eased crossfades. */
+function pulsePlayer(holdMs: number, fadeMs: number): (lt: number) => Array<[0 | 1, number]> {
+  return (lt) => {
+    const total = holdMs + fadeMs
+    const phase = Math.floor(lt / total) % 2
+    const into = lt % total
+    const w = Math.max(0, Math.min(1, (into - holdMs) / fadeMs))
+    const eased = w * w * (3 - 2 * w)
+    return phase === 0
+      ? [
+          [0, 1 - eased],
+          [1, eased]
+        ]
+      : [
+          [1, 1 - eased],
+          [0, eased]
+        ]
+  }
+}
+
+const idleSeq = seqPlayer(SHEET_DEFS.idle.n, 700, 170)
+const waitingSeq = seqPlayer(SHEET_DEFS.waiting.n, 650, 200)
+const boneSeq = seqPlayer(SHEET_DEFS.bone.n, 320, 130)
+const clickSeq = seqPlayer(SHEET_DEFS.click.n, 170, 90)
+const glassesSeq = seqPlayer(SHEET_DEFS.glasses.n, 600, 180)
+const workPulse = pulsePlayer(640, 260)
+const reviewPulse = pulsePlayer(580, 260)
+
+function renderLayers(state: PortraitState, lt: number, contDir: number): RenderLayer[] {
+  switch (state) {
+    case 'idle':
+      return idleSeq(lt).map(([cell, alpha]) => ({ kind: 'sheet', key: 'idle', cell, alpha }))
+    case 'pointer_look': {
+      const index = Math.floor(contDir)
+      const frac = contDir - index
+      const eased = frac * frac * (3 - 2 * frac)
+      const first = ((index % LOOK_DIRECTION_COUNT) + LOOK_DIRECTION_COUNT) % LOOK_DIRECTION_COUNT
+      return [
+        { kind: 'sheet', key: 'pointer', cell: first, alpha: 1 - eased },
+        { kind: 'sheet', key: 'pointer', cell: (first + 1) % LOOK_DIRECTION_COUNT, alpha: eased }
+      ]
+    }
+    case 'working':
+      return workPulse(lt).map(([slot, alpha]) => ({
+        kind: 'still',
+        key: slot === 0 ? 'thinking' : 'idle',
+        alpha
+      }))
+    case 'review':
+      return reviewPulse(lt).map(([slot, alpha]) => ({
+        kind: 'still',
+        key: slot === 0 ? 'thinking' : 'concerned',
+        alpha
+      }))
+    case 'waiting':
+      return waitingSeq(lt).map(([cell, alpha]) => ({ kind: 'sheet', key: 'waiting', cell, alpha }))
+    case 'sleepy':
+      return [{ kind: 'still', key: 'sleepy', alpha: 1 }]
+    case 'error':
+      return [{ kind: 'still', key: 'concerned', alpha: 1 }]
+    case 'completion':
+      return boneSeq(lt).map(([cell, alpha]) => ({ kind: 'sheet', key: 'bone', cell, alpha }))
+    case 'click_reaction':
+      return clickSeq(lt).map(([cell, alpha]) => ({ kind: 'sheet', key: 'click', cell, alpha }))
+    case 'deep_work_glasses':
+      return glassesSeq(lt).map(([cell, alpha]) => ({ kind: 'sheet', key: 'glasses', cell, alpha }))
+  }
 }

--- a/collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx
+++ b/collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx
@@ -12,16 +12,12 @@ import {
 } from '../lib/agentActivity'
 import { quantizePortraitPointer } from './colliePortraitMotion'
 import {
-  PORTRAIT_FRAME_DURATION,
   PORTRAIT_STATIC_FALLBACK,
-  portraitFramesFor,
   STATUS_COPY
 } from './portraitStates'
 import { useColliePortraitState } from './useColliePortraitState'
 import AgentAvatar from './AgentAvatar'
 import ColliePortraitFrame from './ColliePortraitFrame'
-
-const pawFront = new URL('../assets/portrait/paw-front-brand.webp', import.meta.url).href
 
 const MAX_WORKING_ROWS = 3
 const MAX_SETTLED_ROWS = 2
@@ -91,16 +87,13 @@ export default function InteractiveColliePortrait({
 }: Props): React.JSX.Element {
   const [pointerTarget, setPointerTarget] = useState<number | null>(null)
   const [copyIndex, setCopyIndex] = useState(0)
-  const [frameIndex, setFrameIndex] = useState(0)
   const [now, setNow] = useState(Date.now)
-  const { state, pawVisible, paused, reducedMotion, gazeDirection, triggerReaction } = useColliePortraitState(
+  const { state, paused, reducedMotion, triggerReaction } = useColliePortraitState(
     thinking,
     isTyping,
     activeAgents,
     pointerTarget
   )
-  const frames = portraitFramesFor(state, gazeDirection)
-  const frame = frames[frameIndex % frames.length]
   const settledAfterTerminal =
     ['idle', 'sleepy'].includes(state) &&
     ['done', 'error'].includes(thinking?.state || '')
@@ -129,16 +122,6 @@ export default function InteractiveColliePortrait({
     )
     return () => window.clearInterval(timer)
   }, [copyPool])
-
-  useEffect(() => {
-    setFrameIndex(0)
-    if (paused || reducedMotion || frames.length < 2) return
-    const timer = window.setInterval(
-      () => setFrameIndex((current) => (current + 1) % frames.length),
-      PORTRAIT_FRAME_DURATION[state]
-    )
-    return () => window.clearInterval(timer)
-  }, [frames.length, paused, reducedMotion, state])
 
   // One 1 s tick so agent rows' elapsed labels stay live without re-rendering
   // the whole chat screen; freezes as soon as nothing visible remains. The
@@ -183,7 +166,7 @@ export default function InteractiveColliePortrait({
         role="button"
         tabIndex={0}
         aria-label="Pet Collie"
-        data-gaze-direction={gazeDirection ?? 'idle'}
+        data-gaze-direction={pointerTarget ?? 'idle'}
         onPointerMove={handlePointerMove}
         onPointerLeave={() => setPointerTarget(null)}
         onClick={triggerReaction}
@@ -193,17 +176,12 @@ export default function InteractiveColliePortrait({
         <div className="collie-portrait-clip">
           <ColliePortraitFrame
             className="collie-portrait-base"
-            frame={frame}
+            state={state}
+            reducedMotion={reducedMotion}
             fallbackSrc={PORTRAIT_STATIC_FALLBACK}
           />
         </div>
         <span className="collie-ring-foreground" aria-hidden="true" />
-        <img
-          className={`collie-portrait-paw${pawVisible ? ' is-visible' : ''}`}
-          src={pawFront}
-          alt=""
-          draggable={false}
-        />
       </div>
       <div className="collie-portrait-status" role="status" aria-live="polite">
         <span key={status}>{status}</span>

--- a/collie-ui/src/renderer/src/components/colliePortraitMotion.test.ts
+++ b/collie-ui/src/renderer/src/components/colliePortraitMotion.test.ts
@@ -1,19 +1,47 @@
 import { describe, expect, it } from 'vitest'
-import { quantizePortraitPointer, stepPortraitDirection } from './colliePortraitMotion'
+import {
+  chaseDirection,
+  quantizePortraitPointer,
+  smoothFactor,
+  wrapDirectionDelta
+} from './colliePortraitMotion'
 
 describe('Collie portrait pointer motion', () => {
   it('uses a central dead zone and the sixteen clockwise directions', () => {
-    expect(quantizePortraitPointer(0.1, -0.1)).toBeNull()
+    expect(quantizePortraitPointer(0.05, -0.05)).toBeNull()
     expect(quantizePortraitPointer(0, -1)).toBe(0)
     expect(quantizePortraitPointer(1, 0)).toBe(4)
     expect(quantizePortraitPointer(0, 1)).toBe(8)
     expect(quantizePortraitPointer(-1, 0)).toBe(12)
   })
 
-  it('moves one neighbouring direction at a time, including across zero', () => {
-    expect(stepPortraitDirection(0, 4)).toBe(1)
-    expect(stepPortraitDirection(4, 0)).toBe(3)
-    expect(stepPortraitDirection(15, 1)).toBe(0)
-    expect(stepPortraitDirection(1, 15)).toBe(0)
+  it('computes the shortest signed wrap delta across the 16-way circle', () => {
+    expect(wrapDirectionDelta(0, 4)).toBe(4)
+    expect(wrapDirectionDelta(4, 0)).toBe(-4)
+    // Forward across zero: 15.9 → 0.1 is a +0.2 step.
+    expect(wrapDirectionDelta(15.9, 0.1)).toBeCloseTo(0.2, 5)
+    // Backward across zero: 0.1 → 15.9 is a -0.2 step.
+    expect(wrapDirectionDelta(0.1, 15.9)).toBeCloseTo(-0.2, 5)
+    expect(wrapDirectionDelta(8, 8)).toBe(0)
+  })
+
+  it('chases one continuous direction value without snapping across the face', () => {
+    const wrap = (value: number): number => ((value % 16) + 16) % 16
+    // Full lerp reaches the target exactly (and wraps past the circle seam).
+    expect(chaseDirection(0, 4, 1)).toBe(4)
+    expect(wrap(chaseDirection(15.9, 0.1, 1))).toBeCloseTo(0.1, 5)
+    expect(wrap(chaseDirection(0.1, 15.9, 1))).toBeCloseTo(15.9, 5)
+    // Partial lerp moves toward the target the short way, never the long way.
+    expect(chaseDirection(0, 4, 0.5)).toBe(2)
+    expect(chaseDirection(15, 0.5, 0.5)).toBeCloseTo(15.75, 5)
+    // Exactly 8 away is a tie; the delta resolves backward (-8).
+    expect(chaseDirection(0, 8, 0.5)).toBe(-4)
+  })
+
+  it('exponentially smooths a rate over a dt frame', () => {
+    expect(smoothFactor(9, 0)).toBe(0)
+    expect(smoothFactor(9, 1)).toBeCloseTo(0.9999, 4)
+    expect(smoothFactor(9, 0.016)).toBeGreaterThan(0)
+    expect(smoothFactor(9, 0.016)).toBeLessThan(1)
   })
 })

--- a/collie-ui/src/renderer/src/components/colliePortraitMotion.ts
+++ b/collie-ui/src/renderer/src/components/colliePortraitMotion.ts
@@ -1,20 +1,43 @@
 export const LOOK_DIRECTION_COUNT = 16
-export const LOOK_DIRECTION_STEP_MS = 72
 
-/** Returns clockwise look direction: 0 is up, 4 is screen-right. */
+/**
+ * Quantizes a pointer vector into the nearest clockwise look direction:
+ * 0 is up, 4 is screen-right. Used by the state machine to decide when the
+ * portrait enters `pointer_look`; the renderer itself tracks the raw vector
+ * for continuous gaze.
+ */
 export function quantizePortraitPointer(
   x: number,
   y: number,
-  deadZoneRadius = 0.18
+  deadZoneRadius = 0.12
 ): number | null {
   if (Math.hypot(x, y) <= deadZoneRadius) return null
   const degrees = (Math.atan2(x, -y) * 180) / Math.PI
   return ((Math.round(degrees / 22.5) % LOOK_DIRECTION_COUNT) + LOOK_DIRECTION_COUNT) % LOOK_DIRECTION_COUNT
 }
 
-/** Eases through one neighbouring 16-way direction; it never snaps across the face. */
-export function stepPortraitDirection(current: number, target: number): number {
-  const clockwise = (target - current + LOOK_DIRECTION_COUNT) % LOOK_DIRECTION_COUNT
-  if (clockwise === 0) return current
-  return (current + (clockwise <= LOOK_DIRECTION_COUNT / 2 ? 1 : -1) + LOOK_DIRECTION_COUNT) % LOOK_DIRECTION_COUNT
+/**
+ * Shortest signed delta in a 16-way circle: from 15.9 to 0.1 is +0.2 (forward
+ * across zero), from 0.1 to 15.9 is -0.2 (backward across zero). Range (-8, 8].
+ */
+export function wrapDirectionDelta(from: number, to: number): number {
+  return (
+    ((((to - from) % LOOK_DIRECTION_COUNT) + LOOK_DIRECTION_COUNT + LOOK_DIRECTION_COUNT / 2) %
+      LOOK_DIRECTION_COUNT) -
+    LOOK_DIRECTION_COUNT / 2
+  )
+}
+
+/**
+ * Eased chase of ONE continuous direction value toward target. The lerp keeps
+ * it moving every frame; wrap handling means it never sweeps across the face.
+ * A lerp of 1 reaches the target exactly (used in tests).
+ */
+export function chaseDirection(current: number, target: number, lerp = 0.16): number {
+  return current + wrapDirectionDelta(current, target) * lerp
+}
+
+/** Exponential smoothing factor for a rate per second over a dt frame. */
+export function smoothFactor(rate: number, dt: number): number {
+  return 1 - Math.exp(-rate * dt)
 }

--- a/collie-ui/src/renderer/src/components/portraitStates.test.ts
+++ b/collie-ui/src/renderer/src/components/portraitStates.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import {
   FACE_ONLY_ASSET_MANIFEST,
   gazeEnabledForState,
-  portraitFramesFor,
   portraitStateForEngine,
   supportsFaceOnlyDeepWork
 } from './portraitStates'
@@ -39,15 +38,13 @@ describe('portrait state mapping', () => {
   it('enables deep work only through the dedicated face-only glasses strip', () => {
     expect(supportsFaceOnlyDeepWork()).toBe(true)
     expect(FACE_ONLY_ASSET_MANIFEST.deepWorkGlasses.frameCount).toBe(6)
-    expect(portraitFramesFor('deep_work_glasses')).toHaveLength(6)
   })
 
-  it('indexes the 16-way face-only pointer sheet in clockwise order', () => {
+  it('keeps the 16-way face-only pointer sheet in clockwise order', () => {
     expect(FACE_ONLY_ASSET_MANIFEST.pointerLook).toMatchObject({
       columns: 4,
       rows: 4,
       frameCount: 16
     })
-    expect(portraitFramesFor('pointer_look', 12)[0]?.sourceIndex).toBe(12)
   })
 })

--- a/collie-ui/src/renderer/src/components/portraitStates.ts
+++ b/collie-ui/src/renderer/src/components/portraitStates.ts
@@ -18,6 +18,8 @@ const boneCompletionSheet = new URL(
 
 export const PORTRAIT_STATIC_FALLBACK = idle
 
+export const PORTRAIT_STILLS = { idle, sleepy, thinking, concerned, happy } as const
+
 /**
  * This manifest is intentionally limited to the composer portrait artwork.
  * Desktop-pet atlases and their supplemental strips must never be added here:
@@ -40,22 +42,6 @@ export interface FaceOnlyStrip {
   frameCount: number
 }
 
-export interface PortraitFrame {
-  src: string
-  sourceIndex?: number
-  columns?: number
-  rows?: number
-}
-
-const still = (src: string): PortraitFrame => ({ src })
-const stripFrames = (strip: FaceOnlyStrip): PortraitFrame[] =>
-  Array.from({ length: strip.frameCount }, (_, sourceIndex) => ({
-    src: strip.src,
-    sourceIndex,
-    columns: strip.columns,
-    rows: strip.rows
-  }))
-
 export type PortraitState =
   | 'sleepy'
   | 'idle'
@@ -67,66 +53,6 @@ export type PortraitState =
   | 'completion'
   | 'click_reaction'
   | 'deep_work_glasses'
-
-export const PORTRAIT_FRAME_SEQUENCE: Record<PortraitState, readonly PortraitFrame[]> = {
-  // The closed-eye face is an existing genuine portrait pose, rather than a
-  // CSS-scaled copy of idle. It gives the currently available face set a calm
-  // blink until the dedicated six-frame idle strip is delivered.
-  idle: [still(idle), still(idle), still(idle), still(sleepy), still(idle), still(idle)],
-  sleepy: [still(sleepy)],
-  pointer_look: [still(thinking), still(idle)],
-  working: [still(thinking), still(idle), still(thinking)],
-  review: [still(thinking), still(concerned), still(thinking)],
-  waiting: [still(concerned), still(idle)],
-  error: [still(concerned)],
-  completion: [still(happy), still(happy), still(idle)],
-  click_reaction: [still(happy), still(thinking), still(happy)],
-  // This state is unreachable until a dedicated face-only glasses strip is
-  // added to the manifest. Keeping a non-glasses fallback here preserves the
-  // glasses-only invariant even if a caller selects it prematurely.
-  deep_work_glasses: [still(thinking)]
-}
-
-export function portraitFramesFor(
-  state: PortraitState,
-  gazeDirection: number | null = null
-): readonly PortraitFrame[] {
-  if (state === 'idle' && FACE_ONLY_ASSET_MANIFEST.idle) {
-    return stripFrames(FACE_ONLY_ASSET_MANIFEST.idle)
-  }
-  if (state === 'pointer_look' && FACE_ONLY_ASSET_MANIFEST.pointerLook) {
-    const frames = stripFrames(FACE_ONLY_ASSET_MANIFEST.pointerLook)
-    // A supplied 16-frame strip is indexed by the controller's clockwise
-    // direction (0=up, 4=screen-right), rather than CSS-moving one face.
-    return gazeDirection === null ? [frames[0]] : [frames[gazeDirection % frames.length]]
-  }
-  if (state === 'deep_work_glasses' && FACE_ONLY_ASSET_MANIFEST.deepWorkGlasses) {
-    return stripFrames(FACE_ONLY_ASSET_MANIFEST.deepWorkGlasses)
-  }
-  if (state === 'waiting' && FACE_ONLY_ASSET_MANIFEST.waiting) {
-    return stripFrames(FACE_ONLY_ASSET_MANIFEST.waiting)
-  }
-  if (state === 'click_reaction' && FACE_ONLY_ASSET_MANIFEST.clickReaction) {
-    return stripFrames(FACE_ONLY_ASSET_MANIFEST.clickReaction)
-  }
-  if (state === 'completion' && FACE_ONLY_ASSET_MANIFEST.boneCompletion) {
-    return stripFrames(FACE_ONLY_ASSET_MANIFEST.boneCompletion)
-  }
-  return PORTRAIT_FRAME_SEQUENCE[state]
-}
-
-export const PORTRAIT_FRAME_DURATION: Record<PortraitState, number> = {
-  idle: 820,
-  sleepy: 1600,
-  pointer_look: 340,
-  working: 520,
-  review: 660,
-  waiting: 760,
-  error: 1200,
-  completion: 430,
-  click_reaction: 230,
-  deep_work_glasses: 700
-}
 
 export const STATUS_COPY: Partial<Record<PortraitState, string[]>> = {
   working: [

--- a/collie-ui/src/renderer/src/components/useColliePortraitState.ts
+++ b/collie-ui/src/renderer/src/components/useColliePortraitState.ts
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ActiveAgent, ThinkingState } from '../lib/ipc'
-import { LOOK_DIRECTION_STEP_MS, stepPortraitDirection } from './colliePortraitMotion'
 import {
-  gazeEnabledForState,
   portraitStateForEngine,
   supportsFaceOnlyDeepWork,
   type PortraitState
@@ -15,10 +13,8 @@ const CLICK_COOLDOWN_MS = 1_000
 
 interface PortraitModel {
   state: PortraitState
-  pawVisible: boolean
   paused: boolean
   reducedMotion: boolean
-  gazeDirection: number | null
   triggerReaction: () => void
 }
 
@@ -35,7 +31,6 @@ export function useColliePortraitState(
     window.matchMedia('(prefers-reduced-motion: reduce)').matches
   )
   const [deepWorkReady, setDeepWorkReady] = useState(false)
-  const [gazeDirection, setGazeDirection] = useState<number | null>(null)
   const clickCooldownUntil = useRef(0)
   const transientTimer = useRef<number | null>(null)
 
@@ -115,24 +110,6 @@ export function useColliePortraitState(
     return sleepy ? 'sleepy' : 'idle'
   }, [deepWorkReady, engineState, isAssistantWorking, pointerTarget, reducedMotion, sleepy, thinking?.state, transient])
 
-  useEffect(() => {
-    if (!gazeEnabledForState(state) || pointerTarget === null) {
-      setGazeDirection(null)
-      return
-    }
-    if (reducedMotion) {
-      setGazeDirection(null)
-      return
-    }
-    setGazeDirection((current) => current ?? pointerTarget)
-    const timer = window.setInterval(() => {
-      setGazeDirection((current) =>
-        current === null || current === pointerTarget ? pointerTarget : stepPortraitDirection(current, pointerTarget)
-      )
-    }, LOOK_DIRECTION_STEP_MS)
-    return () => window.clearInterval(timer)
-  }, [pointerTarget, reducedMotion, state])
-
   const triggerReaction = useCallback(() => {
     if (state === 'error' || state === 'waiting' || state === 'completion') return
     const now = Date.now()
@@ -143,10 +120,8 @@ export function useColliePortraitState(
 
   return {
     state,
-    pawVisible: state === 'click_reaction' || state === 'completion',
     paused,
     reducedMotion,
-    gazeDirection,
     triggerReaction
   }
 }

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -3104,8 +3104,6 @@ button {
   height: 100%;
   object-fit: contain;
   user-select: none;
-  animation: portrait-crossfade 160ms ease-out both;
-  will-change: opacity;
 }
 
 .collie-ring-foreground {
@@ -3126,26 +3124,6 @@ button {
     inset 0 0 0 2px rgba(255, 244, 205, 0.82),
     0 0 0 4px rgba(224, 151, 36, 0.14),
     0 1px 0 rgba(255, 255, 255, 0.7);
-}
-
-.collie-portrait-paw {
-  position: absolute;
-  z-index: 4;
-  right: -10%;
-  bottom: -5%;
-  width: 38%;
-  height: auto;
-  opacity: 0;
-  pointer-events: none;
-  filter: drop-shadow(-2px 3px 2px rgba(42, 31, 18, 0.3));
-  transform: translateY(7px) rotate(5deg);
-  transform-origin: 55% 20%;
-  transition: opacity 150ms ease, transform 210ms ease;
-}
-
-.collie-portrait-paw.is-visible {
-  opacity: 1;
-  transform: translateY(0) rotate(5deg);
 }
 
 .collie-portrait-status {
@@ -3276,11 +3254,6 @@ button {
 .collie-portrait-stage.is-paused *::before,
 .collie-portrait-stage.is-paused *::after { animation-play-state: paused !important; }
 
-@keyframes portrait-crossfade {
-  from { opacity: 0.35; }
-  to { opacity: 1; }
-}
-
 .dark .collie-ring-background {
   background:
     radial-gradient(circle at 38% 28%, rgba(255, 231, 174, 0.24), transparent 34%),
@@ -3340,12 +3313,10 @@ button {
   .collie-ring-foreground { border-width: 2px; }
   .collie-portrait-status,
   .portrait-agent-list { display: none; }
-  .collie-portrait-paw { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .collie-portrait-base,
-  .collie-portrait-paw,
   .collie-portrait-status > span {
     animation: none !important;
     transition: none !important;


### PR DESCRIPTION
## What

Ports the approved motion prototype (`collie-dog-motion-draft.html`, v3) into the composer **Collie Circle** portrait — replacing the hard frame-stepping with continuous, crossfaded motion. No new art; uses the app's existing webp sheets.

## Before → After

- **Gaze:** 16-way quantized snapping (22.5° steps, 72ms timer) → **one continuously-smoothed direction**, rendered by blending the two adjacent pointer-look cells with eased weight. No ghost-dwell, no snap steps.
- **Blink/walks:** hard cell cuts (160ms CSS fade) → **crossfaded sheet walks** with irregular organic cadence (per-cycle hold = base × (0.82 + 0.36·hash(step))).
- **State changes:** instant swap → **eased 300ms crossfade**, old state renders under the new during the fade.
- **Life at rest:** static between frames → **breathing** (~1.9Hz idle / 1.1Hz sleepy, ±0.6–1%), **layered micro-sway** (±~1.8px, damped 65% in working/glasses), **micro head-tilt** from the gaze vector.
- **Framing:** contain-fit exposed the orange disc at the circle's bottom → **per-sheet alpha-measured auto-framing** on load (fur reaches 10px past the bottom edge, ears keep 14px top margin), cached per image, contain-fit fallback.
- **Paw:** external DOM paw overlay (`paw-front-brand.webp`) removed → click-reaction uses only the **in-sheet paw** from `click-reaction-sheet.webp`.
- **Pointer:** ring-only tracking → **window-wide capture** (dog follows anywhere over the chat window), ±1.5 normalization, ~0.12 dead zone; **ambient look-around wander** when the pointer is away.
- **Reduced motion:** respected — freezes to the static idle frame, no sway/breathing (existing behavior kept).

## Files

- `collie-ui/src/renderer/src/components/ColliePortraitFrame.tsx` — rewritten as the continuous canvas renderer (rAF loop, sequence/pulse players, framing measurement, transitions, life-at-rest motion).
- `collie-ui/src/renderer/src/components/colliePortraitMotion.ts` — continuous gaze math (wrap delta, eased chase, exp smoothing) replacing the quantized stepper.
- `collie-ui/src/renderer/src/components/portraitStates.ts` — removed `PORTRAIT_FRAME_SEQUENCE` / `PORTRAIT_FRAME_DURATION` / `portraitFramesFor` (dead after the renderer rewrite); added `PORTRAIT_STILLS` export.
- `collie-ui/src/renderer/src/components/useColliePortraitState.ts` — dropped stepped-gaze state + paw flag (renderer owns motion now).
- `collie-ui/src/renderer/src/components/InteractiveColliePortrait.tsx` — removed frame-stepping effect + DOM paw; **public Props API unchanged**.
- `collie-ui/src/renderer/src/styles/globals.css` — removed `.collie-portrait-paw` styles + `portrait-crossfade` keyframes.
- Tests updated: `colliePortraitMotion.test.ts` (continuous-chase coverage), `portraitStates.test.ts` (manifest assertions).

## Gates (run fresh on this branch)

- `npm run typecheck` ✅
- `npm test` → **54 files / 362 tests passed** ✅
- `npm run check:assets` (check-portrait-assets.py) → **OK** ✅ (asset layout untouched)
- `npm run build` ✅

## Notes for Rick

- Behavior matches the approved prototype exactly; only the state machine (hard states, transients, cooldowns) is unchanged app logic.
- No merge performed — review at will. Person voice kept; no dog emojis in copy.
