### PR TITLE
fix(budget): bucket expenses by local calendar date

### DIFF
--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -1215,6 +1215,7 @@ class CollieDB:
         spent_at: str | None = None,
     ) -> dict[str, Any]:
         eid = new_id()
+        day = spent_at or self._local_today()
         with self._write() as conn:
             conn.execute(
                 "INSERT INTO expenses (id, amount, category, description, spent_at, "
@@ -1224,7 +1225,7 @@ class CollieDB:
                     amount,
                     category or "Other",
                     description,
-                    spent_at or utc_now()[:10],
+                    day,
                     utc_now(),
                 ),
             )

--- a/collie-core/collie_core/tools/budget.py
+++ b/collie-core/collie_core/tools/budget.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 import math
-from datetime import UTC, datetime
 from typing import Any
 
 from collie_core.permissions.models import PermissionRequest, Risk
@@ -18,8 +17,8 @@ from nanobot.agent.tools.base import Tool, tool_parameters
 __all__ = ["BudgetTool"]
 
 
-def _this_month() -> str:
-    return datetime.now(UTC).strftime("%Y-%m")
+def _this_month(db: Any) -> str:
+    return db._local_today()[:7]
 
 
 def _card(db: Any, month: str) -> str:
@@ -133,10 +132,10 @@ class BudgetTool(Tool):
                 description=str(kwargs.get("description") or "") or None,
                 spent_at=str(kwargs.get("date") or "") or None,
             )
-            return _card(db, _this_month())
+            return _card(db, _this_month(db))
 
         if action == "summary":
-            month = str(kwargs.get("month") or "").strip() or _this_month()
+            month = str(kwargs.get("month") or "").strip() or _this_month(db)
             return _card(db, month)
 
         if action == "set_budget":
@@ -150,7 +149,7 @@ class BudgetTool(Tool):
             if not math.isfinite(amount) or amount < 0 or amount > 1_000_000_000:
                 return self.error("That limit doesn't look right — try a sensible number.")
             db.set_budget(category, amount)
-            return _card(db, _this_month())
+            return _card(db, _this_month(db))
 
         return self.error(
             f"Not sure what to do with action '{action}'. Try log_expense, summary, or set_budget."

--- a/collie-core/tests/collie/test_life_tools_phase3.py
+++ b/collie-core/tests/collie/test_life_tools_phase3.py
@@ -52,6 +52,16 @@ def test_expenses_and_budgets(db: CollieDB) -> None:
     assert db.list_budgets()[0]["monthly_limit"] == 300
 
 
+def test_expense_default_date_uses_local_calendar(
+    db: CollieDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(db, "_local_today", lambda: "2026-08-01")
+
+    expense = db.add_expense(12.5, category="Transport")
+
+    assert expense["spent_at"] == "2026-08-01"
+
+
 def test_health_upsert_per_day(db: CollieDB) -> None:
     db.log_health("steps", 5000, logged_on="2026-07-18")
     db.log_health("steps", 8000, logged_on="2026-07-18")
@@ -112,30 +122,22 @@ async def test_budget_tool_flow(db: CollieDB) -> None:
     assert card["total_budget"] == 300
 
 
-async def test_budget_default_date_and_summary_share_utc_month(
+async def test_budget_default_date_and_summary_share_local_month(
     db: CollieDB, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A local month boundary must not split the default write from its summary."""
-    from datetime import datetime, timezone
-
+    """A UTC/local month boundary must use the user's local calendar month."""
     import collie_core.db as db_module
-    import collie_core.tools.budget as budget_module
-
-    class BoundaryDateTime(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return cls(2026, 7, 31, 16, 30, tzinfo=timezone.utc)
 
     monkeypatch.setattr(db_module, "utc_now", lambda: "2026-07-31T16:30:00+00:00")
-    monkeypatch.setattr(budget_module, "datetime", BoundaryDateTime)
+    monkeypatch.setattr(db, "_local_today", lambda: "2026-08-01")
 
     result = await BudgetTool().execute(action="log_expense", amount=12.5, category="Transport")
     card = json.loads(result)
 
-    assert card["month"] == "2026-07"
+    assert card["month"] == "2026-08"
     assert card["total_spent"] == 12.5
-    assert db.expenses_by_category("2026-07") == [{"category": "Transport", "spent": 12.5}]
-    assert db.expenses_by_category("2026-08") == []
+    assert db.expenses_by_category("2026-07") == []
+    assert db.expenses_by_category("2026-08") == [{"category": "Transport", "spent": 12.5}]
 
 
 async def test_budget_tool_needs_amount(db: CollieDB) -> None:


### PR DESCRIPTION
## Summary
- use `CollieDB._local_today()` for an expense's default `spent_at` date
- derive the budget tool's default current month from that same local-calendar seam
- cover the DB default and a UTC/local month boundary where UTC is still July but the user's local date is August

## Testing
- `python -m pytest tests/collie/test_life_tools_phase3.py tests/collie/test_db.py -q -p no:cacheprovider` (37 passed)
- `python -m ruff check collie_core/db.py collie_core/tools/budget.py tests/collie/test_life_tools_phase3.py`
- `python -m ruff format --check collie_core/db.py collie_core/tools/budget.py tests/collie/test_life_tools_phase3.py`

## Documentation impact
No canonical documentation changes are needed. This aligns budget behavior with the existing local-calendar invariant already used by health data; product intent, interfaces, ownership, and schema are unchanged.

Closes #127
