### PR TITLE
fix(account): persist sync only after baseline upload

### DIFF
--- a/collie-ui/src/main/cloud-sync.test.ts
+++ b/collie-ui/src/main/cloud-sync.test.ts
@@ -8,7 +8,11 @@ const testState = vi.hoisted(() => {
     userData: '',
     coreCalls: [] as Array<{ type: string; payload: Record<string, unknown> }>,
     fetches: [] as Array<{ url: string; init: RequestInit }>,
+    events: [] as string[],
+    toggleValue: false,
+    failCoreType: null as string | null,
     nextFetchResponse: null as Response | null,
+    nextFetchPromise: null as Promise<Response> | null,
     cfg: { url: 'https://test.supabase.co', key: 'test-anon-key' }
   }
 })
@@ -35,13 +39,18 @@ vi.mock('../shared/account-config', () => ({
 vi.mock('./core-client', () => ({
   commandWithCore: (type: string, payload: Record<string, unknown>) => {
     testState.coreCalls.push({ type, payload })
+    if (testState.failCoreType === type) {
+      return Promise.reject(new Error(`core ${type} failed`))
+    }
     if (type === 'get_settings') {
-      const lastSet = [...testState.coreCalls]
-        .reverse()
-        .find((c) => c.type === 'set_setting')
       return Promise.resolve({
-        settings: lastSet?.payload?.value === true ? { 'account.sync_enabled': true } : {}
+        settings: testState.toggleValue ? { 'account.sync_enabled': true } : {}
       })
+    }
+    if (type === 'set_setting') {
+      testState.toggleValue = payload.value === true
+      testState.events.push(`toggle:${String(payload.value)}`)
+      return Promise.resolve({})
     }
     if (type === 'get_profile') return Promise.resolve({ profile: { favorite_color: 'blue' } })
     if (type === 'get_people')
@@ -71,6 +80,20 @@ function makeJwt(sub: string): string {
   return `${enc({ alg: 'none', typ: 'JWT' })}.${enc({ sub })}.${enc({})}`
 }
 
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve
+    reject = onReject
+  })
+  return { promise, resolve, reject }
+}
+
 const globalFetch = global.fetch
 
 import {
@@ -98,16 +121,29 @@ beforeEach(() => {
   testState.userData = mkdtempSync(join(tmpdir(), 'collie-cloud-sync-'))
   testState.coreCalls = []
   testState.fetches = []
+  testState.events = []
+  testState.toggleValue = false
+  testState.failCoreType = null
   testState.nextFetchResponse = null
+  testState.nextFetchPromise = null
   resetSecureStorageCache()
   global.fetch = ((url: string | URL, init: RequestInit = {}): Promise<Response> => {
     const urlString = String(url)
     if (urlString.startsWith('https://test.supabase.co')) {
       testState.fetches.push({ url: urlString, init })
-      return Promise.resolve(
-        testState.nextFetchResponse ??
-          new Response(JSON.stringify([{ created_at: '2026-08-22T00:00:00Z' }]), { status: 200 })
-      )
+      testState.events.push(`fetch:${String(init.method ?? 'GET')}:started`)
+      const response =
+        testState.nextFetchPromise ??
+        Promise.resolve(
+          testState.nextFetchResponse ??
+            new Response(JSON.stringify([{ created_at: '2026-08-22T00:00:00Z' }]), {
+              status: 200
+            })
+        )
+      return response.then((result) => {
+        testState.events.push(`fetch:${String(init.method ?? 'GET')}:resolved`)
+        return result
+      })
     }
     return globalFetch(url, init)
   }) as typeof fetch
@@ -135,9 +171,22 @@ describe('cloud sync status + toggle', () => {
     await expect(enableSync(true)).rejects.toThrow(/Sign in/)
   })
 
-  it('persists the toggle through the core settings table and uploads a baseline', async () => {
+  it('persists true only after the baseline upload succeeds', async () => {
     signInAs('user-1')
-    await enableSync(true)
+    const uploadGate = deferred<Response>()
+    testState.nextFetchPromise = uploadGate.promise
+
+    const transition = enableSync(true)
+    await vi.waitFor(() => {
+      expect(testState.fetches.some((entry) => entry.init.method === 'POST')).toBe(true)
+    })
+    expect(testState.coreCalls.some((call) => call.type === 'set_setting')).toBe(false)
+
+    uploadGate.resolve(
+      new Response(JSON.stringify([{ created_at: '2026-08-22T00:00:00Z' }]), { status: 200 })
+    )
+    await transition
+
     const setCall = testState.coreCalls.find((c) => c.type === 'set_setting')
     expect(setCall?.payload).toEqual({ key: 'account.sync_enabled', value: true })
     expect(testState.coreCalls.some((c) => c.type === 'get_profile')).toBe(true)
@@ -146,6 +195,62 @@ describe('cloud sync status + toggle', () => {
     expect(upload?.init.headers).toMatchObject({
       Prefer: 'resolution=merge-duplicates,return=representation'
     })
+    expect(testState.events.indexOf('fetch:POST:resolved')).toBeLessThan(
+      testState.events.indexOf('toggle:true')
+    )
+  })
+
+  it('leaves sync off when the baseline upload fails', async () => {
+    signInAs('user-1')
+    testState.nextFetchResponse = new Response('unavailable', { status: 503 })
+
+    await expect(enableSync(true)).rejects.toThrow(/503/)
+
+    expect(testState.toggleValue).toBe(false)
+    expect(
+      testState.coreCalls.some(
+        (call) => call.type === 'set_setting' && call.payload.value === true
+      )
+    ).toBe(false)
+
+    // A rejected enable must not poison the serialized transition queue.
+    await expect(enableSync(false)).resolves.toMatchObject({ enabled: false })
+  })
+
+  it('leaves sync off when gathering the baseline fails', async () => {
+    signInAs('user-1')
+    testState.failCoreType = 'get_profile'
+
+    await expect(enableSync(true)).rejects.toThrow(/get_profile/)
+
+    expect(testState.toggleValue).toBe(false)
+    expect(testState.fetches).toHaveLength(0)
+    expect(testState.coreCalls.some((call) => call.type === 'set_setting')).toBe(false)
+  })
+
+  it('lets a newer disable supersede an in-flight enable', async () => {
+    signInAs('user-1')
+    const upload = deferred<Response>()
+    testState.nextFetchPromise = upload.promise
+
+    const enabling = enableSync(true)
+    await vi.waitFor(() => {
+      expect(testState.fetches.some((entry) => entry.init.method === 'POST')).toBe(true)
+    })
+    const disabling = enableSync(false)
+
+    upload.resolve(
+      new Response(JSON.stringify([{ created_at: '2026-08-22T00:00:00Z' }]), { status: 200 })
+    )
+    const [enableStatus, disableStatus] = await Promise.all([enabling, disabling])
+
+    expect(enableStatus.enabled).toBe(false)
+    expect(disableStatus.enabled).toBe(false)
+    expect(
+      testState.coreCalls
+        .filter((call) => call.type === 'set_setting')
+        .map((call) => call.payload.value)
+    ).toEqual([false])
   })
 
   it('refuses to enable when Supabase is unconfigured', async () => {

--- a/collie-ui/src/main/cloud-sync.ts
+++ b/collie-ui/src/main/cloud-sync.ts
@@ -32,6 +32,15 @@ const SYNCED_FILES = ['AGENTS.md', 'VISION.md'] as const
 /** REST timeout — bounded so a hanging network never hangs the UI. */
 const HTTP_TIMEOUT_MS = 15_000
 
+/**
+ * Toggle transitions may overlap when the renderer changes its mind while a
+ * baseline upload is still in flight. Keep writes ordered, and let each
+ * transition detect whether a newer request superseded it before it persists
+ * state. A rejected transition must not poison the queue for later requests.
+ */
+let syncToggleGeneration = 0
+let syncToggleQueue: Promise<void> = Promise.resolve()
+
 export interface SyncSnapshotSummary {
   deviceId: string
   deviceName: string
@@ -311,16 +320,36 @@ export async function getSyncStatus(): Promise<SyncStatus> {
   }
 }
 
-export async function enableSync(enabled: boolean): Promise<SyncStatus> {
+export function enableSync(enabled: boolean): Promise<SyncStatus> {
+  const generation = ++syncToggleGeneration
+  const transition = syncToggleQueue.then(() => applySyncToggle(enabled, generation))
+  syncToggleQueue = transition.then(
+    () => undefined,
+    () => undefined
+  )
+  return transition
+}
+
+async function applySyncToggle(enabled: boolean, generation: number): Promise<SyncStatus> {
+  // A newer queued request already owns the desired state. Avoid unnecessary
+  // network or settings work for this stale transition.
+  if (generation !== syncToggleGeneration) return getSyncStatus()
+
   const status = await getSyncStatus()
+  if (generation !== syncToggleGeneration) return getSyncStatus()
   if (enabled && !status.signedIn) {
     throw new Error('Sign in to Collie before turning on syncing.')
   }
-  await writeToggle(enabled)
+
   if (enabled) {
-    // First flip = immediate baseline upload, so "on" means backed up.
+    // Finish the baseline before persisting true, so a failed upload always
+    // leaves sync durably off. If the user disabled sync while this upload was
+    // running, the newer transition wins and true is never written.
     await uploadSnapshot()
+    if (generation !== syncToggleGeneration) return getSyncStatus()
   }
+
+  await writeToggle(enabled)
   return getSyncStatus()
 }
 

--- a/docs/engineering/architecture/account-cloud-sync.md
+++ b/docs/engineering/architecture/account-cloud-sync.md
@@ -97,8 +97,11 @@ create policy "own rows only"
 3. Confirm dialog states what will be replaced, in plain language.
 
 **Toggle:** stored locally (`settings` key `account.sync_enabled`, default
-off). Turning it on does the first upload immediately. Turning it off stops
-uploads; online copies remain until account deletion.
+off). Turning it on uploads the first snapshot before the enabled state is
+stored, so a failed baseline leaves sync off. Toggle transitions are ordered,
+and a newer request supersedes an in-flight older one before it can persist
+stale state. Turning it off stops uploads; online copies remain until account
+deletion.
 
 **Device identity:** `device_id` = random UUID persisted in userData on first
 run; `device_name` = `<username>'s <os>` at first upload, editable later (v2).
@@ -117,6 +120,9 @@ run; `device_name` = `<username>'s <os>` at first upload, editable later (v2).
 ## 7. Verification matrix
 
 - Toggle on with no account → toggle disabled, plain-language hint
+- Baseline upload fails → toggle remains off and a later toggle still works
+- Toggle off during the baseline upload → the completed upload cannot persist
+  a stale enabled state
 - Sign in → (if enabled) snapshot appears in Supabase with device name
 - Back up twice → still one row per device (upsert, not accumulate)
 - Second device sign-in → sees first device's snapshot, restores, content


### PR DESCRIPTION
## Summary
- upload the first device snapshot before persisting sync as enabled
- serialize toggle transitions and prevent superseded enables from writing stale state
- cover upload/gather failures, completion ordering, queue recovery, and an in-flight enable-to-disable race
- document the truthful toggle invariant

## Verification
- `npm test -- --run src/main/cloud-sync.test.ts` (16 passed)
- `npm run typecheck`
- repository snapshot update + `--check`
- `git diff --check`

Refs #132 as a partial fix. This PR intentionally does not change or claim to fix the non-transactional restore path; that work remains open.