### PR TITLE
fix(core): harden IPC errors and list limits

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -83,6 +83,8 @@ from nanobot.webui.skills_api import webui_skill_detail_payload, webui_skills_pa
 __all__ = ["CollieIPCServer"]
 
 _MAX_FRAME_BYTES = DEFAULT_WEBUI_INGRESS_POLICY.minimum_full_policy_frame_bytes()
+_GENERIC_ERROR_MESSAGE = "Uh oh. That didn't go as planned. Try again?"
+_MAX_LIST_LIMIT = 500
 
 _MAX_PREVIEW_BYTES = 256 * 1024
 _SAFE_PREVIEW_MIMES = frozenset({"image/png", "image/jpeg", "image/webp", "image/gif"})
@@ -127,6 +129,33 @@ _ALLOWED_ORIGIN_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _PERSON_FIELDS = frozenset(
     {"relationship", "birthday", "allergies", "preferences", "gift_ideas", "notes"}
 )
+
+
+def _public_error_message(
+    error: object,
+    *,
+    fallback: str = _GENERIC_ERROR_MESSAGE,
+) -> str:
+    """Return only exception text that is explicitly safe for the renderer."""
+    if isinstance(error, (ValueError, VoiceInputError)):
+        return str(error)
+    return fallback
+
+
+def _bounded_list_limit(
+    value: Any,
+    *,
+    default: int | None,
+    maximum: int = _MAX_LIST_LIMIT,
+) -> int | None:
+    """Parse a renderer list limit without allowing unbounded SQLite LIMITs."""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default if default is not None else maximum
+    return max(1, min(parsed, maximum))
 
 
 @dataclass
@@ -467,11 +496,7 @@ class CollieIPCServer:
             # Never include frame locals in diagnostics: secret-bearing commands
             # carry API keys, OAuth credentials, or Telegram bot tokens.
             logger.error("IPC command failed: {} ({})", kind, type(e).__name__)
