### PR TITLE
feat(routines): edit routines in place + post-create confirmation with Undo

### DIFF
--- a/collie-core/collie_core/automations/custom.py
+++ b/collie-core/collie_core/automations/custom.py
@@ -7,6 +7,7 @@ needed) so it works before a provider is even configured.
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import UTC, datetime
 from typing import Any
@@ -15,7 +16,7 @@ from collie_core.db import CollieDB
 from collie_core.routines.schedule import next_occurrence
 from collie_core.routines.schedule import parse_schedule as parse_structured_schedule
 
-__all__ = ["create_custom_automation", "parse_schedule"]
+__all__ = ["create_custom_automation", "parse_schedule", "update_custom_automation"]
 
 _WEEKDAYS = {
     "monday": "Mon",
@@ -166,3 +167,77 @@ def create_custom_automation(
         schedule_json=structured.to_dict(),
         next_run_at=next_run.isoformat(timespec="seconds") if next_run else None,
     )
+
+
+def update_custom_automation(
+    db: CollieDB,
+    automation_id: str,
+    description: str,
+    *,
+    name: str | None = None,
+    timezone_name: str = "UTC",
+) -> dict[str, Any]:
+    """Edit an existing custom routine: re-parse the description, keep its identity.
+
+    Runs history, id, and enabled state are preserved; schedule, prompt, and
+    description follow the new wording. The next run is recomputed from now.
+    """
+    description = (description or "").strip()
+    if not description:
+        raise ValueError("Tell me what you'd like me to do, and when!")
+
+    current = db.get_automation(automation_id)
+    if current is None:
+        raise ValueError("That routine no longer exists.")
+    if str(current.get("action_type") or "") != "custom":
+        raise ValueError("Built-in routines can't be reworded — pause them or make your own.")
+
+    try:
+        structured = parse_structured_schedule(description, timezone_name)
+    except ValueError as exc:
+        raise ValueError(
+            "I couldn't work out a clear schedule. Try 'weekdays at 8am', "
+            "'every Friday at 5pm', or 'the first day of every month at 9am'. "
+            f"{exc}"
+        ) from exc
+    schedule = parse_schedule(description) or structured.time.strftime("%H:%M")
+    next_run = next_occurrence(structured, datetime.now(UTC))
+
+    label = (name or "").strip()
+    if not label:
+        label = re.sub(r"\s+", " ", description)
+        label = (label[:47] + "…") if len(label) > 48 else label
+
+    prompt = (
+        f"Scheduled task from the user: {description}\n\n"
+        "Carry this out now. Use whatever tools help (weather, calendar, "
+        "reminders, news, web search). Speak in Collie's voice: warm, "
+        "playful, first person, never corporate."
+    )
+
+    current_config = current.get("action_config")
+    if isinstance(current_config, str):
+        try:
+            current_config = json.loads(current_config)
+        except (TypeError, json.JSONDecodeError):
+            current_config = {}
+    if not isinstance(current_config, dict):
+        current_config = {}
+    new_config = {
+        **current_config,
+        "kind": "custom",
+        "prompt": prompt,
+    }
+
+    row = db.update_automation(
+        automation_id,
+        name=label,
+        description=description,
+        schedule=schedule,
+        timezone=timezone_name,
+        schedule_json=structured.to_dict(),
+        next_run_at=next_run.isoformat(timespec="seconds") if next_run else None,
+        action_config=new_config,
+    )
+    row["action_config"] = new_config
+    return row

--- a/collie-core/collie_core/automations/scheduler.py
+++ b/collie-core/collie_core/automations/scheduler.py
@@ -326,7 +326,11 @@ class AutomationScheduler:
                     str(run["id"]),
                     "skipped",
                     error_code="missed_window",
-                    error_message="The scheduled time was outside the recent missed-run window.",
+                    error_message=(
+                        "This one came due while your computer was off, so it was "
+                        "skipped — nothing was lost. It will run again at the next "
+                        "scheduled time."
+                    ),
                 )
                 continue
             task = asyncio.create_task(self._execute_claimed(auto, run))

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -1392,6 +1392,7 @@ class CollieDB:
             "plan_version",
             "routine_status",
             "enabled",
+            "action_config",
         }
         updates = {key: value for key, value in fields.items() if key in allowed}
         if not updates:
@@ -1399,7 +1400,7 @@ class CollieDB:
             if row is None:
                 raise ValueError("routine not found")
             return row
-        for key in ("schedule_json",):
+        for key in ("schedule_json", "action_config"):
             if key in updates and not isinstance(updates[key], str):
                 updates[key] = json.dumps(updates[key])
         updates["updated_at"] = utc_now()

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1828,6 +1828,18 @@ class CollieIPCServer:
         self.db.delete_automation(auto_id)
         return {"deleted": True}
 
+    async def _cmd_update_automation(self, connection: ServerConnection, frame: dict) -> dict:
+        from collie_core.automations.custom import update_custom_automation
+
+        row = update_custom_automation(
+            self.db,
+            str(frame.get("automation_id") or ""),
+            str(frame.get("description") or ""),
+            name=(str(frame["name"]) if frame.get("name") else None),
+            timezone_name=str(frame.get("timezone") or "UTC"),
+        )
+        return {"automation": row}
+
     # -- routines, plans, runs, and approvals ----------------------------------------
 
     async def _cmd_list_routines(self, connection: ServerConnection, frame: dict) -> dict:

