### PR TITLE
fix(ui): block remote images in chat markdown

### DIFF
--- a/collie-ui/src/renderer/src/components/MarkdownContent.test.tsx
+++ b/collie-ui/src/renderer/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { beforeAll, describe, expect, it } from 'vitest'
+import MarkdownContent from './MarkdownContent'
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+function renderIn(content: string): HTMLElement {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  act(() => root.render(<MarkdownContent content={content} />))
+  return container
+}
+
+describe('MarkdownContent image safety', () => {
+  it('renders no images when none are present', () => {
+    expect(renderIn('Just some text with no images.').querySelectorAll('img')).toHaveLength(0)
+  })
+
+  it('blocks remote https images', () => {
+    expect(renderIn('![spy](https://evil.example/pixel.png)').querySelectorAll('img')).toHaveLength(0)
+  })
+
+  it('blocks remote http images', () => {
+    expect(renderIn('![spy](http://evil.example/pixel.png)').querySelectorAll('img')).toHaveLength(0)
+  })
+
+  it('blocks other non-local schemes like file:', () => {
+    expect(renderIn('![local](file:///etc/passwd.png)').querySelectorAll('img')).toHaveLength(0)
+  })
+
+  it('data: URIs never produce a fetchable img (react-markdown v10 strips the src itself)', () => {
+    // Baseline behavior of the markdown library: data: URLs are sanitized out,
+    // so our override has no src to allow — nothing renders. Still no remote fetch.
+    expect(renderIn('![diagram](data:image/png;base64,AAAA)').querySelectorAll('img')).toHaveLength(0)
+  })
+
+  it('keeps same-origin relative paths (the local media server) with their src intact', () => {
+    const img = renderIn('![diagram](/api/media/sig/payload)').querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBe('/api/media/sig/payload')
+  })
+
+  it('still renders links normally', () => {
+    expect(renderIn('[Collie](https://heycollie.com)').querySelector('a')).not.toBeNull()
+  })
+})

--- a/collie-ui/src/renderer/src/components/MarkdownContent.tsx
+++ b/collie-ui/src/renderer/src/components/MarkdownContent.tsx
@@ -5,6 +5,21 @@ interface Props {
   content: string
 }
 
+/**
+ * Only images that never hit the network are allowed into chat:
+ *  - `data:` URIs (self-contained, used by tools/connectors for generated media)
+ *  - relative / same-origin paths (the local media server, e.g. `/api/media/...`)
+ * Anything with a remote scheme (`http:`, `https:`, `file:`, …) is blocked:
+ * loading it would leak the user's IP and let a third-party server track them.
+ */
+function isSafeImageSrc(src: string | undefined): boolean {
+  if (!src) return false
+  if (src.startsWith('data:')) return true
+  // A leading `scheme:` means remote or otherwise non-local — block it.
+  // Relative paths have no scheme and stay local, so they pass.
+  return !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(src)
+}
+
 export default function MarkdownContent({ content }: Props): React.JSX.Element {
   return (
     <div className="message-markdown">
@@ -24,7 +39,11 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
             >
               {children}
             </a>
-          )
+          ),
+          img: ({ src, alt, title }) => {
+            if (!isSafeImageSrc(src)) return null
+            return <img src={src} alt={alt ?? ''} title={title} />
+          }
         }}
       >
         {content}

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,11 +11,11 @@
 
 ## Source inventory
 
-- Core Python files: **516**
-- Core Python test files: **234**
-- Desktop TypeScript/TSX files: **159**
-- Desktop test files: **54**
-- Active Markdown docs: **32**
+- Core Python files: **519**
+- Core Python test files: **236**
+- Desktop TypeScript/TSX files: **173**
+- Desktop test files: **62**
+- Active Markdown docs: **33**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups


### PR DESCRIPTION
# fix(ui): block remote images in chat markdown

Closes the security gap flagged during the 2026-08-23 cleanup sweep (originally
the never-PR'd `codex/security-block-remote-markdown-images` branch).

## Why

Chat markdown could load images from **any** URL (`![title](https://…)`). Every
rendered remote image:
- leaks the user's IP to a third-party server, and
- lets that server track when/how often the app renders its tracker.

Collie's local-first privacy posture says chat must not silently phone remote
servers. Links were already hardened (https-only, routed through the safe
opener); **images were the one remaining hole** — the CSP `img-src` allows
`https:`, so the renderer had to enforce the policy.

## The fix

`MarkdownContent.tsx` gets an `img` component override with one rule:

- **Allowed:** same-origin / relative sources only (the local media server,
  e.g. `/api/media/…`).
- **Blocked:** any scheme-ful remote URL (`http:`, `https:`, `file:`, …) —
  renders nothing.
- **`data:` URIs** — react-markdown v10 already strips these itself (verified:
  it emits `<img alt>` with no `src`), so nothing fetchable ever reaches an
  `<img>`. Covered by a test documenting that baseline.

Also verified: `ThingPreview` renders image *things* via its own `<img
src={state.dataUrl}>` path (not through MarkdownContent) and **still shows
tool-generated images** — this change does not touch that.

## Tests (TDD: failing first, then green)

New `MarkdownContent.test.tsx`, 7 tests:
- blocks remote `https:` / `http:` / `file:` images ❌→✅
- keeps same-origin relative paths with their `src` intact ✅
- `data:` never produces a fetchable img (v10 baseline) ✅
- links still render, no-img case covered ✅

**Gates (fresh, this branch):**
- `vitest` full renderer suite: **62 files / 414 tests passed** (exit 0)
- `MarkdownContent.test.tsx` re-run 3×: 7/7 each (no CI race)
- `npm run typecheck`: clean (web + node)

Included: regenerated `REPOSITORY_SNAPSHOT.md` (separate chore commit) —
my inventory scan caught pre-existing main drift from the #100–#105 merges.

## Review notes

- No secrets; diff is 3 files / +77 −7.
- Rendering remote images at all was a privacy/footprint issue, not a code-exec
  vector (React escapes, CSP is tight on script-src). Risk: low.
- Follow-up (out of scope, tracked): native `data:` image rendering was
  disabled by the v10 library upgrade; if we want generated images visible in
  chat bubbles again, that's a separate feature PR.