### PR TITLE
fix(ui): per-frame horizontal framing — stop chat-head drift + edge clipping

### DIFF
--- a/collie-ui/src/renderer/src/components/ColliePortraitFrame.tsx
+++ b/collie-ui/src/renderer/src/components/ColliePortraitFrame.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { PortraitState } from './portraitStates'
 import { FACE_ONLY_ASSET_MANIFEST, PORTRAIT_STILLS } from './portraitStates'
-import { chaseDirection, smoothFactor } from './colliePortraitMotion'
+import { chaseDirection, horizontalFramingOffset, smoothFactor } from './colliePortraitMotion'
 
 interface Props {
   state: PortraitState
@@ -292,11 +292,15 @@ export default function ColliePortraitFrame({
     const dh = sh * fit
     const scaleFactor = framing ? framing.s : 1
     const dyOffset = framing ? framing.dy : 0
+    const dxOffset = framing ? framing.dxs[cell] ?? 0 : 0
     const width = dw * scaleFactor * scale
     const height = dh * scaleFactor * scale
     context.save()
     context.globalAlpha = Math.max(0, Math.min(1, alpha))
-    context.translate(FRAME_SIZE / 2 + dx, FRAME_SIZE / 2 + dy + dyOffset)
+    context.translate(
+      FRAME_SIZE / 2 + dx + dxOffset,
+      FRAME_SIZE / 2 + dy + dyOffset
+    )
     context.rotate(rotation)
     context.drawImage(img, sx, sy, sw, sh, -width / 2, -height / 2, width, height)
     context.restore()
@@ -339,6 +343,8 @@ const SHEET_DEFS: Record<SheetKey, { src: string; cols: number; rows: number; n:
 interface Framing {
   s: number
   dy: number
+  /** Per-cell horizontal offsets (index = cell), so each frame stays centered. */
+  dxs: number[]
 }
 
 interface SheetAsset {
@@ -387,6 +393,10 @@ function computeFraming(img: HTMLImageElement, cols: number, rows: number): Fram
   const sh = img.naturalHeight / rows
   let top = cellSize
   let bottom = -1
+  // Per-cell horizontal bounds; the union of these would only center the
+  // average, so each cell keeps its own left/right for its own dx.
+  const lefts = new Array<number>(cols * rows).fill(cellSize)
+  const rights = new Array<number>(cols * rows).fill(-1)
   for (let i = 0; i < cols * rows; i++) {
     g.clearRect(0, 0, cellSize, cellSize)
     g.drawImage(img, (i % cols) * sw, Math.floor(i / cols) * sh, sw, sh, 0, 0, cellSize, cellSize)
@@ -401,6 +411,8 @@ function computeFraming(img: HTMLImageElement, cols: number, rows: number): Fram
         if (data[(y * cellSize + x) * 4 + 3] > 16) {
           if (y < top) top = y
           if (y > bottom) bottom = y
+          if (x < lefts[i]) lefts[i] = x
+          if (x > rights[i]) rights[i] = x
         }
       }
     }
@@ -410,11 +422,17 @@ function computeFraming(img: HTMLImageElement, cols: number, rows: number): Fram
   const bottomFraction = (bottom + 1) / cellSize
   const fit = FRAME_SIZE / Math.max(sw, sh)
   const drawHeight = sh * fit
+  const drawWidth = sw * fit
   // Fur must span from (top edge + margin) to (bottom edge + overshoot).
   const spanNeeded = FRAME_SIZE - FRAMING_TOP_MARGIN + FRAMING_OVERSHOOT
   const scale = Math.max(1, spanNeeded / ((bottomFraction - topFraction) * drawHeight))
   const dy = FRAME_SIZE / 2 + FRAMING_OVERSHOOT - (bottomFraction - 0.5) * drawHeight * scale
-  return { s: scale, dy }
+  const dxs = lefts.map((left, i) => {
+    const right = rights[i]
+    if (right < left) return 0
+    return horizontalFramingOffset(left / cellSize, (right + 1) / cellSize, drawWidth, scale, FRAME_SIZE)
+  })
+  return { s: scale, dy, dxs }
 }
 
 // Deterministic per-cycle hold variation — organic blink cadence.

--- a/collie-ui/src/renderer/src/components/colliePortraitMotion.test.ts
+++ b/collie-ui/src/renderer/src/components/colliePortraitMotion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   chaseDirection,
+  horizontalFramingOffset,
   quantizePortraitPointer,
   smoothFactor,
   wrapDirectionDelta
@@ -43,5 +44,25 @@ describe('Collie portrait pointer motion', () => {
     expect(smoothFactor(9, 1)).toBeCloseTo(0.9999, 4)
     expect(smoothFactor(9, 0.016)).toBeGreaterThan(0)
     expect(smoothFactor(9, 0.016)).toBeLessThan(1)
+  })
+
+  it('centers content horizontally and clamps it inside the canvas', () => {
+    const SIZE = 384
+    // Symmetric content: no offset needed.
+    expect(horizontalFramingOffset(0.3, 0.7, 200, 1, SIZE)).toBeCloseTo(0, 5)
+    // Content shifted right within the cell: dx pulls it back to center.
+    const rightShifted = horizontalFramingOffset(0.5, 0.8, 200, 1, SIZE)
+    expect(rightShifted).toBeLessThan(0)
+    expect(rightShifted).toBeCloseTo((0.5 - 0.65) * 200, 5)
+    // Content shifted left: dx pushes it right.
+    const leftShifted = horizontalFramingOffset(0.15, 0.45, 200, 1, SIZE)
+    expect(leftShifted).toBeGreaterThan(0)
+    // Clamp: a heavily off-center but narrow face stays fully visible.
+    const clamped = horizontalFramingOffset(0.02, 0.12, 300, 1.4, SIZE)
+    const contentHalf = ((0.12 - 0.02) * 300 * 1.4) / 2
+    expect(clamped).toBeGreaterThanOrEqual(contentHalf - SIZE / 2)
+    // No clamp when content is wider than the canvas — stays centered.
+    const wide = horizontalFramingOffset(0.05, 0.99, 300, 1.4, SIZE)
+    expect(wide).toBeCloseTo((0.5 - 0.52) * 300 * 1.4, 5)
   })
 })

--- a/collie-ui/src/renderer/src/components/colliePortraitMotion.ts
+++ b/collie-ui/src/renderer/src/components/colliePortraitMotion.ts
@@ -41,3 +41,32 @@ export function chaseDirection(current: number, target: number, lerp = 0.16): nu
 export function smoothFactor(rate: number, dt: number): number {
   return 1 - Math.exp(-rate * dt)
 }
+
+/**
+ * Horizontal framing offset that centers a cell's alpha content bbox on the
+ * canvas, clamped so the content never clips at either side edge.
+ *
+ * bboxLeftFrac/bboxRightFrac are the measured content span (0..1 of the
+ * cell), drawWidth the scaled drawn cell width, scale the framing scale,
+ * frameSize the logical canvas side. Returns a dx to add to the X translate.
+ *
+ * Applied PER CELL (each frame's own bbox) rather than to a union bbox — a
+ * single union offset only centers the average and leaves per-frame drift.
+ */
+export function horizontalFramingOffset(
+  bboxLeftFrac: number,
+  bboxRightFrac: number,
+  drawWidth: number,
+  scale: number,
+  frameSize: number
+): number {
+  const centerFrac = (bboxLeftFrac + bboxRightFrac) / 2
+  let dx = (0.5 - centerFrac) * drawWidth * scale
+  const contentHalf = ((bboxRightFrac - bboxLeftFrac) * drawWidth * scale) / 2
+  if (contentHalf < frameSize / 2) {
+    const minCenter = contentHalf
+    const maxCenter = frameSize - contentHalf
+    dx = Math.max(minCenter - frameSize / 2, Math.min(maxCenter - frameSize / 2, dx))
+  }
+  return dx
+}


### PR DESCRIPTION
## What

Follow-up to PR #97 (merged) from QA: the chat head still drifted horizontally (~26px across pointer-look frames) and wide frames clipped at the canvas edge. Root cause: framing centered the UNION alpha bbox — i.e. the *average* content — while each cell's own face offset stayed uncorrected.

## Fix

- `computeFraming` now measures **each cell's own horizontal alpha bbox** and returns a per-cell `dxs` array (vertical framing stays union — QA confirmed vertical is solid at 1.6px span).
- `drawLayer` applies the current cell's `dx` via `framing.dxs[cell]`, so every frame's face stays centered on the canvas instead of drifting.
- New `horizontalFramingOffset()` in `colliePortraitMotion.ts`: centers content + side-clamps so narrow content never clips at either edge; wider-than-canvas content stays centered. Unit-tested.

## Gates (fresh on this branch, from origin/main @ 999f32d)

- `npm run typecheck` ✅
- `npm test` → **54 files / 363 tests passed** ✅
- `npm run check:assets` (check-portrait-assets.py) → **OK** ✅
- `npm run build` ✅

## Note for Rick

- PR #97 (smooth motion) merged at 12:19Z by you — this is the horizontal-framing follow-up, new branch + PR. No merge performed here.
- Known separate issue (QA Bug 2, not this PR): `dog-portrait-sheet-*.png` agent avatars have NO alpha channel (RGB) — the opaque-square bug needs the source art re-exported with transparency; will add a check-portrait-assets alpha gate once the asset lands.
