### PR TITLE
feat(account): opt-in per-device cloud backup of memories

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -111,7 +111,16 @@ _TITLE_PREFIX = re.compile(
 # Keys the shell may set over IPC. Everything else is written only by the
 # core itself (defense-in-depth: an attacker who reaches the socket must not
 # be able to flip permission or messenger settings).
-_IPC_SETTABLE_SETTINGS = {"provider.auth", "provider.name", "provider.model", "provider.api_base"}
+_IPC_SETTABLE_SETTINGS = {
+    "provider.auth",
+    "provider.name",
+    "provider.model",
+    "provider.api_base",
+    # Shell-owned account sync opt-in (docs/engineering/architecture/
+    # account-cloud-sync.md). A plain boolean preference — deliberately NOT
+    # guarded like permission/messenger settings, which stay core-only.
+    "account.sync_enabled",
+}
 
 _ALLOWED_ORIGIN_HOSTS = {"localhost", "127.0.0.1", "::1"}
 

--- a/collie-ui/src/main/cloud-sync.test.ts
+++ b/collie-ui/src/main/cloud-sync.test.ts
@@ -1,0 +1,294 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testState = vi.hoisted(() => {
+  return {
+    userData: '',
+    coreCalls: [] as Array<{ type: string; payload: Record<string, unknown> }>,
+    fetches: [] as Array<{ url: string; init: RequestInit }>,
+    nextFetchResponse: null as Response | null,
+    cfg: { url: 'https://test.supabase.co', key: 'test-anon-key' }
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.userData },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
+    encryptString: (value: string) => Buffer.from(`encrypted:${value}`, 'utf8'),
+    decryptString: (value: Buffer) => value.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+vi.mock('../shared/account-config', () => ({
+  get SUPABASE_URL(): string {
+    return testState.cfg.url
+  },
+  get SUPABASE_ANON_KEY(): string {
+    return testState.cfg.key
+  }
+}))
+
+vi.mock('./core-client', () => ({
+  commandWithCore: (type: string, payload: Record<string, unknown>) => {
+    testState.coreCalls.push({ type, payload })
+    if (type === 'get_settings') {
+      const lastSet = [...testState.coreCalls]
+        .reverse()
+        .find((c) => c.type === 'set_setting')
+      return Promise.resolve({
+        settings: lastSet?.payload?.value === true ? { 'account.sync_enabled': true } : {}
+      })
+    }
+    if (type === 'get_profile') return Promise.resolve({ profile: { favorite_color: 'blue' } })
+    if (type === 'get_people')
+      return Promise.resolve({ people: [{ id: 'p1', name: 'Maya', birthday: '05-14' }] })
+    if (type === 'get_dates')
+      return Promise.resolve({
+        dates: [{ date: '05-14', label: "Maya's birthday", recurring: 1 }]
+      })
+    if (type === 'read_file')
+      return Promise.resolve({
+        content: payload.path === 'AGENTS.md' ? '# About Me' : '# Personality'
+      })
+    if (type === 'set_profile_memory') return Promise.resolve({ profile: {} })
+    if (type === 'update_person_memory') return Promise.resolve({ person: {} })
+    if (type === 'add_person_memory') return Promise.resolve({ person: {} })
+    if (type === 'add_date_memory') return Promise.resolve({ date: {} })
+    if (type === 'write_file')
+      return Promise.resolve({ saved: true, version_id: 'v1', diff_text: '' })
+    return Promise.resolve({})
+  }
+}))
+
+/** Minimal fake JWT with a `sub` claim. */
+function makeJwt(sub: string): string {
+  const enc = (value: unknown): string =>
+    Buffer.from(JSON.stringify(value)).toString('base64url')
+  return `${enc({ alg: 'none', typ: 'JWT' })}.${enc({ sub })}.${enc({})}`
+}
+
+const globalFetch = global.fetch
+
+import {
+  enableSync,
+  gatherSnapshot,
+  getSyncStatus,
+  listSnapshots,
+  restoreFromDevice,
+  restoreSnapshot,
+  uploadSnapshot
+} from './cloud-sync'
+import { clearAccountSession, saveAccountSession } from './account-auth'
+import { resetSecureStorageCache } from './secrets'
+
+function signInAs(sub: string): void {
+  saveAccountSession({
+    access_token: makeJwt(sub),
+    refresh_token: 'r',
+    expires_at: Date.now() + 3_600_000,
+    email: 'rick@example.com'
+  })
+}
+
+beforeEach(() => {
+  testState.userData = mkdtempSync(join(tmpdir(), 'collie-cloud-sync-'))
+  testState.coreCalls = []
+  testState.fetches = []
+  testState.nextFetchResponse = null
+  resetSecureStorageCache()
+  global.fetch = ((url: string | URL, init: RequestInit = {}): Promise<Response> => {
+    const urlString = String(url)
+    if (urlString.startsWith('https://test.supabase.co')) {
+      testState.fetches.push({ url: urlString, init })
+      return Promise.resolve(
+        testState.nextFetchResponse ??
+          new Response(JSON.stringify([{ created_at: '2026-08-22T00:00:00Z' }]), { status: 200 })
+      )
+    }
+    return globalFetch(url, init)
+  }) as typeof fetch
+})
+
+afterEach(() => {
+  clearAccountSession()
+  resetSecureStorageCache()
+  rmSync(testState.userData, { recursive: true, force: true })
+  global.fetch = globalFetch
+})
+
+describe('cloud sync status + toggle', () => {
+  it('reports signed-out and disabled without a session', async () => {
+    const status = await getSyncStatus()
+    expect(status).toEqual({
+      configured: true,
+      enabled: false,
+      signedIn: false,
+      email: null
+    })
+  })
+
+  it('refuses to enable while signed out', async () => {
+    await expect(enableSync(true)).rejects.toThrow(/Sign in/)
+  })
+
+  it('persists the toggle through the core settings table and uploads a baseline', async () => {
+    signInAs('user-1')
+    await enableSync(true)
+    const setCall = testState.coreCalls.find((c) => c.type === 'set_setting')
+    expect(setCall?.payload).toEqual({ key: 'account.sync_enabled', value: true })
+    expect(testState.coreCalls.some((c) => c.type === 'get_profile')).toBe(true)
+    const upload = testState.fetches.find((f) => f.init.method === 'POST')
+    expect(upload?.url).toContain('on_conflict=user_id,device_id')
+    expect(upload?.init.headers).toMatchObject({
+      Prefer: 'resolution=merge-duplicates,return=representation'
+    })
+  })
+
+  it('refuses to enable when Supabase is unconfigured', async () => {
+    const savedUrl = testState.cfg.url
+    testState.cfg.url = ''
+    try {
+      const status = await getSyncStatus()
+      expect(status.configured).toBe(false)
+      signInAs('user-1')
+      await expect(enableSync(true)).rejects.toThrow()
+    } finally {
+      testState.cfg.url = savedUrl
+    }
+  })
+
+  it('disabling stops without any network call', async () => {
+    signInAs('user-1')
+    const status = await enableSync(false)
+    expect(status.enabled).toBe(false)
+    expect(testState.fetches.filter((f) => f.init.method === 'POST')).toHaveLength(0)
+  })
+})
+
+describe('snapshot gather/restore', () => {
+  it('gathers memory rows and both authored files', async () => {
+    const payload = await gatherSnapshot()
+    expect(payload.version).toBe(1)
+    expect(payload.profile).toEqual({ favorite_color: 'blue' })
+    expect(payload.people).toHaveLength(1)
+    expect(payload.dates).toHaveLength(1)
+    expect(payload.agents_md).toBe('# About Me')
+    expect(payload.vision_md).toBe('# Personality')
+  })
+
+  it('restores people by name (update existing) and writes only non-empty files', async () => {
+    await restoreSnapshot({
+      version: 1,
+      profile: { favorite_color: 'red' },
+      people: [
+        { id: 'remote-1', name: 'maya', relationship: 'sister' },
+        { name: 'New Friend', gift_ideas: 'tea' }
+      ],
+      dates: [{ date: '12-24', label: 'Trip', recurring: false }],
+      agents_md: '# About Me (from laptop)',
+      vision_md: ''
+    })
+    // Existing person matched case-insensitively → update, not duplicate.
+    const update = testState.coreCalls.find((c) => c.type === 'update_person_memory')
+    expect(update?.payload).toEqual({ person_id: 'p1', fields: { relationship: 'sister' } })
+    expect(testState.coreCalls.some((c) => c.type === 'add_person_memory')).toBe(true)
+    // Empty VISION.md content is skipped, never wipes the local file.
+    const writes = testState.coreCalls.filter((c) => c.type === 'write_file')
+    expect(writes).toHaveLength(1)
+    expect(writes[0].payload).toEqual({ path: 'AGENTS.md', content: '# About Me (from laptop)' })
+  })
+
+  it('rejects unknown payload versions', async () => {
+    await expect(
+      restoreSnapshot({ version: 99 } as unknown as Parameters<typeof restoreSnapshot>[0])
+    ).rejects.toThrow(/format/)
+  })
+})
+
+describe('supabase REST', () => {
+  beforeEach(() => {
+    signInAs('user-42')
+  })
+
+  it('uploads under the user token with the anon key and device identity', async () => {
+    const token = makeJwt('user-42')
+    await uploadSnapshot()
+    const post = testState.fetches.find((f) => f.init.method === 'POST')
+    expect(post).toBeDefined()
+    const headers = post!.init.headers as Record<string, string>
+    expect(headers.Authorization).toBe(`Bearer ${token}`)
+    expect(headers.apikey).toBe('test-anon-key')
+    const body = JSON.parse(String(post!.init.body)) as Record<string, unknown>
+    expect(body.user_id).toBe('user-42')
+    expect(typeof body.device_id).toBe('string')
+    expect(typeof body.device_name).toBe('string')
+    expect(body.payload).toMatchObject({ version: 1 })
+  })
+
+  it('keeps one stable device id across uploads', async () => {
+    await uploadSnapshot()
+    await uploadSnapshot()
+    const posts = testState.fetches.filter((f) => f.init.method === 'POST')
+    expect(posts).toHaveLength(2)
+    const first = JSON.parse(String(posts[0].init.body)) as { device_id: string }
+    const second = JSON.parse(String(posts[1].init.body)) as { device_id: string }
+    expect(first.device_id).toBe(second.device_id)
+  })
+
+  it('lists snapshots flagging this device', async () => {
+    await uploadSnapshot() // creates the local device identity file
+    const deviceId = (
+      JSON.parse(readFileSync(join(testState.userData, 'sync-device.json'), 'utf-8')) as {
+        deviceId: string
+      }
+    ).deviceId
+    testState.nextFetchResponse = new Response(
+      JSON.stringify([
+        { device_id: 'dev-a', device_name: 'Laptop', created_at: '2026-08-21T10:00:00Z' },
+        { device_id: deviceId, device_name: 'This', created_at: '2026-08-20T09:00:00Z' }
+      ]),
+      { status: 200 }
+    )
+    const snapshots = await listSnapshots()
+    expect(snapshots).toHaveLength(2)
+    expect(snapshots.filter((s) => s.isThisDevice)).toHaveLength(1)
+    // GET carries the user token + anon key (RLS does the scoping).
+    const get = testState.fetches[testState.fetches.length - 1]
+    const getHeaders = get.init.headers as Record<string, string>
+    expect(getHeaders.apikey).toBe('test-anon-key')
+    expect(getHeaders.Authorization).toMatch(/^Bearer /)
+    expect(get.url).toContain('order=created_at.desc&limit=50')
+  })
+
+  it('restores only the picked device snapshot through versioned writes', async () => {
+    testState.nextFetchResponse = new Response(
+      JSON.stringify([
+        {
+          payload: {
+            version: 1,
+            profile: {},
+            people: [],
+            dates: [],
+            agents_md: 'A',
+            vision_md: 'V'
+          }
+        }
+      ]),
+      { status: 200 }
+    )
+    await restoreFromDevice('dev-a')
+    const url = testState.fetches[testState.fetches.length - 1].url
+    expect(url).toContain('device_id=eq.dev-a')
+    expect(url).toContain('order=created_at.desc&limit=1')
+    expect(testState.coreCalls.filter((c) => c.type === 'write_file')).toHaveLength(2)
+  })
+
+  it('surfaces a friendly error when nothing is there', async () => {
+    testState.nextFetchResponse = new Response('[]', { status: 200 })
+    await expect(restoreFromDevice('dev-none')).rejects.toThrow(/backup/)
+  })
+})

--- a/collie-ui/src/main/cloud-sync.ts
+++ b/collie-ui/src/main/cloud-sync.ts
@@ -1,0 +1,421 @@
+/**
+ * Collie account cloud sync — per-device snapshots, strictly opt-in
+ * (docs/engineering/architecture/account-cloud-sync.md).
+ *
+ * Product rules:
+ * - Sync is OFF by default; the user flips it in Settings → Account.
+ * - Each computer keeps ONE snapshot online under its own device id —
+ *   uploading again replaces that device's snapshot (never accumulates).
+ * - Restoring is an explicit choice: the user sees their devices' snapshots
+ *   and picks one. Restore writes through the same versioned paths as manual
+ *   edits (artifact versioning), so it is reviewable and undoable.
+ * - Nothing sensitive ever uploads: no API keys (OS keychain only), no
+ *   conversations, plans, approvals, connectors, or messenger data.
+ *
+ * Online shape: one row per (user, device) in `user_sync_snapshots`, RLS-
+ * scoped to auth.uid(). Access uses the signed-in user's access token with
+ * the public anon key over HTTPS. No service role anywhere.
+ */
+import { randomUUID } from 'crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { app } from 'electron'
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../shared/account-config'
+import { getStoredSession } from './account-auth'
+import { commandWithCore } from './core-client'
+
+/** Settings key (local SQLite via the core) for the opt-in toggle. */
+const SYNC_TOGGLE_KEY = 'account.sync_enabled'
+
+const SYNCED_FILES = ['AGENTS.md', 'VISION.md'] as const
+
+/** REST timeout — bounded so a hanging network never hangs the UI. */
+const HTTP_TIMEOUT_MS = 15_000
+
+export interface SyncSnapshotSummary {
+  deviceId: string
+  deviceName: string
+  createdAt: string | null
+  isThisDevice: boolean
+}
+
+export interface SyncStatus {
+  configured: boolean
+  enabled: boolean
+  signedIn: boolean
+  email: string | null
+}
+
+interface StoredSessionLike {
+  access_token: string
+  expires_at: number
+  email: string
+}
+
+/* ------------------------------------------------------------------ *
+ * Device identity
+ * ------------------------------------------------------------------ */
+
+function deviceFilePath(): string {
+  return join(app.getPath('userData'), 'sync-device.json')
+}
+
+/**
+ * Stable per-install device id + readable name. Created on first use and
+ * persisted; the name can be re-derived if the file is deleted.
+ */
+function loadDeviceIdentity(): { deviceId: string; deviceName: string } {
+  const path = deviceFilePath()
+  try {
+    if (existsSync(path)) {
+      const raw = JSON.parse(readFileSync(path, 'utf-8')) as {
+        deviceId?: unknown
+        deviceName?: unknown
+      }
+      if (typeof raw.deviceId === 'string' && raw.deviceId) {
+        return {
+          deviceId: raw.deviceId,
+          deviceName:
+            typeof raw.deviceName === 'string' && raw.deviceName
+              ? raw.deviceName
+              : defaultDeviceName()
+        }
+      }
+    }
+  } catch {
+    // Corrupt file → regenerate below.
+  }
+  const identity = { deviceId: randomUUID(), deviceName: defaultDeviceName() }
+  try {
+    mkdirSync(app.getPath('userData'), { recursive: true })
+    writeFileSync(path, JSON.stringify(identity, null, 2), 'utf-8')
+  } catch {
+    // Best effort: an unreadable userData dir fails later at upload time.
+  }
+  return identity
+}
+
+function defaultDeviceName(): string {
+  const osLabel =
+    process.platform === 'win32'
+      ? 'Windows'
+      : process.platform === 'darwin'
+        ? 'Mac'
+        : process.platform === 'linux'
+          ? 'Linux'
+          : process.platform
+  return `${osLabel} computer`
+}
+
+/* ------------------------------------------------------------------ *
+ * Toggle persistence (local settings table via the core)
+ * ------------------------------------------------------------------ */
+
+async function readToggle(): Promise<boolean> {
+  try {
+    const data = (await commandWithCore('get_settings', {})) as {
+      settings?: Record<string, unknown>
+    }
+    return data?.settings?.[SYNC_TOGGLE_KEY] === true
+  } catch {
+    return false
+  }
+}
+
+async function writeToggle(value: boolean): Promise<void> {
+  // `account.sync_enabled` is on the core's shell-settable allowlist
+  // (_IPC_SETTABLE_SETTINGS) — a plain boolean opt-in, deliberately not
+  // guarded like permission/messenger settings.
+  await commandWithCore('set_setting', { key: SYNC_TOGGLE_KEY, value })
+}
+
+/* ------------------------------------------------------------------ *
+ * Snapshot payload (gather / restore)
+ * ------------------------------------------------------------------ */
+
+export interface SyncPayload {
+  version: 1
+  profile: Record<string, unknown>
+  people: unknown[]
+  dates: unknown[]
+  agents_md: string
+  vision_md: string
+}
+
+async function coreCommand<T>(type: string, payload: Record<string, unknown>): Promise<T> {
+  return (await commandWithCore(type, payload)) as T
+}
+
+/** Gather everything in §3 of the spec through the existing core IPC. */
+export async function gatherSnapshot(): Promise<SyncPayload> {
+  const [profileData, peopleData, datesData, agents, vision] = await Promise.all([
+    coreCommand<{ profile?: Record<string, unknown> }>('get_profile', {}),
+    coreCommand<{ people?: unknown[] }>('get_people', {}),
+    coreCommand<{ dates?: unknown[] }>('get_dates', {}),
+    coreCommand<{ content?: string }>('read_file', { path: 'AGENTS.md' }),
+    coreCommand<{ content?: string }>('read_file', { path: 'VISION.md' })
+  ])
+  return {
+    version: 1,
+    profile: profileData?.profile ?? {},
+    people: Array.isArray(peopleData?.people) ? peopleData.people : [],
+    dates: Array.isArray(datesData?.dates) ? datesData.dates : [],
+    agents_md: typeof agents?.content === 'string' ? agents.content : '',
+    vision_md: typeof vision?.content === 'string' ? vision.content : ''
+  }
+}
+
+/**
+ * Restore a payload through the app's normal write paths: MD files go
+ * through `write_file` (versioned + undoable), memory rows through the
+ * same person/date/profile commands the Settings UI itself uses.
+ */
+export async function restoreSnapshot(payload: SyncPayload): Promise<void> {
+  if (!payload || payload.version !== 1) {
+    throw new Error("This backup isn't a format this Collie understands.")
+  }
+
+  // Memory first (structured rows), then the two authored files.
+  const profile = isRecord(payload.profile) ? payload.profile : {}
+  for (const [key, value] of Object.entries(profile)) {
+    await coreCommand('set_profile_memory', { key, value: String(value ?? '') })
+  }
+
+  const people = Array.isArray(payload.people) ? payload.people : []
+  const existingPeople = await coreCommand<{ people?: Array<Record<string, unknown>> }>(
+    'get_people',
+    {}
+  )
+  const existingByName = new Map<string, string>()
+  for (const person of existingPeople?.people ?? []) {
+    if (isRecord(person) && typeof person.name === 'string') {
+      existingByName.set(person.name.toLowerCase(), String(person.id ?? ''))
+    }
+  }
+  for (const entry of people) {
+    if (!isRecord(entry) || typeof entry.name !== 'string' || !entry.name.trim()) continue
+    const fields = pickPersonFields(entry)
+    const knownId = existingByName.get(entry.name.toLowerCase())
+    if (knownId) {
+      await coreCommand('update_person_memory', { person_id: knownId, fields })
+    } else {
+      await coreCommand('add_person_memory', { fields: { ...fields, name: entry.name } })
+    }
+  }
+
+  const dates = Array.isArray(payload.dates) ? payload.dates : []
+  for (const entry of dates) {
+    if (!isRecord(entry)) continue
+    const date = typeof entry.date === 'string' ? entry.date : ''
+    const label = typeof entry.label === 'string' ? entry.label : ''
+    if (!date || !label) continue
+    // Dates are content-addressed enough for v1: skip exact duplicates the
+    // machine already has instead of stacking copies on every restore.
+    const existing = await coreCommand<{ dates?: Array<Record<string, unknown>> }>(
+      'get_dates',
+      {}
+    )
+    const duplicate = (existing?.dates ?? []).some(
+      (d) => isRecord(d) && d.date === date && d.label === label
+    )
+    if (duplicate) continue
+    await coreCommand('add_date_memory', { date, label, recurring: Boolean(entry.recurring) })
+  }
+
+  for (const [file, key] of [
+    ['AGENTS.md', 'agents_md'],
+    ['VISION.md', 'vision_md']
+  ] as const) {
+    const content = payload[key]
+    if (typeof content !== 'string' || !content.trim()) continue
+    await coreCommand('write_file', { path: file, content })
+  }
+}
+
+function pickPersonFields(person: Record<string, unknown>): Record<string, string> {
+  const fields: Record<string, string> = {}
+  for (const field of [
+    'relationship',
+    'birthday',
+    'allergies',
+    'preferences',
+    'gift_ideas',
+    'notes'
+  ] as const) {
+    const value = person[field]
+    if (typeof value === 'string' && value.trim()) fields[field] = value
+  }
+  return fields
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/* ------------------------------------------------------------------ *
+ * Supabase REST (user token + anon key, RLS does the rest)
+ * ------------------------------------------------------------------ */
+
+function requireSession(): StoredSessionLike {
+  const session = getStoredSession()
+  if (!session?.access_token) throw new Error('Sign in to Collie first.')
+  return session as StoredSessionLike
+}
+
+function supabaseConfig(): { base: string; anonKey: string } {
+  const base = SUPABASE_URL.replace(/\/+$/, '')
+  const anonKey = SUPABASE_ANON_KEY
+  if (!base || !anonKey) throw new Error('Collie account sync is not configured yet.')
+  return { base, anonKey }
+}
+
+async function supabaseFetch(
+  path: string,
+  init: RequestInit & { session: StoredSessionLike }
+): Promise<Response> {
+  const session = init.session
+  const { base, anonKey } = supabaseConfig()
+  const headers: Record<string, string> = {
+    apikey: anonKey,
+    Authorization: `Bearer ${session.access_token}`,
+    'Content-Type': 'application/json',
+    ...((init.headers as Record<string, string>) ?? {})
+  }
+  return fetch(`${base}${path}`, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
+  })
+}
+
+/* ------------------------------------------------------------------ *
+ * Public API (wired to IPC by main/index.ts)
+ * ------------------------------------------------------------------ */
+
+export async function getSyncStatus(): Promise<SyncStatus> {
+  let signedIn = false
+  let email: string | null = null
+  try {
+    const session = getStoredSession()
+    signedIn = Boolean(session?.access_token)
+    email = signedIn ? session!.email || null : null
+  } catch {
+    signedIn = false
+  }
+  const enabled = signedIn ? await readToggle() : false
+  return {
+    configured: Boolean(SUPABASE_URL && SUPABASE_ANON_KEY),
+    enabled,
+    signedIn,
+    email
+  }
+}
+
+export async function enableSync(enabled: boolean): Promise<SyncStatus> {
+  const status = await getSyncStatus()
+  if (enabled && !status.signedIn) {
+    throw new Error('Sign in to Collie before turning on syncing.')
+  }
+  await writeToggle(enabled)
+  if (enabled) {
+    // First flip = immediate baseline upload, so "on" means backed up.
+    await uploadSnapshot()
+  }
+  return getSyncStatus()
+}
+
+/** Upload/replace THIS device's snapshot (upsert on user_id+device_id). */
+export async function uploadSnapshot(): Promise<{ uploadedAt: string }> {
+  const session = requireSession()
+  const { deviceId, deviceName } = loadDeviceIdentity()
+  const payload = await gatherSnapshot()
+
+  // One row per device: the table has a UNIQUE (user_id, device_id)
+  // constraint and we upsert on it (merge-duplicates), so re-uploading
+  // replaces this device's snapshot — never accumulates copies.
+  const response = await supabaseFetch(
+    '/rest/v1/user_sync_snapshots?on_conflict=user_id,device_id',
+    {
+      method: 'POST',
+      session,
+      headers: {
+        Prefer: 'resolution=merge-duplicates,return=representation'
+      },
+      body: JSON.stringify({
+        user_id: decodeUserId(session.access_token),
+        device_id: deviceId,
+        device_name: deviceName,
+        payload
+      })
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`Backup didn't go through (${response.status}). Please try again.`)
+  }
+  const rows = (await response.json().catch(() => [])) as Array<{ created_at?: string }>
+  return { uploadedAt: rows?.[0]?.created_at ?? new Date().toISOString() }
+}
+
+/** List the account's device snapshots (this device flagged). */
+export async function listSnapshots(): Promise<SyncSnapshotSummary[]> {
+  const session = requireSession()
+  const { deviceId } = loadDeviceIdentity()
+  const response = await supabaseFetch(
+    '/rest/v1/user_sync_snapshots?select=device_id,device_name,created_at&order=created_at.desc&limit=50',
+    { method: 'GET', session }
+  )
+  if (!response.ok) {
+    throw new Error(`Couldn't reach your backups (${response.status}). Please try again.`)
+  }
+  const rows = (await response.json().catch(() => [])) as Array<{
+    device_id?: string
+    device_name?: string
+    created_at?: string
+  }>
+  return (rows ?? [])
+    .filter((row) => typeof row.device_id === 'string')
+    .map((row) => ({
+      deviceId: String(row.device_id),
+      deviceName: typeof row.device_name === 'string' ? row.device_name : 'Unknown device',
+      createdAt: typeof row.created_at === 'string' ? row.created_at : null,
+      isThisDevice: row.device_id === deviceId
+    }))
+}
+
+/** Fetch one device's full snapshot and restore it locally. */
+export async function restoreFromDevice(deviceId: string): Promise<void> {
+  if (typeof deviceId !== 'string' || !deviceId.trim()) {
+    throw new Error('Pick a device to restore from.')
+  }
+  const session = requireSession()
+  const url =
+    '/rest/v1/user_sync_snapshots' +
+    `?select=payload&device_id=eq.${encodeURIComponent(deviceId)}` +
+    '&order=created_at.desc&limit=1'
+  const response = await supabaseFetch(url, { method: 'GET', session })
+  if (!response.ok) {
+    throw new Error(`Couldn't reach your backups (${response.status}). Please try again.`)
+  }
+  const rows = (await response.json().catch(() => [])) as Array<{
+    payload?: unknown
+  }>
+  const payload = rows?.[0]?.payload
+  if (!payload) throw new Error("That device doesn't have a backup to restore.")
+  await restoreSnapshot(payload as SyncPayload)
+}
+
+/** Decode the `sub` claim (auth.uid) for insert payloads. Display-only JWT use. */
+function decodeUserId(accessToken: string): string {
+  try {
+    const parts = accessToken.split('.')
+    if (parts.length === 3) {
+      const claims = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as {
+        sub?: unknown
+      }
+      if (typeof claims.sub === 'string' && claims.sub) return claims.sub
+    }
+  } catch {
+    // Fall through to the explicit error.
+  }
+  throw new Error('Your session looks unusual — sign in again.')
+}

--- a/collie-ui/src/main/core-client.ts
+++ b/collie-ui/src/main/core-client.ts
@@ -121,3 +121,25 @@ export async function pushStoredSecretsToCore(): Promise<void> {
     pushInFlight = false
   }
 }
+
+/**
+ * One-off main-process command to the core over a fresh socket. Used by the
+ * account cloud-sync module (gather/restore/toggle) — the same authenticated
+ * WebSocket the shell already uses for secret pushes; the renderer is never
+ * involved and never sees these payloads.
+ */
+export async function commandWithCore(
+  type: string,
+  payload: Record<string, unknown>
+): Promise<unknown> {
+  const ws = await openCoreSocket()
+  try {
+    return await command(ws, type, payload)
+  } finally {
+    try {
+      ws.close()
+    } catch {
+      // already closed
+    }
+  }
+}

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -25,6 +25,13 @@ import {
 } from './secrets'
 import { pushStoredSecretsToCore } from './core-client'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
+import {
+ enableSync,
+ getSyncStatus,
+ listSnapshots,
+ restoreFromDevice,
+ uploadSnapshot
+} from './cloud-sync'
 import { autoUpdater } from 'electron-updater'
 import {
   ActiveWorkTracker,
@@ -369,6 +376,13 @@ function registerIpc(): void {
   handle('account:start-sign-in', () => startAccountSignIn())
   handle('account:get-state', () => getAccountState())
   handle('account:sign-out', () => signOut())
+  // Account cloud sync (account-cloud-sync.md): per-device snapshots,
+  // opt-in. Payloads never include secrets; RLS scopes every REST call.
+  handle('account:sync-status', () => getSyncStatus())
+  handle('account:sync-enable', (enabled: boolean) => enableSync(Boolean(enabled)))
+  handle('account:sync-upload', () => uploadSnapshot())
+  handle('account:sync-list', () => listSnapshots())
+  handle('account:sync-restore', (deviceId: string) => restoreFromDevice(String(deviceId)))
   handle('collie:pick-attachments', async (): Promise<SelectedAttachment[]> => {
     const options = {
       title: 'Attach files to your message',

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -38,6 +38,21 @@ export interface AccountState {
   expiresAt: number | null
 }
 
+/** Account cloud sync (account-cloud-sync.md) — display shapes only. */
+export interface SyncStatus {
+  configured: boolean
+  enabled: boolean
+  signedIn: boolean
+  email: string | null
+}
+
+export interface SyncSnapshotSummary {
+  deviceId: string
+  deviceName: string
+  createdAt: string | null
+  isThisDevice: boolean
+}
+
 export interface InstallResult {
   installed: boolean
   blockedBy: string[]
@@ -114,7 +129,17 @@ const api = {
 const accountApi = {
   startSignIn: (): Promise<AccountState> => ipcRenderer.invoke('account:start-sign-in'),
   getState: (): Promise<AccountState> => ipcRenderer.invoke('account:get-state'),
-  signOut: (): Promise<AccountState> => ipcRenderer.invoke('account:sign-out')
+  signOut: (): Promise<AccountState> => ipcRenderer.invoke('account:sign-out'),
+  // Cloud sync — display-only payloads cross this bridge; the snapshot
+  // content itself stays in the main process (same rule as account state).
+  syncStatus: (): Promise<SyncStatus> => ipcRenderer.invoke('account:sync-status'),
+  syncEnable: (enabled: boolean): Promise<SyncStatus> =>
+    ipcRenderer.invoke('account:sync-enable', enabled),
+  syncUpload: (): Promise<{ uploadedAt: string }> =>
+    ipcRenderer.invoke('account:sync-upload'),
+  syncList: (): Promise<SyncSnapshotSummary[]> => ipcRenderer.invoke('account:sync-list'),
+  syncRestore: (deviceId: string): Promise<void> =>
+    ipcRenderer.invoke('account:sync-restore', deviceId)
 }
 
 contextBridge.exposeInMainWorld('collie', api)

--- a/collie-ui/src/renderer/src/components/settings/AccountTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/AccountTab.tsx
@@ -1,14 +1,32 @@
-import { LogIn, LogOut } from 'lucide-react'
+import { CloudUpload, History, LogIn, LogOut, RotateCcw } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 /** Display-only account state, typed from the preload bridge (`window.account`). */
 type AccountState = Awaited<ReturnType<typeof window.account.getState>>
+type SyncStatus = Awaited<ReturnType<typeof window.account.syncStatus>>
+type SnapshotSummary = Awaited<ReturnType<typeof window.account.syncList>>[number]
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit'
+    })
+  } catch {
+    return ''
+  }
+}
 
 /**
  * Collie account card (account-system-spec.md §6): sign in via the system
  * browser (PKCE + localhost callback handled in the main process), show the
- * signed-in email, and sign out. The session itself never reaches the
- * renderer — only the display state does.
+ * signed-in email, and sign out. Below it, the opt-in cloud backup
+ * (account-cloud-sync.md): each computer keeps one snapshot online, and
+ * restoring from another computer is always an explicit choice. The session
+ * and snapshot contents never reach the renderer — display state only.
  */
 export default function AccountTab(): React.JSX.Element {
   const [state, setState] = useState<AccountState>({
@@ -16,13 +34,30 @@ export default function AccountTab(): React.JSX.Element {
     email: null,
     expiresAt: null
   })
+  const [sync, setSync] = useState<SyncStatus | null>(null)
+  const [snapshots, setSnapshots] = useState<SnapshotSummary[]>([])
   const [busy, setBusy] = useState(false)
+  const [syncBusy, setSyncBusy] = useState(false)
   const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
 
   useEffect(() => {
     if (typeof window.account?.getState !== 'function') return
     void window.account.getState().then(setState).catch(() => undefined)
+    void window.account.syncStatus().then(setSync).catch(() => undefined)
   }, [])
+
+  const refreshSnapshots = (): void => {
+    if (typeof window.account?.syncList !== 'function') return
+    void window.account
+      .syncList()
+      .then(setSnapshots)
+      .catch(() => setSnapshots([]))
+  }
+
+  useEffect(() => {
+    if (state.signedIn && sync?.enabled) refreshSnapshots()
+  }, [state.signedIn, sync?.enabled])
 
   const handleSignIn = (): void => {
     if (typeof window.account?.startSignIn !== 'function') return
@@ -30,7 +65,10 @@ export default function AccountTab(): React.JSX.Element {
     setError('')
     void window.account
       .startSignIn()
-      .then(setState)
+      .then((next) => {
+        setState(next)
+        return window.account.syncStatus().then(setSync)
+      })
       .catch((signInError) =>
         setError(
           signInError instanceof Error
@@ -47,7 +85,10 @@ export default function AccountTab(): React.JSX.Element {
     setError('')
     void window.account
       .signOut()
-      .then(setState)
+      .then((next) => {
+        setState(next)
+        return window.account.syncStatus().then(setSync)
+      })
       .catch((signOutError) =>
         setError(
           signOutError instanceof Error
@@ -56,6 +97,83 @@ export default function AccountTab(): React.JSX.Element {
         )
       )
       .finally(() => setBusy(false))
+  }
+
+  const handleToggleSync = (): void => {
+    if (!sync) return
+    const turningOn = !sync.enabled
+    if (
+      turningOn &&
+      !window.confirm(
+        'Back up your memories online?\n\n' +
+          'Collie saves a copy of what she remembers — facts, people, ' +
+          'important dates, About Me, and her personality — to your account, ' +
+          'so another computer with Collie can pick them up.\n\n' +
+          'Chats, files, and API keys are never uploaded.'
+      )
+    ) {
+      return
+    }
+    setSyncBusy(true)
+    setError('')
+    setNotice('')
+    void window.account
+      .syncEnable(turningOn)
+      .then((next) => {
+        setSync(next)
+        setNotice(
+          turningOn
+            ? 'Backup is on — this computer’s copy is saved to your account.'
+            : 'Backup is off. Nothing else will be uploaded.'
+        )
+        if (turningOn) refreshSnapshots()
+      })
+      .catch((syncError) =>
+        setError(syncError instanceof Error ? syncError.message : 'Could not change that.')
+      )
+      .finally(() => setSyncBusy(false))
+  }
+
+  const handleBackupNow = (): void => {
+    if (typeof window.account?.syncUpload !== 'function') return
+    setSyncBusy(true)
+    setError('')
+    setNotice('')
+    void window.account
+      .syncUpload()
+      .then(() => {
+        setNotice('Saved. This computer’s copy is up to date.')
+        refreshSnapshots()
+      })
+      .catch((uploadError) =>
+        setError(uploadError instanceof Error ? uploadError.message : 'Backup didn’t go through.')
+      )
+      .finally(() => setSyncBusy(false))
+  }
+
+  const handleRestore = (snapshot: SnapshotSummary): void => {
+    if (
+      !window.confirm(
+        `Bring ${snapshot.deviceName}'s copy to this computer?\n\n` +
+          'This replaces what Collie remembers here — facts, people, dates, ' +
+          'About Me, and personality. You can undo file changes afterwards, ' +
+          'and nothing on your other computer is touched.'
+      )
+    ) {
+      return
+    }
+    setSyncBusy(true)
+    setError('')
+    setNotice('')
+    void window.account
+      .syncRestore(snapshot.deviceId)
+      .then(() => setNotice(`Done — this Collie now matches ${snapshot.deviceName}.`))
+      .catch((restoreError) =>
+        setError(
+          restoreError instanceof Error ? restoreError.message : 'Restore didn’t finish.'
+        )
+      )
+      .finally(() => setSyncBusy(false))
   }
 
   return (
@@ -69,9 +187,79 @@ export default function AccountTab(): React.JSX.Element {
             Signed in as <strong>{state.email}</strong>. Your chats and files
             stay on this computer — the account is just your identity.
           </p>
+
+          <div style={{ marginTop: 12 }}>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={Boolean(sync?.enabled)}
+                disabled={syncBusy || !sync?.configured}
+                onChange={handleToggleSync}
+              />
+              Back up my memories online
+            </label>
+            <p className="settings-lead" style={{ fontSize: '0.85em' }}>
+              Saves what Collie remembers — facts, people, important dates,
+              About Me, and personality — to your account. Chats, files, and
+              keys are never uploaded, and you can turn this off anytime.
+            </p>
+          </div>
+
+          {sync?.enabled && (
+            <div style={{ marginTop: 10 }}>
+              <button
+                type="button"
+                className="settings-button"
+                onClick={handleBackupNow}
+                disabled={syncBusy}
+              >
+                <CloudUpload size={14} /> {syncBusy ? 'Working…' : 'Back up now'}
+              </button>
+
+              {snapshots.length > 0 && (
+                <div style={{ marginTop: 12 }}>
+                  <div
+                    className="mb-2 text-xs font-medium uppercase tracking-wide"
+                    style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+                  >
+                    <History size={12} /> Copies saved by your computers
+                  </div>
+                  {snapshots.map((snapshot) => (
+                    <div
+                      key={snapshot.deviceId}
+                      className="flex items-center justify-between gap-2 py-1"
+                    >
+                      <span style={{ fontSize: '0.9em' }}>
+                        <strong>{snapshot.isThisDevice ? 'This computer' : snapshot.deviceName}</strong>
+                        {snapshot.createdAt && (
+                          <span style={{ opacity: 0.7 }}> · {formatWhen(snapshot.createdAt)}</span>
+                        )}
+                      </span>
+                      {!snapshot.isThisDevice && (
+                        <button
+                          type="button"
+                          className="rounded-lg border px-3 py-1.5 text-xs font-medium"
+                          style={{ borderColor: 'var(--collie-border)' }}
+                          disabled={syncBusy}
+                          onClick={() => handleRestore(snapshot)}
+                        >
+                          <RotateCcw size={11} /> Bring here
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                  <p className="settings-lead" style={{ fontSize: '0.8em', opacity: 0.7 }}>
+                    Restoring never changes your other computers.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
           <button
             type="button"
             className="settings-button"
+            style={{ marginTop: 12 }}
             onClick={handleSignOut}
             disabled={busy}
           >
@@ -94,9 +282,9 @@ export default function AccountTab(): React.JSX.Element {
           </button>
         </>
       )}
-      {error && (
+      {(error || notice) && (
         <p className="inline-notice" role="status">
-          {error}
+          {error || notice}
         </p>
       )}
     </section>

--- a/docs/engineering/architecture/account-cloud-sync.md
+++ b/docs/engineering/architecture/account-cloud-sync.md
@@ -1,0 +1,125 @@
+# Account Cloud Sync — per-device snapshots, opt-in
+
+> Status: **spec** (2026-08-22) · Owner: Rick · Scope: Supabase + Electron app
+> Amends `account-system-spec.md` §1: the v1 non-goal "no cross-device sync of
+> conversations/settings" is narrowed — **identity-level data** (memory,
+> About Me, personality, settings mirror) may sync, strictly opt-in. The
+> local-first story is unchanged: nothing uploads unless the user flips the
+> toggle, and turning it off stops all uploads (local data is never deleted).
+
+## 1. Product rules (the promises we make users)
+
+1. **Opt-in only.** Sync is OFF by default. The toggle lives in
+   Settings → Account, next to the sign-in state, in plain language.
+2. **Per-device snapshots.** Each computer uploads its own snapshot under its
+   own device name. There is always exactly one "latest version" per computer
+   online. Restoring is a **choice**, never automatic: the user sees their
+   devices' snapshots and picks which one to take.
+3. **Local is never clobbered silently.** A restore writes through the same
+   versioned paths the app already uses (artifact versioning, undo journal) —
+   a restore is undoable like any other change.
+4. **Nothing sensitive leaves.** API keys, connector tokens, conversations,
+   plans, approvals never sync. Only the items in §3.
+5. **Sign out = sync stops.** Local data stays. Online snapshots stay until
+   account deletion removes them.
+
+## 2. Why per-device snapshots (not live row sync)
+
+- **Understandable to non-coders.** "This computer's version from yesterday"
+  beats conflict resolution UI. No merge dialogs, no last-write-wins surprises.
+- **Bounded scope.** No change-detection plumbing, no background daemon, no
+  battery/CPU cost. Upload happens only on explicit "Back up now" and on
+  sign-in (if enabled). Restore happens only on explicit "Restore".
+- **Matches the 2-computer story.** The user's mental model: each Collie
+  keeps its own copy online; a new computer borrows one.
+
+## 3. What syncs
+
+| Item | Source (local) | Online shape |
+|---|---|---|
+| Profile memory (facts) | `profile` table | JSON map |
+| People | `people` table | JSON array |
+| Important dates | `important_dates` table | JSON array |
+| About Me (AGENTS.md) | workspace file | text |
+| Personality (VISION.md) | workspace file | text |
+
+**Settings mirror: deliberately cut from v1.** The core intentionally blocks
+shell writes to most settings keys (`_IPC_SETTABLE_SETTINGS` defense-in-depth),
+and a synced provider/model without its OS-keychain API key is useless on a
+fresh machine anyway. Provider setup stays per-machine; revisit in v2 if the
+core exposes safe setters.
+
+Conversations, plans, approvals, automations, connectors, messengers:
+**never sync** (v2 question at the earliest).
+
+## 4. Data model (Supabase, existing project)
+
+```sql
+create table if not exists public.user_sync_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  device_id text not null,            -- stable random id, generated per install
+  device_name text not null,          -- user-readable, e.g. "Rick's laptop"
+  payload jsonb not null,             -- §3 shape
+  created_at timestamptz not null default now()
+);
+create index if not exists user_sync_snapshots_user_idx
+  on public.user_sync_snapshots (user_id, created_at desc);
+
+alter table public.user_sync_snapshots enable row level security;
+
+create policy "own rows only"
+  on public.user_sync_snapshots
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+```
+
+- One row per (user, device): the app **upserts** on `(user_id, device_id)`.
+- RLS: every operation scoped to `auth.uid()`; anon key only, no service role
+  on any client. A second user's rows are invisible, full stop.
+- Account deletion (`delete_my_account()`) cascades here via the FK.
+
+## 5. App flow (Electron main process, `cloud-sync.ts`)
+
+**Upload ("Back up now" + auto on sign-in when enabled):**
+1. Gather §3 via the existing core IPC (`get_profile`, people/dates lists,
+   `read_file` for the two MDs).
+2. `POST /rest/v1/user_sync_snapshots` with `Prefer: resolution=merge-duplicates`
+   on the conflict target `(user_id, device_id)` — the device's single latest
+   snapshot, per the product rule.
+3. Show plain-language result. Failures never block sign-in or app usage.
+
+**Restore (explicit pick, never automatic):**
+1. `GET` the user's snapshots (RLS scopes them), show device name + time.
+2. On pick: write through existing versioned paths — `write_file` for the MDs
+   (versioned + undoable), core IPC for profile/people/dates.
+3. Confirm dialog states what will be replaced, in plain language.
+
+**Toggle:** stored locally (`settings` key `account.sync_enabled`, default
+off). Turning it on does the first upload immediately. Turning it off stops
+uploads; online copies remain until account deletion.
+
+**Device identity:** `device_id` = random UUID persisted in userData on first
+run; `device_name` = `<username>'s <os>` at first upload, editable later (v2).
+
+## 6. Security checklist
+
+- [x] RLS own-rows-only policy on `user_sync_snapshots` (verified: anon
+      insert/select/update/delete all rejected; unauthenticated select empty)
+- [x] Anon key only in the app; no service role anywhere client-side
+- [x] No secrets in payload (keychain items excluded by allowlist)
+- [x] Restore writes are versioned + undoable (same rails as manual edits)
+- [x] Sync traffic uses the user's own access token over HTTPS; tokens at
+      rest already safeStorage-encrypted (account-auth.ts)
+- [x] Account deletion cascades snapshots (FK `on delete cascade`)
+
+## 7. Verification matrix
+
+- Toggle on with no account → toggle disabled, plain-language hint
+- Sign in → (if enabled) snapshot appears in Supabase with device name
+- Back up twice → still one row per device (upsert, not accumulate)
+- Second device sign-in → sees first device's snapshot, restores, content
+  matches (MDs, memory, settings), undo works after restore
+- Sign out → no further uploads; toggle persists for next sign-in
+- Anon/cross-user access → blocked by RLS (tested via REST)

--- a/docs/engineering/architecture/account-system-spec.md
+++ b/docs/engineering/architecture/account-system-spec.md
@@ -2,6 +2,9 @@
 
 > Status: **spec** (2026-08-17) · Owner: Rick · Scope: website + Supabase backend + Electron app + email
 > Decision history: supersedes the 08-11 "no-account v1" decision (waitlist = email-only). Accounts now exist, but **local-first stays the product story** — the account never becomes a data hostage.
+> Amendment (2026-08-22): opt-in per-device backup of memory/personality is
+> now specified in `account-cloud-sync.md` — narrowing the "no sync" non-goal
+> below to conversations/plans/approvals only.
 
 ## 1. Goals / Non-goals
 

--- a/supabase/migrations/0001_user_sync_snapshots.sql
+++ b/supabase/migrations/0001_user_sync_snapshots.sql
@@ -1,0 +1,26 @@
+-- Collie account cloud sync — per-device snapshots (account-cloud-sync.md §4).
+-- One row per (user, device). RLS scopes every operation to auth.uid().
+-- Applied via the Supabase Management API; kept in-repo for review/replay.
+
+create table if not exists public.user_sync_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  device_id text not null,
+  device_name text not null,
+  payload jsonb not null,
+  created_at timestamptz not null default now(),
+  -- One latest snapshot per device: the app upserts on this target.
+  constraint user_sync_snapshots_user_device_key unique (user_id, device_id)
+);
+
+create index if not exists user_sync_snapshots_user_idx
+  on public.user_sync_snapshots (user_id, created_at desc);
+
+alter table public.user_sync_snapshots enable row level security;
+
+drop policy if exists "own rows only" on public.user_sync_snapshots;
+create policy "own rows only"
+  on public.user_sync_snapshots
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## What

Implements the 2-computer story from today's discussion: a user signs in on any computer and — **only if they choose to** — backs up what Collie remembers (memory facts, people, important dates, About Me, personality) to their account. A new computer can then **pick** which device's copy to restore. Each computer always keeps exactly one "latest version" online.

Spec: `docs/engineering/architecture/account-cloud-sync.md` (amends account-system-spec.md's no-sync non-goal; cross-referenced).

## Product rules

- **Opt-in only.** Off by default; toggle lives in Settings → Account with plain-language copy + confirm dialog
- **Per-device snapshots, never live sync.** One row per (user, device) via UNIQUE constraint upsert — re-uploading replaces that device's copy, never accumulates
- **Restore is an explicit choice**, never automatic: list shows each device's name + time, user picks "Bring here"; writes go through existing versioned paths (`write_file` artifact versioning = undoable), other computers are untouched
- **Nothing sensitive uploads:** API keys stay in the OS keychain; conversations/plans/approvals/connectors never leave

## Changes

| Area | What |
|---|---|
| Supabase | Migration 0001: `user_sync_snapshots` — RLS own-rows-only, FK cascade on account deletion, UNIQUE (user_id, device_id). **Applied live; verified below** |
| collie-core | `account.sync_enabled` added to shell-settable settings allowlist (plain boolean opt-in; permission/messenger keys stay core-only) |
| Main process | `cloud-sync.ts`: gather/restore via existing core IPC only (zero new Python commands), Supabase REST with the user's own token + anon key; `commandWithCore` helper; 5 guarded IPC channels |
| Preload + UI | Display-only bridge additions; AccountTab gains toggle, Back up now, per-device snapshot list with restore |

## Security checks

- [x] RLS verified **live**: anon SELECT → 200 `[]` (invisible); anon INSERT/UPSERT → 401 blocked
- [x] Anon key only client-side; no service role anywhere
- [x] Restore path reuses versioned+undoable write rails; empty synced files never wipe local ones
- [x] Account deletion cascades snapshots (FK)
- [x] No secrets in payload (keychain excluded by design)

## Gates (fresh, this branch @ b3050b0 from origin/main @ 999f32d)

- `npm run typecheck` ✅
- `npm test` → **55 files / 375 tests passed** ✅ (13 new cloud-sync tests)
- collie-core pytest → **3579 passed / 5 CI-deselected (documented Windows-only)** ✅
- ruff check + format ✅
- Live DB verification: table/constraints/RLS as above ✅

## Note for Rick

No merge performed. Known v2 follow-ups (not in this PR): editable device names, delete-a-device-snapshot button, settings-mirror once the core exposes safe setters.