### PR TITLE
fix(providers): cache and serialize Claude OAuth refreshes

### DIFF
--- a/collie-core/collie_core/providers/claude_oauth.py
+++ b/collie-core/collie_core/providers/claude_oauth.py
@@ -76,20 +76,18 @@ class ClaudeOAuthProvider(AnthropicProvider):
     """AnthropicProvider variant authenticated with a subscription Bearer token."""
 
     def __init__(self, default_model: str = _DEFAULT_MODEL):
-        token = _current_access_token()
-        if token is None:
-            raise RuntimeError("Not signed in with Claude. Complete the OAuth flow first.")
         # Skip AnthropicProvider.__init__ client construction; build our own
-        # Bearer-authenticated client instead.
+        # Bearer-authenticated client lazily after the first async token load.
         from nanobot.providers.base import LLMProvider
 
         LLMProvider.__init__(self, api_key=None, api_base=None)
         self.default_model = default_model
         self.extra_headers: dict[str, str] = {"anthropic-beta": _OAUTH_BETA_HEADER}
-        self._access_token = token.access
-        self._access_token_expires_at = token.expires_at
+        self._access_token: str | None = None
+        self._access_token_expires_at = 0.0
         self._token_lock = asyncio.Lock()
-        self._client = self._build_client(token.access)
+        self._refresh_task: asyncio.Task[_AccessToken | None] | None = None
+        self._client: Any | None = None
 
     def _build_client(self, access: str) -> Any:
         from anthropic import AsyncAnthropic
@@ -101,7 +99,19 @@ class ClaudeOAuthProvider(AnthropicProvider):
         )
 
     def _token_is_fresh(self, now: float) -> bool:
-        return now < self._access_token_expires_at - _EXPIRY_SKEW_SECONDS
+        return (
+            self._access_token is not None
+            and self._client is not None
+            and now < self._access_token_expires_at - _EXPIRY_SKEW_SECONDS
+        )
+
+    @staticmethod
+    async def _load_access_token() -> _AccessToken | None:
+        try:
+            return await asyncio.to_thread(_current_access_token)
+        except Exception:
+            logger.debug("Claude OAuth token refresh failed")
+            return None
 
     async def refresh_auth(self) -> bool:
         """Refresh near-expiry auth once without blocking the event loop."""
@@ -111,28 +121,43 @@ class ClaudeOAuthProvider(AnthropicProvider):
         async with self._token_lock:
             if self._token_is_fresh(time.time()):
                 return True
-            try:
-                token = await asyncio.to_thread(_current_access_token)
-            except Exception:
-                logger.debug("Claude OAuth token refresh failed")
-                return False
+            task = self._refresh_task
+            if task is None:
+                task = asyncio.create_task(self._load_access_token())
+                self._refresh_task = task
+
+        # A cancelled caller must not cancel or discard the shared worker: a
+        # second turn should await the same token refresh instead of starting
+        # another rotating-refresh-token exchange.
+        token = await asyncio.shield(task)
+        async with self._token_lock:
+            if self._refresh_task is task:
+                self._refresh_task = None
             if token is None:
                 return False
 
             token_changed = token.access != self._access_token
+            client = self._client
+            if token_changed or client is None:
+                client = self._build_client(token.access)
             self._access_token = token.access
             self._access_token_expires_at = token.expires_at
-            if token_changed:
-                self._client = self._build_client(token.access)
+            self._client = client
             return True
 
     def get_default_model(self) -> str:
         return self.default_model
 
     async def chat(self, *args: Any, **kwargs: Any) -> Any:
-        await self.refresh_auth()
+        if not await self.refresh_auth():
+            return self._handle_error(
+                RuntimeError("Not signed in with Claude. Complete the OAuth flow first.")
+            )
         return await super().chat(*args, **kwargs)
 
     async def chat_stream(self, *args: Any, **kwargs: Any) -> Any:
-        await self.refresh_auth()
+        if not await self.refresh_auth():
+            return self._handle_error(
+                RuntimeError("Not signed in with Claude. Complete the OAuth flow first.")
+            )
         return await super().chat_stream(*args, **kwargs)

