### PR TITLE
test(core): make service credential tests portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,13 @@ jobs:
             echo "tkinter unavailable in the runner Python — ignoring pet tests"
             PET="--ignore=tests/collie/test_pet_status.py"
           fi
-          # Documented Linux-only failures are deselected, never masked with
-          # `|| true`:
-          #  - test_services.py credential/connect/disconnect tests exercise
-          #    CredentialStore, which raises "Encrypted service credentials
-          #    require Windows DPAPI." on non-win32 (collie_core/services/
-          #    credentials.py:38).
+          # The documented Linux-only escape-path failure is deselected, never
+          # masked with `|| true`:
           #  - test_ipc.py::test_read_write_file_rejects_escape_paths is
           #    Windows-shaped and flaky on Linux (documented in
           #    docs + repo testing notes).
-          # These tests are NOT deselected on Windows — the
-          # collie-core-windows job runs them for real (see below).
+          # This test is NOT deselected on Windows — the collie-core-windows
+          # job runs it for real (see below).
           #
           # The full suite (tests/ — not just tests/collie) gates merges so
           # tests/tools, tests/providers and the rest cannot regress silently.
@@ -83,17 +79,13 @@ jobs:
           # moves.
           python -m pytest tests -q $PET \
             --cov=nanobot --cov=collie_core --cov-report=term-missing \
-            --deselect tests/collie/test_services.py::test_credential_store_roundtrip \
-            --deselect tests/collie/test_services.py::test_connect_api_key_service \
-            --deselect tests/collie/test_services.py::test_connect_oauth_service \
-            --deselect tests/collie/test_services.py::test_disconnect_service \
             --deselect tests/collie/test_ipc.py::test_read_write_file_rejects_escape_paths
 
   # The supported product runtime is Windows + CPython 3.12 (see
   # .github/workflows/release.yml: stage-core.cjs stages python312.dll).
-  # The Linux job above deselects five tests that only make sense on
-  # Windows (DPAPI-backed CredentialStore + the escape-path check) — this
-  # job actually runs them, plus the whole suite, on the real platform.
+  # The Linux job above deselects the Windows-shaped escape-path test; this
+  # job runs it, the real-DPAPI integration test, and the whole suite on the
+  # supported platform.
   collie-core-windows:
     name: collie-core (Python 3.12, Windows — supported runtime)
     runs-on: windows-latest
@@ -121,10 +113,9 @@ jobs:
         run: python -m ruff format --check collie_core tests/collie tests/tools
 
       - name: Test (full backend suite, no deselection)
-        # Windows is the supported runtime: the DPAPI/service credential
-        # tests and the ipc escape-path test that are deselected on Linux
-        # must actually pass here. tkinter ships with the setup-python
-        # CPython on Windows, so the pet tests run too.
+        # Windows is the supported runtime: real DPAPI and the ipc escape-path
+        # check must pass here. tkinter ships with the setup-python CPython on
+        # Windows, so the pet tests run too.
         shell: bash
         run: |
           set -o pipefail

--- a/collie-core/tests/collie/test_services.py
+++ b/collie-core/tests/collie/test_services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import threading
 import time
 import urllib.parse
@@ -64,8 +65,24 @@ def test_platform_gating() -> None:
 # -- credential store ------------------------------------------------------------
 
 
+_FAKE_PROTECTION_PREFIX = b"TEST-PROTECTED\x00"
+
+
+def _fake_protect(data: bytes) -> bytes:
+    return _FAKE_PROTECTION_PREFIX + data[::-1]
+
+
+def _fake_unprotect(data: bytes) -> bytes:
+    assert data.startswith(_FAKE_PROTECTION_PREFIX)
+    return data[len(_FAKE_PROTECTION_PREFIX) :][::-1]
+
+
+def _portable_credential_store(path: Path) -> CredentialStore:
+    return CredentialStore(path, protect=_fake_protect, unprotect=_fake_unprotect)
+
+
 def test_credential_store_roundtrip(tmp_path: Path) -> None:
-    store = CredentialStore(tmp_path / "creds")
+    store = _portable_credential_store(tmp_path / "creds")
     assert store.load("todoist") is None
     store.save("todoist", {"todoist_token": "tok-123"})
     assert store.load("todoist") == {"todoist_token": "tok-123"}
@@ -73,6 +90,17 @@ def test_credential_store_roundtrip(tmp_path: Path) -> None:
     store.delete("todoist")
     assert store.load("todoist") is None
     store.delete("todoist")  # idempotent
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows DPAPI")
+def test_credential_store_real_dpapi_roundtrip(tmp_path: Path) -> None:
+    store = CredentialStore(tmp_path / "creds")
+    store.save("todoist", {"todoist_token": "tok-123"})
+
+    blob = (tmp_path / "creds" / "todoist.bin").read_bytes()
+    assert blob.startswith(b"COLLIE-DPAPI\x00")
+    assert b"tok-123" not in blob
+    assert store.load("todoist") == {"todoist_token": "tok-123"}
 
 
 # -- fake OAuth service ------------------------------------------------------------
@@ -188,7 +216,7 @@ def manager(tmp_path: Path):
     db = CollieDB(tmp_path / "collie.db")
     mgr = ServiceManager(
         db,
-        credentials=CredentialStore(tmp_path / "creds"),
+        credentials=_portable_credential_store(tmp_path / "creds"),
         oauth_runner=lambda spec, service_name: {
             "access_token": "at-fake",
             "refresh_token": "rt-fake",


### PR DESCRIPTION
## Summary
- use reversible fake protection for portable `CredentialStore` and `ServiceManager` unit tests
- retain a separate Windows-only integration test that exercises real DPAPI encryption and round-trip behavior
- remove all four service-credential deselections from Linux CI so API-key connect, OAuth connect, disconnect, and credential-store behavior stay covered cross-platform

## Testing
- `python -m pytest -p no:cacheprovider tests/collie/test_services.py -q` (16 passed)
- `python -m ruff check nanobot collie_core tests`
- `python -m ruff format --check collie_core tests/collie tests/tools` (176 files formatted)
- `git diff --check`

## Documentation impact
No canonical documentation change: this only improves test portability and CI coverage. The workflow comments were updated to reflect the remaining Linux-only IPC deselection and the dedicated Windows DPAPI integration coverage.

Closes #133