### PR TITLE
fix(core): wipe memory_journal in clear_all (#117)

### DIFF
--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -3624,6 +3624,7 @@ class CollieDB:
                 "run_task_state_revisions",
                 "tool_events",
                 "turn_events",
+                "memory_journal",
                 "artifact_versions",
                 "run_steps",
                 "approval_requests",

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -350,6 +350,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.add_message(conv["id"], "user", "hi")
     db.set_profile("dietary", "vegan")
     db.add_person("Sam")
+    db.log_memory_journal("profile", "dietary", "add", "vegan")
     data = db.export_all()
     assert data["schema_version"] == 14
     assert len(data["conversations"]) == 1
@@ -359,6 +360,10 @@ def test_export_and_clear(db: CollieDB) -> None:
     assert db.list_conversations(include_archived=True) == []
     assert db.all_profile() == {}
     assert db.list_people() == []
+    # "Delete everything" must also wipe the memory journal: its rows carry
+    # snapshots of remembered values, so leaving them behind leaks data the
+    # wipe promised to remove (#117).
+    assert db.list_memory_journal() == []
 
 
 def test_concurrent_access(db: CollieDB) -> None:


### PR DESCRIPTION
Fixes #117.

## What

`clear_all()` wiped 31 tables but omitted `memory_journal`, whose rows store JSON snapshots of every remembered value. "Delete everything" left medications, addresses, names behind — visible in Settings → Memory and still in the DB file. Adds the table to the wipe list (FK-safe position: independent table) and extends the export/clear test with a journal row that must be gone after the wipe.

## Verification

- New assertion fails on `main` (red), passes with the fix (green)
- `tests/collie/test_db.py` 19/19 pass; ruff clean

Draft for owner review — no merge without sign-off.