### PR TITLE
fix(account): bind sign-in callback to flow with OAuth state nonce

### DIFF
--- a/collie-ui/src/main/account-auth.test.ts
+++ b/collie-ui/src/main/account-auth.test.ts
@@ -249,6 +249,14 @@ describe('getAccountState', () => {
   })
 })
 
+/** Extract the per-attempt OAuth `state` nonce from the opened authorize URL. */
+function openedAuthorizeState(): string {
+  const url = new URL(testState.openedUrl)
+  const state = url.searchParams.get('state')
+  if (!state) throw new Error('expected a state param on the authorize URL')
+  return state
+}
+
 describe('startAccountSignIn', () => {
   it('completes the browser-callback flow end to end', async () => {
     const signInPromise = startAccountSignIn()
@@ -265,10 +273,14 @@ describe('startAccountSignIn', () => {
     expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256')
     expect(authorizeUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/)
     expect(authorizeUrl.searchParams.get('client_id')).toBe('test-anon-key')
+    // A fresh, per-attempt state nonce is carried on the authorize URL.
+    const stateNonce = authorizeUrl.searchParams.get('state')
+    expect(stateNonce).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(stateNonce).not.toBe(authorizeUrl.searchParams.get('code_challenge'))
 
-    // Simulate the browser redirect after the user signs in.
+    // Simulate the browser redirect after the user signs in, echoing the state.
     const callbackResponse = await realFetch(
-      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me&state=${stateNonce}`
     )
     expect(callbackResponse.status).toBe(200)
 
@@ -334,7 +346,7 @@ describe('startAccountSignIn', () => {
     )
 
     const callbackResponse = await realFetch(
-      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me&state=${openedAuthorizeState()}`
     )
     expect(callbackResponse.status).toBe(200)
 
@@ -401,7 +413,7 @@ describe('sign-in callback CSRF defenses (issue #106)', () => {
 
     // The flow is untouched: the legitimate redirect still completes it.
     const ok = await realFetch(
-      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me&state=${openedAuthorizeState()}`
     )
     expect(ok.status).toBe(200)
     const state = await signInPromise
@@ -420,12 +432,64 @@ describe('sign-in callback CSRF defenses (issue #106)', () => {
     expect(status).toBe(400)
 
     const ok = await realFetch(
-      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me`
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me&state=${openedAuthorizeState()}`
     )
     expect(ok.status).toBe(200)
     const state = await signInPromise
     expect(state.signedIn).toBe(true)
     expect(state.email).toBe('tester@heycollie.com')
+  })
+
+  it('rejects a callback carrying a mismatched or missing state and never exchanges it', async () => {
+    const signInPromise = startAccountSignIn()
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+    const state = openedAuthorizeState()
+
+    // A code minted for a DIFFERENT flow echoes the wrong state — reject it.
+    const wrong = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=attacker-code&state=not-the-issued-state`
+    )
+    expect(wrong.status).toBe(400)
+    expect(testState.exchange).toBeNull()
+
+    // A callback with NO state at all is equally rejected.
+    const missing = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=attacker-code`
+    )
+    expect(missing.status).toBe(400)
+    expect(testState.exchange).toBeNull()
+
+    // The flow survives the rejected probes: the correct state still completes it.
+    const ok = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me&state=${state}`
+    )
+    expect(ok.status).toBe(200)
+    const accountState = await signInPromise
+    expect(accountState.signedIn).toBe(true)
+    expect(accountState.email).toBe('tester@heycollie.com')
+    // Only the well-state-bound code was exchanged.
+    expect(testState.exchange?.body).toEqual({
+      auth_code: 'exchange-me',
+      code_verifier: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/)
+    })
+  })
+
+  it('completes the callback when the correct issued state is echoed back', async () => {
+    const signInPromise = startAccountSignIn()
+    await vi.waitFor(() => {
+      expect(testState.openedUrl).toContain('/auth/v1/authorize')
+    })
+    const state = openedAuthorizeState()
+
+    const ok = await realFetch(
+      `http://${CALLBACK_HOST}:${CALLBACK_PORT}/callback?code=exchange-me&state=${state}`
+    )
+    expect(ok.status).toBe(200)
+    const accountState = await signInPromise
+    expect(accountState.signedIn).toBe(true)
+    expect(accountState.email).toBe('tester@heycollie.com')
   })
 })
 

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -326,7 +326,8 @@ function buildAuthorizeUrl(
   baseUrl: string,
   anonKey: string,
   challenge: string,
-  callbackUrl: string
+  callbackUrl: string,
+  state: string
 ): string {
   const url = new URL(`${baseUrl}/auth/v1/authorize`)
   url.searchParams.set('aud', 'authenticated')
@@ -335,14 +336,20 @@ function buildAuthorizeUrl(
   url.searchParams.set('code_challenge', challenge)
   url.searchParams.set('code_challenge_method', 'S256')
   url.searchParams.set('client_id', anonKey)
+  url.searchParams.set('state', state)
   return url.toString()
 }
 
 /**
  * Single-use callback wait: resolve with the `code` from the browser's
- * redirect, close the server, or reject after `timeoutMs`.
+ * redirect, close the server, or reject after `timeoutMs`. The callback is
+ * bound to the flow that initiated it through the `expectedState` nonce.
  */
-function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string> {
+function waitForCallbackCode(
+  server: Server,
+  timeoutMs: number,
+  expectedState: string
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       server.close()
@@ -358,8 +365,10 @@ function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string>
       // fixed, well-known port while the browser flow is in flight. Requiring
       // the exact Host blocks common DNS-rebinding delivery, and rejecting an
       // Origin blocks common cross-site fetch/XHR delivery (a top-level
-      // browser redirect normally sends no Origin). These checks do not bind
-      // the callback to the flow that initiated it, so issue #106 remains open.
+      // browser redirect normally sends no Origin). The per-attempt OAuth
+      // `state` nonce additionally binds the callback to THIS sign-in flow, so
+      // a code minted for a different (or none) attempt is rejected before it
+      // is exchanged — closing the login-CSRF / account-hijack surface.
       const host = (req.headers.host ?? '').toLowerCase()
       if (host !== `${CALLBACK_HOST}:${CALLBACK_PORT}`) {
         res.writeHead(404).end('Not found')
@@ -396,6 +405,14 @@ function waitForCallbackCode(server: Server, timeoutMs: number): Promise<string>
       const code = url.searchParams.get('code')
       if (!code) {
         res.writeHead(400).end('Missing code')
+        return
+      }
+      // Bind the callback to this flow: the browser must echo back the state
+      // nonce we placed on the authorize URL. A missing or mismatched state
+      // means this code was minted for a different (or no) sign-in attempt, so
+      // reject it and keep waiting rather than exchange it into a session.
+      if (url.searchParams.get('state') !== expectedState) {
+        res.writeHead(400).end('Bad request')
         return
       }
       clearTimeout(timer)
@@ -436,6 +453,9 @@ export async function startAccountSignIn(
   }
   const timeoutMs = options.timeoutMs ?? SIGN_IN_TIMEOUT_MS
   const { verifier, challenge } = createPkcePair()
+  // Per-attempt OAuth `state` nonce (issue #106): binds the callback to THIS
+  // sign-in flow so a code minted for a different attempt is never exchanged.
+  const state = base64UrlEncode(randomBytes(32))
 
   const server = createServer()
   const port = await new Promise<number>((resolve, reject) => {
@@ -458,13 +478,13 @@ export async function startAccountSignIn(
 
   const callbackUrl = `http://${CALLBACK_HOST}:${port}/callback`
   try {
-    await shell.openExternal(buildAuthorizeUrl(baseUrl, anonKey, challenge, callbackUrl))
+    await shell.openExternal(buildAuthorizeUrl(baseUrl, anonKey, challenge, callbackUrl, state))
   } catch (error) {
     closeServer(server)
     throw error
   }
 
-  const code = await waitForCallbackCode(server, timeoutMs)
+  const code = await waitForCallbackCode(server, timeoutMs, state)
 
   const response = await fetch(`${baseUrl}/auth/v1/token?grant_type=pkce`, {
     method: 'POST',


### PR DESCRIPTION
## What
Binds the account sign-in callback to the flow that initiated it by issuing and validating a per-attempt OAuth `state` nonce (login-CSRF mitigation). The PKCE verifier exchange is unchanged.

`collie-ui/src/main/account-auth.ts`:
- Generate `state = base64UrlEncode(randomBytes(32))` per sign-in attempt.
- Set it on the authorize URL (`state` param).
- Require the callback to echo the exact `state`; a missing/mismatched state → `400 Bad request`, and the flow keeps waiting instead of exchanging a foreign code into a session.

## Why
Closes the remaining security gap in #106. The Host/Origin checks (from the prior partial fix) were defense-in-depth only; the callback was not cryptographically bound to the initiating flow, leaving a login-CSRF / account-hijack surface during the callback window. The `state` nonce (alongside existing PKCE) now binds returned codes to this specific sign-in attempt.

## Verification
- `npx vitest run src/main/account-auth.test.ts` — **20 passed** (added tests: mismatched/missing state is rejected and never exchanged; correct state completes).
- `npm run typecheck` — clean.

Closes #106
