### PR TITLE
fix(security): block untrusted remote image requests

### DIFF
--- a/collie-ui/src/renderer/src/components/MarkdownContent.test.tsx
+++ b/collie-ui/src/renderer/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import MarkdownContent from './MarkdownContent'
+
+const roots: Root[] = []
+
+function render(content: string): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(<MarkdownContent content={content} />))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+describe('MarkdownContent images', () => {
+  it('does not render remote image URLs', () => {
+    const container = render('![tracking pixel](https://tracker.example/pixel.png)')
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('Remote image hidden for privacy: tracking pixel')
+  })
+
+  it('also blocks protocol-relative remote image URLs', () => {
+    const container = render('![tracking pixel](//tracker.example/pixel.png)')
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('Remote image hidden for privacy')
+  })
+
+  it('preserves local relative images', () => {
+    const container = render('![local](./assets/example.png)')
+    const images = container.querySelectorAll('img')
+
+    expect(images).toHaveLength(1)
+    expect(images[0]?.getAttribute('src')).toBe('./assets/example.png')
+  })
+})

--- a/collie-ui/src/renderer/src/components/MarkdownContent.test.tsx
+++ b/collie-ui/src/renderer/src/components/MarkdownContent.test.tsx
@@ -40,11 +40,28 @@ describe('MarkdownContent images', () => {
     expect(container.textContent).toContain('Remote image hidden for privacy')
   })
 
+  it.each([
+    'http://tracker.example/pixel.png',
+    'file:///C:/Users/example/private.png',
+    'blob:https://tracker.example/id'
+  ])('blocks scheme-bearing image source %s', (source) => {
+    const container = render(`![tracking pixel](${source})`)
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('Remote image hidden for privacy')
+  })
+
   it('preserves local relative images', () => {
     const container = render('![local](./assets/example.png)')
     const images = container.querySelectorAll('img')
 
     expect(images).toHaveLength(1)
     expect(images[0]?.getAttribute('src')).toBe('./assets/example.png')
+  })
+
+  it('preserves supported inline raster images', () => {
+    const container = render('![inline](data:image/png;base64,iVBORw0KGgo=)')
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=')
   })
 })

--- a/collie-ui/src/renderer/src/components/MarkdownContent.tsx
+++ b/collie-ui/src/renderer/src/components/MarkdownContent.tsx
@@ -1,15 +1,9 @@
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { safeImageSource } from '../lib/safeImageSource'
 
 interface Props {
   content: string
-}
-
-function isLocalMarkdownImage(src: string | undefined): boolean {
-  if (!src) return false
-  const value = src.trim()
-  if (/^data:image\/(?:gif|jpe?g|png|webp);base64,/i.test(value)) return true
-  return !/^(?:[a-z][a-z\d+.-]*:|[\\/]{2})/i.test(value)
 }
 
 export default function MarkdownContent({ content }: Props): React.JSX.Element {
@@ -17,6 +11,11 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
     <div className="message-markdown">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        urlTransform={(url, key, node) => (
+          key === 'src' && node.tagName === 'img'
+            ? (safeImageSource(url) ?? '')
+            : defaultUrlTransform(url)
+        )}
         components={{
           a: ({ href, children }) => (
             <a
@@ -32,14 +31,16 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
               {children}
             </a>
           ),
-          img: ({ src, alt }) =>
-            isLocalMarkdownImage(src) ? (
-              <img src={src} alt={alt ?? ''} loading="lazy" />
+          img: ({ src, alt }) => {
+            const safeSource = safeImageSource(src)
+            return safeSource ? (
+              <img src={safeSource} alt={alt ?? ''} loading="lazy" />
             ) : (
               <span className="message-markdown-remote-image" role="note">
                 Remote image hidden for privacy{alt ? `: ${alt}` : '.'}
               </span>
             )
+          }
         }}
       >
         {content}

--- a/collie-ui/src/renderer/src/components/MarkdownContent.tsx
+++ b/collie-ui/src/renderer/src/components/MarkdownContent.tsx
@@ -5,6 +5,13 @@ interface Props {
   content: string
 }
 
+function isLocalMarkdownImage(src: string | undefined): boolean {
+  if (!src) return false
+  const value = src.trim()
+  if (/^data:image\/(?:gif|jpe?g|png|webp);base64,/i.test(value)) return true
+  return !/^(?:[a-z][a-z\d+.-]*:|[\\/]{2})/i.test(value)
+}
+
 export default function MarkdownContent({ content }: Props): React.JSX.Element {
   return (
     <div className="message-markdown">
@@ -24,7 +31,15 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
             >
               {children}
             </a>
-          )
+          ),
+          img: ({ src, alt }) =>
+            isLocalMarkdownImage(src) ? (
+              <img src={src} alt={alt ?? ''} loading="lazy" />
+            ) : (
+              <span className="message-markdown-remote-image" role="note">
+                Remote image hidden for privacy{alt ? `: ${alt}` : '.'}
+              </span>
+            )
         }}
       >
         {content}

--- a/collie-ui/src/renderer/src/components/cards/NewsCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/NewsCard.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import NewsCard from './NewsCard'
+
+const roots: Root[] = []
+
+function renderImage(source: unknown): HTMLElement {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(
+    <NewsCard data={{ articles: [{ headline: 'Headline', source: 'Publisher', image: source }] }} />
+  ))
+  return container
+}
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+describe('NewsCard images', () => {
+  it.each([
+    'https://tracker.example/pixel.png',
+    '//tracker.example/pixel.png',
+    'file:///C:/Users/example/private.png',
+    'blob:https://tracker.example/id'
+  ])('does not render scheme-bearing or protocol-relative source %s', (source) => {
+    const container = renderImage(source)
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('Headline')
+  })
+
+  it.each([
+    ['./assets/news.png', './assets/news.png'],
+    ['data:image/webp;base64,UklGRg==', 'data:image/webp;base64,UklGRg==']
+  ])('preserves safe local or inline raster source %s', (source, expected) => {
+    const container = renderImage(source)
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(expected)
+  })
+})