--- a/collie-core/tests/collie/test_update_custom_automations.py
+++ b/collie-core/tests/collie/test_update_custom_automations.py
@@ -1,0 +1,53 @@
+"""Tests for update_custom_automation — plain-English routine editing."""
+
+import pytest
+
+from collie_core.automations.custom import create_custom_automation, update_custom_automation
+from collie_core.db import CollieDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return CollieDB(tmp_path / "test.db")
+
+
+def test_update_rewords_schedule_and_prompt(db: CollieDB) -> None:
+    row = create_custom_automation(db, "water the plants every Monday at 9am", name="Plants")
+    updated = update_custom_automation(db, str(row["id"]), "water the plants every Friday at 5pm")
+    assert updated["schedule"] == "Fri 17:00"
+    config = updated["action_config"]
+    if isinstance(config, str):
+        import json
+
+        config = json.loads(config)
+    assert "every Friday at 5pm" in config["prompt"]
+    # next run was recomputed
+    assert updated["next_run_at"]
+
+
+def test_update_preserves_identity_and_enabled_state(db: CollieDB) -> None:
+    row = create_custom_automation(db, "stretch every day at noon", name="Stretch")
+    db.toggle_automation(str(row["id"]), False)
+    before_id = str(row["id"])
+    updated = update_custom_automation(db, before_id, "stretch every day at 3pm")
+    assert str(updated["id"]) == before_id
+    assert updated["enabled"] == 0  # paused stays paused
+
+
+def test_update_rejects_builtin(db: CollieDB) -> None:
+    from collie_core.automations.scheduler import seed_builtin_automations
+
+    seed_builtin_automations(db)
+    with pytest.raises(ValueError, match="Built-in"):
+        update_custom_automation(db, "collie-morning-briefing", "brief me at noon instead")
+
+
+def test_update_rejects_unclear_schedule(db: CollieDB) -> None:
+    row = create_custom_automation(db, "jog every Tuesday at 7am", name="Jog")
+    with pytest.raises(ValueError, match="couldn't work out"):
+        update_custom_automation(db, str(row["id"]), "sometimes jog maybe")
+
+
+def test_update_missing_routine(db: CollieDB) -> None:
+    with pytest.raises(ValueError, match="no longer exists"):
+        update_custom_automation(db, "nope-gone", "jog every Tuesday at 7am")

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -1026,6 +1026,15 @@ export class CollieClient {
     return this.command('create_automation', { description, name, timezone })
   }
 
+  updateAutomation(
+    automationId: string,
+    description: string,
+    name?: string,
+    timezone?: string
+  ): Promise<{ automation: CollieAutomation }> {
+    return this.command('update_automation', { automation_id: automationId, description, name, timezone })
+  }
+
   deleteAutomation(automationId: string): Promise<{ deleted: boolean }> {
     return this.command('delete_automation', { automation_id: automationId })
   }

--- a/collie-ui/src/renderer/src/screens/RoutinesScreen.polish.test.tsx
+++ b/collie-ui/src/renderer/src/screens/RoutinesScreen.polish.test.tsx
@@ -14,7 +14,10 @@ const hooks = vi.hoisted(() => {
     listRoutines: vi.fn(async () => ({ routines: [] as CollieAutomation[] })),
     listRoutineRuns: vi.fn(async () => ({ runs: [] as CollieRun[] })),
     pauseRoutine: vi.fn(),
-    resumeRoutine: vi.fn()
+    resumeRoutine: vi.fn(),
+    createAutomation: vi.fn(),
+    updateAutomation: vi.fn(),
+    deleteAutomation: vi.fn()
   }
   return { client }
 })
@@ -23,15 +26,27 @@ vi.mock('lucide-react', () => ({
   Clock3: () => null,
   History: () => null,
   Pause: () => null,
+  Pencil: () => null,
   Play: () => null,
   Plus: () => null,
   RotateCcw: () => null,
   Rocket: () => null,
   Settings2: () => null,
   Trash2: () => null,
+  Undo2: () => null,
   X: () => null
 }))
 vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+
