### PR TITLE
Fix numeric weather in Today at a glance

### DIFF
--- a/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.test.tsx
@@ -52,6 +52,28 @@ describe('TodayGlanceCard', () => {
     expect(container.textContent).toContain('Coming up')
   })
 
+  it('renders numeric temperatures from the Open-Meteo payload', () => {
+    const container = render(
+      <TodayGlanceCard
+        data={{
+          weather: {
+            location: 'Berlin, Germany',
+            icon: '☀️',
+            temp: 24.3,
+            condition: 'Clear',
+            high: 26.1,
+            low: 14.2,
+            rain_chance: 10
+          }
+        }}
+      />
+    )
+
+    expect(container.querySelector('[aria-label="Today at a glance"]')).not.toBeNull()
+    expect(container.textContent).toContain('24.3°C')
+    expect(container.textContent).toContain('H 26.1° · L 14.2°')
+  })
+
   it('shows the rain hint only above the threshold', () => {
     const rainy = {
       ...fullData,

--- a/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.tsx
+++ b/collie-ui/src/renderer/src/components/cards/TodayGlanceCard.tsx
@@ -1,10 +1,10 @@
 interface GlanceWeather {
   location?: string
   icon?: string
-  temp?: string
+  temp?: string | number
   condition?: string
-  high?: string
-  low?: string
+  high?: string | number
+  low?: string | number
   rain_chance?: number
 }
 
@@ -19,6 +19,11 @@ interface Props {
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
+}
+
+function asTemperature(value: unknown): string | number | undefined {
+  if (typeof value === 'string') return value
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function friendlyDue(dueAt: string): string {
@@ -36,11 +41,11 @@ function friendlyDue(dueAt: string): string {
 export default function TodayGlanceCard({ data }: Props): React.JSX.Element | null {
   const weatherRaw = data.weather as Record<string, unknown> | undefined
   const weather: GlanceWeather = weatherRaw ?? {}
-  const temp = asString(weather.temp)
+  const temp = asTemperature(weather.temp)
   const condition = asString(weather.condition)
   const icon = asString(weather.icon) || '⛅'
-  const high = asString(weather.high)
-  const low = asString(weather.low)
+  const high = asTemperature(weather.high)
+  const low = asTemperature(weather.low)
   const rainChance = typeof weather.rain_chance === 'number' ? weather.rain_chance : null
   const location = asString(weather.location)
 


### PR DESCRIPTION
## Summary
- render finite numeric `temp`, `high`, and `low` values in the Today at a glance card
- preserve the existing string temperature payload behavior
- cover the live Open-Meteo numeric payload shape with a focused renderer regression test

## Root cause
The core forwards Open-Meteo temperatures as numbers, but the renderer discarded every non-string temperature. That made the weather section disappear even when valid current conditions were present.

## Verification
- `npm test -- src/renderer/src/components/cards/TodayGlanceCard.test.tsx` (5 passed)
- `npm test` (61 files passed; 407 passed, 1 skipped)
- `npm run typecheck`
- `npm run build`

## Documentation impact
None. This restores the existing Today at a glance contract without changing product intent, component ownership, interfaces, architecture, or release claims.