--- a/collie-ui/src/renderer/src/components/cards/NewsCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/NewsCard.tsx
@@ -1,3 +1,5 @@
+import { safeImageSource } from '../../lib/safeImageSource'
+
 interface Props {
   data: Record<string, unknown>
 }
@@ -29,28 +31,31 @@ export default function NewsCard({ data }: Props): React.JSX.Element {
         </span>
       </div>
       <div className="space-y-2">
-        {articles.map((article, i) => (
-          <div key={i} className="flex gap-3 rounded-xl p-2" style={{ background: 'var(--collie-bone)' }}>
-            {(article.image as string) && (
-              <div className="h-14 w-14 shrink-0 overflow-hidden rounded-lg">
-                <img
-                  src={String(article.image || '')}
-                  alt=""
-                  className="h-full w-full object-cover"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
-                />
-              </div>
-            )}
-            <div className="min-w-0 flex-1">
-              <div className="line-clamp-2 text-sm font-semibold" style={{ color: 'var(--collie-nose)' }}>
-                {article.headline as string}
-              </div>
-              <div className="mt-1 text-xs" style={{ color: 'var(--collie-paw)' }}>
-                {article.source as string}
+        {articles.map((article, i) => {
+          const imageSource = safeImageSource(article.image)
+          return (
+            <div key={i} className="flex gap-3 rounded-xl p-2" style={{ background: 'var(--collie-bone)' }}>
+              {imageSource && (
+                <div className="h-14 w-14 shrink-0 overflow-hidden rounded-lg">
+                  <img
+                    src={imageSource}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                  />
+                </div>
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="line-clamp-2 text-sm font-semibold" style={{ color: 'var(--collie-nose)' }}>
+                  {article.headline as string}
+                </div>
+                <div className="mt-1 text-xs" style={{ color: 'var(--collie-paw)' }}>
+                  {article.source as string}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/collie-ui/src/renderer/src/lib/safeImageSource.ts
+++ b/collie-ui/src/renderer/src/lib/safeImageSource.ts
@@ -1,0 +1,18 @@
+const BASE64_RASTER_IMAGE = /^data:image\/(?:gif|jpe?g|png|webp);base64,/i
+const SCHEME_OR_NETWORK_PATH = /^(?:[a-z][a-z\d+.-]*:|[\\/]{2})/i
+const ASCII_CONTROL = /[\u0000-\u001f\u007f]/
+
+/**
+ * Restrict untrusted image metadata to renderer-local paths or supported
+ * inline raster images. Scheme-bearing and network-path inputs could make the
+ * renderer contact an attacker-controlled host when assigned to an img src.
+ */
+export function safeImageSource(source: unknown): string | null {
+  if (typeof source !== 'string') return null
+
+  const value = source.trim()
+  if (!value || ASCII_CONTROL.test(value)) return null
+  if (BASE64_RASTER_IMAGE.test(value)) return value
+  if (SCHEME_OR_NETWORK_PATH.test(value)) return null
+  return value
+}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -2041,6 +2041,7 @@ button {
 .message-markdown th,
 .message-markdown td { border: 1px solid var(--line); padding: 6px 8px; text-align: left; }
 .message-markdown th { background: var(--bone); font-weight: 700; }
+.message-markdown-remote-image { color: var(--muted); font-size: 0.9em; font-style: italic; }
 
 .thinking-note {
   color: var(--muted);

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,11 +11,11 @@
 
 ## Source inventory
 
-- Core Python files: **516**
-- Core Python test files: **234**
-- Desktop TypeScript/TSX files: **159**
-- Desktop test files: **54**
-- Active Markdown docs: **32**
+- Core Python files: **519**
+- Core Python test files: **236**
+- Desktop TypeScript/TSX files: **175**
+- Desktop test files: **63**
+- Active Markdown docs: **33**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups


### PR DESCRIPTION
## Summary

- enforce one shared safe-image policy for untrusted Markdown and NewsCard image sources
- block scheme-bearing and protocol-relative image URLs before they reach an `<img src>` sink
- preserve renderer-local paths and allowlisted base64 raster images
- add focused regressions for MarkdownContent and NewsCard

## Security impact

Assistant/model output and external card data could previously create an arbitrary HTTPS image request when rendered, exposing the user's IP address, timing, and request metadata. Both untrusted renderer sinks now fail closed for scheme-bearing and network-path sources, including `http:`, `https:`, `file:`, `blob:`, and protocol-relative forms. SVG and other non-allowlisted data images remain blocked.

Closes #63.

Codex Security finding: `csf_8b673756a8eb8a7e8de63323`
Fingerprint: `codex-security/v1:sha256:620c2af575983ed46fd4cd61ac1e7a814f8f90aca4ee0e5fafcd7f36d6578407`

## Verification

- `npm test -- MarkdownContent.test.tsx NewsCard.test.tsx` — 13 passed
- `npm test` — 419 passed, 1 skipped
- `npm run typecheck` — passed
- `npm run build` — passed
- `tools/update_project_snapshot.py --check` — passed

## Documentation impact

No product intent, architecture, interface, or release-policy documentation changed. The deterministic repository inventory was regenerated because this PR adds renderer source and test files.