+/** Set a controlled textarea value the way React's onChange actually hears. */
+const typeInto = (textarea: HTMLTextAreaElement, value: string): void => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )!.set!
+  setter.call(textarea, value)
+  textarea.dispatchEvent(new Event('input', { bubbles: true }))
+}
 
 const routine = (over: Partial<CollieAutomation>): CollieAutomation => ({
   id: 'r1',
@@ -155,5 +170,98 @@ describe('RoutinesScreen UX polish', () => {
     expect(document.querySelector('.section-header p')!.textContent).toBe(
       'Put tasks on repeat — see what ran and fix misses.'
     )
+  })
+
+  it('shows a confirmation banner with Undo after creating a routine', async () => {
+    hooks.client.listRoutines
+      .mockResolvedValueOnce({ routines: [] })
+      .mockResolvedValue({
+        routines: [
+          routine({
+            id: 'custom-new',
+            name: 'Every weekday at 8am, brief me',
+            action_type: 'custom'
+          })
+        ]
+      })
+    hooks.client.createAutomation.mockResolvedValue({
+      automation: { id: 'custom-new', name: 'Every weekday at 8am, brief me' }
+    })
+    await renderScreen()
+    // Create one via the dialog.
+    await act(async () => {
+      ;(
+        Array.from(document.querySelectorAll('button')).find((b) =>
+          b.textContent!.includes('Create routine')
+        ) as HTMLButtonElement
+      ).click()
+    })
+    const textarea = document.querySelector('.dialog-card textarea') as HTMLTextAreaElement
+    await act(async () => {
+      typeInto(textarea, 'Every weekday at 8am, brief me on the day')
+    })
+    await act(async () => {
+      ;(
+        Array.from(document.querySelectorAll('.dialog-card button')).find(
+          (b) => b.textContent!.trim() === 'Create routine'
+        ) as HTMLButtonElement
+      ).click()
+    })
+    const banner = document.querySelector('.routine-created-banner')
+    expect(banner).toBeTruthy()
+    expect(banner!.textContent).toContain('Collie will repeat')
+    // One-tap Undo removes it.
+    hooks.client.deleteAutomation.mockResolvedValue({ deleted: true })
+    await act(async () => {
+      ;(banner!.querySelector('button') as HTMLButtonElement).click()
+    })
+    expect(hooks.client.deleteAutomation).toHaveBeenCalledWith('custom-new')
+    expect(document.querySelector('.routine-created-banner')).toBeNull()
+  })
+
+  it('edits a custom routine through the pencil button and dialog', async () => {
+    hooks.client.listRoutines.mockResolvedValue({
+      routines: [routine({ id: 'custom-1', description: 'jog every Tuesday at 7am', action_type: 'custom' })]
+    })
+    hooks.client.updateAutomation.mockResolvedValue({
+      automation: { id: 'custom-1', description: 'jog every Friday at 7am' }
+    })
+    await renderScreen()
+    await act(async () => {
+      ;(
+        document.querySelector('.loop-edit[aria-label="Edit Morning Briefing"]') as HTMLButtonElement
+      ).click()
+    })
+    const dialog = document.querySelector('.dialog-card')
+    expect(dialog).toBeTruthy()
+    expect(dialog!.textContent).toContain('Change what Collie repeats')
+    const textarea = dialog!.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('jog every Tuesday at 7am')
+    await act(async () => {
+      typeInto(textarea, 'jog every Friday at 7am')
+    })
+    await act(async () => {
+      ;(
+        Array.from(dialog!.querySelectorAll('button')).find(
+          (b) => b.textContent!.trim() === 'Save changes'
+        ) as HTMLButtonElement
+      ).click()
+    })
+    expect(hooks.client.updateAutomation).toHaveBeenCalledWith(
+      'custom-1',
+      'jog every Friday at 7am',
+      undefined,
+      expect.any(String)
+    )
+    expect(document.querySelector('.dialog-card')).toBeNull()
+  })
+
+  it('does not offer Edit on built-in routines', async () => {
+    hooks.client.listRoutines.mockResolvedValue({
+      routines: [routine({ id: 'collie-morning-briefing' })]
+    })
+    await renderScreen()
+    expect(document.querySelector('.loop-edit')).toBeNull()
+    expect(document.querySelector('.loop-delete')).toBeNull()
   })
 })

