### PR TITLE
feat(ui+core): normie chat cards — Today at a glance, health streaks, countdown chips, compare duel

### DIFF
--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -961,6 +961,17 @@ class CollieRuntime:
                 "message": assistant,
             }
         )
+        # Morning briefings get a seeable "Today at a glance" card (weather +
+        # next 24h reminders) under the text. Best-effort: never blocks the
+        # briefing itself.
+        if isinstance(action_config, dict) and action_config.get("kind") == "morning":
+            try:
+                from collie_core.tools.today_glance import attach_today_glance
+
+                await attach_today_glance(self.db, conv_id, self.ipc)
+            except Exception:
+                logger.exception("Today-at-a-glance card failed for {}", auto_id)
+
         await self.ipc.broadcast(
             {
                 "type": "automation",

--- a/collie-core/collie_core/tools/health.py
+++ b/collie-core/collie_core/tools/health.py
@@ -52,6 +52,22 @@ def _card(db: Any) -> str:
         else:
             break
 
+    # Per-habit dot grids for the streak view (HealthStreaks): one entry per
+    # metric per day, oldest → newest; None = nothing logged that day.
+    habit_specs = [
+        ("steps", "Steps", "👟", "#e8913a"),
+        ("water_cups", "Water", "💧", "#6baed6"),
+        ("sleep_hours", "Sleep", "😴", "#8b7ec8"),
+    ]
+    habits: list[dict[str, Any]] = []
+    for key, label, icon, color in habit_specs:
+        days: list[float | None] = []
+        for i in range(6, -1, -1):
+            day = (today - timedelta(days=i)).isoformat()
+            value = by_day.get(day, {}).get(key)
+            days.append(value if value else None)
+        habits.append({"key": key, "label": label, "icon": icon, "color": color, "days": days})
+
     weight_row = db.health_latest("weight")
     payload: dict[str, Any] = {
         "card_type": "health",
@@ -60,6 +76,7 @@ def _card(db: Any) -> str:
         "sleep_hours": _safe_float(latest.get("sleep_hours", 0)),
         "water_cups": int(_safe_float(latest.get("water_cups", 0))),
         "grid": grid,
+        "habits": habits,
     }
     if weight_row is not None:
         payload["weight"] = _safe_float(weight_row["value"])

--- a/collie-core/collie_core/tools/today_glance.py
+++ b/collie-core/collie_core/tools/today_glance.py
@@ -1,0 +1,136 @@
+"""Today-at-a-glance card data for the Morning Briefing routine (F023/F024).
+
+Collects today's weather, upcoming reminders, and important dates from the
+same local stores the chat tools use, and emits one ``today_glance`` card
+payload so the morning briefing renders as a seeable summary instead of
+prose-only. Every section degrades independently: no location or no
+reminders simply drops that row. Calendar events stay out for now — the
+calendar only speaks MCP, which needs a live service call the scheduler
+should not make synchronously.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+__all__ = ["today_glance_card", "attach_today_glance"]
+
+_MAX_REMINDERS = 3
+
+
+def _weather_section(db: Any) -> dict[str, Any] | None:
+    """Current conditions via the same open-meteo path the weather tool uses."""
+    location = str(db.get_profile("location", "") or "").strip()
+    if not location:
+        return None
+
+    # Reuse the weather tool's fetchers (blocking, so callers run this off
+    # the event loop) instead of instantiating the tool class.
+    from collie_core.tools.weather import _OPEN_METEO_FORECAST, _api_get, _geocode
+
+    try:
+        geo = _geocode(location)
+        if geo is None:
+            return None
+        params = urlencode(
+            {
+                "latitude": geo["lat"],
+                "longitude": geo["lon"],
+                "current": "temperature_2m,apparent_temperature,weather_code,is_day",
+                "daily": "weather_code,temperature_2m_max,temperature_2m_min,"
+                "precipitation_probability_max",
+                "timezone": geo["timezone"],
+                "forecast_days": "2",
+            }
+        )
+        data = _api_get(f"{_OPEN_METEO_FORECAST}?{params}")
+    except Exception:
+        # Weather must never break the morning briefing.
+        return None
+
+    current = data.get("current") if isinstance(data, dict) else None
+    if not isinstance(current, dict) or not current:
+        return None
+
+    from collie_core.tools.weather import _icon_from_code, _weather_description
+
+    try:
+        code = int(current.get("weather_code", 0) or 0)
+    except (TypeError, ValueError):
+        code = 0
+    daily = data.get("daily") if isinstance(data, dict) else None
+    times = daily.get("time", []) if isinstance(daily, dict) else []
+    highs = daily.get("temperature_2m_max", []) if isinstance(daily, dict) else []
+    lows = daily.get("temperature_2m_min", []) if isinstance(daily, dict) else []
+    rain = daily.get("precipitation_probability_max", []) if isinstance(daily, dict) else []
+
+    section: dict[str, Any] = {
+        "location": f"{geo['name']}, {geo['country']}".rstrip(", "),
+        "icon": _icon_from_code(code, bool(current.get("is_day", 1))),
+        "temp": current.get("temperature_2m"),
+        "condition": _weather_description(code),
+        "high": highs[0] if highs else None,
+        "low": lows[0] if lows else None,
+        "rain_chance": rain[0] if rain else None,
+    }
+    if times:
+        section["date"] = str(times[0])
+    return section
+
+
+def _reminders_section(db: Any) -> list[dict[str, str]]:
+    """Upcoming reminders due within the next 24 hours, soonest first."""
+    now = datetime.now(timezone.utc)  # noqa: UP017
+    horizon = now + timedelta(days=1)
+    items: list[dict[str, str]] = []
+    for row in db.list_reminders():
+        if len(items) >= _MAX_REMINDERS:
+            break
+        with contextlib.suppress(TypeError, ValueError):
+            due = datetime.fromisoformat(str(row.get("due_at") or ""))
+            if due.tzinfo is None:
+                due = due.replace(tzinfo=timezone.utc)  # noqa: UP017
+            if now <= due <= horizon:
+                items.append(
+                    {"text": str(row.get("text") or ""), "due_at": str(row.get("due_at") or "")}
+                )
+    return items
+
+
+def today_glance_card(db: Any) -> dict[str, Any] | None:
+    """Build the ``today_glance`` payload, or None when there is nothing to show."""
+    weather = _weather_section(db)
+    reminders = _reminders_section(db)
+
+    if weather is None and not reminders:
+        return None
+
+    payload: dict[str, Any] = {
+        "card_type": "today_glance",
+        "date": datetime.now().astimezone().strftime("%A, %B %d").replace(" 0", " "),
+        "reminders": reminders,
+    }
+    if weather is not None:
+        payload["weather"] = weather
+    return payload
+
+
+async def attach_today_glance(db: Any, conv_id: str, ipc: Any) -> None:
+    """Persist + broadcast the card as its own quiet assistant message.
+
+    Called by the runtime right after the morning-briefing text lands. The
+    card rides *below* the streamed text (never instead of it), so it goes
+    out as a separate message rather than mutating the briefing text. The
+    weather fetch is blocking, so it runs on a worker thread.
+    """
+    import asyncio
+
+    payload = await asyncio.to_thread(today_glance_card, db)
+    if payload is None:
+        return
+    card_type = payload.pop("card_type")
+    card = db.add_message(conv_id, "assistant", "", card_type=card_type, card_data=payload)
+    await ipc.broadcast({"type": "message", "conversation_id": conv_id, "message": card})

--- a/collie-core/tests/collie/test_life_tools_phase3.py
+++ b/collie-core/tests/collie/test_life_tools_phase3.py
@@ -154,6 +154,7 @@ async def test_health_tool_flow(db: CollieDB) -> None:
     await tool.execute(action="log", metric="steps", value=7500, date=today)
     await tool.execute(action="log", metric="sleep_hours", value=7.5, date=today)
     await tool.execute(action="log", metric="steps", value=4000, date=yesterday)
+    await tool.execute(action="log", metric="water_cups", value=6, date=yesterday)
     result = await tool.execute(action="summary")
     card = json.loads(result)
     assert card["card_type"] == "health"
@@ -161,6 +162,15 @@ async def test_health_tool_flow(db: CollieDB) -> None:
     assert card["sleep_hours"] == 7.5
     assert card["streak_days"] == 2
     assert len(card["grid"]) == 7
+
+    habits = {h["key"]: h for h in card["habits"]}
+    assert set(habits) == {"steps", "water_cups", "sleep_hours"}
+    steps_days = habits["steps"]["days"]
+    assert len(steps_days) == 7
+    assert steps_days[-1] == 7500  # today, newest last
+    assert steps_days[-2] == 4000  # yesterday
+    assert steps_days[0] is None  # nothing logged 6 days ago
+    assert habits["water_cups"]["days"][-2] == 6
 
 
 async def test_health_tool_rejects_unknown_metric(db: CollieDB) -> None:

--- a/collie-core/tests/collie/test_today_glance.py
+++ b/collie-core/tests/collie/test_today_glance.py
@@ -1,0 +1,83 @@
+"""Tests for the Today-at-a-glance card payload (morning briefing)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.tools.today_glance import attach_today_glance, today_glance_card
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    database = CollieDB(tmp_path / "collie.db")
+    yield database
+    database.close()
+
+
+def _due_in_hours(hours: float) -> str:
+    return (
+        datetime.now(timezone.utc)  # noqa: UP017
+        + timedelta(hours=hours)
+    ).isoformat(timespec="seconds")
+
+
+def test_payload_none_without_weather_or_reminders(db: CollieDB) -> None:
+    # No location in profile, no reminders -> nothing to show.
+    assert today_glance_card(db) is None
+
+
+def test_reminders_within_24h_are_included_and_capped(db: CollieDB) -> None:
+    db.add_reminder("Call the dentist", _due_in_hours(3))
+    db.add_reminder("Take out trash", _due_in_hours(20))
+    db.add_reminder("Far away thing", _due_in_hours(72))
+    for i in range(5):
+        db.add_reminder(f"extra {i}", _due_in_hours(4 + i))
+
+    payload = today_glance_card(db)
+    assert payload is not None
+    assert payload["card_type"] == "today_glance"
+    texts = [item["text"] for item in payload["reminders"]]
+    assert "Far away thing" not in texts  # outside the 24h horizon
+    assert len(texts) <= 3  # capped
+
+
+def test_past_and_completed_reminders_excluded(db: CollieDB) -> None:
+    rid = db.add_reminder("Already done", _due_in_hours(-1))["id"]
+    db.complete_reminder(str(rid))
+    db.add_reminder("Still pending but way later", _due_in_hours(48))
+
+    payload = today_glance_card(db)
+    assert payload is None  # nothing due within 24h
+
+
+async def test_attach_today_glance_persists_and_broadcasts(db: CollieDB) -> None:
+    conv = db.create_conversation(title="🔔 Morning Briefing")
+    db.add_reminder("Water the plants", _due_in_hours(5))
+
+    class FakeIPC:
+        def __init__(self) -> None:
+            self.sent: list[dict] = []
+
+        async def broadcast(self, payload: dict) -> None:
+            self.sent.append(payload)
+
+    ipc = FakeIPC()
+    await attach_today_glance(db, conv["id"], ipc)
+
+    assert len(ipc.sent) == 1
+    message = ipc.sent[0]["message"]
+    assert message["role"] == "assistant"
+    data = (
+        json.loads(message["card_data"])
+        if isinstance(message["card_data"], str)
+        else message["card_data"]
+    )
+    assert data["reminders"][0]["text"] == "Water the plants"
+
+    stored = db.get_messages(conv["id"])
+    assert len(stored) == 1

--- a/collie-ui/src/renderer/src/components/cards/CardRenderer.tsx
+++ b/collie-ui/src/renderer/src/components/cards/CardRenderer.tsx
@@ -1,4 +1,6 @@
 import WeatherCard from './WeatherCard'
+import TodayGlanceCard from './TodayGlanceCard'
+import CompareCard from './CompareCard'
 import CalendarCard from './CalendarCard'
 import ReminderCard from './ReminderCard'
 import EmailCard from './EmailCard'
@@ -24,6 +26,10 @@ export default function CardRenderer({ cardType, cardData }: Props): React.JSX.E
   switch (cardType) {
     case 'weather':
       return <WeatherCard data={cardData} />
+    case 'compare':
+      return <CompareCard data={cardData} />
+    case 'today_glance':
+      return <TodayGlanceCard data={cardData} />
     case 'calendar':
       return <CalendarCard data={cardData} />
     case 'reminder':

--- a/collie-ui/src/renderer/src/components/cards/CompareCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/CompareCard.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import CompareCard, { parseCompareCardData } from './CompareCard'
+
+const roots: Root[] = []
+
+function render(element: React.ReactNode): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(element))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+const duel = {
+  question: 'Which laptop?',
+  options: [
+    { name: 'Lenovo IdeaPad', price: '$549', wins: ['Lighter', 'Longer battery'] },
+    { name: 'Acer Swift', price: '$479', wins: ['Cheaper'] }
+  ],
+  verdict: 'The Lenovo — the lighter body and longer battery are worth the $70.'
+}
+
+describe('parseCompareCardData', () => {
+  it('accepts exactly two well-formed options', () => {
+    const parsed = parseCompareCardData(duel)
+    expect(parsed).not.toBeNull()
+    expect(parsed?.options[0].name).toBe('Lenovo IdeaPad')
+    expect(parsed?.options[1].price).toBe('$479')
+    expect(parsed?.verdict).toContain('Lenovo')
+  })
+
+  it('rejects three or more options — that is a table, not a duel', () => {
+    const parsed = parseCompareCardData({
+      options: [
+        { name: 'A', wins: [] },
+        { name: 'B', wins: [] },
+        { name: 'C', wins: [] }
+      ]
+    })
+    expect(parsed).toBeNull()
+  })
+
+  it('rejects one option and malformed records', () => {
+    expect(parseCompareCardData({ options: [{ name: 'Only one' }] })).toBeNull()
+    expect(parseCompareCardData({ options: [null, { name: '' }, 42] })).toBeNull()
+    expect(parseCompareCardData({})).toBeNull()
+  })
+
+  it('caps long names, verdicts and win lists defensively', () => {
+    const parsed = parseCompareCardData({
+      options: [
+        { name: 'x'.repeat(200), wins: Array.from({ length: 10 }, (_, i) => `point ${i}`) },
+        { name: 'B' }
+      ],
+      verdict: 'y'.repeat(500)
+    })
+    expect(parsed?.options[0].name.length).toBeLessThanOrEqual(80)
+    expect(parsed?.options[0].wins.length).toBeLessThanOrEqual(3)
+    expect(parsed?.verdict?.length).toBeLessThanOrEqual(200)
+  })
+})
+
+describe('CompareCard', () => {
+  it('renders both finalists with names, prices and wins', () => {
+    const container = render(<CompareCard data={duel} />)
+    expect(container.querySelector('[aria-label="Comparison"]')).not.toBeNull()
+    expect(container.textContent).toContain('Which laptop?')
+    expect(container.textContent).toContain('Lenovo IdeaPad')
+    expect(container.textContent).toContain('$479')
+    expect(container.textContent).toContain('Longer battery')
+  })
+
+  it("shows Collie's pick verdict", () => {
+    const container = render(<CompareCard data={duel} />)
+    expect(container.textContent).toContain("Collie's pick")
+    expect(container.textContent).toContain('worth the $70')
+  })
+
+  it('renders nothing for three or more options', () => {
+    const container = render(
+      <CompareCard
+        data={{
+          options: [{ name: 'A' }, { name: 'B' }, { name: 'C' }],
+          verdict: 'nope'
+        }}
+      />
+    )
+    expect(container.querySelector('[aria-label="Comparison"]')).toBeNull()
+  })
+
+  it('works without optional fields', () => {
+    const container = render(
+      <CompareCard data={{ options: [{ name: 'Tea' }, { name: 'Coffee' }] }} />
+    )
+    expect(container.textContent).toContain('Which one?')
+    expect(container.textContent).toContain('Coffee')
+  })
+})

--- a/collie-ui/src/renderer/src/components/cards/CompareCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/CompareCard.tsx
@@ -1,0 +1,146 @@
+import { Trophy } from 'lucide-react'
+
+interface CompareOption {
+  name: string
+  price?: string
+  wins: string[]
+  icon?: string
+}
+
+interface ParsedCompare {
+  question?: string
+  options: [CompareOption, CompareOption]
+  verdict?: string
+}
+
+const MAX_NAME_LEN = 80
+const MAX_POINT_LEN = 60
+const MAX_POINTS_PER_OPTION = 3
+
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function parsePoints(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const points: string[] = []
+  for (const entry of value) {
+    const text = cleanText(entry)
+    if (!text || text.length > MAX_POINT_LEN) continue
+    if (points.length >= MAX_POINTS_PER_OPTION) break
+    points.push(text)
+  }
+  return points.slice(0, MAX_POINTS_PER_OPTION)
+}
+
+/**
+ * Defensive parsing for model/tool-supplied compare data. Only exactly two
+ * usable options render a card — three or more is a table job (plain markdown),
+ * not a decision card.
+ */
+export function parseCompareCardData(data: Record<string, unknown>): ParsedCompare | null {
+  const rawOptions = Array.isArray(data.options) ? data.options : []
+  const parsed: CompareOption[] = []
+
+  for (const raw of rawOptions) {
+    if (raw === null || typeof raw !== 'object') continue
+    const record = raw as Record<string, unknown>
+    const name = cleanText(record.name).slice(0, MAX_NAME_LEN)
+    if (!name) continue
+    const price = cleanText(record.price).slice(0, 24)
+    parsed.push({
+      name,
+      ...(price ? { price } : {}),
+      wins: parsePoints(record.wins ?? record.points),
+      ...(cleanText(record.icon) ? { icon: cleanText(record.icon).slice(0, 8) } : {})
+    })
+  }
+
+  // Exactly two — never truncate a bigger list into a fake duel.
+  if (parsed.length !== 2) return null
+
+  const question = cleanText(data.question).slice(0, 120)
+  const verdict = cleanText(data.verdict ?? data.why).slice(0, 200)
+
+  return {
+    ...(question ? { question } : {}),
+    options: [parsed[0], parsed[1]],
+    ...(verdict ? { verdict } : {})
+  }
+}
+
+function OptionColumn({ option, winner }: { option: CompareOption; winner: boolean }): React.JSX.Element {
+  return (
+    <div
+      className="flex-1 rounded-xl p-3"
+      style={{
+        background: winner ? 'var(--collie-bone)' : 'transparent',
+        border: `1px solid ${winner ? 'var(--collie-grass)' : 'var(--collie-fur)'}`
+      }}
+    >
+      <div className="flex items-center gap-2">
+        {option.icon && <span className="text-lg" aria-hidden="true">{option.icon}</span>}
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: 'var(--collie-nose)' }}>
+          {option.name}
+        </span>
+      </div>
+      {option.price && (
+        <div className="mt-0.5 text-sm font-bold" style={{ color: 'var(--collie-amber)' }}>
+          {option.price}
+        </div>
+      )}
+      {option.wins.length > 0 && (
+        <ul className="mt-2 space-y-1">
+          {option.wins.map((point, index) => (
+            <li key={index} className="flex items-start gap-1.5 text-xs leading-snug" style={{ color: 'var(--collie-paw)' }}>
+              <span aria-hidden="true" style={{ color: 'var(--collie-grass)' }}>✓</span>
+              <span className="min-w-0">{point}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/**
+ * A vs B duel card for "which should I pick?" answers. Shows exactly two
+ * side-by-side finalists with a clear Collie's pick — never a wide grid.
+ * Data with more than two options (or fewer) renders nothing; the streamed
+ * text above stays the full answer.
+ */
+export default function CompareCard({ data }: { data: Record<string, unknown> }): React.JSX.Element | null {
+  const parsed = parseCompareCardData(data)
+  if (!parsed) return null
+
+  return (
+    <section
+      aria-label="Comparison"
+      className="collie-reveal mt-3 w-full max-w-md rounded-2xl border p-4"
+      style={{ background: 'var(--collie-bg)', borderColor: 'var(--collie-fur)' }}
+    >
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-lg" aria-hidden="true">⚖️</span>
+        <span className="font-semibold" style={{ color: 'var(--collie-nose)' }}>
+          {parsed.question || 'Which one?'}
+        </span>
+      </div>
+
+      <div className="flex items-stretch gap-2">
+        <div className="w-4 shrink-0" aria-hidden="true" />
+        <OptionColumn option={parsed.options[0]} winner={false} />
+        <OptionColumn option={parsed.options[1]} winner={false} />
+      </div>
+
+      {parsed.verdict && (
+        <div className="mt-3 flex items-start gap-2 rounded-xl p-3" style={{ background: 'var(--collie-bone)' }}>
+          <Trophy size={16} className="mt-0.5 shrink-0" style={{ color: 'var(--collie-amber)' }} aria-hidden="true" />
+          <p className="text-xs leading-snug" style={{ color: 'var(--collie-nose)' }}>
+            <span className="font-semibold">Collie's pick: </span>
+            {parsed.verdict}
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/components/cards/HealthCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/HealthCard.tsx
@@ -2,6 +2,8 @@ interface Props {
   data: Record<string, unknown>
 }
 
+import HealthStreaks from './HealthStreaks'
+
 export default function HealthCard({ data }: Props): React.JSX.Element {
   const streak = (data.streak_days as number) || 0
   const steps = (data.steps as number) || 0
@@ -44,20 +46,7 @@ export default function HealthCard({ data }: Props): React.JSX.Element {
           <div className="text-xs" style={{ color: 'var(--collie-paw)' }}>cups</div>
         </div>
       </div>
-      {grid && grid.length > 0 && (
-        <div className="flex gap-1">
-          {grid.map((val, i) => (
-            <div key={i}
-              className="h-3 flex-1 rounded-sm"
-              style={{
-                background: val > 0
-                  ? `color-mix(in srgb, var(--collie-grass) ${val * 25}%, var(--collie-fur))`
-                  : 'var(--collie-fur)'
-              }}
-            />
-          ))}
-        </div>
-      )}
+      <HealthStreaks habits={data.habits} grid={grid} />
     </div>
   )
 }

--- a/collie-ui/src/renderer/src/components/cards/HealthStreaks.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/HealthStreaks.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import HealthCard from './HealthCard'
+
+const roots: Root[] = []
+
+function render(element: React.ReactNode): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(element))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+const baseData = {
+  streak_days: 3,
+  steps: 7500,
+  sleep_hours: 7.5,
+  water_cups: 6,
+  habits: [
+    { key: 'steps', label: 'Steps', icon: '👟', color: '#e8913a', days: [5000, 8000, null, 6200, 9100, 3000, 7500] },
+    { key: 'water_cups', label: 'Water', icon: '💧', color: '#6baed6', days: [4, 6, 5, 6, null, 7, 6] }
+  ]
+}
+
+describe('HealthCard habit streaks', () => {
+  it('renders one dot-grid row per logged habit', () => {
+    const container = render(<HealthCard data={baseData} />)
+    const section = container.querySelector('[aria-label="Habit streaks"]')
+    expect(section).not.toBeNull()
+    expect(section?.textContent).toContain('Steps')
+    expect(section?.textContent).toContain('Water')
+    // 7 dots per habit row
+    expect(section?.querySelectorAll('[role="img"]').length).toBe(2)
+    expect(section?.querySelectorAll('span[aria-hidden="true"].rounded-full').length).toBe(14)
+  })
+
+  it('keeps rendering with only the legacy grid and no habits', () => {
+    const container = render(<HealthCard data={{ steps: 100, grid: [1, 2, 0, 1, 2, 2, 1] }} />)
+    expect(container.textContent).toContain('100')
+    // Legacy strip renders inside the (empty) streaks section wrapper
+    const strip = container.querySelector('[aria-label="Habit streaks"] > div[aria-hidden="true"]')
+    expect(strip?.children.length).toBe(7)
+    expect(container.querySelector('[aria-label="Habit streaks"]')?.textContent).not.toContain('Steps')
+  })
+
+  it('drops all-empty or malformed habit rows', () => {
+    const container = render(
+      <HealthCard
+        data={{
+          habits: [
+            { key: 'steps', label: 'Steps', days: [null, null, null, null, null, null, null] },
+            { key: 'water', label: 'Water', days: 'nope' },
+            null,
+            { key: 'sleep', label: 'Sleep', days: [8] }
+          ]
+        }}
+      />
+    )
+    const labels = container.querySelector('[aria-label="Habit streaks"]')?.textContent ?? ''
+    expect(labels).toContain('Sleep')
+    expect(labels).not.toContain('Steps')
+    expect(labels).not.toContain('Water')
+  })
+})

--- a/collie-ui/src/renderer/src/components/cards/HealthStreaks.tsx
+++ b/collie-ui/src/renderer/src/components/cards/HealthStreaks.tsx
@@ -1,0 +1,94 @@
+interface HabitRow {
+  key: string
+  label: string
+  icon: string
+  color: string
+  /** One value per day, oldest → newest (7 entries). Null = nothing logged. */
+  days: Array<number | null>
+}
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+function parseDays(value: unknown): Array<number | null> {
+  if (!Array.isArray(value)) return []
+  return value.slice(0, 7).map((entry) =>
+    typeof entry === 'number' && Number.isFinite(entry) && entry >= 0 ? entry : null
+  )
+}
+
+function Dot({ filled, color }: { filled: boolean; color: string }): React.JSX.Element {
+  return (
+    <span
+      className="h-2.5 w-2.5 rounded-full"
+      style={{ background: filled ? color : 'var(--collie-fur)' }}
+      aria-hidden="true"
+    />
+  )
+}
+
+/**
+ * "Today at a glance" for habits: one row per tracked metric with a
+ * GitHub-style 7-day dot grid — green dot = logged that day. Data comes from
+ * the health tool's ``habits`` array; the legacy ``grid`` intensity strip
+ * still renders when present.
+ */
+export default function HealthStreaks({
+  habits,
+  grid
+}: {
+  habits: unknown
+  grid?: unknown
+}): React.JSX.Element | null {
+  const rowsRaw = Array.isArray(habits) ? habits : []
+  const rows: HabitRow[] = []
+  for (const raw of rowsRaw) {
+    if (raw === null || typeof raw !== 'object') continue
+    const record = raw as Record<string, unknown>
+    const key = typeof record.key === 'string' ? record.key : ''
+    const label = typeof record.label === 'string' ? record.label : ''
+    if (!key || !label) continue
+    const days = parseDays(record.days)
+    if (!days.some((day) => day !== null)) continue // never show an all-empty habit row
+    const icon = typeof record.icon === 'string' ? record.icon : '•'
+    const color = typeof record.color === 'string' ? record.color : 'var(--collie-grass)'
+    rows.push({ key, label, icon, color, days })
+  }
+  const weekGrid = Array.isArray(grid) ? (grid as number[]) : []
+  if (rows.length === 0 && weekGrid.length === 0) return null
+
+  return (
+    <section aria-label="Habit streaks" className="mt-3 space-y-2">
+      {rows.map((row) => (
+        <div key={row.key} className="flex items-center gap-2">
+          <span className="w-5 text-center text-sm" aria-hidden="true">{row.icon}</span>
+          <span className="w-12 shrink-0 text-xs" style={{ color: 'var(--collie-paw)' }}>
+            {row.label}
+          </span>
+          <span className="flex flex-1 justify-end gap-1.5" role="img" aria-label={`${row.label} last 7 days`}>
+            {row.days.map((day, index) => (
+              <Dot key={index} filled={day !== null} color={row.color} />
+            ))}
+          </span>
+        </div>
+      ))}
+      {weekGrid.length > 0 && (
+        <div className="flex gap-1 pt-1" aria-hidden="true">
+          {weekGrid.map((value, index) => (
+            <div
+              key={index}
+              className="h-1.5 flex-1 rounded-sm"
+              style={{
+                background:
+                  value > 0
+                    ? `color-mix(in srgb, var(--collie-grass) ${value * 25}%, var(--collie-fur))`
+                    : 'var(--collie-fur)'
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/components/cards/ReminderCard.countdown.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/ReminderCard.countdown.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import ReminderCard from './ReminderCard'
+
+const roots: Root[] = []
+
+function render(element: React.ReactNode): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(element))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+function iso(daysAhead: number, hour = 12): string {
+  const date = new Date()
+  date.setDate(date.getDate() + daysAhead)
+  date.setHours(hour, 0, 0, 0)
+  return date.toISOString()
+}
+
+describe('ReminderCard countdown chips', () => {
+  it('shows a today! chip and an in-days chip', () => {
+    const container = render(
+      <ReminderCard
+        data={{
+          items: [
+            { text: 'Call the dentist', due_at: iso(0, 15) },
+            { text: 'Water the plants', due_at: iso(3) }
+          ]
+        }}
+      />
+    )
+    expect(container.textContent).toContain('today!')
+    expect(container.textContent).toContain('in 3 days')
+    expect(container.textContent).not.toContain('overdue')
+  })
+
+  it('hides chips for far-away reminders', () => {
+    const container = render(
+      <ReminderCard data={{ items: [{ text: 'Renew passport', due_at: iso(30) }] }} />
+    )
+    expect(container.textContent).toContain('Renew passport')
+    expect(container.querySelector('.rounded-full.px-2')).toBeNull()
+  })
+
+  it('marks overdue reminders with a loud chip', () => {
+    const container = render(
+      <ReminderCard data={{ items: [{ text: 'Late thing', due_at: iso(-1, 1) }] }} />
+    )
+    expect(container.textContent).toContain('overdue')
+  })
+})

--- a/collie-ui/src/renderer/src/components/cards/ReminderCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/ReminderCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { countdownLabel } from '../../lib/countdown'
 
 interface Props {
   data: Record<string, unknown>
@@ -32,39 +33,55 @@ export default function ReminderCard({ data }: Props): React.JSX.Element {
         </span>
       </div>
       <div className="space-y-2">
-        {items.map((item, i) => (
-          <div key={i} className="flex items-center gap-3 rounded-xl p-3"
-            style={{
-              background: done.has(i) ? 'var(--collie-fur)' : 'var(--collie-bone)',
-              opacity: done.has(i) ? 0.6 : 1
-            }}>
-            <button
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 text-xs"
+        {items.map((item, i) => {
+          const dueLabel = countdownLabel(item.due_at as string)
+          const isToday = dueLabel === 'today!' || dueLabel === 'overdue'
+          return (
+            <div key={i} className="flex items-center gap-3 rounded-xl p-3"
               style={{
-                borderColor: done.has(i) ? 'var(--collie-grass)' : 'var(--collie-paw)',
-                background: done.has(i) ? 'var(--collie-grass)' : 'transparent',
-                color: done.has(i) ? 'white' : 'transparent'
-              }}
-              onClick={() => setDone((prev) => {
-                const next = new Set(prev)
-                if (next.has(i)) next.delete(i)
-                else next.add(i)
-                return next
-              })}
-            >
-              ✓
-            </button>
-            <div className="flex-1">
-              <div className={`text-sm ${done.has(i) ? 'line-through' : ''}`}
-                style={{ color: 'var(--collie-nose)' }}>
-                {item.text as string}
+                background: done.has(i) ? 'var(--collie-fur)' : 'var(--collie-bone)',
+                opacity: done.has(i) ? 0.6 : 1
+              }}>
+              <button
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 text-xs"
+                style={{
+                  borderColor: done.has(i) ? 'var(--collie-grass)' : 'var(--collie-paw)',
+                  background: done.has(i) ? 'var(--collie-grass)' : 'transparent',
+                  color: done.has(i) ? 'white' : 'transparent'
+                }}
+                onClick={() => setDone((prev) => {
+                  const next = new Set(prev)
+                  if (next.has(i)) next.delete(i)
+                  else next.add(i)
+                  return next
+                })}
+              >
+                ✓
+              </button>
+              <div className="min-w-0 flex-1">
+                <div className={`text-sm ${done.has(i) ? 'line-through' : ''}`}
+                  style={{ color: 'var(--collie-nose)' }}>
+                  {item.text as string}
+                </div>
+                <div className="text-xs" style={{ color: 'var(--collie-paw)' }}>
+                  {item.due_at as string}
+                </div>
               </div>
-              <div className="text-xs" style={{ color: 'var(--collie-paw)' }}>
-                {item.due_at as string}
-              </div>
+              {!done.has(i) && dueLabel && (
+                <span
+                  className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold"
+                  aria-label={isToday ? 'Due now' : undefined}
+                  style={{
+                    color: isToday ? 'white' : 'var(--collie-nose)',
+                    background: isToday ? 'var(--collie-amber)' : 'var(--collie-fur)'
+                  }}
+                >
+                  {dueLabel}
+                </span>
+              )}
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import TodayGlanceCard from './TodayGlanceCard'
+
+const roots: Root[] = []
+
+function render(element: React.ReactNode): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(element))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+const fullData = {
+  date: 'Saturday, August 22',
+  weather: {
+    location: 'Berlin, Germany',
+    icon: '☀️',
+    temp: '24',
+    condition: 'Clear',
+    high: '26',
+    low: '14',
+    rain_chance: 10
+  },
+  reminders: [
+    { text: 'Call the dentist', due_at: '2026-08-22T15:00:00+00:00' },
+    { text: 'Take out trash', due_at: '2026-08-23T08:30:00+00:00' }
+  ]
+}
+
+describe('TodayGlanceCard', () => {
+  it('renders weather and reminder sections together', () => {
+    const container = render(<TodayGlanceCard data={fullData} />)
+    expect(container.querySelector('[aria-label="Today at a glance"]')).not.toBeNull()
+    expect(container.textContent).toContain('Today at a glance')
+    expect(container.textContent).toContain('24°C')
+    expect(container.textContent).toContain('Clear')
+    expect(container.textContent).toContain('Call the dentist')
+    expect(container.textContent).toContain('Coming up')
+  })
+
+  it('shows the rain hint only above the threshold', () => {
+    const rainy = {
+      ...fullData,
+      weather: { ...fullData.weather, rain_chance: 60 }
+    }
+    const container = render(<TodayGlanceCard data={rainy} />)
+    expect(container.textContent).toContain('60% rain')
+
+    const dry = render(<TodayGlanceCard data={{ ...fullData, reminders: [] }} />)
+    expect(dry.textContent).not.toContain('% rain')
+  })
+
+  it('renders reminders only when there is no weather data', () => {
+    const container = render(
+      <TodayGlanceCard
+        data={{
+          reminders: [{ text: 'Water the plants', due_at: '2026-08-22T18:00:00' }]
+        }}
+      />
+    )
+    expect(container.querySelector('[aria-label="Today at a glance"]')).not.toBeNull()
+    expect(container.textContent).toContain('Water the plants')
+    expect(container.textContent).not.toContain('°C')
+  })
+
+  it('renders nothing when every section is empty or malformed', () => {
+    expect(
+      render(<TodayGlanceCard data={{}} />).querySelector('[aria-label="Today at a glance"]')
+    ).toBeNull()
+    expect(
+      render(<TodayGlanceCard data={{ reminders: [{}, { text: '   ' }] }} />).querySelector(
+        '[aria-label="Today at a glance"]'
+      )
+    ).toBeNull()
+  })
+})

--- a/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.tsx
@@ -1,0 +1,130 @@
+interface GlanceWeather {
+  location?: string
+  icon?: string
+  temp?: string
+  condition?: string
+  high?: string
+  low?: string
+  rain_chance?: number
+}
+
+interface GlanceReminder {
+  text: string
+  due_at: string | undefined
+}
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function friendlyDue(dueAt: string): string {
+  const parsed = new Date(dueAt)
+  if (Number.isNaN(parsed.getTime())) return dueAt
+  return parsed.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+}
+
+/**
+ * "Today at a glance" — one quiet card under the Morning Briefing: today's
+ * weather row plus what's coming up in the next 24 hours. Sections drop out
+ * independently when there is no data; the card renders only when at least
+ * one section has something to show.
+ */
+export default function TodayGlanceCard({ data }: Props): React.JSX.Element | null {
+  const weatherRaw = data.weather as Record<string, unknown> | undefined
+  const weather: GlanceWeather = weatherRaw ?? {}
+  const temp = asString(weather.temp)
+  const condition = asString(weather.condition)
+  const icon = asString(weather.icon) || '⛅'
+  const high = asString(weather.high)
+  const low = asString(weather.low)
+  const rainChance = typeof weather.rain_chance === 'number' ? weather.rain_chance : null
+  const location = asString(weather.location)
+
+  const remindersRaw = Array.isArray(data.reminders) ? data.reminders : []
+  const reminders: GlanceReminder[] = []
+  for (const item of remindersRaw) {
+    if (reminders.length >= 3) break
+    const record = item as Record<string, unknown>
+    const text = asString(record?.text)
+    if (!text || text.trim() === '') continue
+    reminders.push({ text, due_at: asString(record?.due_at) })
+  }
+
+  const dateLabel = asString(data.date) ?? ''
+  const hasWeather = temp !== undefined && condition !== undefined
+  const hasReminders = reminders.length > 0
+
+  if (!hasWeather && !hasReminders) return null
+
+  return (
+    <section
+      aria-label="Today at a glance"
+      className="collie-reveal mt-3 w-full max-w-md rounded-2xl border p-4"
+      style={{ background: 'var(--collie-bg)', borderColor: 'var(--collie-fur)' }}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <span className="text-lg" aria-hidden="true">🌅</span>
+        <span className="font-semibold" style={{ color: 'var(--collie-nose)' }}>
+          Today at a glance
+        </span>
+        {dateLabel && (
+          <span className="ml-auto text-xs" style={{ color: 'var(--collie-paw)' }}>
+            {dateLabel}
+          </span>
+        )}
+      </div>
+
+      {hasWeather && (
+        <div
+          className="mb-3 flex items-center gap-3 rounded-xl p-3"
+          style={{ background: 'var(--collie-bone)' }}
+        >
+          <span className="text-3xl" aria-hidden="true">{icon}</span>
+          <div className="min-w-0">
+            <div className="text-xl font-bold leading-tight" style={{ color: 'var(--collie-nose)' }}>
+              {temp}°C{' '}
+              <span className="text-sm font-normal" style={{ color: 'var(--collie-paw)' }}>
+                {condition}
+              </span>
+            </div>
+            <div className="mt-0.5 flex flex-wrap gap-x-3 text-xs" style={{ color: 'var(--collie-paw)' }}>
+              {high != null && low != null && (
+                <span>
+                  H {high}° · L {low}°
+                </span>
+              )}
+              {rainChance !== null && rainChance > 20 && <span>☂️ {rainChance}% rain</span>}
+              {location && <span className="truncate">{location}</span>}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {hasReminders && (
+        <div className="space-y-1.5">
+          <div className="text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--collie-paw)' }}>
+            Coming up
+          </div>
+          {reminders.map((item, index) => (
+            <div
+              key={index}
+              className="flex items-center justify-between gap-3 rounded-xl px-3 py-2"
+              style={{ background: 'var(--collie-bone)' }}
+            >
+              <span className="min-w-0 truncate text-sm" style={{ color: 'var(--collie-nose)' }}>
+                {item.text}
+              </span>
+              <span className="shrink-0 text-xs font-medium" style={{ color: 'var(--collie-amber)' }}>
+                {item.due_at ? friendlyDue(item.due_at) : ''}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/lib/countdown.test.ts
+++ b/collie-ui/src/renderer/src/lib/countdown.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { countdownLabel } from './countdown'
+
+function daysFromNowAt(hour: number, days: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + days)
+  date.setHours(hour, 30, 0, 0)
+  return date.toISOString()
+}
+
+describe('countdownLabel', () => {
+  it('labels today, tomorrow, and the coming week', () => {
+    expect(countdownLabel(daysFromNowAt(9, 0))).toBe('today!')
+    expect(countdownLabel(daysFromNowAt(23, 1))).toBe('tomorrow')
+    expect(countdownLabel(daysFromNowAt(12, 3))).toBe('in 3 days')
+    expect(countdownLabel(daysFromNowAt(12, 6))).toBe('in 6 days')
+  })
+
+  it('marks overdue and caps at next week', () => {
+    expect(countdownLabel(daysFromNowAt(1, -1))).toBe('overdue')
+    expect(countdownLabel(daysFromNowAt(12, 7))).toBe('next week')
+    expect(countdownLabel(daysFromNowAt(12, 20))).toBeNull()
+  })
+
+  it('handles malformed input', () => {
+    expect(countdownLabel('not a date')).toBeNull()
+  })
+})

--- a/collie-ui/src/renderer/src/lib/countdown.ts
+++ b/collie-ui/src/renderer/src/lib/countdown.ts
@@ -1,0 +1,18 @@
+/** Friendly countdown labels for reminder due times ("today!", "in 3 days"). */
+export function countdownLabel(dueAt: string, now: Date = new Date()): string | null {
+  const due = new Date(dueAt)
+  if (Number.isNaN(due.getTime())) return null
+
+  const startOfToday = new Date(now)
+  startOfToday.setHours(0, 0, 0, 0)
+  const startOfDueDay = new Date(due)
+  startOfDueDay.setHours(0, 0, 0, 0)
+
+  const dayDiff = Math.round((startOfDueDay.getTime() - startOfToday.getTime()) / 86_400_000)
+  if (dayDiff < 0) return 'overdue'
+  if (dayDiff === 0) return 'today!'
+  if (dayDiff === 1) return 'tomorrow'
+  if (dayDiff < 7) return `in ${dayDiff} days`
+  if (dayDiff < 14) return 'next week'
+  return null // far-away reminders don't need a chip
+}


### PR DESCRIPTION
# feat: normie chat cards — Today at a glance, health streaks, countdown chips, compare duel

Four "less read, more see" chat visuals, per the locked design direction:
visuals attach **below** the streamed text and never replace it.

## 1. ⚖️ CompareCard (`compare` card type)

When someone asks Collie to weigh **exactly two** options ("which laptop?"),
the answer gets a side-by-side duel card: both finalists with price + up to
3 winning points each, plus a "Collie's pick" verdict line.

- **Exactly two options render a card — anything else renders nothing.**
  Three or more is deliberately refused (that's a table job for plain
  markdown, per product decision); the parser never truncates a bigger list
  into a fake duel.
- Defensive parsing: length caps on names/points/verdict, malformed records
  dropped. UI-side only; no engine changes. Full text stays source of truth.
- New: `CompareCard.tsx` (+ `parseCompareCardData`), `CardRenderer` case,
  8 tests.

## 2. 🌅 TodayGlanceCard (`today_glance` card type)

The Morning Briefing routine now ends with a seeable summary card under its
text: today's weather row (icon, temp, H/L, rain hint when >20%) plus
"Coming up" — reminders due in the next 24 h, capped at 3 with friendly
times.

- Backend `collie_core/tools/today_glance.py`: builds the payload from the
  profile location (same open-meteo path as the weather tool) + reminders
  store; every section degrades independently, nothing to show → no card.
- Hooked best-effort into `_run_automation` after a `kind == "morning"`
  briefing lands — a card failure can never break the briefing itself.
- New: `today_glance.py`, `attach_today_glance`, runtime hook,
  `TodayGlanceCard.tsx`, 4 backend + 4 UI tests.

## 3. 👟💧😴 Health habit streaks

The health card now shows one 7-day dot-grid row per tracked habit
(steps/water/sleep): filled dot = logged that day. Instant "am I keeping
the streak?" glance instead of raw numbers.

- `health.py` emits a `habits` array (7 entries per metric, oldest →
  newest, None = not logged) alongside the existing data; legacy `grid`
  strip still renders.
- `HealthStreaks.tsx`: drops all-empty/malformed rows so an all-empty habit
  never shows; renders standalone when only the legacy grid exists.
- New: `HealthStreaks.tsx`, extended HealthTool tests, 3 UI tests.

## 4. ⏰ Reminder countdown chips

Reminder rows get a small chip next to each due time: `today!` /
`tomorrow` / `in 3 days` / `next week`; today-or-overdue is loud amber,
far-away reminders get no chip at all. Chips hide while a reminder is
ticked done. Pure UI (`lib/countdown.ts`), no engine changes.

## Gates

- `collie-ui`: `npm test` — 59 files / **383 passed**, `npm run typecheck` clean.
- `collie-core`: pytest subset (today_glance, life_tools_phase3, reminders,
  automations, weather) — **55 passed**; ruff check + format clean.
- No new dependencies. Normie voice throughout ("Coming up", "today!",
  "Collie's pick"), dog only in visuals.