-            safe_message = (
-                str(e)
-                if isinstance(e, (ValueError, VoiceInputError))
-                else "Uh oh. That didn't go as planned. Try again?"
-            )
+            safe_message = _public_error_message(e)
             await self._send(
                 connection,
                 {
@@ -649,12 +674,12 @@ class CollieIPCServer:
 
     async def _cmd_get_messages(self, connection: ServerConnection, frame: dict) -> dict:
         conv_id = str(frame.get("conversation_id") or "")
-        limit = frame.get("limit")
+        limit = _bounded_list_limit(frame.get("limit"), default=None)
         # Off the event loop: a long conversation loads asynchronously.
         messages = await asyncio.to_thread(
             self.db.get_messages,
             conv_id,
-            int(limit) if limit is not None else None,
+            limit,
         )
         return {"messages": messages}
 
@@ -663,13 +688,13 @@ class CollieIPCServer:
         conv_id = str(frame.get("conversation_id") or "") or None
         session_key = str(frame.get("session_key") or "") or None
         since = str(frame.get("since") or "") or None
-        limit = frame.get("limit")
+        limit = _bounded_list_limit(frame.get("limit"), default=200)
         turns = await asyncio.to_thread(
             self.db.list_turn_events,
             conversation_id=conv_id,
             session_key=session_key,
             since=since,
-            limit=int(limit) if limit is not None else 200,
+            limit=limit,
         )
         return {"turns": turns}
 
@@ -677,12 +702,12 @@ class CollieIPCServer:
         """List tool events (most recent first) — read-only telemetry."""
         turn_id = str(frame.get("turn_id") or "") or None
         tool_name = str(frame.get("tool_name") or "") or None
-        limit = frame.get("limit")
+        limit = _bounded_list_limit(frame.get("limit"), default=500)
         events = await asyncio.to_thread(
             self.db.list_tool_events,
             turn_id=turn_id,
             tool_name=tool_name,
-            limit=int(limit) if limit is not None else 500,
+            limit=limit,
         )
         return {"tool_events": events}
 
@@ -2000,10 +2025,11 @@ class CollieIPCServer:
         }
 
     async def _cmd_list_routine_runs(self, connection: ServerConnection, frame: dict) -> dict:
+        limit = _bounded_list_limit(frame.get("limit"), default=100)
         return {
             "runs": self.db.list_runs(
                 routine_id=str(frame.get("routine_id") or ""),
-                limit=int(frame.get("limit") or 100),
+                limit=limit,
             )
         }
 
@@ -3208,7 +3234,9 @@ class CollieIPCServer:
                         run_id,
                         str(current["step_key"]),
                         status="failed",
-                        error_message=str(event.get("error") or "Tool execution failed")[:500],
+                        error_message=_public_error_message(
+                            event.get("error"), fallback="Tool execution failed."
+                        ),
                     )
                     failed_step = next(
                         (
@@ -3326,6 +3354,7 @@ class CollieIPCServer:
             )
             return
         except Exception as e:
+            safe_error = _public_error_message(e)
             if run_id:
                 self._active_material_runs.pop(run_id, None)
             terminal_task: dict[str, Any] | None = None
@@ -3342,7 +3371,7 @@ class CollieIPCServer:
                             run_id,
                             str(current["step_key"]),
                             status="failed",
-                            error_message=str(e)[:500] or "Task execution failed.",
+                            error_message=safe_error,
                         )
                         failed_step = next(
                             (
@@ -3356,8 +3385,8 @@ class CollieIPCServer:
                     self.db.transition_run(
                         run_id,
                         "failed",
-                        error_code=type(e).__name__,
-                        error_message=str(e)[:1000],
+                        error_code="chat_turn_failed",
+                        error_message=safe_error,
                     )
                     await self.broadcast({"type": "run_failed", "run": self.db.get_run(run_id)})
                     terminal_task = self.db.get_run_task(run_id)
@@ -3379,7 +3408,7 @@ class CollieIPCServer:
                             expected_revision=int(active["revision"]),
                             step_key=str(failing),
                             status="failed",
-                            error_message=str(e)[:500] or "Task execution failed.",
+                            error_message=safe_error,
                         )
                         await self._broadcast_task_state(terminal_task)
                     else:
@@ -3437,8 +3466,8 @@ class CollieIPCServer:
                 {
                     "type": "error",
                     "conversation_id": conv_id,
-                    "message": "Uh oh. That didn't go as planned. Try again?",
-                    "detail": str(e),
+                    "message": safe_error,
+                    "detail": safe_error,
                 }
             )
             return

--- a/collie-core/tests/collie/test_ipc.py
+++ b/collie-core/tests/collie/test_ipc.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 import websockets
+from loguru import logger
 
 from collie_core.db import CollieDB
 from collie_core.ipc.server import CollieIPCServer
@@ -818,11 +819,15 @@ async def test_chat_without_runner_reports_friendly_error(tmp_path: Path) -> Non
 
 @pytest.mark.asyncio
 async def test_chat_runner_exception_is_friendly(tmp_path: Path) -> None:
+    private_detail = "C:\\Users\\alice\\.collie\\provider-secret.txt"
+
     async def broken_runner(content, *, conversation_id, on_stream, on_progress):
-        raise RuntimeError("boom")
+        raise RuntimeError(private_detail)
 
     db = CollieDB(tmp_path / "c.db")
     srv = CollieIPCServer(db, port=_free_port(), chat_runner=broken_runner)
+    logged: list[str] = []
+    sink_id = logger.add(logged.append, format="{message}\n{exception}")
     await srv.start()
     try:
         ws = await _connect(srv)
@@ -830,8 +835,12 @@ async def test_chat_runner_exception_is_friendly(tmp_path: Path) -> None:
         await _recv_until(ws, "ok")
         err = await _recv_until(ws, "error")
         assert "didn't go as planned" in err["message"]
+        assert err["detail"] == err["message"]
+        assert private_detail not in json.dumps(err)
+        assert private_detail in "".join(logged)
         await ws.close()
     finally:
+        logger.remove(sink_id)
         await srv.stop()
         db.close()
 
