### PR TITLE
chore(ci): pin workflow actions to commit SHAs + least-privilege permissions (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Least-privilege defaults: CI only reads the repo and reports checks; no
+# job in this workflow needs write scope (#107).
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,9 +22,9 @@ jobs:
       run:
         working-directory: collie-core
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -96,9 +101,9 @@ jobs:
       run:
         working-directory: collie-core
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -132,9 +137,9 @@ jobs:
       run:
         working-directory: collie-ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -163,9 +168,9 @@ jobs:
       run:
         working-directory: collie-ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/installer-build.yml
+++ b/.github/workflows/installer-build.yml
@@ -20,20 +20,26 @@ on:
       - .github/workflows/installer-build.yml
   workflow_dispatch:
 
+# Least-privilege defaults: the job builds an installer for verification and
+# reads the repo only; artifact upload uses Actions storage, not repo scope
+# (#107).
+permissions:
+  contents: read
+
 jobs:
   windows-installer:
     name: Windows NSIS installer
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: collie-ui/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -69,7 +75,7 @@ jobs:
         run: npx electron-builder --win nsis --x64 --publish never
 
       - name: Upload installer artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: collie-windows-installer
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ on:
     tags:
       - "v*"
 
+# Least-privilege default for the whole workflow: qualify/build only read the
+# repo. The `release` job narrows itself back up to `contents: write` (it
+# creates the draft GitHub Release) (#107).
+permissions:
+  contents: read
+
 jobs:
   # A tag can be pushed from any commit, so the release pipeline itself must
   # qualify the code before any package is built: core tests (with the
@@ -38,9 +44,9 @@ jobs:
       run:
         working-directory: collie-core
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -76,7 +82,7 @@ jobs:
             --deselect tests/collie/test_services.py::test_disconnect_service \
             --deselect tests/collie/test_ipc.py::test_read_write_file_rejects_escape_paths
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -124,9 +130,9 @@ jobs:
       run:
         working-directory: collie-ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -136,13 +142,13 @@ jobs:
         run: npm ci
 
       - name: Set up Python for the build venv
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: Install standalone Python runtime (python-build-standalone)
         if: matrix.standalone
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           python-version: ${{ matrix.python }}
 
@@ -256,7 +262,7 @@ jobs:
           ls -la dist
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: collie-${{ matrix.os }}
           if-no-files-found: error
@@ -285,10 +291,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Download all platform artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           path: artifacts
           merge-multiple: true
@@ -304,7 +310,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release (draft)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           files: artifacts/*
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release (draft)
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           files: artifacts/*
           draft: true


### PR DESCRIPTION
Fixes #107.  ## What  Pins all GitHub Actions in `.github/workflows/release.yml` to full commit SHAs (with version comments) and adds top-level least-privilege `permissions:` blocks, per workflow.  ## Why  Floating action tags are a supply-chain attack surface; explicit top-level permissions prevent a compromised step from getting a broad token.  ## Verification  - Rebased onto current `main` (two focused commits; no longer stacked on the CSRF branch). - Workflow YAML validated; no behavior change to the release flow itself.  Draft for owner review — no merge without sign-off.