### PR TITLE
fix(ui): fail closed while core reconnects

### DIFF
--- a/collie-ui/src/renderer/src/components/ChatInput.test.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.test.tsx
@@ -135,6 +135,37 @@ import ChatInput, {
 } from './ChatInput'
 import type { AttachmentDraft } from '../lib/ipc'
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function submissionProps(
+  onSend: (text: string, attachments: AttachmentDraft[]) => Promise<boolean>
+) {
+  return {
+    onSend,
+    onStop: vi.fn(),
+    busy: false,
+    mode: 'execute' as const,
+    onModeChange: vi.fn(),
+    onProviderChange: vi.fn(),
+    onProjectChange: vi.fn(),
+    onAddProject: vi.fn(),
+    onAddModel: vi.fn(),
+    approvalPreset: 'ask' as const,
+    onApprovalPresetChange: vi.fn(),
+    fileAccessScope: { mode: 'selected_folder' as const },
+    onFileAccessScopeChange: vi.fn(),
+    onChooseFileAccessFolders: vi.fn(),
+    onTypingChange: vi.fn(),
+    onTranscribe: vi.fn().mockResolvedValue('')
+  }
+}
+
 function findElementByAriaLabel(
   value: unknown,
   ariaLabel: string
@@ -363,6 +394,76 @@ describe('ChatInput compose command listener', () => {
     expect(hooks.stateValue(0)).toBe('')
     expect(hooks.stateValue(1)).toEqual([])
     expect(onTypingChange).toHaveBeenCalledWith(false)
+  })
+
+  it('single-flights rapid submits while an acknowledgement is pending', async () => {
+    const eventTarget = Object.assign(new EventTarget(), {
+      setTimeout: vi.fn(() => 1),
+      clearTimeout: vi.fn()
+    })
+    vi.stubGlobal('window', eventTarget)
+    vi.stubGlobal('document', new EventTarget())
+    const acknowledgement = deferred<boolean>()
+    const onSend = vi.fn(() => acknowledgement.promise)
+    const props = submissionProps(onSend)
+
+    hooks.beginRender()
+    ChatInput(props)
+    hooks.setState(0, 'Send once')
+    hooks.beginRender()
+    const output = ChatInput(props)
+    const send = findElementByAriaLabel(output, 'chat.send').props.onClick as () => void
+
+    send()
+    send()
+    expect(onSend).toHaveBeenCalledTimes(1)
+
+    acknowledgement.resolve(false)
+    await Promise.resolve()
+    await Promise.resolve()
+    send()
+    expect(onSend).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes sent attachment identities but keeps files added while send is pending', async () => {
+    const eventTarget = Object.assign(new EventTarget(), {
+      setTimeout: vi.fn(() => 1),
+      clearTimeout: vi.fn()
+    })
+    vi.stubGlobal('window', eventTarget)
+    vi.stubGlobal('document', new EventTarget())
+    const sent: AttachmentDraft = {
+      name: 'sent.txt',
+      mime: 'text/plain',
+      size: 4,
+      data_url: 'data:text/plain;base64,c2VudA=='
+    }
+    const added: AttachmentDraft = {
+      name: 'added.txt',
+      mime: 'text/plain',
+      size: 5,
+      data_url: 'data:text/plain;base64,YWRkZWQ='
+    }
+    const acknowledgement = deferred<boolean>()
+    const props = submissionProps(vi.fn(() => acknowledgement.promise))
+
+    hooks.beginRender()
+    ChatInput(props)
+    hooks.setState(0, 'Send with files')
+    hooks.setState(1, [sent])
+    hooks.beginRender()
+    const output = ChatInput(props)
+    const send = findElementByAriaLabel(output, 'chat.send').props.onClick as () => void
+    send()
+
+    hooks.setState(1, [sent, added])
+    hooks.beginRender()
+    ChatInput(props)
+    acknowledgement.resolve(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(hooks.stateValue<AttachmentDraft[]>(1)).toEqual([added])
   })
 })
 

--- a/collie-ui/src/renderer/src/components/ChatInput.test.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.test.tsx
@@ -135,6 +135,26 @@ import ChatInput, {
 } from './ChatInput'
 import type { AttachmentDraft } from '../lib/ipc'
 