--- a/collie-ui/src/renderer/src/screens/RoutinesScreen.polish.test.tsx
+++ b/collie-ui/src/renderer/src/screens/RoutinesScreen.polish.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import RoutinesScreen from './RoutinesScreen'
+import type { CollieAutomation, CollieRun } from '../lib/ipc'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const hooks = vi.hoisted(() => {
+  const client = {
+    connected: true,
+    on: vi.fn(() => () => undefined),
+    listRoutines: vi.fn(async () => ({ routines: [] as CollieAutomation[] })),
+    listRoutineRuns: vi.fn(async () => ({ runs: [] as CollieRun[] })),
+    pauseRoutine: vi.fn(),
+    resumeRoutine: vi.fn()
+  }
+  return { client }
+})
+
+vi.mock('lucide-react', () => ({
+  Clock3: () => null,
+  History: () => null,
+  Pause: () => null,
+  Play: () => null,
+  Plus: () => null,
+  RotateCcw: () => null,
+  Rocket: () => null,
+  Settings2: () => null,
+  Trash2: () => null,
+  X: () => null
+}))
+vi.mock('../lib/ipc', () => ({ collieClient: hooks.client }))
+
+const routine = (over: Partial<CollieAutomation>): CollieAutomation => ({
+  id: 'r1',
+  name: 'Morning Briefing',
+  description: 'Weather + calendar',
+  schedule: '07:00',
+  enabled: 1,
+  ...over
+})
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+const renderScreen = async (): Promise<void> => {
+  container = document.body.appendChild(document.createElement('div'))
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<RoutinesScreen />)
+  })
+}
+
+describe('RoutinesScreen UX polish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    root?.unmount()
+    container?.remove()
+    container = null
+    root = null
+  })
+
+  it('shows Paused instead of a stale past Next date', async () => {
+    hooks.client.listRoutines.mockResolvedValue({
+      routines: [
+        routine({
+          id: 'paused-one',
+          name: 'Evening Wind-Down',
+          enabled: 0,
+          next_run_at: '2026-08-02T21:00:00+00:00'
+        })
+      ]
+    })
+    await renderScreen()
+    expect(document.querySelector('main')!.textContent).not.toContain('8/2/2026')
+    expect(document.querySelector('main')!.textContent).toContain('Next: Paused')
+  })
+
+  it('hides the Plan badge for routines without a plan version', async () => {
+    hooks.client.listRoutines.mockResolvedValue({ routines: [routine({ plan_version: null as unknown as number })] })
+    await renderScreen()
+    expect(document.querySelector('main')!.textContent).not.toContain('Plan:')
+  })
+
+  it('keeps the Plan badge when the routine has a plan version', async () => {
+    hooks.client.listRoutines.mockResolvedValue({ routines: [routine({ plan_version: 3 })] })
+    await renderScreen()
+    expect(document.querySelector('main')!.textContent).toContain('Plan: v3')
+  })
+
+  it('renders human schedule text instead of raw codes', async () => {
+    hooks.client.listRoutines.mockResolvedValue({
+      routines: [routine({ schedule: 'Sun 18:00' })]
+    })
+    await renderScreen()
+    expect(document.querySelector('main')!.textContent).toContain('Sundays at 6 pm')
+  })
+
+  it('groups system-maintenance routines under their own label', async () => {
+    hooks.client.listRoutines.mockResolvedValue({
+      routines: [
+        routine({ id: 'user-one', name: 'My Custom Routine' }),
+        routine({ id: 'collie-memory-maintenance', name: 'Memory maintenance' }),
+        routine({ id: 'collie-gardener-suggestions', name: 'Improvement suggestions' })
+      ]
+    })
+    await renderScreen()
+    const mainText = document.querySelector('main')!
+    const groupLabel = Array.from(mainText.querySelectorAll('h3')).find((h) =>
+      h.textContent!.includes('System maintenance')
+    )
+    expect(groupLabel).toBeTruthy()
+    // The user's routine must appear before the system group in DOM order.
+    const userIndex = mainText.textContent!.indexOf('My Custom Routine')
+    const systemIndex = mainText.textContent!.indexOf('Memory maintenance')
+    expect(userIndex).toBeGreaterThanOrEqual(0)
+    expect(systemIndex).toBeGreaterThan(userIndex)
+  })
+
+  it('labels missed-window skips as Missed with reassurance, not error jargon', async () => {
+    hooks.client.listRoutines.mockResolvedValue({ routines: [routine({})] })
+    hooks.client.listRoutineRuns.mockResolvedValue({
+      runs: [
+        {
+          id: 'run-1',
+          status: 'skipped',
+          trigger_type: 'schedule',
+          scheduled_for: '2026-08-20T07:00:00+00:00',
+          error_code: 'missed_window'
+        } as unknown as CollieRun
+      ]
+    })
+    await renderScreen()
+    await act(async () => {
+      ;(
+        Array.from(document.querySelectorAll('button')).find((b) =>
+          b.textContent!.includes('History')
+        ) as HTMLButtonElement
+      ).click()
+    })
+    const mainText = document.querySelector('main')!.textContent!
+    expect(mainText).toContain('Missed')
+    expect(mainText).toContain('Your computer was likely off')
+    expect(mainText).not.toContain('missed-run window')
+  })
+
+  it('uses the friendlier subtitle', async () => {
+    hooks.client.listRoutines.mockResolvedValue({ routines: [] })
+    await renderScreen()
+    expect(document.querySelector('.section-header p')!.textContent).toBe(
+      'Put tasks on repeat — see what ran and fix misses.'
+    )
+  })
+})

