### PR TITLE
fix(reminders): resolve displayed short IDs safely

### DIFF
--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -1117,31 +1117,49 @@ class CollieDB:
         )
 
     @staticmethod
-    def _reminder_match(reminder_id: str) -> str:
-        """Full-ID or displayed 8-char prefix match."""
-        return reminder_id if len(reminder_id) >= 32 else reminder_id + "%"
+    def _resolve_reminder_id(conn: sqlite3.Connection, reminder_id: str) -> str | None:
+        """Resolve an exact ID or one unambiguous displayed 8-character prefix."""
+        exact = conn.execute("SELECT id FROM reminders WHERE id = ?", (reminder_id,)).fetchone()
+        if exact is not None:
+            return str(exact["id"])
+        if len(reminder_id) != 8 or any(
+            character not in "0123456789abcdefABCDEF" for character in reminder_id
+        ):
+            return None
+        matches = conn.execute(
+            "SELECT id FROM reminders WHERE substr(id, 1, 8) = ? LIMIT 2",
+            (reminder_id.lower(),),
+        ).fetchall()
+        return str(matches[0]["id"]) if len(matches) == 1 else None
 
     def complete_reminder(self, reminder_id: str) -> bool:
         with self._write() as conn:
+            resolved_id = self._resolve_reminder_id(conn, reminder_id)
+            if resolved_id is None:
+                return False
             cursor = conn.execute(
                 "UPDATE reminders SET completed = 1 WHERE id = ?",
-                (self._reminder_match(reminder_id),),
+                (resolved_id,),
             )
             return cursor.rowcount > 0
 
     def snooze_reminder(self, reminder_id: str, until: str) -> bool:
         with self._write() as conn:
+            resolved_id = self._resolve_reminder_id(conn, reminder_id)
+            if resolved_id is None:
+                return False
             cursor = conn.execute(
                 "UPDATE reminders SET snoozed_until = ? WHERE id = ?",
-                (until, self._reminder_match(reminder_id)),
+                (until, resolved_id),
             )
             return cursor.rowcount > 0
 
     def delete_reminder(self, reminder_id: str) -> bool:
         with self._write() as conn:
-            cursor = conn.execute(
-                "DELETE FROM reminders WHERE id = ?", (self._reminder_match(reminder_id),)
-            )
+            resolved_id = self._resolve_reminder_id(conn, reminder_id)
+            if resolved_id is None:
+                return False
+            cursor = conn.execute("DELETE FROM reminders WHERE id = ?", (resolved_id,))
             return cursor.rowcount > 0
 
     # -- shopping list -----------------------------------------------------------------------

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -274,6 +274,70 @@ def test_reminders(db: CollieDB) -> None:
     assert len(db.list_reminders(include_completed=True)) == 1
 
 
+def _mutate_reminder(db: CollieDB, action: str, reminder_id: str) -> bool:
+    if action == "complete":
+        return db.complete_reminder(reminder_id)
+    if action == "snooze":
+        return db.snooze_reminder(reminder_id, "2026-07-21T09:00:00+00:00")
+    return db.delete_reminder(reminder_id)
+
+
+@pytest.mark.parametrize("action", ["complete", "snooze", "delete"])
+@pytest.mark.parametrize("id_form", ["full", "displayed"])
+def test_reminder_mutations_resolve_full_and_displayed_ids(
+    db: CollieDB, action: str, id_form: str
+) -> None:
+    reminder = db.add_reminder("water the plants", "2026-07-20T09:00:00+00:00")
+    reminder_id = str(reminder["id"])
+
+    assert _mutate_reminder(db, action, reminder_id if id_form == "full" else reminder_id[:8])
+    reminders = db.list_reminders(include_completed=True)
+    if action == "delete":
+        assert reminders == []
+    elif action == "complete":
+        assert reminders[0]["completed"] == 1
+    else:
+        assert reminders[0]["snoozed_until"] == "2026-07-21T09:00:00+00:00"
+
+
+@pytest.mark.parametrize("action", ["complete", "snooze", "delete"])
+def test_reminder_mutations_reject_ambiguous_displayed_id(db: CollieDB, action: str) -> None:
+    db.add_reminder(
+        "first",
+        "2026-07-20T09:00:00+00:00",
+        reminder_id="deadbeef000000000000000000000001",
+    )
+    db.add_reminder(
+        "second",
+        "2026-07-20T09:00:00+00:00",
+        reminder_id="deadbeef000000000000000000000002",
+    )
+
+    assert not _mutate_reminder(db, action, "deadbeef")
+    reminders = db.list_reminders(include_completed=True)
+    assert len(reminders) == 2
+    assert all(not reminder["completed"] for reminder in reminders)
+    assert all(reminder["snoozed_until"] is None for reminder in reminders)
+
+
+@pytest.mark.parametrize("action", ["complete", "snooze", "delete"])
+@pytest.mark.parametrize("malformed_id", ["deadbee", "deadbee%"])
+def test_reminder_mutations_reject_malformed_displayed_id(
+    db: CollieDB, action: str, malformed_id: str
+) -> None:
+    db.add_reminder(
+        "water the plants",
+        "2026-07-20T09:00:00+00:00",
+        reminder_id="deadbeef000000000000000000000001",
+    )
+
+    assert not _mutate_reminder(db, action, malformed_id)
+    reminders = db.list_reminders(include_completed=True)
+    assert len(reminders) == 1
+    assert not reminders[0]["completed"]
+    assert reminders[0]["snoozed_until"] is None
+
+
 def test_automations(db: CollieDB) -> None:
     a = db.add_automation(
         "Morning Briefing",


### PR DESCRIPTION
## Summary
- resolve reminder IDs exactly before considering a displayed short ID
- accept only an eight-character hexadecimal prefix and require it to identify exactly one reminder
- use the resolved exact ID for complete, snooze, and delete mutations
- cover full IDs, displayed IDs, ambiguous prefixes, and malformed prefixes across all three actions

## Testing
- `python -m pytest tests/collie/test_db.py tests/collie/test_reminders.py -q -p no:cacheprovider` (56 passed)
- `python -m ruff check collie_core/db.py tests/collie/test_db.py`
- `python -m ruff format --check collie_core/db.py tests/collie/test_db.py`

## Documentation impact
No canonical documentation changes are needed. This restores the behavior already represented by the tool's displayed reminder IDs without changing product intent, interfaces, ownership, or storage schema.

Closes #118
