### PR TITLE
fix(connectors): report remote revocation honestly

### DIFF
--- a/collie-core/collie_core/connectors/drivers/official_mcp.py
+++ b/collie-core/collie_core/connectors/drivers/official_mcp.py
@@ -8,7 +8,11 @@ from typing import Any
 import httpx
 
 from collie_core.connectors.auth import build_oauth_provider
-from collie_core.connectors.models import ConnectorDefinition, ProbeResult
+from collie_core.connectors.models import (
+    ConnectorDefinition,
+    ProbeResult,
+    RemoteRevocationStatus,
+)
 from collie_core.connectors.policy import cached_tool
 from collie_core.services.credentials import CredentialStore
 
@@ -71,7 +75,7 @@ class OfficialMcpDriver:
                 granted = str(actual).split()
         return ProbeResult(tools=tools, granted_scopes=granted)
 
-    def revoke(self, definition: ConnectorDefinition, connection_id: str) -> None:
+    def revoke(self, definition: ConnectorDefinition, connection_id: str) -> RemoteRevocationStatus:
         # MCP OAuth does not expose a universal revocation endpoint. Local token
         # deletion is immediate; provider-side revocation remains provider-specific.
-        return
+        return RemoteRevocationStatus.UNSUPPORTED

--- a/collie-core/collie_core/connectors/manager.py
+++ b/collie-core/collie_core/connectors/manager.py
@@ -17,6 +17,7 @@ from collie_core.connectors.models import (
     ConnectorDefinition,
     ConnectorDriverKind,
     ProbeResult,
+    RemoteRevocationStatus,
 )
 from collie_core.db import CollieDB, utc_now
 from collie_core.services.credentials import CredentialStore
@@ -446,7 +447,11 @@ class ConnectorManager:
     def remove(self, connection_id: str, *, origin: str = "connectors_ui") -> dict[str, Any]:
         row = self.db.get_connector_connection(connection_id)
         if row is None:
-            return {"connection_id": connection_id, "status": "disconnected"}
+            return {
+                "connection_id": connection_id,
+                "status": "disconnected",
+                "remote_revocation": RemoteRevocationStatus.NOT_APPLICABLE.value,
+            }
         definition = connector_def(str(row["provider_id"]))
         with self._lock:
             # A concurrent connect() must not resurrect this connection.
@@ -458,11 +463,12 @@ class ConnectorManager:
                 auth_type=str(row["auth_type"]),
                 status=ConnectionStatus.REVOKING.value,
             )
+        remote_revocation = RemoteRevocationStatus.UNSUPPORTED
         if definition is not None:
             try:
                 import asyncio
 