--- a/collie-core/collie_core/providers/claude_oauth.py
+++ b/collie-core/collie_core/providers/claude_oauth.py
@@ -10,6 +10,9 @@ ChatGPT (Codex) provider, keeping both OAuth paths symmetrical.
 
 from __future__ import annotations
 
+import asyncio
+import time
+from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
@@ -41,6 +44,13 @@ ANTHROPIC_OAUTH_PROVIDER = OAuthProviderConfig(
 
 _OAUTH_BETA_HEADER = "oauth-2025-04-20"
 _DEFAULT_MODEL = "claude-sonnet-4-6"
+_EXPIRY_SKEW_SECONDS = 60
+
+
+@dataclass(frozen=True, slots=True)
+class _AccessToken:
+    access: str
+    expires_at: float
 
 
 def claude_storage() -> Any:
@@ -49,7 +59,7 @@ def claude_storage() -> Any:
     return DpapiTokenStorage(token_filename=ANTHROPIC_OAUTH_PROVIDER.token_filename)
 
 
-def _current_access_token() -> str | None:
+def _current_access_token() -> _AccessToken | None:
     from oauth_cli_kit import get_token
 
     try:
@@ -57,52 +67,72 @@ def _current_access_token() -> str | None:
     except Exception:
         logger.debug("No Claude OAuth token available")
         return None
-    return token.access if token and token.access else None
+    if not token or not token.access:
+        return None
+    return _AccessToken(access=str(token.access), expires_at=float(token.expires) / 1000)
 
 
 class ClaudeOAuthProvider(AnthropicProvider):
     """AnthropicProvider variant authenticated with a subscription Bearer token."""
 
     def __init__(self, default_model: str = _DEFAULT_MODEL):
-        access = _current_access_token()
-        if not access:
+        token = _current_access_token()
+        if token is None:
             raise RuntimeError("Not signed in with Claude. Complete the OAuth flow first.")
         # Skip AnthropicProvider.__init__ client construction; build our own
         # Bearer-authenticated client instead.
-        from anthropic import AsyncAnthropic
-
         from nanobot.providers.base import LLMProvider
 
         LLMProvider.__init__(self, api_key=None, api_base=None)
         self.default_model = default_model
         self.extra_headers: dict[str, str] = {"anthropic-beta": _OAUTH_BETA_HEADER}
-        self._client = AsyncAnthropic(
-            auth_token=access,
-            default_headers=dict(self.extra_headers),
-            max_retries=0,
-        )
+        self._access_token = token.access
+        self._access_token_expires_at = token.expires_at
+        self._token_lock = asyncio.Lock()
+        self._client = self._build_client(token.access)
 
-    def refresh_auth(self) -> bool:
-        """Re-read the (possibly refreshed) token and rebuild the client."""
-        access = _current_access_token()
-        if not access:
-            return False
+    def _build_client(self, access: str) -> Any:
         from anthropic import AsyncAnthropic
 
-        self._client = AsyncAnthropic(
+        return AsyncAnthropic(
             auth_token=access,
             default_headers=dict(self.extra_headers),
             max_retries=0,
         )
-        return True
+
+    def _token_is_fresh(self, now: float) -> bool:
+        return now < self._access_token_expires_at - _EXPIRY_SKEW_SECONDS
+
+    async def refresh_auth(self) -> bool:
+        """Refresh near-expiry auth once without blocking the event loop."""
+        if self._token_is_fresh(time.time()):
+            return True
+
+        async with self._token_lock:
+            if self._token_is_fresh(time.time()):
+                return True
+            try:
+                token = await asyncio.to_thread(_current_access_token)
+            except Exception:
+                logger.debug("Claude OAuth token refresh failed")
+                return False
+            if token is None:
+                return False
+
+            token_changed = token.access != self._access_token
+            self._access_token = token.access
+            self._access_token_expires_at = token.expires_at
+            if token_changed:
+                self._client = self._build_client(token.access)
+            return True
 
     def get_default_model(self) -> str:
         return self.default_model
 
     async def chat(self, *args: Any, **kwargs: Any) -> Any:
-        self.refresh_auth()
+        await self.refresh_auth()
         return await super().chat(*args, **kwargs)
 
     async def chat_stream(self, *args: Any, **kwargs: Any) -> Any:
-        self.refresh_auth()
+        await self.refresh_auth()
         return await super().chat_stream(*args, **kwargs)

--- a/collie-core/collie_core/providers/claude_oauth.py
+++ b/collie-core/collie_core/providers/claude_oauth.py
@@ -100,9 +100,15 @@ class ClaudeOAuthProvider(AnthropicProvider):
 
     def _token_is_fresh(self, now: float) -> bool:
         return (
+            self._token_is_unexpired(now)
+            and now < self._access_token_expires_at - _EXPIRY_SKEW_SECONDS
+        )
+
+    def _token_is_unexpired(self, now: float) -> bool:
+        return (
             self._access_token is not None
             and self._client is not None
-            and now < self._access_token_expires_at - _EXPIRY_SKEW_SECONDS
+            and now < self._access_token_expires_at
         )
 
     @staticmethod
@@ -134,7 +140,10 @@ class ClaudeOAuthProvider(AnthropicProvider):
             if self._refresh_task is task:
                 self._refresh_task = None
             if token is None:
-                return False
+                # The skew is an early-refresh window, not an early-expiry
+                # window. A transient storage/network failure may keep using
+                # the cached client until the access token actually expires.
+                return self._token_is_unexpired(time.time())
 
             token_changed = token.access != self._access_token
             client = self._client

--- a/collie-core/tests/collie/test_auth.py
+++ b/collie-core/tests/collie/test_auth.py
@@ -410,17 +410,28 @@ def test_claude_oauth_provider_requires_token(monkeypatch: pytest.MonkeyPatch) -
         claude_oauth.ClaudeOAuthProvider()
 
 
-def test_claude_oauth_provider_builds_bearer_client(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_claude_oauth_provider_builds_bearer_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from collie_core.providers import claude_oauth
 
-    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: "tok-abc")
+    monkeypatch.setattr(
+        claude_oauth,
+        "_current_access_token",
+        lambda: claude_oauth._AccessToken("tok-abc", 2_000_000_000),
+    )
     provider = claude_oauth.ClaudeOAuthProvider(default_model="claude-sonnet-4-6")
     assert provider.get_default_model() == "claude-sonnet-4-6"
     assert provider.extra_headers["anthropic-beta"] == "oauth-2025-04-20"
     assert provider._client.auth_token == "tok-abc"
 
-    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: "tok-refreshed")
-    assert provider.refresh_auth() is True
+    provider._access_token_expires_at = 0
+    monkeypatch.setattr(
+        claude_oauth,
+        "_current_access_token",
+        lambda: claude_oauth._AccessToken("tok-refreshed", 2_000_000_000),
+    )
+    assert await provider.refresh_auth() is True
     assert provider._client.auth_token == "tok-refreshed"
 
 
@@ -436,7 +447,11 @@ def test_runtime_provider_override(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     runtime.db.set_setting("provider.auth", "claude-oauth")
     from collie_core.providers import claude_oauth
 
-    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: "tok")
+    monkeypatch.setattr(
+        claude_oauth,
+        "_current_access_token",
+        lambda: claude_oauth._AccessToken("tok", 2_000_000_000),
+    )
     provider = runtime._provider_override()
     assert type(provider).__name__ == "ClaudeOAuthProvider"
 

--- a/collie-core/tests/collie/test_auth.py
+++ b/collie-core/tests/collie/test_auth.py
@@ -402,12 +402,18 @@ def test_cancelled_oauth_attempt_closes_callback_server(
     assert closed == ["shutdown", "close"]
 
 
-def test_claude_oauth_provider_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_claude_oauth_provider_defers_token_load(monkeypatch: pytest.MonkeyPatch) -> None:
     from collie_core.providers import claude_oauth
 
-    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: None)
-    with pytest.raises(RuntimeError, match="Not signed in"):
-        claude_oauth.ClaudeOAuthProvider()
+    monkeypatch.setattr(
+        claude_oauth,
+        "_current_access_token",
+        lambda: pytest.fail("constructor must not load OAuth storage"),
+    )
+
+    provider = claude_oauth.ClaudeOAuthProvider()
+
+    assert provider._client is None
 
 
 async def test_claude_oauth_provider_builds_bearer_client(
@@ -421,6 +427,7 @@ async def test_claude_oauth_provider_builds_bearer_client(
         lambda: claude_oauth._AccessToken("tok-abc", 2_000_000_000),
     )
     provider = claude_oauth.ClaudeOAuthProvider(default_model="claude-sonnet-4-6")
+    assert await provider.refresh_auth()
     assert provider.get_default_model() == "claude-sonnet-4-6"
     assert provider.extra_headers["anthropic-beta"] == "oauth-2025-04-20"
     assert provider._client.auth_token == "tok-abc"
@@ -447,13 +454,21 @@ def test_runtime_provider_override(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     runtime.db.set_setting("provider.auth", "claude-oauth")
     from collie_core.providers import claude_oauth
 
+    token_reads = 0
+
+    def load_token() -> claude_oauth._AccessToken:
+        nonlocal token_reads
+        token_reads += 1
+        return claude_oauth._AccessToken("tok", 2_000_000_000)
+
     monkeypatch.setattr(
         claude_oauth,
         "_current_access_token",
-        lambda: claude_oauth._AccessToken("tok", 2_000_000_000),
+        load_token,
     )
     provider = runtime._provider_override()
     assert type(provider).__name__ == "ClaudeOAuthProvider"
+    assert token_reads == 0
 
     runtime.db.set_setting("provider.auth", "chatgpt-oauth")
     provider = runtime._provider_override()

--- a/collie-core/tests/collie/test_claude_oauth_refresh.py
+++ b/collie-core/tests/collie/test_claude_oauth_refresh.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -31,6 +33,7 @@ async def test_valid_cached_token_skips_storage_reads(
     monkeypatch.setattr(claude_oauth.AnthropicProvider, "chat", fake_chat)
     provider = claude_oauth.ClaudeOAuthProvider()
 
+    assert calls == 0
     assert await provider.chat(messages=[]) == "ok"
     assert await provider.refresh_auth()
     assert calls == 1
@@ -50,6 +53,7 @@ async def test_concurrent_near_expiry_refreshes_once(
 
     monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
     provider = claude_oauth.ClaudeOAuthProvider()
+    assert await provider.refresh_auth()
 
     assert await asyncio.gather(provider.refresh_auth(), provider.refresh_auth()) == [True, True]
     assert calls == 2
@@ -71,6 +75,7 @@ async def test_blocking_token_loader_does_not_block_event_loop(
 
     monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
     provider = claude_oauth.ClaudeOAuthProvider()
+    assert await provider.refresh_auth()
 
     started = asyncio.get_running_loop().time()
     refresh = asyncio.create_task(provider.refresh_auth())
@@ -95,6 +100,7 @@ async def test_client_rebuilds_only_when_access_token_changes(
     )
     monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: next(tokens))
     provider = claude_oauth.ClaudeOAuthProvider()
+    assert await provider.refresh_auth()
     initial_client = provider._client
 
     assert await provider.refresh_auth()
@@ -124,8 +130,65 @@ async def test_refresh_failure_keeps_cached_client(
 
     monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
     provider = claude_oauth.ClaudeOAuthProvider()
+    assert await provider.refresh_auth()
     initial_client = provider._client
 
     assert not await provider.refresh_auth()
     assert provider._access_token == "cached"
     assert provider._client is initial_client
+
+
+async def test_cancelled_waiter_keeps_single_refresh_in_flight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def load_token() -> claude_oauth._AccessToken:
+        nonlocal calls
+        calls += 1
+        started.set()
+        assert release.wait(2)
+        return _token("shared", time.time() + 3600)
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
+    provider = claude_oauth.ClaudeOAuthProvider()
+    first = asyncio.create_task(provider.refresh_auth())
+    while not started.is_set():
+        await asyncio.sleep(0)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    second = asyncio.create_task(provider.refresh_auth())
+    await asyncio.sleep(0.01)
+    assert calls == 1
+    release.set()
+
+    assert await second
+    assert calls == 1
+    assert provider._access_token == "shared"
+
+
+def test_oauth_expiry_milliseconds_and_skew_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    import oauth_cli_kit
+
+    expires_ms = 2_000_000_000_000
+    monkeypatch.setattr(
+        oauth_cli_kit,
+        "get_token",
+        lambda **_kwargs: SimpleNamespace(access="tok", expires=expires_ms),
+    )
+    monkeypatch.setattr(claude_oauth, "claude_storage", lambda: object())
+
+    token = claude_oauth._current_access_token()
+
+    assert token == _token("tok", 2_000_000_000)
+    provider = claude_oauth.ClaudeOAuthProvider()
+    provider._access_token = token.access
+    provider._access_token_expires_at = token.expires_at
+    provider._client = object()
+    assert provider._token_is_fresh(token.expires_at - 60.001)
+    assert not provider._token_is_fresh(token.expires_at - 60)

--- a/collie-core/tests/collie/test_claude_oauth_refresh.py
+++ b/collie-core/tests/collie/test_claude_oauth_refresh.py
@@ -1,0 +1,131 @@
+"""Concurrency and caching tests for the Claude OAuth provider."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from collie_core.providers import claude_oauth
+
+
+def _token(access: str, expires_at: float) -> claude_oauth._AccessToken:
+    return claude_oauth._AccessToken(access=access, expires_at=expires_at)
+
+
+async def test_valid_cached_token_skips_storage_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def load_token() -> claude_oauth._AccessToken:
+        nonlocal calls
+        calls += 1
+        return _token("cached", time.time() + 3600)
+
+    async def fake_chat(*_args, **_kwargs):
+        return "ok"
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
+    monkeypatch.setattr(claude_oauth.AnthropicProvider, "chat", fake_chat)
+    provider = claude_oauth.ClaudeOAuthProvider()
+
+    assert await provider.chat(messages=[]) == "ok"
+    assert await provider.refresh_auth()
+    assert calls == 1
+
+
+async def test_concurrent_near_expiry_refreshes_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = time.time()
+    tokens = iter([_token("old", now + 30), _token("new", now + 3600)])
+    calls = 0
+
+    def load_token() -> claude_oauth._AccessToken:
+        nonlocal calls
+        calls += 1
+        return next(tokens)
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
+    provider = claude_oauth.ClaudeOAuthProvider()
+
+    assert await asyncio.gather(provider.refresh_auth(), provider.refresh_auth()) == [True, True]
+    assert calls == 2
+    assert provider._access_token == "new"
+
+
+async def test_blocking_token_loader_does_not_block_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = time.time()
+    calls = 0
+
+    def load_token() -> claude_oauth._AccessToken:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            time.sleep(0.2)
+        return _token("cached", now + (30 if calls == 1 else 3600))
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
+    provider = claude_oauth.ClaudeOAuthProvider()
+
+    started = asyncio.get_running_loop().time()
+    refresh = asyncio.create_task(provider.refresh_auth())
+    await asyncio.sleep(0.01)
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert elapsed < 0.1
+    assert not refresh.done()
+    assert await refresh
+
+
+async def test_client_rebuilds_only_when_access_token_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = time.time()
+    tokens = iter(
+        [
+            _token("same", now + 30),
+            _token("same", now + 3600),
+            _token("changed", now + 3600),
+        ]
+    )
+    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: next(tokens))
+    provider = claude_oauth.ClaudeOAuthProvider()
+    initial_client = provider._client
+
+    assert await provider.refresh_auth()
+    assert provider._client is initial_client
+
+    provider._access_token_expires_at = 0
+    assert await provider.refresh_auth()
+    assert provider._client is not initial_client
+    assert provider._client.auth_token == "changed"
+
+
+@pytest.mark.parametrize("failure", ["missing", "error"])
+async def test_refresh_failure_keeps_cached_client(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    now = time.time()
+    calls = 0
+
+    def load_token() -> claude_oauth._AccessToken | None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _token("cached", now + 30)
+        if failure == "error":
+            raise RuntimeError("storage unavailable")
+        return None
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", load_token)
+    provider = claude_oauth.ClaudeOAuthProvider()
+    initial_client = provider._client
+
+    assert not await provider.refresh_auth()
+    assert provider._access_token == "cached"
+    assert provider._client is initial_client

--- a/collie-core/tests/collie/test_claude_oauth_refresh.py
+++ b/collie-core/tests/collie/test_claude_oauth_refresh.py
@@ -133,9 +133,54 @@ async def test_refresh_failure_keeps_cached_client(
     assert await provider.refresh_auth()
     initial_client = provider._client
 
-    assert not await provider.refresh_auth()
+    assert await provider.refresh_auth()
     assert provider._access_token == "cached"
     assert provider._client is initial_client
+
+
+@pytest.mark.parametrize("method_name", ["chat", "chat_stream"])
+async def test_transient_refresh_failure_uses_unexpired_cached_client(
+    monkeypatch: pytest.MonkeyPatch, method_name: str
+) -> None:
+    now = time.time()
+    tokens = iter([_token("cached", now + 30), None])
+
+    async def provider_call(*_args, **_kwargs):
+        return "used cached client"
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: next(tokens))
+    monkeypatch.setattr(claude_oauth.AnthropicProvider, method_name, provider_call)
+    provider = claude_oauth.ClaudeOAuthProvider()
+    assert await provider.refresh_auth()
+
+    result = await getattr(provider, method_name)(messages=[])
+
+    assert result == "used cached client"
+    assert provider._access_token == "cached"
+
+
+@pytest.mark.parametrize("method_name", ["chat", "chat_stream"])
+@pytest.mark.parametrize("state", ["expired", "no_client"])
+async def test_missing_or_expired_auth_fails_honestly(
+    monkeypatch: pytest.MonkeyPatch, method_name: str, state: str
+) -> None:
+    now = time.time()
+    tokens = iter([_token("cached", now + 3600), None]) if state == "expired" else iter([None])
+
+    async def unexpected_provider_call(*_args, **_kwargs):
+        pytest.fail("provider call must not run without unexpired auth")
+
+    monkeypatch.setattr(claude_oauth, "_current_access_token", lambda: next(tokens))
+    monkeypatch.setattr(claude_oauth.AnthropicProvider, method_name, unexpected_provider_call)
+    provider = claude_oauth.ClaudeOAuthProvider()
+    if state == "expired":
+        assert await provider.refresh_auth()
+        provider._access_token_expires_at = now - 1
+
+    result = await getattr(provider, method_name)(messages=[])
+
+    assert result.finish_reason == "error"
+    assert "Not signed in with Claude" in (result.content or "")
 
 
 async def test_cancelled_waiter_keeps_single_refresh_in_flight(


### PR DESCRIPTION
## Summary
- defer Claude OAuth storage/network work until the first async model call, keeping constructor and runtime configuration non-blocking
- cache the access token and millisecond expiry with a 60-second refresh skew
- coalesce near-expiry loads behind a double-checked lock and a shared, shielded refresh task
- keep that single-flight worker alive when one waiting turn is cancelled
- run the blocking oauth-cli-kit token load/refresh in `asyncio.to_thread`
- update cached expiry without rebuilding the Anthropic client when the access token is unchanged
- after a transient refresh/storage failure inside the skew window, keep using the cached client only until the token's actual expiry
- fail honestly when auth is expired or no client has ever been initialized

## Testing
- `python -m pytest tests/collie/test_claude_oauth_refresh.py tests/collie/test_auth.py -q -p no:cacheprovider` (36 passed)
- `python -m ruff check collie_core/providers/claude_oauth.py tests/collie/test_auth.py tests/collie/test_claude_oauth_refresh.py`
- `python -m ruff format --check collie_core/providers/claude_oauth.py tests/collie/test_auth.py tests/collie/test_claude_oauth_refresh.py`

Regression coverage includes constructor/configuration with zero token reads, the cached fast path, concurrent refresh coalescing, event-loop responsiveness with a blocking loader, cancellation-safe single-flight behavior, same-token versus changed-token client handling, transient failures through real `chat` and `chat_stream` wrappers, expired/missing-auth failures, expiry millisecond conversion, and the exact skew boundary.

## Documentation impact
No canonical documentation changes are needed. This changes provider refresh internals without changing provider availability, authentication flows, public interfaces, ownership, or product claims.

Closes #125
