### PR TITLE
fix(account): add Host/Origin checks to sign-in callback

### DIFF
--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 import { mkdtempSync, rmSync } from 'fs'
-import { createServer } from 'http'
+import { createServer, request as httpRequest } from 'http'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -354,6 +354,78 @@ describe('startAccountSignIn', () => {
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()))
     }
+  })
+})
+
+/**
+ * Raw callback GET with fully controlled headers — realFetch can't fake a
+ * Host or Origin header, so login-CSRF probes use Node's http client with
+ * `setHost: false` and an explicit host header.
+ */
+function rawCallback(opts: { host?: string; origin?: string }): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {
+      host: opts.host ?? `${CALLBACK_HOST}:${CALLBACK_PORT}`
+    }
+    if (opts.origin !== undefined) headers.origin = opts.origin
+    const req = httpRequest(
+      {
+        hostname: CALLBACK_HOST,
+        port: CALLBACK_PORT,
+        path: '/callback?code=attacker-code',
+        method: 'GET',
+        headers,
+        setHost: false
+      },
+      (res) => {
+        res.resume()
+        resolve(res.statusCode ?? 0)
+      }
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+describe('sign-in callback CSRF defenses (issue #106)', () => {
+  it('rejects a callback addressed to a foreign Host (DNS-rebinding defense)', async () => {
+    const signInPromise = startAccountSignIn()
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+
+    // An attacker page that rebinds its name to 127.0.0.1 delivers its own
+    // code — the request arrives, but Host is the attacker's name.
+    const status = await rawCallback({ host: 'evil.example.com' })
+    expect(status).toBe(404)
+
+    // The flow is untouched: the legitimate redirect still completes it.
+    const ok = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+    )
+    expect(ok.status).toBe(200)
+    const state = await signInPromise
+    expect(state.signedIn).toBe(true)
+    expect(state.email).toBe('tester@heycollie.com')
+  })
+
+  it('rejects a callback carrying an Origin header (cross-site fetch defense)', async () => {
+    const signInPromise = startAccountSignIn()
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+
+    // A top-level browser redirect sends no Origin; cross-site fetch/XHR does.
+    const status = await rawCallback({ origin: 'http://evil.example.com' })
+    expect(status).toBe(400)
+
+    const ok = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+    )
+    expect(ok.status).toBe(200)
+    const state = await signInPromise
+    expect(state.signedIn).toBe(true)
+    expect(state.email).toBe('tester@heycollie.com')
   })
 })
 

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -354,13 +354,12 @@ function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string>
         res.writeHead(405).end('Method not allowed')
         return
       }
-      // Login-CSRF defense (issue #106): the listener sits on a fixed,
-      // well-known port while the browser flow is in flight, so any local
-      // process — or a cross-site page that reaches 127.0.0.1 (DNS
-      // rebinding) — could try to deliver its own auth code. Two cheap
-      // gates close that: the request must be addressed to this exact
-      // host:port (rebinding changes Host), and a browser's top-level
-      // redirect carries no Origin header — cross-site fetch/XHR does.
+      // Login-CSRF defense in depth (issue #106): the listener sits on a
+      // fixed, well-known port while the browser flow is in flight. Requiring
+      // the exact Host blocks common DNS-rebinding delivery, and rejecting an
+      // Origin blocks common cross-site fetch/XHR delivery (a top-level
+      // browser redirect normally sends no Origin). These checks do not bind
+      // the callback to the flow that initiated it, so issue #106 remains open.
       const host = (req.headers.host ?? '').toLowerCase()
       if (host !== `${CALLBACK_HOST}:${CALLBACK_PORT}`) {
         res.writeHead(404).end('Not found')

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -354,6 +354,22 @@ function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string>
         res.writeHead(405).end('Method not allowed')
         return
       }
+      // Login-CSRF defense (issue #106): the listener sits on a fixed,
+      // well-known port while the browser flow is in flight, so any local
+      // process — or a cross-site page that reaches 127.0.0.1 (DNS
+      // rebinding) — could try to deliver its own auth code. Two cheap
+      // gates close that: the request must be addressed to this exact
+      // host:port (rebinding changes Host), and a browser's top-level
+      // redirect carries no Origin header — cross-site fetch/XHR does.
+      const host = (req.headers.host ?? '').toLowerCase()
+      if (host !== `${CALLBACK_HOST}:${CALLBACK_PORT}`) {
+        res.writeHead(404).end('Not found')
+        return
+      }
+      if (req.headers.origin !== undefined) {
+        res.writeHead(400).end('Bad request')
+        return
+      }
       let url: URL
       try {
         url = new URL(req.url ?? '/', `http://${CALLBACK_HOST}`)


### PR DESCRIPTION
Partial defense-in-depth mitigation for issue #106. This PR intentionally leaves that issue unresolved.

## What

Hardens the account sign-in loopback callback in `collie-ui/src/main/account-auth.ts`:

- **Host check** — the callback request must be addressed to exactly `127.0.0.1:8123`, which blocks common DNS-rebinding delivery where the request retains an attacker-controlled Host.
- **Origin check** — any request carrying an `Origin` header is rejected, which blocks common cross-site fetch/XHR delivery; a normal top-level browser redirect does not carry one.

These are defense-in-depth checks for common delivery paths. They are not a complete login-CSRF fix.

## Remaining limitation

The callback is still not cryptographically bound to the sign-in flow that initiated it. A same-host local process, or another request that satisfies these header checks, can still race a code delivery during the callback window. PKCE remains the primary token-theft defense, but the account-selection/login-CSRF surface remains unresolved.

Issue #106 must remain open until the callback is bound to the initiating flow (or the flow is otherwise redesigned to provide equivalent protection).

## Verification

- `npm test -- src/main/account-auth.test.ts` — 18 tests passed.
- `npm run typecheck` — passed.
- All five hosted CI jobs pass on the adapted head.