--- a/collie-ui/src/renderer/src/screens/RoutinesScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/RoutinesScreen.tsx
@@ -3,12 +3,14 @@ import {
   Clock3,
   History,
   Pause,
+  Pencil,
   Play,
   Plus,
   RotateCcw,
   Rocket,
   Settings2,
   Trash2,
+  Undo2,
   X
 } from 'lucide-react'
 import {
@@ -56,6 +58,11 @@ export default function RoutinesScreen(): React.JSX.Element {
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState('')
   const [history, setHistory] = useState<Record<string, CollieRun[]>>({})
+  // Edit flow: which routine is open, plus the text being edited.
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editText, setEditText] = useState('')
+  // Post-create confirmation: the freshly created routine, kept for one-tap Undo.
+  const [justCreated, setJustCreated] = useState<{ id: string; name: string } | null>(null)
 
   const refresh = async (): Promise<void> => {
     if (new URLSearchParams(window.location.search).has('preview')) {
@@ -121,7 +128,7 @@ export default function RoutinesScreen(): React.JSX.Element {
     if (!description.trim()) return
     setBusy(true)
     try {
-      await collieClient.createAutomation(
+      const result = await collieClient.createAutomation(
         description.trim(),
         undefined,
         Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -129,9 +136,54 @@ export default function RoutinesScreen(): React.JSX.Element {
       setDescription('')
       setCreating(false)
       await refresh()
-      setNotice('Your new routine is scheduled.')
+      // Show what Collie understood, with a one-tap Undo — free-text schedule
+      // parsing is magic until the user sees the interpretation.
+      setJustCreated({ id: result.automation.id, name: result.automation.name })
+      setNotice('')
     } catch (error) {
       setNotice(error instanceof Error ? error.message : 'I could not create that routine.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const undoCreate = async (): Promise<void> => {
+    if (!justCreated) return
+    const target = justCreated
+    setJustCreated(null)
+    setBusy(true)
+    try {
+      await collieClient.deleteAutomation(target.id)
+      await refresh()
+      setNotice('Undone — that routine was removed.')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not remove that routine.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const startEdit = (loop: LoopItem): void => {
+    setEditingId(loop.id)
+    setEditText(loop.description || '')
+  }
+
+  const saveEdit = async (): Promise<void> => {
+    if (!editingId || !editText.trim()) return
+    setBusy(true)
+    try {
+      await collieClient.updateAutomation(
+        editingId,
+        editText.trim(),
+        undefined,
+        Intl.DateTimeFormat().resolvedOptions().timeZone
+      )
+      setEditingId(null)
+      setEditText('')
+      await refresh()
+      setNotice('Routine updated.')
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'I could not update that routine.')
     } finally {
       setBusy(false)
     }
@@ -273,15 +325,27 @@ export default function RoutinesScreen(): React.JSX.Element {
           {loop.enabled === 1 ? 'Pause' : 'Resume'}
         </button>
         {!loop.id.startsWith('collie-') && (
-          <button
-            type="button"
-            className="icon-button loop-delete"
-            aria-label={`Delete ${loop.name}`}
-            onClick={() => void remove(loop)}
-            disabled={busy}
-          >
-            <Trash2 size={15} />
-          </button>
+          <>
+            <button
+              type="button"
+              className="icon-button loop-edit"
+              aria-label={`Edit ${loop.name}`}
+              title="Edit this routine"
+              onClick={() => startEdit(loop)}
+              disabled={busy}
+            >
+              <Pencil size={15} />
+            </button>
+            <button
+              type="button"
+              className="icon-button loop-delete"
+              aria-label={`Delete ${loop.name}`}
+              onClick={() => void remove(loop)}
+              disabled={busy}
+            >
+              <Trash2 size={15} />
+            </button>
+          </>
         )}
       </div>
     </article>
@@ -301,6 +365,16 @@ export default function RoutinesScreen(): React.JSX.Element {
 
       <div className="section-scroll">
         {notice && <p className="inline-notice" role="status">{notice}</p>}
+        {justCreated && (
+          <div className="routine-created-banner" role="status">
+            <span>
+              Collie will repeat: <strong>{justCreated.name}</strong>
+            </span>
+            <button type="button" className="secondary-button routine-undo" onClick={() => void undoCreate()} disabled={busy}>
+              <Undo2 size={13} /> Undo
+            </button>
+          </div>
+        )}
         {loading ? (
           <div className="section-loading">Checking your routines...</div>
         ) : loops.length > 0 ? (
@@ -375,6 +449,68 @@ export default function RoutinesScreen(): React.JSX.Element {
                 onClick={() => void createLoop()}
               >
                 {busy ? 'Setting the schedule...' : 'Create routine'}
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {editingId && (
+        <div className="dialog-backdrop" role="presentation">
+          <section
+            className="dialog-card"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="edit-loop-title"
+          >
+            <div className="dialog-heading">
+              <div>
+                <span className="detail-label">EDIT ROUTINE</span>
+                <h2 id="edit-loop-title">Change what Collie repeats</h2>
+              </div>
+              <button
+                type="button"
+                className="icon-button"
+                onClick={() => {
+                  setEditingId(null)
+                  setEditText('')
+                }}
+                aria-label="Close"
+              >
+                <X size={17} />
+              </button>
+            </div>
+            <label className="form-field">
+              <span>Describe the task and schedule</span>
+              <textarea
+                value={editText}
+                onChange={(event) => setEditText(event.target.value)}
+                rows={5}
+                placeholder="Every weekday at 8am, brief me on today's weather, calendar, and priorities."
+                autoFocus
+              />
+            </label>
+            <p className="dialog-hint">
+              Reword it freely — its history and pause state stay put.
+            </p>
+            <div className="dialog-actions">
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={() => {
+                  setEditingId(null)
+                  setEditText('')
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="primary-button"
+                disabled={busy || !editText.trim()}
+                onClick={() => void saveEdit()}
+              >
+                {busy ? 'Saving...' : 'Save changes'}
               </button>
             </div>
           </section>

--- a/collie-ui/src/renderer/src/screens/RoutinesScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/RoutinesScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Clock3,
   History,
@@ -7,6 +7,7 @@ import {
   Plus,
   RotateCcw,
   Rocket,
+  Settings2,
   Trash2,
   X
 } from 'lucide-react'
@@ -21,6 +22,31 @@ const LOOP_STARTERS = [
   'Every Friday at 5pm, help me review the week and plan something enjoyable.',
   'On the first day of every month at 9am, remind me to review my budget.'
 ]
+
+/** Built-in system-maintenance routines shown in their own quiet group. */
+const SYSTEM_IDS = new Set(['collie-memory-maintenance', 'collie-gardener-suggestions'])
+
+function friendlySchedule(schedule: string | undefined): string {
+  const raw = (schedule || '').trim()
+  if (!raw) return ''
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+  const parts = raw.split(/\s+/)
+  const clock = (t: string): string => {
+    const [h, m] = t.split(':').map((n) => parseInt(n, 10))
+    if (Number.isNaN(h)) return t
+    const suffix = h < 12 ? 'am' : 'pm'
+    const hour = h % 12 === 0 ? 12 : h % 12
+    return m ? `${hour}:${String(m).padStart(2, '0')} ${suffix}` : `${hour} ${suffix}`
+  }
+  if (parts.length === 1) return `Every day at ${clock(parts[0])}`
+  if (parts.length === 2 && /^\d+$/.test(parts[0])) return `Day ${parseInt(parts[0], 10)} of the month at ${clock(parts[1])}`
+  if (parts.length === 2 && days.includes(parts[0])) return `${dayName(parts[0])}s at ${clock(parts[1])}`
+  return raw
+}
+
+function dayName(code: string): string {
+  return ({ Mon: 'Monday', Tue: 'Tuesday', Wed: 'Wednesday', Thu: 'Thursday', Fri: 'Friday', Sat: 'Saturday', Sun: 'Sunday' } as Record<string, string>)[code] || code
+}
 
 export default function RoutinesScreen(): React.JSX.Element {
   const [loops, setLoops] = useState<LoopItem[]>([])
@@ -85,7 +111,7 @@ export default function RoutinesScreen(): React.JSX.Element {
       }
       setNotice(enabled ? `${loop.name} is enabled.` : `${loop.name} is paused.`)
     } catch (error) {
-      setNotice(error instanceof Error ? error.message : 'I could not update that loop.')
+      setNotice(error instanceof Error ? error.message : 'I could not update that routine.')
     } finally {
       setBusy(false)
     }
@@ -105,7 +131,7 @@ export default function RoutinesScreen(): React.JSX.Element {
       await refresh()
       setNotice('Your new routine is scheduled.')
     } catch (error) {
-      setNotice(error instanceof Error ? error.message : 'I could not create that loop.')
+      setNotice(error instanceof Error ? error.message : 'I could not create that routine.')
     } finally {
       setBusy(false)
     }
@@ -119,7 +145,7 @@ export default function RoutinesScreen(): React.JSX.Element {
       await refresh()
       setNotice(`${loop.name} was deleted.`)
     } catch (error) {
-      setNotice(error instanceof Error ? error.message : 'I could not delete that loop.')
+      setNotice(error instanceof Error ? error.message : 'I could not delete that routine.')
     } finally {
       setBusy(false)
     }
@@ -150,12 +176,123 @@ export default function RoutinesScreen(): React.JSX.Element {
     setHistory((current) => ({ ...current, [loop.id]: data.runs }))
   }
 
+  /** A paused card has no honest "Next" until it runs again. */
+  const nextRunLabel = (loop: LoopItem): string => {
+    if (loop.enabled !== 1) return 'Paused'
+    if (!loop.next_run_at) return 'Not scheduled'
+    return new Date(loop.next_run_at).toLocaleString()
+  }
+
+  /** Missed-window skips are normal life (computer off), not errors. */
+  const runLine = (loop: LoopItem, run: CollieRun): React.JSX.Element => (
+    <div key={run.id}>
+      {run.status === 'skipped' && (run as { error_code?: string }).error_code === 'missed_window' ? (
+        <>
+          <strong>Missed</strong>
+          <span>{run.scheduled_for ? new Date(run.scheduled_for).toLocaleString() : run.trigger_type}</span>
+          <small>Your computer was likely off — nothing was lost.</small>
+        </>
+      ) : (
+        <>
+          <strong>{run.status}</strong>
+          <span>{run.started_at ? new Date(run.started_at).toLocaleString() : run.trigger_type}</span>
+          {run.error_message ? <small>{run.error_message}</small> : null}
+        </>
+      )}
+      {run.status === 'failed' ? (
+        <button
+          className="routine-retry"
+          onClick={() => void (async () => {
+            await collieClient.retryRoutineRun(run.id)
+            setNotice('Retry started.')
+            const data = await collieClient.listRoutineRuns(loop.id)
+            setHistory((current) => ({ ...current, [loop.id]: data.runs }))
+          })()}
+        >
+          <RotateCcw size={11} /> Retry
+        </button>
+      ) : null}
+    </div>
+  )
+
+  const userLoops = useMemo(() => loops.filter((loop) => !SYSTEM_IDS.has(loop.id)), [loops])
+  const systemLoops = useMemo(() => loops.filter((loop) => SYSTEM_IDS.has(loop.id)), [loops])
+
+  const renderCard = (loop: LoopItem): React.JSX.Element => (
+    <article key={loop.id} className={`loop-card ${loop.enabled === 1 ? '' : 'is-paused'}`}>
+      <div className="loop-icon"><Clock3 size={20} /></div>
+      <div className="loop-copy">
+        <div className="loop-title-row">
+          <h2>{loop.name}</h2>
+          <span className={`loop-state ${loop.enabled === 1 ? 'is-running' : ''}`}>
+            {loop.routine_status === 'needs_attention'
+              ? 'Needs attention'
+              : loop.enabled === 1 ? 'Enabled' : 'Paused'}
+          </span>
+        </div>
+        {loop.description && <p>{loop.description}</p>}
+        <div className="loop-schedule"><Clock3 size={13} /> {friendlySchedule(loop.schedule) || 'Schedule set by Collie'}</div>
+        <div className="routine-facts">
+          <span>Next: {nextRunLabel(loop)}</span>
+          <span>Last success: {loop.last_success_at ? new Date(loop.last_success_at).toLocaleString() : 'Never'}</span>
+          {loop.last_failure_at ? <span>Last failure: {new Date(loop.last_failure_at).toLocaleString()}</span> : null}
+          {loop.plan_version ? <span>Plan: v{loop.plan_version}</span> : null}
+        </div>
+        {history[loop.id] ? (
+          <div className="routine-history">
+            {history[loop.id].length ? history[loop.id].slice(0, 5).map((run) => runLine(loop, run)) : <span>No runs yet.</span>}
+          </div>
+        ) : null}
+      </div>
+      <div className="loop-actions">
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={() => void runNow(loop)}
+          disabled={busy || (loop.action_type === 'approved_plan' && !loop.plan_version)}
+        >
+          <Rocket size={14} /> Run now
+        </button>
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={() => void toggleHistory(loop)}
+          disabled={busy}
+        >
+          <History size={14} /> History
+        </button>
+        <button
+          type="button"
+          className="secondary-button"
+          role="switch"
+          aria-checked={loop.enabled === 1}
+          onClick={() => void toggle(loop)}
+          disabled={busy}
+        >
+          {loop.enabled === 1 ? <Pause size={14} /> : <Play size={14} />}
+          {loop.enabled === 1 ? 'Pause' : 'Resume'}
+        </button>
+        {!loop.id.startsWith('collie-') && (
+          <button
+            type="button"
+            className="icon-button loop-delete"
+            aria-label={`Delete ${loop.name}`}
+            onClick={() => void remove(loop)}
+            disabled={busy}
+          >
+            <Trash2 size={15} />
+          </button>
+        )}
+      </div>
+    </article>
+  )
+
   return (
     <main className="section-workspace flex min-w-0 flex-1 flex-col overflow-hidden">
       <header className="section-header">
         <div>
           <h1>Routines</h1>
-          <p>Schedule approved plans with visible history and recovery.</p>
+          <p>Put tasks on repeat — see what ran and fix misses.</p>
         </div>
         <button type="button" className="primary-button" onClick={() => setCreating(true)}>
           <Plus size={16} /> Create routine
@@ -167,95 +304,17 @@ export default function RoutinesScreen(): React.JSX.Element {
         {loading ? (
           <div className="section-loading">Checking your routines...</div>
         ) : loops.length > 0 ? (
-          <div className="loop-list">
-            {loops.map((loop) => (
-              <article key={loop.id} className={`loop-card ${loop.enabled === 1 ? '' : 'is-paused'}`}>
-                <div className="loop-icon"><Clock3 size={20} /></div>
-                <div className="loop-copy">
-                  <div className="loop-title-row">
-                    <h2>{loop.name}</h2>
-                    <span className={`loop-state ${loop.enabled === 1 ? 'is-running' : ''}`}>
-                      {loop.routine_status === 'needs_attention'
-                        ? 'Needs attention'
-                        : loop.enabled === 1 ? 'Enabled' : 'Paused'}
-                    </span>
-                  </div>
-                  {loop.description && <p>{loop.description}</p>}
-                  <div className="loop-schedule"><Clock3 size={13} /> {loop.schedule || 'Schedule set by Collie'}</div>
-                  <div className="routine-facts">
-                    <span>Next: {loop.next_run_at ? new Date(loop.next_run_at).toLocaleString() : 'Not scheduled'}</span>
-                    <span>Last success: {loop.last_success_at ? new Date(loop.last_success_at).toLocaleString() : 'Never'}</span>
-                    {loop.last_failure_at ? <span>Last failure: {new Date(loop.last_failure_at).toLocaleString()}</span> : null}
-                    <span>Plan: {loop.plan_version ? `v${loop.plan_version}` : 'Needs review'}</span>
-                  </div>
-                  {history[loop.id] ? (
-                    <div className="routine-history">
-                      {history[loop.id].length ? history[loop.id].slice(0, 5).map((run) => (
-                        <div key={run.id}>
-                          <strong>{run.status}</strong>
-                          <span>{run.started_at ? new Date(run.started_at).toLocaleString() : run.trigger_type}</span>
-                          {run.error_message ? <small>{run.error_message}</small> : null}
-                          {run.status === 'failed' ? (
-                            <button
-                              className="routine-retry"
-                              onClick={() => void (async () => {
-                                await collieClient.retryRoutineRun(run.id)
-                                setNotice('Retry started.')
-                                const data = await collieClient.listRoutineRuns(loop.id)
-                                setHistory((current) => ({ ...current, [loop.id]: data.runs }))
-                              })()}
-                            >
-                              <RotateCcw size={11} /> Retry
-                            </button>
-                          ) : null}
-                        </div>
-                      )) : <span>No runs yet.</span>}
-                    </div>
-                  ) : null}
-                </div>
-                <div className="loop-actions">
-                  <button
-                    type="button"
-                    className="secondary-button"
-                    onClick={() => void runNow(loop)}
-                    disabled={busy || (loop.action_type === 'approved_plan' && !loop.plan_version)}
-                  >
-                    <Rocket size={14} /> Run now
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary-button"
-                    onClick={() => void toggleHistory(loop)}
-                    disabled={busy}
-                  >
-                    <History size={14} /> History
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary-button"
-                    role="switch"
-                    aria-checked={loop.enabled === 1}
-                    onClick={() => void toggle(loop)}
-                    disabled={busy}
-                  >
-                    {loop.enabled === 1 ? <Pause size={14} /> : <Play size={14} />}
-                    {loop.enabled === 1 ? 'Pause' : 'Resume'}
-                  </button>
-                  {!loop.id.startsWith('collie-') && (
-                    <button
-                      type="button"
-                      className="icon-button loop-delete"
-                      aria-label={`Delete ${loop.name}`}
-                      onClick={() => void remove(loop)}
-                      disabled={busy}
-                    >
-                      <Trash2 size={15} />
-                    </button>
-                  )}
-                </div>
-              </article>
-            ))}
-          </div>
+          <>
+            {userLoops.length > 0 ? (
+              <div className="loop-list">{userLoops.map(renderCard)}</div>
+            ) : null}
+            {systemLoops.length > 0 ? (
+              <>
+                <h3 className="routine-group-label"><Settings2 size={13} /> System maintenance</h3>
+                <div className="loop-list">{systemLoops.map(renderCard)}</div>
+              </>
+            ) : null}
+          </>
         ) : (
           <div className="loops-empty">
             <span className="section-placeholder-icon"><Clock3 size={25} /></span>

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1013,6 +1013,9 @@ button {
 
 .loop-list { display: grid; gap: 10px; }
 .routine-group-label { display: flex; align-items: center; gap: 6px; margin: 18px 0 8px; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.routine-created-banner { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; padding: 10px 14px; border: 1px solid var(--grass-dark); border-radius: 12px; background: var(--bone); color: var(--ink); font-size: 12.5px; }
+.routine-created-banner strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.routine-undo { flex-shrink: 0; }
 .loop-card { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: center; gap: 14px; padding: 16px; border: 1px solid var(--line); border-radius: 15px; background: #fff; box-shadow: var(--shadow-sm); }
 .loop-card.is-paused { background: #fafaf8; opacity: 0.78; }
 .loop-icon { display: grid; width: 42px; height: 42px; place-items: center; border-radius: 13px; background: var(--bone); color: var(--grass-dark); }

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1012,6 +1012,7 @@ button {
 }
 
 .loop-list { display: grid; gap: 10px; }
+.routine-group-label { display: flex; align-items: center; gap: 6px; margin: 18px 0 8px; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
 .loop-card { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: center; gap: 14px; padding: 16px; border: 1px solid var(--line); border-radius: 15px; background: #fff; box-shadow: var(--shadow-sm); }
 .loop-card.is-paused { background: #fafaf8; opacity: 0.78; }
 .loop-icon { display: grid; width: 42px; height: 42px; place-items: center; border-radius: 13px; background: var(--bone); color: var(--grass-dark); }


### PR DESCRIPTION
> ⚠️ Stacked on #104 — merge that one first; this diff shrinks to just the edit feature after.

## What

Non-coders shouldn't have to delete + recreate a routine just to change the time.

- ✏️ **Edit button** on custom routines → same plain-language dialog as creation. Core re-parses the wording, updates schedule + prompt, recomputes next run — while keeping id, run history, and pause state untouched.
- **Post-create confirmation**: banner "Collie will repeat: …" with one-tap **Undo**, replacing silent fire-and-forget creation.
- Built-ins stay non-editable (core guard + no UI button).

Core changes: \`update_custom_automation()\` + \`update_automation\` IPC command; \`db.update_automation\` accepts \`action_config\` (JSON-serialised).

## Verification

- Core: 5 new tests (reword/prompt, identity + paused preserved, builtin reject, unclear-schedule reject, missing row) — 30/30 automation tests green
- UI: edit-dialog round-trip, banner+undo, built-ins-have-no-edit tests — 15/15 green
- Typecheck clean, build clean, live instance round-trip verified by screenshot (edit saved → card re-parsed to "Fridays at 5 pm" with correct next run)