-                asyncio.run(
+                outcome = asyncio.run(
                     asyncio.wait_for(
                         asyncio.to_thread(
                             self._driver_factory(definition).revoke,
@@ -472,7 +478,11 @@ class ConnectorManager:
                         timeout=10,
                     )
                 )
+                remote_revocation = RemoteRevocationStatus(
+                    outcome or RemoteRevocationStatus.REVOKED
+                )
             except Exception:
+                remote_revocation = RemoteRevocationStatus.FAILED
                 logger.warning("Remote connector revocation unavailable: {}", definition.id)
         with self._lock:
             self._cancelled.discard(connection_id)
@@ -484,6 +494,7 @@ class ConnectorManager:
             "provider_id": row["provider_id"],
             "status": "disconnected",
             "origin": origin,
+            "remote_revocation": remote_revocation.value,
         }
 
     # -- runtime and legacy facade ------------------------------------------
@@ -529,12 +540,17 @@ class ConnectorManager:
     def disconnect(self, provider_id: str) -> dict[str, Any]:
         row = next(iter(self.db.list_connector_connections(provider_id)), None)
         if row is None:
-            return {"service_id": provider_id, "status": "disconnected"}
+            return {
+                "service_id": provider_id,
+                "status": "disconnected",
+                "remote_revocation": RemoteRevocationStatus.NOT_APPLICABLE.value,
+            }
         result = self.remove(str(row["id"]))
         return {
             "service_id": provider_id,
             "connection_id": result["connection_id"],
             "status": result["status"],
+            "remote_revocation": result["remote_revocation"],
         }
 
     @staticmethod

--- a/collie-core/collie_core/connectors/models.py
+++ b/collie-core/collie_core/connectors/models.py
@@ -25,6 +25,15 @@ class ConnectorDriverKind(StrEnum):
     CUSTOM_MCP = "custom_mcp"
 
 
+class RemoteRevocationStatus(StrEnum):
+    """Safe, user-facing result of a best-effort provider revocation."""
+
+    REVOKED = "revoked"
+    UNSUPPORTED = "unsupported"
+    FAILED = "failed"
+    NOT_APPLICABLE = "not_applicable"
+
+
 @dataclass(frozen=True, slots=True)
 class ConnectorDefinition:
     id: str

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -2472,7 +2472,8 @@ class CollieIPCServer:
     async def _cmd_remove_connector(self, connection: ServerConnection, frame: dict) -> dict:
         if self._service_manager is None:
             raise ValueError("connectors aren't available yet")
-        result = self._service_manager.remove(
+        result = await asyncio.to_thread(
+            self._service_manager.remove,
             str(frame.get("connection_id") or ""),
             origin=str(frame.get("origin") or "connectors_ui"),
         )
@@ -2507,7 +2508,7 @@ class CollieIPCServer:
         if self._service_manager is None:
             raise ValueError("services aren't available yet")
         service_id = str(frame.get("service_id") or "")
-        result = self._service_manager.disconnect(service_id)
+        result = await asyncio.to_thread(self._service_manager.disconnect, service_id)
         result["reconfigured"] = await self._reconfigure_quietly()
         return result
 

--- a/collie-core/tests/collie/test_connectors.py
+++ b/collie-core/tests/collie/test_connectors.py
@@ -12,7 +12,11 @@ import pytest
 
 from collie_core.connectors.catalog import CONNECTOR_CATALOG, connector_def
 from collie_core.connectors.manager import ConnectorManager
-from collie_core.connectors.models import ConnectorDriverKind, ProbeResult
+from collie_core.connectors.models import (
+    ConnectorDriverKind,
+    ProbeResult,
+    RemoteRevocationStatus,
+)
 from collie_core.connectors.policy import classify_connector_tool
 from collie_core.db import CollieDB
 from collie_core.services.credentials import CredentialStore
@@ -20,9 +24,18 @@ from nanobot.agent.tools.mcp import MCPToolWrapper
 
 
 class _FakeDriver:
-    def __init__(self, store: CredentialStore, *, fail: bool = False) -> None:
+    def __init__(
+        self,
+        store: CredentialStore,
+        *,
+        fail: bool = False,
+        revoke_status: RemoteRevocationStatus = RemoteRevocationStatus.REVOKED,
+        revoke_error: Exception | None = None,
+    ) -> None:
         self.store = store
         self.fail = fail
+        self.revoke_status = revoke_status
+        self.revoke_error = revoke_error
         self.revoked: list[str] = []
 
     def connect_and_probe(self, definition, connection_id: str) -> ProbeResult:
@@ -54,8 +67,11 @@ class _FakeDriver:
     def probe(self, definition, connection_id: str) -> ProbeResult:
         return self.connect_and_probe(definition, connection_id)
 
-    def revoke(self, definition, connection_id: str) -> None:
+    def revoke(self, definition, connection_id: str) -> RemoteRevocationStatus:
         self.revoked.append(connection_id)
+        if self.revoke_error is not None:
+            raise self.revoke_error
+        return self.revoke_status
 
 
 @pytest.fixture()
@@ -221,10 +237,55 @@ def test_connect_probe_runtime_bind_and_remove(
 
     removed = manager.remove(connection_id)
     assert removed["status"] == "disconnected"
+    assert removed["remote_revocation"] == "revoked"
     assert driver.revoked == [connection_id]
     assert connector_store.load(f"connector:{connection_id}") is None
     assert manager.get_connection(connection_id) is None
     assert manager.mcp_servers_for_config() == {}
+    db.close()
+
+
+@pytest.mark.parametrize(
+    ("revoke_status", "revoke_error", "expected"),
+    [
+        (RemoteRevocationStatus.UNSUPPORTED, None, "unsupported"),
+        (
+            RemoteRevocationStatus.REVOKED,
+            RuntimeError("provider detail must-not-leak access_token=secret"),
+            "failed",
+        ),
+    ],
+)
+def test_remove_reports_safe_remote_revocation_and_always_cleans_up_locally(
+    tmp_path: Path,
+    connector_store: CredentialStore,
+    monkeypatch: pytest.MonkeyPatch,
+    revoke_status: RemoteRevocationStatus,
+    revoke_error: Exception | None,
+    expected: str,
+) -> None:
+    _enable_connector_for_unit_test(monkeypatch, "notion")
+    db = CollieDB(tmp_path / "collie.db")
+    driver = _FakeDriver(
+        connector_store,
+        revoke_status=revoke_status,
+        revoke_error=revoke_error,
+    )
+    manager = ConnectorManager(
+        db,
+        credentials=connector_store,
+        driver_factory=lambda definition: driver,
+    )
+    connection_id = manager.connect("notion")["connection_id"]
+
+    removed = manager.remove(connection_id)
+
+    assert removed["remote_revocation"] == expected
+    assert "must-not-leak" not in repr(removed)
+    assert "secret" not in repr(removed)
+    assert driver.revoked == [connection_id]
+    assert connector_store.load(f"connector:{connection_id}") is None
+    assert manager.get_connection(connection_id) is None
     db.close()
 
 

--- a/collie-core/tests/collie/test_ipc.py
+++ b/collie-core/tests/collie/test_ipc.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import socket
 import threading
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -882,6 +883,102 @@ async def test_service_commands_roundtrip(tmp_path: Path) -> None:
         services = (await _recv_until(ws, "ok"))["data"]["services"]
         by_id = {s["id"]: s for s in services}
         assert by_id["todoist"]["status"] == "coming_soon"
+        await ws.close()
+    finally:
+        await srv.stop()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_connector_removal_ipc_runs_revocation_off_loop_and_reports_safe_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from collie_core.connectors import catalog
+    from collie_core.connectors import manager as connector_manager
+    from collie_core.connectors.catalog import connector_def
+    from collie_core.connectors.manager import ConnectorManager
+    from collie_core.connectors.models import ProbeResult, RemoteRevocationStatus
+    from collie_core.services.credentials import CredentialStore
+
+    definition = connector_def("notion")
+    assert definition is not None
+    monkeypatch.setitem(
+        catalog._BY_ID,
+        "notion",
+        replace(definition, available=True, release_status="alpha", note=""),
+    )
+    monkeypatch.setattr(connector_manager, "connector_def", catalog.connector_def)
+
+    store = CredentialStore(
+        tmp_path / "credentials",
+        protect=lambda value: value[::-1],
+        unprotect=lambda value: value[::-1],
+    )
+    revocation_outcomes: list[Exception | RemoteRevocationStatus] = [
+        RuntimeError("provider detail must-not-leak access_token=secret"),
+        RemoteRevocationStatus.UNSUPPORTED,
+    ]
+    revoke_threads: list[int] = []
+
+    class ThreadCheckingDriver:
+        def connect_and_probe(self, definition, connection_id: str) -> ProbeResult:
+            store.save(
+                f"connector:{connection_id}",
+                {"tokens": {"access_token": "secret-access-token"}},
+            )
+            return ProbeResult(
+                tools=[
+                    {
+                        "name": "search_pages",
+                        "schema_hash": "read-hash",
+                        "annotations": {"readOnlyHint": True},
+                        "risk": "read",
+                    }
+                ]
+            )
+
+        def revoke(self, definition, connection_id: str) -> RemoteRevocationStatus:
+            # This would raise if the IPC handler called remove() directly on
+            # its running event loop, reproducing issue #114.
+            asyncio.run(asyncio.sleep(0))
+            revoke_threads.append(threading.get_ident())
+            outcome = revocation_outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    driver = ThreadCheckingDriver()
+    db = CollieDB(tmp_path / "collie.db")
+    manager = ConnectorManager(
+        db,
+        credentials=store,
+        driver_factory=lambda definition: driver,
+    )
+    srv = CollieIPCServer(db, port=_free_port(), service_manager=manager)
+    await srv.start()
+    event_loop_thread = threading.get_ident()
+    try:
+        ws = await _connect(srv)
+
+        first_id = (await asyncio.to_thread(manager.connect, "notion"))["connection_id"]
+        await _send(ws, type="remove_connector", id="remove-1", connection_id=first_id)
+        first = (await _recv_until(ws, "ok"))["data"]
+        assert first["remote_revocation"] == "failed"
+        assert "must-not-leak" not in repr(first)
+        assert "secret" not in repr(first)
+        assert store.load(f"connector:{first_id}") is None
+        assert manager.get_connection(first_id) is None
+
+        second_id = (await asyncio.to_thread(manager.connect, "notion"))["connection_id"]
+        await _send(ws, type="disconnect_service", id="remove-2", service_id="notion")
+        second = (await _recv_until(ws, "ok"))["data"]
+        assert second["connection_id"] == second_id
+        assert second["remote_revocation"] == "unsupported"
+        assert store.load(f"connector:{second_id}") is None
+        assert manager.get_connection(second_id) is None
+
+        assert len(revoke_threads) == 2
+        assert all(thread_id != event_loop_thread for thread_id in revoke_threads)
         await ws.close()
     finally:
         await srv.stop()

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -232,6 +232,12 @@ export interface ConnectorConnection {
   route: string
 }
 
+export type RemoteRevocationStatus =
+  | 'revoked'
+  | 'unsupported'
+  | 'failed'
+  | 'not_applicable'
+
 export interface Subagent {
   id: string
   name: string
@@ -506,6 +512,7 @@ export type CollieEvent =
       status?: string
       message?: string
       origin?: string
+      remote_revocation?: RemoteRevocationStatus
     }
 
 type Listener = (event: CollieEvent) => void
@@ -1248,7 +1255,12 @@ export class CollieClient {
 
   removeConnector(
     connectionId: string
-  ): Promise<{ connection_id: string; status: string; reconfigured?: boolean }> {
+  ): Promise<{
+    connection_id: string
+    status: string
+    remote_revocation: RemoteRevocationStatus
+    reconfigured?: boolean
+  }> {
     return this.command('remove_connector', {
       connection_id: connectionId,
       origin: 'connectors_ui'

--- a/collie-ui/src/renderer/src/screens/ConnectorsScreen.test.ts
+++ b/collie-ui/src/renderer/src/screens/ConnectorsScreen.test.ts
@@ -18,6 +18,7 @@ vi.mock('../lib/ipc', () => ({
 import ConnectorCard from '../components/connectors/ConnectorCard'
 import {
   connectorConnectNotice,
+  connectorRemovalNotice,
   matchesActiveConnectorAuthStart,
   matchesActiveConnectorStatus
 } from './ConnectorsScreen'
@@ -60,6 +61,13 @@ describe('connector connection status truthfulness', () => {
     expect(connectorConnectNotice('Notion', 'auth_required')).toContain('fresh sign-in')
     expect(connectorConnectNotice('Notion', 'auth_required')).not.toContain('Connected')
     expect(connectorConnectNotice('Notion', 'failed')).not.toContain('Connected')
+  })
+
+  it('reports the provider-side result honestly after local removal', () => {
+    expect(connectorRemovalNotice('Notion', 'revoked')).toContain('access was revoked')
+    expect(connectorRemovalNotice('Notion', 'unsupported')).toContain("can't revoke access")
+    expect(connectorRemovalNotice('Notion', 'failed')).toContain("couldn't confirm")
+    expect(connectorRemovalNotice('Notion', 'not_applicable')).toContain('Connection removed')
   })
 
   it('only accepts auth and testing events for its active UI connection', () => {

--- a/collie-ui/src/renderer/src/screens/ConnectorsScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ConnectorsScreen.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   collieClient,
   type ConnectorCatalogItem,
-  type ConnectorConnection
+  type ConnectorConnection,
+  type RemoteRevocationStatus
 } from '../lib/ipc'
 import { splitConnectorCatalog } from '../lib/connectorCatalog'
 import ConnectorAuthProgress from '../components/connectors/ConnectorAuthProgress'
@@ -21,6 +22,28 @@ export function connectorConnectNotice(name: string, status: string): string {
     return `${name} needs a fresh sign-in before Collie can use it.`
   if (connectorIsInFlight(status)) return `${name} sign-in is already in progress.`
   return `${name} needs attention before Collie can use it.`
+}
+
+export function connectorRemovalNotice(
+  name: string,
+  remoteRevocation: RemoteRevocationStatus
+): string {
+  if (remoteRevocation === 'revoked') {
+    return `Connection removed. ${name} also confirmed that Collie's access was revoked.`
+  }
+  if (remoteRevocation === 'unsupported') {
+    return (
+      `Connection removed from Collie. I can't revoke access with ${name} automatically yet, ` +
+      `so you may also want to remove Collie in ${name}'s connected-app settings.`
+    )
+  }
+  if (remoteRevocation === 'failed') {
+    return (
+      `Connection removed from Collie, but I couldn't confirm that ${name} signed out. ` +
+      `You may also want to remove Collie in ${name}'s connected-app settings.`
+    )
+  }
+  return 'Connection removed. You can reconnect any time.'
 }
 
 export function matchesActiveConnectorAuthStart(
@@ -275,10 +298,10 @@ export default function ConnectorsScreen(): React.JSX.Element {
               setBusy(true)
               void collieClient
                 .removeConnector(removing.id)
-                .then(() => {
+                .then(({ remote_revocation }) => {
                   setRemoving(null)
                   setSelected(null)
-                  setNotice('Connection removed. You can reconnect any time.')
+                  setNotice(connectorRemovalNotice(removing.provider_name, remote_revocation))
                   return refresh()
                 })
                 .catch((error) =>


### PR DESCRIPTION
## Summary

- move both connector-removal IPC paths onto worker threads so the synchronous manager never calls `asyncio.run()` on the server event loop
- return a safe `remote_revocation` outcome (`revoked`, `unsupported`, `failed`, or `not_applicable`) while always deleting the local credential and connection row
- make the current official MCP driver report its provider-side revocation limitation honestly and show actionable renderer copy when remote revocation is unsupported or fails
- add manager and real WebSocket regressions covering the event-loop bug, non-leaking failure results, legacy disconnect compatibility, and local cleanup

This does not add RFC 7009/provider-specific token revocation. Current official MCP connections therefore report `unsupported`, and the UI tells the user how to finish revocation in the provider's connected-app settings. That satisfies the issue's expected fallback: removal no longer silently claims remote revocation succeeded.

## Verification

- `python -m pytest tests/collie/test_connectors.py tests/collie/test_ipc.py -q` (52 passed)
- `python -m pytest tests/collie/test_e2e_phase3.py -q` (1 passed)
- `python -m ruff check` on changed Python files
- `python -m ruff format --check` on changed Python files
- `npm test -- --silent --reporter=dot` (423 passed, 1 skipped)
- `npm run typecheck`
- `npm run build`

Closes #114