@@ -1332,6 +1341,105 @@ async def test_approve_plan_is_idempotent(tmp_path: Path) -> None:
 
 
 # -- C5: message limits -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "database_method", "default_limit"),
+    [
+        ("get_messages", "get_messages", None),
+        ("get_run_records", "list_turn_events", 200),
+        ("get_tool_events", "list_tool_events", 500),
+        ("list_routine_runs", "list_runs", 100),
+    ],
+)
+@pytest.mark.parametrize(
+    ("raw_limit", "bounded_limit"),
+    [(-1, 1), (0, 1), (10**9, 500)],
+)
+async def test_renderer_list_limits_are_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    database_method: str,
+    default_limit: int | None,
+    raw_limit: int,
+    bounded_limit: int,
+) -> None:
+    db = CollieDB(tmp_path / f"{command}-{raw_limit}.db")
+    captured: list[int | None] = []
+
+    if command == "get_messages":
+        def capture_messages(_conversation_id: str, limit: int | None) -> list[dict]:
+            captured.append(limit)
+            return []
+
+        replacement = capture_messages
+    else:
+        def capture_rows(**kwargs: Any) -> list[dict]:
+            captured.append(kwargs["limit"])
+            return []
+
+        replacement = capture_rows
+
+    monkeypatch.setattr(db, database_method, replacement)
+    srv = CollieIPCServer(db)
+    frame = {"limit": raw_limit, "conversation_id": "conv", "routine_id": "routine"}
+    try:
+        result = await getattr(srv, f"_cmd_{command}")(None, frame)
+        assert result
+        assert captured == [bounded_limit]
+        default_frame = {"conversation_id": "conv", "routine_id": "routine"}
+        await getattr(srv, f"_cmd_{command}")(None, default_frame)
+        assert captured == [bounded_limit, default_limit]
+    finally:
+        await srv.stop()
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "database_method", "expected_limit"),
+    [
+        ("get_messages", "get_messages", 500),
+        ("get_run_records", "list_turn_events", 200),
+        ("get_tool_events", "list_tool_events", 500),
+        ("list_routine_runs", "list_runs", 100),
+    ],
+)
+async def test_renderer_list_limits_use_safe_fallbacks_for_invalid_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    database_method: str,
+    expected_limit: int,
+) -> None:
+    db = CollieDB(tmp_path / f"{command}-invalid.db")
+    captured: list[int | None] = []
+
+    if command == "get_messages":
+        def capture_messages(_conversation_id: str, limit: int | None) -> list[dict]:
+            captured.append(limit)
+            return []
+
+        replacement = capture_messages
+    else:
+        def capture_rows(**kwargs: Any) -> list[dict]:
+            captured.append(kwargs["limit"])
+            return []
+
+        replacement = capture_rows
+
+    monkeypatch.setattr(db, database_method, replacement)
+    srv = CollieIPCServer(db)
+    frame = {"limit": "not-a-number", "conversation_id": "conv", "routine_id": "routine"}
+    try:
+        result = await getattr(srv, f"_cmd_{command}")(None, frame)
+        assert result
+        assert captured == [expected_limit]
+    finally:
+        await srv.stop()
+        db.close()
 
 
 def test_get_messages_limit_semantics(tmp_path: Path) -> None:

--- a/collie-core/tests/collie/test_ipc.py
+++ b/collie-core/tests/collie/test_ipc.py
@@ -1370,12 +1370,14 @@ async def test_renderer_list_limits_are_bounded(
     captured: list[int | None] = []
 
     if command == "get_messages":
+
         def capture_messages(_conversation_id: str, limit: int | None) -> list[dict]:
             captured.append(limit)
             return []
 
         replacement = capture_messages
     else:
+
         def capture_rows(**kwargs: Any) -> list[dict]:
             captured.append(kwargs["limit"])
             return []
@@ -1418,12 +1420,14 @@ async def test_renderer_list_limits_use_safe_fallbacks_for_invalid_values(
     captured: list[int | None] = []
 
     if command == "get_messages":
+
         def capture_messages(_conversation_id: str, limit: int | None) -> list[dict]:
             captured.append(limit)
             return []
 
         replacement = capture_messages
     else:
+
         def capture_rows(**kwargs: Any) -> list[dict]:
             captured.append(kwargs["limit"])
             return []

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -289,6 +289,57 @@ def _claim_plan_run(db: CollieDB, conversation_id: str) -> dict:
     return db.claim_plan_execution(plan["id"], plan["version"], plan["plan_hash"])["run"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_kind", ["checklist", "plan"])
+async def test_chat_failure_sanitizes_renderer_task_state(
+    db: CollieDB, task_kind: str
+) -> None:
+    private_detail = "provider failed at C:\\Users\\alice\\.collie\\secret.json"
+    conversation = db.create_conversation("Private failure")
+    conversation_id = str(conversation["id"])
+    run = _claim_plan_run(db, conversation_id) if task_kind == "plan" else None
+    checklist = None
+    if run is None:
+        checklist = _create_checklist(db, conversation_id)
+
+    async def broken_runner(*_args, **_kwargs):
+        raise RuntimeError(private_detail)
+
+    server = CollieIPCServer(db, chat_runner=broken_runner)
+    recorder = _RecordingConnection()
+    server._clients.add(recorder)  # type: ignore[arg-type]
+    try:
+        await server._run_chat_turn(
+            conversation_id,
+            "Do the work",
+            run_id=str(run["id"]) if run is not None else None,
+        )
+
+        rendered = json.dumps(recorder.frames)
+        persisted = json.dumps(db.get_messages(conversation_id))
+        assert private_detail not in rendered
+        assert private_detail not in persisted
+        assert "didn't go as planned" in rendered
+
+        if run is not None:
+            run_state = json.dumps(
+                {
+                    "run": db.get_run(str(run["id"])),
+                    "steps": db.list_run_steps(str(run["id"])),
+                }
+            )
+            assert private_detail not in run_state
+            assert "didn't go as planned" in run_state
+        else:
+            assert checklist is not None
+            task = db.get_task_checklist(str(checklist["id"]))
+            task_state = json.dumps(task)
+            assert private_detail not in task_state
+            assert "didn't go as planned" in task_state
+    finally:
+        await server.stop()
+
+
 def _permission_request(
     action: str, risk: Risk, *, approve_for_me: bool = True
 ) -> PermissionRequest:
@@ -1053,6 +1104,9 @@ async def test_plan_run_tool_error_fails_only_the_selected_step(db: CollieDB) ->
             "queued",
             "queued",
         ]
+        failed_step = db.list_run_steps(str(run["id"]))[0]
+        assert failed_step["error_message"] == "Tool execution failed."
+        assert "network failed" not in json.dumps(db.get_run_task(str(run["id"])))
         assert db.get_run(str(run["id"]))["error_code"] == "step_failed"
     finally:
         await server.stop()

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -291,9 +291,7 @@ def _claim_plan_run(db: CollieDB, conversation_id: str) -> dict:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("task_kind", ["checklist", "plan"])
-async def test_chat_failure_sanitizes_renderer_task_state(
-    db: CollieDB, task_kind: str
-) -> None:
+async def test_chat_failure_sanitizes_renderer_task_state(db: CollieDB, task_kind: str) -> None:
     private_detail = "provider failed at C:\\Users\\alice\\.collie\\secret.json"
     conversation = db.create_conversation("Private failure")
     conversation_id = str(conversation["id"])


### PR DESCRIPTION
## Summary
- sanitize renderer-visible chat-turn failures through one public-error helper while retaining full exception detail in server logs
- sanitize persisted/broadcast plan and checklist failure state, including raw tool-progress error strings
- bound renderer-controlled limits for messages, run records, tool events, and routine runs with endpoint-compatible defaults
- add focused regressions for private detail redaction, legitimate logging, default limits, invalid values, negative values, and oversized values

## Verification
- python -m pytest tests/collie -q — 742 passed, 4 skipped
- python -m ruff check nanobot collie_core tests — passed
- git diff --check — passed

Closes #121
Closes #124