+function findElementByAriaLabel(
+  value: unknown,
+  ariaLabel: string
+): { props: Record<string, unknown> } {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      try {
+        return findElementByAriaLabel(item, ariaLabel)
+      } catch {
+        // Keep looking through sibling elements.
+      }
+    }
+  } else if (value && typeof value === 'object') {
+    const props = (value as { props?: Record<string, unknown> }).props
+    if (props?.['aria-label'] === ariaLabel) return { props }
+    if (props && 'children' in props) return findElementByAriaLabel(props.children, ariaLabel)
+  }
+  throw new Error(`Element with aria-label ${ariaLabel} was not found.`)
+}
+
 describe('ChatInput compose command listener', () => {
   beforeEach(() => {
     hooks.reset()
@@ -282,6 +302,67 @@ describe('ChatInput compose command listener', () => {
     output = JSON.stringify(ChatInput(props))
     expect(output).toContain('attachment-thumbnail')
     expect(output).toContain('data:image/png;base64,thumbnail')
+  })
+
+  it('keeps the draft until the engine accepts the submission', async () => {
+    const eventTarget = Object.assign(new EventTarget(), {
+      setTimeout: vi.fn(() => 1),
+      clearTimeout: vi.fn()
+    })
+    vi.stubGlobal('window', eventTarget)
+    vi.stubGlobal('document', new EventTarget())
+    const attachment: AttachmentDraft = {
+      name: 'notes.txt',
+      mime: 'text/plain',
+      size: 5,
+      data_url: 'data:text/plain;base64,aGVsbG8='
+    }
+    const onSend = vi.fn().mockResolvedValue(false)
+    const onTypingChange = vi.fn()
+    const props = {
+      onSend,
+      onStop: vi.fn(),
+      busy: false,
+      mode: 'execute' as const,
+      onModeChange: vi.fn(),
+      onProviderChange: vi.fn(),
+      onProjectChange: vi.fn(),
+      onAddProject: vi.fn(),
+      onAddModel: vi.fn(),
+      approvalPreset: 'ask' as const,
+      onApprovalPresetChange: vi.fn(),
+      fileAccessScope: { mode: 'selected_folder' as const },
+      onFileAccessScopeChange: vi.fn(),
+      onChooseFileAccessFolders: vi.fn(),
+      onTypingChange,
+      onTranscribe: vi.fn().mockResolvedValue('')
+    }
+
+    hooks.beginRender()
+    ChatInput(props)
+    hooks.setState(0, 'Send these notes')
+    hooks.setState(1, [attachment])
+    hooks.beginRender()
+    let output = ChatInput(props)
+    const firstSend = findElementByAriaLabel(output, 'chat.send').props.onClick as () => void
+    firstSend()
+    await Promise.resolve()
+
+    expect(onSend).toHaveBeenCalledWith('Send these notes', [attachment])
+    expect(hooks.stateValue(0)).toBe('Send these notes')
+    expect(hooks.stateValue(1)).toEqual([attachment])
+    expect(onTypingChange).not.toHaveBeenCalledWith(false)
+
+    onSend.mockResolvedValueOnce(true)
+    hooks.beginRender()
+    output = ChatInput(props)
+    const retrySend = findElementByAriaLabel(output, 'chat.send').props.onClick as () => void
+    retrySend()
+    await Promise.resolve()
+
+    expect(hooks.stateValue(0)).toBe('')
+    expect(hooks.stateValue(1)).toEqual([])
+    expect(onTypingChange).toHaveBeenCalledWith(false)
   })
 })
 

--- a/collie-ui/src/renderer/src/components/ChatInput.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.tsx
@@ -305,13 +305,12 @@ export default function ChatInput({
   const [promptLength, setPromptLength] = useState(0)
   const [deletingPrompt, setDeletingPrompt] = useState(false)
   const textRef = useRef(text)
-  const attachmentsRef = useRef(attachments)
+  const submittingRef = useRef(false)
   const recorderRef = useRef<LocalDictationRecorder | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const footerRef = useRef<HTMLDivElement>(null)
   const onTypingChangeRef = useRef(onTypingChange)
   textRef.current = text
-  attachmentsRef.current = attachments
   onTypingChangeRef.current = onTypingChange
   const t = useT()
   const activeProvider = providers.find((item) => item.is_default === 1)
@@ -435,26 +434,34 @@ export default function ChatInput({
   }, [text])
 
   const submit = async (): Promise<void> => {
-      const trimmed = text.trim()
-      if (!trimmed && attachments.length === 0) return
-      if (steering && attachments.length > 0) {
-        // Mid-turn steering cannot carry files — never drop them silently.
-        setAttachmentError(
-          'Attachments only go with a new message. Finish or stop the current task first.'
-        )
-        return
-      }
-      const submittedText = text
-      const submittedAttachments = attachments
-      const accepted = await onSend(trimmed, submittedAttachments)
-      if (!accepted) return
-      if (textRef.current === submittedText) {
-        setText('')
-        onTypingChange?.(false)
-      }
-      if (attachmentsRef.current === submittedAttachments) setAttachments([])
-      setAttachmentError('')
+    if (submittingRef.current) return
+    const trimmed = text.trim()
+    if (!trimmed && attachments.length === 0) return
+    if (steering && attachments.length > 0) {
+      // Mid-turn steering cannot carry files — never drop them silently.
+      setAttachmentError(
+        'Attachments only go with a new message. Finish or stop the current task first.'
+      )
+      return
     }
+    const submittedText = text
+    const submittedAttachments = attachments
+    submittingRef.current = true
+    let accepted = false
+    try {
+      accepted = await onSend(trimmed, submittedAttachments)
+    } finally {
+      submittingRef.current = false
+    }
+    if (!accepted) return
+    if (textRef.current === submittedText) {
+      setText('')
+      onTypingChange?.(false)
+    }
+    const submittedIdentities = new Set(submittedAttachments)
+    setAttachments((current) => current.filter((item) => !submittedIdentities.has(item)))
+    setAttachmentError('')
+  }
 
   const pickAttachments = async (): Promise<void> => {
     setAttachmentError('')

--- a/collie-ui/src/renderer/src/components/ChatInput.tsx
+++ b/collie-ui/src/renderer/src/components/ChatInput.tsx
@@ -241,7 +241,7 @@ export async function buildImagePreviews(
 }
 
 interface Props {
-  onSend: (text: string, attachments: AttachmentDraft[]) => void
+  onSend: (text: string, attachments: AttachmentDraft[]) => Promise<boolean>
   onStop: () => void
   busy: boolean
   steering?: boolean
@@ -304,10 +304,14 @@ export default function ChatInput({
   const [promptIndex, setPromptIndex] = useState(0)
   const [promptLength, setPromptLength] = useState(0)
   const [deletingPrompt, setDeletingPrompt] = useState(false)
+  const textRef = useRef(text)
+  const attachmentsRef = useRef(attachments)
   const recorderRef = useRef<LocalDictationRecorder | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const footerRef = useRef<HTMLDivElement>(null)
   const onTypingChangeRef = useRef(onTypingChange)
+  textRef.current = text
+  attachmentsRef.current = attachments
   onTypingChangeRef.current = onTypingChange
   const t = useT()
   const activeProvider = providers.find((item) => item.is_default === 1)
@@ -430,7 +434,7 @@ export default function ChatInput({
     setCommandIndex(0)
   }, [text])
 
-    const submit = (): void => {
+  const submit = async (): Promise<void> => {
       const trimmed = text.trim()
       if (!trimmed && attachments.length === 0) return
       if (steering && attachments.length > 0) {
@@ -440,10 +444,15 @@ export default function ChatInput({
         )
         return
       }
-      onSend(trimmed, attachments)
-      setText('')
-      onTypingChange?.(false)
-      setAttachments([])
+      const submittedText = text
+      const submittedAttachments = attachments
+      const accepted = await onSend(trimmed, submittedAttachments)
+      if (!accepted) return
+      if (textRef.current === submittedText) {
+        setText('')
+        onTypingChange?.(false)
+      }
+      if (attachmentsRef.current === submittedAttachments) setAttachments([])
       setAttachmentError('')
     }
 
@@ -698,7 +707,7 @@ export default function ChatInput({
             }
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault()
-              submit()
+              void submit()
             }
           }}
           className="flex-1 resize-none bg-transparent px-1 py-1.5 outline-none"
@@ -735,7 +744,7 @@ export default function ChatInput({
         ) : null}
         <button
           type="button"
-          onClick={submit}
+          onClick={() => void submit()}
           disabled={!text.trim() && attachments.length === 0}
           title={steering ? 'Add instructions to this task' : t('chat.send')}
           aria-label={steering ? 'Add instructions to this task' : t('chat.send')}

--- a/collie-ui/src/renderer/src/lib/ipc.test.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.test.ts
@@ -142,6 +142,50 @@ describe('CollieClient connection startup', () => {
     client.close()
   })
 
+  it('backs reconnects off exponentially, caps the delay, and resets after open', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const client = new CollieClient(4321, null, () => 0.5)
+    client.connect()
+    FakeWebSocket.instances[0].open()
+    FakeWebSocket.instances[0].close()
+
+    const delays = [1200, 2400, 4800, 9600, 19_200, 30_000, 30_000]
+    for (const [index, delay] of delays.entries()) {
+      const before = FakeWebSocket.instances.length
+      await vi.advanceTimersByTimeAsync(delay - 1)
+      expect(FakeWebSocket.instances).toHaveLength(before)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(FakeWebSocket.instances).toHaveLength(before + 1)
+      if (index < delays.length - 1) FakeWebSocket.instances.at(-1)!.close()
+    }
+
+    const recovered = FakeWebSocket.instances.at(-1)!
+    recovered.open()
+    recovered.close()
+    const beforeReset = FakeWebSocket.instances.length
+    await vi.advanceTimersByTimeAsync(1199)
+    expect(FakeWebSocket.instances).toHaveLength(beforeReset)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(FakeWebSocket.instances).toHaveLength(beforeReset + 1)
+    client.close()
+  })
+
+  it('applies deterministic jitter to the reconnect delay', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const client = new CollieClient(4321, null, () => 0)
+    client.connect()
+    FakeWebSocket.instances[0].open()
+    FakeWebSocket.instances[0].close()
+
+    await vi.advanceTimersByTimeAsync(959)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    client.close()
+  })
+
   it('sends Change plan with the generated authenticated envelope id intact', async () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const client = new CollieClient(4321)

--- a/collie-ui/src/renderer/src/lib/ipc.test.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.test.ts
@@ -32,13 +32,13 @@ class FakeWebSocket {
 describe('CollieClient connection startup', () => {
   afterEach(() => {
     FakeWebSocket.instances = []
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
-  it('reuses an in-flight socket and flushes queued commands once', async () => {
+  it('reuses an in-flight socket and sends a connected command once', async () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const client = new CollieClient(4321)
-    const reply = client.command<{ configured: boolean }>('get_status')
 
     client.connect()
     client.connect()
@@ -46,6 +46,7 @@ describe('CollieClient connection startup', () => {
     expect(FakeWebSocket.instances).toHaveLength(1)
     const socket = FakeWebSocket.instances[0]
     socket.open()
+    const reply = client.command<{ configured: boolean }>('get_status')
     expect(socket.send).toHaveBeenCalledTimes(1)
 
     const request = JSON.parse(socket.send.mock.calls[0][0] as string)
@@ -60,13 +61,94 @@ describe('CollieClient connection startup', () => {
     client.close()
   })
 
-  it('sends Change plan with the generated authenticated envelope id intact', async () => {
+  it('fails closed while disconnected and never replays the command after reconnect', async () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const client = new CollieClient(4321)
-    const reply = client.changePlan('conversation-1', 'run-1')
+
+    const reply = client.command('toggle_automation', {
+      automation_id: 'automation-1',
+      enabled: true
+    })
+    await expect(reply).rejects.toEqual(
+      expect.objectContaining({
+        name: 'CollieConnectionError',
+        code: 'CORE_RESTARTING',
+        message: "Collie's engine is restarting. Try again in a moment."
+      })
+    )
+
     client.connect()
     const socket = FakeWebSocket.instances[0]
     socket.open()
+    expect(socket.send).not.toHaveBeenCalled()
+    client.close()
+  })
+
+  it('rejects in-flight commands and clears their timers when the socket closes', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const client = new CollieClient(4321)
+    client.connect()
+    const socket = FakeWebSocket.instances[0]
+    socket.open()
+
+    const reply = client.chat(null, 'Do this once')
+    expect(socket.send).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(1)
+    socket.close()
+
+    await expect(reply).rejects.toEqual(
+      expect.objectContaining({
+        name: 'CollieConnectionError',
+        code: 'CONNECTION_INTERRUPTED',
+        message:
+          'Collie lost the connection before confirming that action. Check its result before trying again.'
+      })
+    )
+    // Only the reconnect timer remains; the 120-second command timer is gone.
+    expect(vi.getTimerCount()).toBe(1)
+
+    client.connect()
+    const replacement = FakeWebSocket.instances[1]
+    replacement.open()
+    expect(replacement.send).not.toHaveBeenCalled()
+    client.close()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('cleans up timed-out commands without leaking their late reply to listeners', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const client = new CollieClient(4321)
+    const listener = vi.fn()
+    client.on(listener)
+    client.connect()
+    const socket = FakeWebSocket.instances[0]
+    socket.open()
+
+    const reply = client.command('get_status', {}, 50)
+    const request = JSON.parse(socket.send.mock.calls[0][0] as string)
+    const rejected = expect(reply).rejects.toThrow('Collie took too long to answer.')
+    await vi.advanceTimersByTimeAsync(50)
+    await rejected
+
+    socket.onmessage?.({
+      data: JSON.stringify({ id: request.id, type: 'error', message: 'late reply' })
+    })
+    expect(listener).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: request.id, type: 'error' })
+    )
+    client.close()
+  })
+
+  it('sends Change plan with the generated authenticated envelope id intact', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const client = new CollieClient(4321)
+    client.connect()
+    const socket = FakeWebSocket.instances[0]
+    socket.open()
+    const reply = client.changePlan('conversation-1', 'run-1')
     const request = JSON.parse(socket.send.mock.calls[0][0] as string)
     expect(request).toMatchObject({
       type: 'change_plan',
@@ -96,6 +178,9 @@ describe('CollieClient connection startup', () => {
   it('sends execute mode and the explicit file-access scope with chat', async () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const client = new CollieClient(4321)
+    client.connect()
+    const socket = FakeWebSocket.instances[0]
+    socket.open()
     const reply = client.chat(
       null,
       'Organize these files',
@@ -104,9 +189,6 @@ describe('CollieClient connection startup', () => {
       'C:\\Selected',
       { mode: 'chosen_folders', roots: ['C:\\First', 'C:\\Second'] }
     )
-    client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
     const request = JSON.parse(socket.send.mock.calls[0][0] as string)
     expect(request).toMatchObject({
       type: 'chat',
@@ -131,10 +213,10 @@ describe('CollieClient connection startup', () => {
   it('keeps General Chat narrow when no selected folder exists', async () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const client = new CollieClient(4321)
-    const reply = client.chat(null, 'Hello')
     client.connect()
     const socket = FakeWebSocket.instances[0]
     socket.open()
+    const reply = client.chat(null, 'Hello')
     const request = JSON.parse(socket.send.mock.calls[0][0] as string)
     expect(request.execution_mode).toBe('execute')
     expect(request).toMatchObject({

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -1,6 +1,6 @@
 /**
  * CollieClient — typed client for the Python core's WebSocket IPC.
- * Auto-reconnects; queues commands until connected.
+ * Auto-reconnects; commands fail closed while the core is unavailable.
  */
 
 export interface CollieMessage {
@@ -510,13 +510,37 @@ export type CollieEvent =
 
 type Listener = (event: CollieEvent) => void
 
+const CORE_RESTARTING_MESSAGE = "Collie's engine is restarting. Try again in a moment."
+const CONNECTION_INTERRUPTED_MESSAGE =
+  "Collie lost the connection before confirming that action. Check its result before trying again."
+
+type CollieConnectionErrorCode =
+  | 'CORE_RESTARTING'
+  | 'CONNECTION_INTERRUPTED'
+  | 'CONNECTION_CLOSED'
+
+export class CollieConnectionError extends Error {
+  constructor(
+    message = CORE_RESTARTING_MESSAGE,
+    readonly code: CollieConnectionErrorCode = 'CORE_RESTARTING'
+  ) {
+    super(message)
+    this.name = 'CollieConnectionError'
+  }
+}
+
+interface PendingRequest {
+  settle: (event: CollieEvent) => void
+  fail: (error: Error) => void
+}
+
 export class CollieClient {
   private ws: WebSocket | null = null
   private url: string
   private token: string | null = null
   private listeners = new Set<Listener>()
-  private pending = new Map<string, (event: CollieEvent) => void>()
-  private queue: string[] = []
+  private pending = new Map<string, PendingRequest>()
+  private retryTimer: ReturnType<typeof setTimeout> | null = null
   private seq = 0
   private closed = false
   connected = false
@@ -533,6 +557,10 @@ export class CollieClient {
     if (this.ws) {
       const socket = this.ws
       this.ws = null
+      this.connected = false
+      this.failPending(
+        new CollieConnectionError(CONNECTION_INTERRUPTED_MESSAGE, 'CONNECTION_INTERRUPTED')
+      )
       socket.close()
     }
   }
@@ -558,7 +586,6 @@ export class CollieClient {
     socket.onopen = () => {
       if (this.ws !== socket) return
       this.connected = true
-      for (const raw of this.queue.splice(0)) socket.send(raw)
       for (const listener of this.listeners) listener({ type: 'connection_opened' })
     }
     socket.onmessage = (e) => {
@@ -569,13 +596,10 @@ export class CollieClient {
         return
       }
       const id = 'id' in event ? (event.id as string | undefined) : undefined
-      if (id && this.pending.has(id)) {
-        const resolve = this.pending.get(id)!
-        this.pending.delete(id)
-        resolve(event)
+      if (id && (event.type === 'ok' || event.type === 'error')) {
+        this.pending.get(id)?.settle(event)
         // Command replies (ok AND error) are consumed by the caller — never
-        // fanned out to listeners where a background error would leak into
-        // the chat as a conversation error.
+        // fanned out to listeners, even if the caller already timed out.
         return
       }
       for (const listener of this.listeners) listener(event)
@@ -584,6 +608,9 @@ export class CollieClient {
       if (this.ws !== socket) return
       this.ws = null
       this.connected = false
+      this.failPending(
+        new CollieConnectionError(CONNECTION_INTERRUPTED_MESSAGE, 'CONNECTION_INTERRUPTED')
+      )
       this.retry()
     }
     socket.onerror = () => {
@@ -592,13 +619,26 @@ export class CollieClient {
   }
 
   private retry(): void {
-    if (this.closed) return
-    setTimeout(() => this.connect(), 1200)
+    if (this.closed || this.retryTimer) return
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null
+      this.connect()
+    }, 1200)
   }
 
   close(): void {
     this.closed = true
-    this.ws?.close()
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+    const socket = this.ws
+    this.ws = null
+    this.connected = false
+    this.failPending(
+      new CollieConnectionError("Collie's engine connection closed.", 'CONNECTION_CLOSED')
+    )
+    socket?.close()
   }
 
   on(listener: Listener): () => void {
@@ -606,13 +646,10 @@ export class CollieClient {
     return () => this.listeners.delete(listener)
   }
 
-  private sendRaw(frame: Record<string, unknown>): void {
-    const raw = JSON.stringify(frame)
-    if (this.connected && this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(raw)
-    } else {
-      this.queue.push(raw)
-    }
+  private failPending(error: Error): void {
+    const pending = [...this.pending.values()]
+    this.pending.clear()
+    for (const request of pending) request.fail(error)
   }
 
   /** Fire a command and await its ok/error reply. */
@@ -621,18 +658,41 @@ export class CollieClient {
     payload: Record<string, unknown> = {},
     timeoutMs = 120_000
   ): Promise<T> {
+    const socket = this.ws
+    if (!this.connected || !socket || socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new CollieConnectionError())
+    }
+
     const id = `c${++this.seq}`
     return new Promise<T>((resolve, reject) => {
-      const timer = setTimeout(() => {
+      let timer: ReturnType<typeof setTimeout> | null = null
+      let settled = false
+      const finish = (action: () => void): void => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
         this.pending.delete(id)
-        reject(new Error('Collie took too long to answer.'))
+        action()
+      }
+      const pending: PendingRequest = {
+        settle: (event) => {
+          finish(() => {
+            if (event.type === 'ok') resolve(event.data as T)
+            else reject(new Error((event as { message?: string }).message || 'error'))
+          })
+        },
+        fail: (error) => finish(() => reject(error))
+      }
+      timer = setTimeout(() => {
+        pending.fail(new Error('Collie took too long to answer.'))
       }, timeoutMs)
-      this.pending.set(id, (event) => {
-        clearTimeout(timer)
-        if (event.type === 'ok') resolve(event.data as T)
-        else reject(new Error((event as { message?: string }).message || 'error'))
-      })
-      this.sendRaw({ type, id, ...payload })
+      this.pending.set(id, pending)
+      try {
+        socket.send(JSON.stringify({ type, id, ...payload }))
+      } catch {
+        pending.fail(new CollieConnectionError())
+        socket.close()
+      }
     })
   }
 

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -510,6 +510,9 @@ export type CollieEvent =
 
 type Listener = (event: CollieEvent) => void
 
+const RECONNECT_BASE_DELAY_MS = 1200
+const RECONNECT_MAX_DELAY_MS = 30_000
+const RECONNECT_JITTER_RATIO = 0.2
 const CORE_RESTARTING_MESSAGE = "Collie's engine is restarting. Try again in a moment."
 const CONNECTION_INTERRUPTED_MESSAGE =
   "Collie lost the connection before confirming that action. Check its result before trying again."
@@ -541,11 +544,16 @@ export class CollieClient {
   private listeners = new Set<Listener>()
   private pending = new Map<string, PendingRequest>()
   private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
   private seq = 0
   private closed = false
   connected = false
 
-  constructor(port = 3818, token?: string | null) {
+  constructor(
+    port = 3818,
+    token?: string | null,
+    private readonly random: () => number = Math.random
+  ) {
     this.url = `ws://127.0.0.1:${port}`
     this.token = token || null
   }
@@ -573,6 +581,10 @@ export class CollieClient {
     ) {
       return
     }
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
     let socket: WebSocket
     try {
       socket = this.token
@@ -586,6 +598,7 @@ export class CollieClient {
     socket.onopen = () => {
       if (this.ws !== socket) return
       this.connected = true
+      this.reconnectAttempts = 0
       for (const listener of this.listeners) listener({ type: 'connection_opened' })
     }
     socket.onmessage = (e) => {
@@ -620,10 +633,17 @@ export class CollieClient {
 
   private retry(): void {
     if (this.closed || this.retryTimer) return
+    const exponentialDelay = Math.min(
+      RECONNECT_MAX_DELAY_MS,
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts
+    )
+    this.reconnectAttempts += 1
+    const jitter = 1 - RECONNECT_JITTER_RATIO + this.random() * RECONNECT_JITTER_RATIO * 2
+    const delayMs = Math.min(RECONNECT_MAX_DELAY_MS, Math.round(exponentialDelay * jitter))
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null
       this.connect()
-    }, 1200)
+    }, delayMs)
   }
 
   close(): void {

--- a/collie-ui/src/renderer/src/screens/ChatScreen.ordering.test.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.ordering.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AttachmentDraft, CollieEvent, CollieMessage, TaskState } from '../lib/ipc'
 
 interface ChatInputProps {
-  onSend: (text: string, attachments: AttachmentDraft[]) => void
+  onSend: (text: string, attachments: AttachmentDraft[]) => Promise<boolean>
   onProjectChange: (path: string) => void
   taskProgress?: TaskState | null
 }
@@ -76,8 +76,8 @@ vi.mock('./SkillsScreen', () => ({ default: () => null }))
 vi.mock('./RoutinesScreen', () => ({ default: () => null }))
 vi.mock('./ConnectorsScreen', () => ({ default: () => null }))
 vi.mock('../components/MessageList', () => ({
-  default: ({ messages }: { messages: CollieMessage[] }) => (
-    <ol>
+  default: ({ messages, streaming }: { messages: CollieMessage[]; streaming: boolean }) => (
+    <ol data-streaming={String(streaming)}>
       {messages.map((message) => (
         <li data-message={`${message.role}:${message.id}`} key={message.id}>
           {message.content}
@@ -179,6 +179,20 @@ describe('ChatScreen paced assistant completion order', () => {
       undefined,
       { mode: 'selected_folder' }
     )
+  })
+
+  it('recovers from a rejected send and reports that the draft was not accepted', async () => {
+    const message = "Collie's engine is restarting. Try again in a moment."
+    hooks.client.chat.mockRejectedValueOnce(new Error(message))
+    let accepted = true
+
+    await act(async () => {
+      accepted = await hooks.chatInput().onSend('Keep this draft', [])
+    })
+
+    expect(accepted).toBe(false)
+    expect(container.querySelector('ol')?.dataset.streaming).toBe('false')
+    expect(container.textContent).toContain(message)
   })
 
   it('passes active task progress into the chat input window', async () => {

--- a/collie-ui/src/renderer/src/screens/ChatScreen.starter.test.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.starter.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import type { AttachmentDraft, CollieEvent, Conversation, TaskState } from '../lib/ipc'
 
 interface ChatInputProps {
-  onSend: (text: string, attachments: AttachmentDraft[]) => void
+  onSend: (text: string, attachments: AttachmentDraft[]) => Promise<boolean>
   onProjectChange: (path: string) => void
   taskProgress?: TaskState | null
 }

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -753,7 +753,7 @@ export default function ChatScreen({
   ) : undefined
 
   const send = useCallback(
-    async (text: string, attachments: AttachmentDraft[]) => {
+    async (text: string, attachments: AttachmentDraft[]): Promise<boolean> => {
       setErrorText('')
       const conversationId = activeIdRef.current
       if (isWorkActive && conversationId) {
@@ -765,8 +765,9 @@ export default function ChatScreen({
               ? error.message
               : 'I could not add those instructions to the active task.'
           )
+          return false
         }
-        return
+        return true
       }
       if (conversationId) {
         setTaskTimings((previous) => ({
@@ -798,13 +799,23 @@ export default function ChatScreen({
         }
         if (command_handled) void refreshCommandCatalog()
         void refreshConversations()
+        return true
       } catch (e) {
+        setStreaming(false)
+        if (conversationId) {
+          setTaskTimings((previous) => {
+            const next = { ...previous }
+            delete next[conversationId]
+            return next
+          })
+        }
         setErrorText(e instanceof Error ? e.message : String(e))
         setPortraitThinking({
           state: 'error',
           phrase: 'I could not start that response.',
           pet_animation: 'concerned'
         })
+        return false
       }
     },
     [
@@ -1161,7 +1172,7 @@ export default function ChatScreen({
               recentAgents={recentAgents}
             />
             <ChatInput
-              onSend={(text, attachments) => void send(text, attachments)}
+              onSend={send}
               onStop={() => void stop()}
               busy={isWorkActive}
               steering={isWorkActive}


### PR DESCRIPTION
## Summary
- remove the renderer's unbounded raw WebSocket command queue so commands fail closed while the core is unavailable
- reject and clean up in-flight requests on disconnect, distinguish restart from unconfirmed outcomes, and consume late command replies safely
- retain chat drafts until the core acknowledges them, single-flight rapid submits, preserve files added mid-send, and unwind optimistic streaming on rejection
- reconnect with capped exponential backoff and jitter, resetting after a successful open

## Tests
- `npm test` (63 files; 431 passed, 1 skipped)
- `npm run typecheck`
- focused IPC, reconnect, composer mutation, and ChatScreen recovery tests

## Scope
Addresses only the renderer WebSocket queue/replay finding in #134. It intentionally does not close #134 because the headless temp-home and OpenAI stream findings remain separate.

Documentation impact check: no canonical docs changed; this restores the existing recovery and user-control invariants without changing component ownership or product intent.