### PR TITLE
fix(routines): stop monthly clocks becoming calendar days

### DIFF
--- a/collie-core/collie_core/routines/schedule.py
+++ b/collie-core/collie_core/routines/schedule.py
@@ -33,7 +33,7 @@ _TIME_RE = re.compile(
     re.IGNORECASE,
 )
 _MONTH_DAY_RE = re.compile(
-    r"\b(?:on\s+)?(?:the\s+)?(\d{1,2})(?:st|nd|rd|th)?(?:\s+day)?\b",
+    r"\b(?:on\s+)?(?:the\s+)?(\d{1,2})(?:st|nd|rd|th)(?:\s+day)?\b",
     re.IGNORECASE,
 )
 _ISO_DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")

--- a/collie-core/tests/collie/test_safe_execution.py
+++ b/collie-core/tests/collie/test_safe_execution.py
@@ -138,6 +138,18 @@ def test_structured_weekdays_and_monthly_schedules() -> None:
     assert occurrence.astimezone().tzinfo is not None
 
 
+@pytest.mark.parametrize(
+    "description",
+    [
+        "run this every month at 7:30am",
+        "monthly at 9 pm",
+    ],
+)
+def test_monthly_schedule_does_not_treat_clock_hour_as_day(description: str) -> None:
+    with pytest.raises(ValueError, match="Which numbered day of the month"):
+        parse_schedule(description)
+
+
 def test_plan_versions_invalidate_old_approval(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "db.sqlite")
     raw = {


### PR DESCRIPTION
## Summary
- require an explicit ordinal when parsing a numeric monthly day
- prevent clock hours such as `7` in `7:30am` or `9` in `9 pm` from becoming the day of month
- add regression coverage for both reported forms

## Testing
- `python -m pytest tests/collie/test_safe_execution.py tests/collie/test_custom_automations.py -q -p no:cacheprovider` (52 passed)
- `python -m ruff check collie_core/routines/schedule.py tests/collie/test_safe_execution.py`

## Documentation impact
No canonical documentation changes are needed. This restores the parser's existing clarification behavior without changing product intent, interfaces, ownership, or routine capabilities.

Closes #120
