### PR TITLE
fix(core): prevent Codex TLS verification downgrade

### DIFF
--- a/collie-core/nanobot/providers/openai_codex_provider.py
+++ b/collie-core/nanobot/providers/openai_codex_provider.py
@@ -81,25 +81,13 @@ class OpenAICodexProvider(LLMProvider):
             headers = _build_headers(token.account_id, token.access)
 
             stage = "codex_request"
-            try:
-                content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
-                    DEFAULT_CODEX_URL, headers, body, verify=True,
-                    proxy=self.proxy,
-                    on_content_delta=on_content_delta,
-                    on_thinking_delta=on_thinking_delta,
-                    on_tool_call_delta=on_tool_call_delta,
-                )
-            except Exception as e:
-                if "CERTIFICATE_VERIFY_FAILED" not in str(e):
-                    raise
-                logger.warning("SSL verification failed for Codex API; retrying with verify=False")
-                content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
-                    DEFAULT_CODEX_URL, headers, body, verify=False,
-                    proxy=self.proxy,
-                    on_content_delta=on_content_delta,
-                    on_thinking_delta=on_thinking_delta,
-                    on_tool_call_delta=on_tool_call_delta,
-                )
+            content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
+                DEFAULT_CODEX_URL, headers, body, verify=True,
+                proxy=self.proxy,
+                on_content_delta=on_content_delta,
+                on_thinking_delta=on_thinking_delta,
+                on_tool_call_delta=on_tool_call_delta,
+            )
             return LLMResponse(
                 content=content,
                 tool_calls=tool_calls,

--- a/collie-core/tests/providers/test_openai_codex_provider.py
+++ b/collie-core/tests/providers/test_openai_codex_provider.py
@@ -173,6 +173,46 @@ async def test_codex_request_uses_configured_proxy(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_codex_certificate_failure_never_disables_tls_verification(monkeypatch) -> None:
+    _mock_codex_token(monkeypatch)
+    verify_calls: list[bool] = []
+
+    async def fake_request(*args: Any, verify: bool, **kwargs: Any):
+        _ = args, kwargs
+        verify_calls.append(verify)
+        raise httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
+
+    provider = OpenAICodexProvider()
+    response = await provider.chat([{"role": "user", "content": "hello"}])
+
+    assert verify_calls == [True]
+    assert response.finish_reason == "error"
+    assert response.error_kind == "connection"
+
+
+@pytest.mark.asyncio
+async def test_codex_success_keeps_tls_verification_enabled(monkeypatch) -> None:
+    _mock_codex_token(monkeypatch)
+    verify_calls: list[bool] = []
+
+    async def fake_request(*args: Any, verify: bool, **kwargs: Any):
+        _ = args, kwargs
+        verify_calls.append(verify)
+        return "ok", [], "stop", {}, None
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
+
+    provider = OpenAICodexProvider()
+    response = await provider.chat([{"role": "user", "content": "hello"}])
+
+    assert verify_calls == [True]
+    assert response.content == "ok"
+    assert response.finish_reason == "stop"
+
+
+@pytest.mark.asyncio
 async def test_codex_prompt_cache_key_uses_stable_conversation_prefix(monkeypatch) -> None:
     bodies: list[dict] = []
 


### PR DESCRIPTION
## Summary
- remove the automatic Codex request retry with TLS certificate verification disabled
- preserve the existing verified request and provider error-response behavior
- add focused regressions for certificate failure and successful verified requests

## Security impact
A TLS certificate validation failure is now terminal for the Codex request attempt. Collie no longer resubmits the ChatGPT OAuth bearer token, conversation, or tool definitions over an unverified connection.

## Validation
- `python -m compileall -q nanobot/providers/openai_codex_provider.py tests/providers/test_openai_codex_provider.py`
- `python -m pytest tests/providers/test_openai_codex_provider.py -q` (23 passed)
- `python -m pytest tests/providers -q` (733 passed)
- `python -m ruff check nanobot collie_core tests`
- isolated reproduction: certificate failure produced `verify_calls == [True]` and an error response; before the patch it produced `[True, False]` and accepted the simulated compromised response

Closes #115
Closes #116