### PR TITLE
fix(core): clean up implicit headless homes

### DIFF
--- a/collie-core/collie_core/headless.py
+++ b/collie-core/collie_core/headless.py
@@ -32,6 +32,7 @@ import asyncio
 import contextlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -79,7 +80,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help=(
             "COLLIE_HOME directory (created if missing). Defaults to "
-            "$COLLIE_HOME or a fresh tempfile.mkdtemp()."
+            "$COLLIE_HOME or a fresh temporary directory removed after the run."
         ),
     )
     parser.add_argument(
@@ -166,12 +167,30 @@ def _git_commit() -> str:
     return "unknown"
 
 
-def _resolve_home(home_flag: str | None) -> Path:
-    """Resolve --home > $COLLIE_HOME > a fresh temp dir, creating it."""
+def _resolve_home(home_flag: str | None) -> tuple[Path, bool]:
+    """Resolve the bench home and report whether this process owns it."""
     root = home_flag or os.environ.get("COLLIE_HOME")
+    owned = not root
     path = Path(root).expanduser() if root else Path(tempfile.mkdtemp(prefix="collie-bench-"))
     path.mkdir(parents=True, exist_ok=True)
-    return path
+    return path, owned
+
+
+@contextlib.contextmanager
+def _headless_home(home_flag: str | None):
+    """Set ``COLLIE_HOME`` for one run and clean up only owned temp homes."""
+    previous_home = os.environ.get("COLLIE_HOME")
+    home, owned = _resolve_home(home_flag)
+    os.environ["COLLIE_HOME"] = str(home)
+    try:
+        yield home
+    finally:
+        if previous_home is None:
+            os.environ.pop("COLLIE_HOME", None)
+        else:
+            os.environ["COLLIE_HOME"] = previous_home
+        if owned:
+            shutil.rmtree(home, ignore_errors=True)
 
 
 def _normalize_usage(usage: dict[str, Any]) -> dict[str, int]:
@@ -238,8 +257,14 @@ async def run_one(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     ``COLLIE_HOME`` is set from ``--home`` / the environment BEFORE any
     ``CollieDB`` is built, so the bench never touches the real user home.
     """
-    home = _resolve_home(args.home)
-    os.environ["COLLIE_HOME"] = str(home)
+    with _headless_home(args.home) as home:
+        return await _run_one_in_home(args, home)
+
+
+async def _run_one_in_home(
+    args: argparse.Namespace, home: Path
+) -> tuple[int, dict[str, Any]]:
+    """Run one task inside an already-scoped headless home."""
 
     document = _empty_document(args.task, args.provider)
     exit_code = EXIT_OK
@@ -255,20 +280,21 @@ async def run_one(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         _emit(document, args.json_out)
         return exit_code, document
 
-    db = CollieDB(home / "collie.db")
-    # Approval preset is persisted BEFORE the runtime is constructed so the
-    # PermissionEvaluator reads it at init — the exact same setting the IPC
-    # path writes, never a bypass. (argparse already restricts to
-    # allow|ask|deny.)
-    db.set_setting("permissions.local_write_preset", args.approval_preset)
-    # --max-iterations maps to agent.max_tool_iterations; build_config clamps
-    # to 1..2000, and the flag must never reach the engine outside that range.
-    db.set_setting(
-        "agent.max_tool_iterations",
-        min(MAX_ITERATIONS_MAX, max(MAX_ITERATIONS_MIN, args.max_iterations)),
-    )
+    db: CollieDB | None = None
     runtime: CollieRuntime | None = None
     try:
+        db = CollieDB(home / "collie.db")
+        # Approval preset is persisted BEFORE the runtime is constructed so the
+        # PermissionEvaluator reads it at init — the exact same setting the IPC
+        # path writes, never a bypass. (argparse already restricts to
+        # allow|ask|deny.)
+        db.set_setting("permissions.local_write_preset", args.approval_preset)
+        # --max-iterations maps to agent.max_tool_iterations; build_config clamps
+        # to 1..2000, and the flag must never reach the engine outside that range.
+        db.set_setting(
+            "agent.max_tool_iterations",
+            min(MAX_ITERATIONS_MAX, max(MAX_ITERATIONS_MIN, args.max_iterations)),
+        )
         runtime = CollieRuntime(port=0, db=db)
         # -- provider ---------------------------------------------------------
         # The exact transactional path the UI uses: validate + persist +
@@ -381,7 +407,8 @@ async def run_one(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             recorder = RunRecorder.active_for(runtime.db)
             if recorder is not None:
                 recorder.shutdown()
-        db.close()
+        if db is not None:
+            db.close()
 
 
 def _emit(document: dict[str, Any], json_out: str | None) -> None:

--- a/collie-core/collie_core/headless.py
+++ b/collie-core/collie_core/headless.py
@@ -261,9 +261,7 @@ async def run_one(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         return await _run_one_in_home(args, home)
 
 
-async def _run_one_in_home(
-    args: argparse.Namespace, home: Path
-) -> tuple[int, dict[str, Any]]:
+async def _run_one_in_home(args: argparse.Namespace, home: Path) -> tuple[int, dict[str, Any]]:
     """Run one task inside an already-scoped headless home."""
 
     document = _empty_document(args.task, args.provider)

--- a/collie-core/tests/collie/test_headless.py
+++ b/collie-core/tests/collie/test_headless.py
@@ -143,9 +143,7 @@ def _args(
     )
 
 
-def _capture_auto_home(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str
-) -> Path:
+def _capture_auto_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str) -> Path:
     """Make the otherwise-random default temp home observable to a test."""
     auto_home = tmp_path / name
 
@@ -258,9 +256,7 @@ async def test_headless_default_temp_home_is_removed_after_database_closes(
 
     runner, llm_port = await _serve(_fake_openai_app())
     try:
-        exit_code, _document = await headless.run_one(
-            _args(tmp_path, llm_port, home=None)
-        )
+        exit_code, _document = await headless.run_one(_args(tmp_path, llm_port, home=None))
     finally:
         await runner.cleanup()
 
@@ -305,9 +301,7 @@ async def test_headless_default_temp_home_is_removed_after_task_error(
     monkeypatch.setattr(headless.CollieRuntime, "_chat", fail_chat)
     runner, llm_port = await _serve(_fake_openai_app())
     try:
-        exit_code, document = await headless.run_one(
-            _args(tmp_path, llm_port, home=None)
-        )
+        exit_code, document = await headless.run_one(_args(tmp_path, llm_port, home=None))
     finally:
         await runner.cleanup()
 
@@ -378,9 +372,7 @@ async def test_headless_preserves_explicit_and_inherited_homes(
     inherited_home.mkdir()
     monkeypatch.setenv("COLLIE_HOME", str(inherited_home))
 
-    exit_code, _document = await headless.run_one(
-        _args(tmp_path, 9999, home=str(explicit_home))
-    )
+    exit_code, _document = await headless.run_one(_args(tmp_path, 9999, home=str(explicit_home)))
     assert exit_code == 3
     assert explicit_home.is_dir()
     assert headless.os.environ["COLLIE_HOME"] == str(inherited_home)

--- a/collie-core/tests/collie/test_headless.py
+++ b/collie-core/tests/collie/test_headless.py
@@ -18,7 +18,7 @@ import pytest
 from aiohttp import web
 
 import collie_core.headless as headless
-from collie_core.db import CollieDB, collie_home
+from collie_core.db import CollieDB
 from collie_core.telemetry.prompt_hashes import hash_tool_schema
 
 FAKE_KEY = "sk-bench-secret-0123456789abcdef"
@@ -129,7 +129,6 @@ def _args(
     return headless._parse_args(
         [
             f"--task={values['task']}",
-            f"--home={values['home']}",
             f"--model={values['model']}",
             f"--provider={values['provider']}",
             f"--api-base={values['api_base']}",
@@ -138,9 +137,25 @@ def _args(
             f"--max-iterations={values['max_iterations']}",
             f"--approval-preset={values['approval_preset']}",
         ]
+        + ([f"--home={values['home']}"] if values["home"] is not None else [])
         + ([f"--session-key={values['session_key']}"] if values["session_key"] else [])
         + ([f"--json-out={values['json_out']}"] if values["json_out"] else [])
     )
+
+
+def _capture_auto_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str
+) -> Path:
+    """Make the otherwise-random default temp home observable to a test."""
+    auto_home = tmp_path / name
+
+    def fake_mkdtemp(*, prefix: str) -> str:
+        assert prefix == "collie-bench-"
+        auto_home.mkdir()
+        return str(auto_home)
+
+    monkeypatch.setattr(headless.tempfile, "mkdtemp", fake_mkdtemp)
+    return auto_home
 
 
 @pytest.mark.asyncio
@@ -218,19 +233,89 @@ async def test_headless_runs_task_and_outputs_contract(
 
 
 @pytest.mark.asyncio
+async def test_headless_default_temp_home_is_removed_after_database_closes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+    auto_home = _capture_auto_home(tmp_path, monkeypatch, "owned-success-home")
+    events: list[str] = []
+    original_close = headless.CollieDB.close
+    original_rmtree = headless.shutil.rmtree
+
+    def recording_close(db: CollieDB) -> None:
+        events.append("db.close")
+        original_close(db)
+
+    def recording_rmtree(path: Path, *, ignore_errors: bool = False) -> None:
+        assert Path(path) == auto_home
+        assert "db.close" in events
+        events.append("rmtree")
+        original_rmtree(path, ignore_errors=ignore_errors)
+
+    monkeypatch.setattr(headless.CollieDB, "close", recording_close)
+    monkeypatch.setattr(headless.shutil, "rmtree", recording_rmtree)
+
+    runner, llm_port = await _serve(_fake_openai_app())
+    try:
+        exit_code, _document = await headless.run_one(
+            _args(tmp_path, llm_port, home=None)
+        )
+    finally:
+        await runner.cleanup()
+
+    assert exit_code == 0
+    assert events[-2:] == ["db.close", "rmtree"]
+    assert not auto_home.exists()
+    assert "COLLIE_HOME" not in headless.os.environ
+
+
+@pytest.mark.asyncio
 async def test_headless_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
     monkeypatch.delenv("COLLIE_HOME", raising=False)
+    auto_home = _capture_auto_home(tmp_path, monkeypatch, "owned-timeout-home")
 
     runner, llm_port = await _serve(_fake_openai_app(delay_s=30))
     try:
-        exit_code, document = await headless.run_one(_args(tmp_path, llm_port, timeout=1))
+        exit_code, document = await headless.run_one(
+            _args(tmp_path, llm_port, timeout=1, home=None)
+        )
     finally:
         await runner.cleanup()
 
     assert exit_code == 2
     assert document["exit_state"] == "timeout"
     assert "timed out" in (document["error"] or "")
+    assert not auto_home.exists()
+    assert "COLLIE_HOME" not in headless.os.environ
+
+
+@pytest.mark.asyncio
+async def test_headless_default_temp_home_is_removed_after_task_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+    auto_home = _capture_auto_home(tmp_path, monkeypatch, "owned-error-home")
+
+    async def fail_chat(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("bench task failed")
+
+    monkeypatch.setattr(headless.CollieRuntime, "_chat", fail_chat)
+    runner, llm_port = await _serve(_fake_openai_app())
+    try:
+        exit_code, document = await headless.run_one(
+            _args(tmp_path, llm_port, home=None)
+        )
+    finally:
+        await runner.cleanup()
+
+    assert exit_code == 1
+    assert document["exit_state"] == "error"
+    assert document["error"] == "bench task failed"
+    assert not auto_home.exists()
+    assert "COLLIE_HOME" not in headless.os.environ
 
 
 @pytest.mark.asyncio
@@ -241,8 +326,9 @@ async def test_headless_missing_key(
     monkeypatch.delenv("COLLIE_BENCH_KEY", raising=False)
     monkeypatch.delenv("COLLIE_PROVIDER_API_KEY", raising=False)
     monkeypatch.delenv("COLLIE_HOME", raising=False)
+    auto_home = _capture_auto_home(tmp_path, monkeypatch, "owned-missing-key-home")
 
-    exit_code, document = await headless.run_one(_args(tmp_path, 9999))
+    exit_code, document = await headless.run_one(_args(tmp_path, 9999, home=None))
 
     assert exit_code == 3
     assert document["exit_state"] == "error"
@@ -253,6 +339,56 @@ async def test_headless_missing_key(
     assert FAKE_KEY not in captured.err
     # The key never appears in the JSON either
     assert FAKE_KEY not in json.dumps(document)
+    assert not auto_home.exists()
+    assert "COLLIE_HOME" not in headless.os.environ
+
+
+@pytest.mark.asyncio
+async def test_headless_configuration_failure_cleans_default_temp_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COLLIE_BENCH_KEY", FAKE_KEY)
+    monkeypatch.delenv("COLLIE_HOME", raising=False)
+    auto_home = _capture_auto_home(tmp_path, monkeypatch, "owned-config-home")
+
+    async def reject_candidate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"configured": False, "error": "provider rejected"}
+
+    monkeypatch.setattr(
+        headless.CollieRuntime,
+        "_configure_provider_candidate",
+        reject_candidate,
+    )
+    exit_code, document = await headless.run_one(_args(tmp_path, 9999, home=None))
+
+    assert exit_code == 3
+    assert document["error"] == "provider rejected"
+    assert not auto_home.exists()
+    assert "COLLIE_HOME" not in headless.os.environ
+
+
+@pytest.mark.asyncio
+async def test_headless_preserves_explicit_and_inherited_homes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("COLLIE_BENCH_KEY", raising=False)
+    monkeypatch.delenv("COLLIE_PROVIDER_API_KEY", raising=False)
+    inherited_home = tmp_path / "inherited-home"
+    explicit_home = tmp_path / "explicit-home"
+    inherited_home.mkdir()
+    monkeypatch.setenv("COLLIE_HOME", str(inherited_home))
+
+    exit_code, _document = await headless.run_one(
+        _args(tmp_path, 9999, home=str(explicit_home))
+    )
+    assert exit_code == 3
+    assert explicit_home.is_dir()
+    assert headless.os.environ["COLLIE_HOME"] == str(inherited_home)
+
+    exit_code, _document = await headless.run_one(_args(tmp_path, 9999, home=None))
+    assert exit_code == 3
+    assert inherited_home.is_dir()
+    assert headless.os.environ["COLLIE_HOME"] == str(inherited_home)
 
 
 @pytest.mark.asyncio
@@ -300,8 +436,9 @@ async def test_headless_isolated_home(tmp_path: Path, monkeypatch: pytest.Monkey
         await runner.cleanup()
     assert exit_code == 0
 
-    # collie_home() points inside --home (COLLIE_HOME was set by run_one)
-    assert collie_home().resolve() == (tmp_path / "bench-home").resolve()
+    # The run wrote inside --home, then restored the caller's environment.
+    assert (tmp_path / "bench-home" / "collie.db").exists()
+    assert "COLLIE_HOME" not in headless.os.environ
     assert document["conversation_id"]
 
     # The real user home never gained a collie DB


### PR DESCRIPTION
## Problem

The internal headless benchmark creates a `collie-bench-*` home when neither `--home` nor `COLLIE_HOME` is supplied, but never removes it. The missing-key return happens before runtime/database teardown, and `run_one` also leaves `COLLIE_HOME` changed for in-process callers.

## Solution

- Track whether the resolved home is owned by the headless run.
- Scope `COLLIE_HOME` for one run and restore the caller's previous environment afterward.
- Remove only implicitly created temporary homes.
- Preserve explicit `--home` and inherited `COLLIE_HOME` directories.
- Keep teardown ordered: runtime/telemetry shutdown, database close, then directory cleanup.
- Cover setup and every documented exit state, including the missing-key early return.

## Tests

- `python -m pytest tests/collie/test_headless.py tests/collie/test_prompt_hashes.py -q` (17 passed)
- `python -m ruff check collie_core/headless.py tests/collie/test_headless.py`
- `git diff --check`

## Documentation impact

No product, architecture, or public release truth changed. The internal `--help` text now clarifies that an implicit temporary home is removed after the run.

Partial fix for #134: this addresses subfinding 1 only. The OpenAI SDK stream-closure and renderer WebSocket queue findings remain open, so this PR intentionally does not close the issue.