### PR TITLE
fix(security): fail closed on provider token storage

### DIFF
--- a/collie-core/collie_core/providers/storage.py
+++ b/collie-core/collie_core/providers/storage.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from collie_core.services.credentials import CredentialStore
+from collie_core.services.credentials import CredentialStore, DpapiUnavailableError
 
 __all__ = ["DpapiTokenStorage", "legacy_oauth_data_root"]
 
@@ -89,24 +89,8 @@ class DpapiTokenStorage:
         return legacy
 
     def save(self, token: Any) -> None:
-        with _DpapiErrorsFallback():
-            self._store.save(self._service_id, _token_to_dict(token))
-            return
-        self._plain_storage().save(token)
-
-
-class _DpapiErrorsFallback:
-    """Context manager that swallows non-Windows DPAPI errors.
-
-    ``CredentialStore`` raises ``RuntimeError`` when DPAPI is unavailable
-    (non-Windows). Any other failure (real encryption errors on Windows)
-    propagates so tokens are never silently stored in plaintext.
-    """
-
-    def __enter__(self) -> None:
-        return None
-
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
-        if exc_type is None:
-            return False
-        return bool(issubclass(exc_type, RuntimeError))
+        token_data = _token_to_dict(token)
+        try:
+            self._store.save(self._service_id, token_data)
+        except DpapiUnavailableError:
+            self._plain_storage().save(token)

--- a/collie-core/collie_core/services/credentials.py
+++ b/collie-core/collie_core/services/credentials.py
@@ -17,11 +17,15 @@ from typing import Any
 
 from collie_core.db import collie_home
 
-__all__ = ["CredentialStore"]
+__all__ = ["CredentialStore", "DpapiUnavailableError"]
 
 
 _MAGIC = b"COLLIE-DPAPI\x00"
 _CRYPTPROTECT_UI_FORBIDDEN = 0x1
+
+
+class DpapiUnavailableError(RuntimeError):
+    """Raised when the current platform cannot provide Windows DPAPI."""
 
 
 if sys.platform == "win32":
@@ -37,7 +41,7 @@ def _blob(data: bytes) -> tuple[_DataBlob, object]:
 
 def _dpapi_protect(data: bytes) -> bytes:
     if sys.platform != "win32":
-        raise RuntimeError(
+        raise DpapiUnavailableError(
             "Connected-service credentials can only be stored securely on "
             "Windows for now (Windows DPAPI). On macOS and Linux these "
             "connectors aren't available yet."
@@ -66,7 +70,7 @@ def _dpapi_protect(data: bytes) -> bytes:
 
 def _dpapi_unprotect(data: bytes) -> bytes:
     if sys.platform != "win32":
-        raise RuntimeError("Encrypted service credentials require Windows DPAPI.")
+        raise DpapiUnavailableError("Encrypted service credentials require Windows DPAPI.")
     import ctypes
 
     source, source_buffer = _blob(data)

--- a/collie-core/tests/collie/test_auth.py
+++ b/collie-core/tests/collie/test_auth.py
@@ -493,6 +493,61 @@ def test_dpapi_token_storage_round_trip(fake_dpapi_store) -> None:
     assert loaded.account_id == "a1"
 
 
+@pytest.mark.parametrize("error", [RuntimeError("unexpected"), OSError("disk failure")])
+def test_dpapi_token_storage_unexpected_save_errors_never_fall_back_to_plaintext(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    from collie_core.providers.storage import DpapiTokenStorage
+
+    home = tmp_path / "home"
+    legacy_root = tmp_path / "legacy"
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    monkeypatch.setenv("COLLIE_OAUTH_ROOT", str(legacy_root))
+    storage = DpapiTokenStorage(token_filename="claude.json")
+
+    def fail_save(*_args) -> None:
+        raise error
+
+    monkeypatch.setattr(storage._store, "save", fail_save)
+
+    with pytest.raises(type(error), match=str(error)):
+        storage.save(FakeToken(access="acc", refresh="ref", expires=1234))
+
+    assert storage._plain is None
+    assert not storage.get_token_path().exists()
+    assert not (legacy_root / "auth" / "claude.json").exists()
+
+
+def test_dpapi_token_storage_falls_back_only_when_dpapi_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import collie_core.services.credentials as credentials_mod
+    from collie_core.providers.storage import DpapiTokenStorage
+    from collie_core.services.credentials import DpapiUnavailableError
+
+    home = tmp_path / "home"
+    legacy_root = tmp_path / "legacy"
+    monkeypatch.setenv("COLLIE_HOME", str(home))
+    monkeypatch.setenv("COLLIE_OAUTH_ROOT", str(legacy_root))
+
+    with monkeypatch.context() as platform_patch:
+        platform_patch.setattr(credentials_mod.sys, "platform", "non-windows-test")
+        with pytest.raises(DpapiUnavailableError):
+            credentials_mod._dpapi_protect(b"payload")
+
+    storage = DpapiTokenStorage(token_filename="claude.json")
+
+    def unavailable(_data: bytes) -> bytes:
+        raise DpapiUnavailableError("DPAPI is unavailable")
+
+    monkeypatch.setattr(storage._store, "_protect", unavailable)
+    storage.save(FakeToken(access="acc", refresh="ref", expires=1234, account_id=None))
+
+    assert not storage.get_token_path().exists()
+    assert (legacy_root / "auth" / "claude.json").exists()
+    assert storage.load().refresh == "ref"
+
+
 def test_legacy_oauth_root_honors_isolation_environment(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- introduce a dedicated `DpapiUnavailableError` for the intentional non-Windows provider-token fallback
- fail closed for unexpected `RuntimeError`, `OSError`, and other storage failures instead of writing OAuth tokens to plaintext
- add focused regression coverage for both the fail-closed path and the legitimate unavailable-platform fallback

## Security invariant
Long-lived provider access and refresh tokens must never silently downgrade to plaintext when protected storage fails unexpectedly. Plaintext fallback remains limited to the explicit platform-unavailable condition already supported for non-Windows development.

## Testing
- `python -m pytest tests/collie/test_auth.py tests/collie/test_services.py::test_credential_store_roundtrip -q` (26 passed)
- `python -m ruff check collie_core/providers/storage.py collie_core/services/credentials.py tests/collie/test_auth.py`
- `python -m ruff format --check collie_core/providers/storage.py collie_core/services/credentials.py tests/collie/test_auth.py`
- `git diff --check`

## Documentation impact
No canonical documentation change: this patch enforces the existing protected-secret invariant and does not change product intent, architecture, dependencies, repository shape, or release claims.

Closes #126