### PR TITLE
fix(versions): make artifact rollback race-safe (per-artifact lock + mark-after-write)

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1384,13 +1384,19 @@ class CollieIPCServer:
     async def _cmd_apply_dream_proposal(self, connection: ServerConnection, frame: dict) -> dict:
         """Approve the pending Dream proposal: re-validate, write, version."""
         from collie_core.memory.dream import apply_dream_proposal
-        from collie_core.versions import VersionStore
+        from collie_core.versions import VersionStore, artifact_lock
 
-        return await asyncio.to_thread(
-            apply_dream_proposal,
-            workspace=collie_home() / "workspace",
-            version_store=VersionStore(self.db),
-        )
+        def _apply() -> dict:
+            # Same-artifact serialization as the rollback path (memory_dream /
+            # MEMORY.md). Lock held on the worker thread; no await inside the
+            # lock, so a concurrent rollback can't clobber the write.
+            with artifact_lock("memory_dream", "MEMORY.md"):
+                return apply_dream_proposal(
+                    workspace=collie_home() / "workspace",
+                    version_store=VersionStore(self.db),
+                )
+
+        return await asyncio.to_thread(_apply)
 
     async def _cmd_dismiss_dream_proposal(self, connection: ServerConnection, frame: dict) -> dict:
         """Dismiss the pending Dream proposal without applying it."""
@@ -1412,21 +1418,33 @@ class CollieIPCServer:
         self, connection: ServerConnection, frame: dict
     ) -> dict:
         """Approve one suggestion: re-validate, apply, version (undoable)."""
-        from collie_core.gardener.propose import ProposalValidationError
+        from collie_core.gardener.propose import ProposalValidationError, validate_suggestion
         from collie_core.gardener.runner import apply_suggestion
-        from collie_core.versions import VersionStore
+        from collie_core.versions import VersionStore, artifact_lock
 
         suggestion = frame.get("suggestion")
         if not isinstance(suggestion, dict):
             raise ValueError("A suggestion is required to approve.")
         try:
-            result = await asyncio.to_thread(
-                apply_suggestion,
-                workspace=collie_home() / "workspace",
-                suggestion=suggestion,
-                version_store=VersionStore(self.db),
-                subagent_loader=self._subagent_loader,
-            )
+            cleaned = validate_suggestion(suggestion)
+        except ProposalValidationError as exc:
+            raise ValueError(str(exc)) from exc
+
+        def _apply() -> dict:
+            # Hold the artifact lock across the read-modify-write so a
+            # concurrent rollback (or another apply) on the same artifact
+            # can't clobber this edit. Lock + apply run on the worker thread —
+            # no await inside the lock, so the event loop never blocks on it.
+            with artifact_lock(cleaned["artifact_type"], cleaned["artifact_key"]):
+                return apply_suggestion(
+                    workspace=collie_home() / "workspace",
+                    suggestion=cleaned,
+                    version_store=VersionStore(self.db),
+                    subagent_loader=self._subagent_loader,
+                )
+
+        try:
+            result = await asyncio.to_thread(_apply)
         except ProposalValidationError as exc:
             raise ValueError(str(exc)) from exc
         return result
@@ -1722,24 +1740,34 @@ class CollieIPCServer:
     async def _cmd_write_file(self, connection: ServerConnection, frame: dict) -> dict:
         file_path = self._resolve_workspace_path(str(frame.get("path") or ""))
         content = str(frame.get("content") or "")
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        before = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
         artifact = self._classify_workspace_artifact(file_path)
-        version_id: str | None = None
-        diff_text: str | None = None
-        if artifact is not None and before != content:
-            from collie_core.versions import VersionStore, make_diff
+        if artifact is not None:
+            # Serialize with any concurrent rollback/apply on this artifact.
+            from collie_core.versions import VersionStore, artifact_lock, make_diff
 
-            version_id = VersionStore(self.db).snapshot(
-                artifact[0], artifact[1], before, content, source="user"
-            )
-            if version_id is not None:
-                diff_text = make_diff(before, content, artifact[1])
+            with artifact_lock(artifact[0], artifact[1]):
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                before = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
+                version_id: str | None = None
+                diff_text: str | None = None
+                if before != content:
+                    version_id = VersionStore(self.db).snapshot(
+                        artifact[0], artifact[1], before, content, source="user"
+                    )
+                    if version_id is not None:
+                        diff_text = make_diff(before, content, artifact[1])
+                file_path.write_text(content, encoding="utf-8")
+                return {
+                    "saved": True,
+                    "version_id": version_id,
+                    "diff_text": diff_text,
+                }
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content, encoding="utf-8")
         return {
             "saved": True,
-            "version_id": version_id,
-            "diff_text": diff_text,
+            "version_id": None,
+            "diff_text": None,
         }
 
     def _classify_workspace_artifact(self, file_path: Path) -> tuple[str, str] | None:
@@ -1798,7 +1826,7 @@ class CollieIPCServer:
 
     async def _cmd_rollback_artifact(self, connection: ServerConnection, frame: dict) -> dict:
         """Undo one artifact version (no-clobber guarded) and re-sync state."""
-        from collie_core.versions import VersionConflictError, VersionStore
+        from collie_core.versions import VersionConflictError, VersionStore, artifact_lock
 
         version_id = str(frame.get("version_id") or "")
         row = self.db.get_artifact_version(version_id)
@@ -1807,24 +1835,32 @@ class CollieIPCServer:
         artifact_type = str(row["artifact_type"])
         key = str(row["artifact_key"])
         target = self._artifact_target(artifact_type, key)
-        current = target.read_text(encoding="utf-8") if target.exists() else ""
-        try:
-            result = VersionStore(self.db).rollback(
-                artifact_type,
-                key,
-                to_version=int(row["version"]),
-                current_text=current,
-            )
-        except VersionConflictError as exc:
-            raise ValueError(str(exc)) from exc
-        restored = result["restored_text"]
-        if restored:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(restored, encoding="utf-8")
-        elif target.exists():
-            target.unlink()
+        # Serialize with any concurrent Gardener/Dream apply on the same
+        # artifact. Read -> validate -> write -> mark must be atomic against a
+        # concurrent apply, otherwise a newer edit could be clobbered between
+        # the read and the write. The mark is covered too so a failed write
+        # leaves the row applied (artifact unchanged) — never desynced.
+        with artifact_lock(artifact_type, key):
+            current = target.read_text(encoding="utf-8") if target.exists() else ""
+            try:
+                result = VersionStore(self.db).rollback(
+                    artifact_type,
+                    key,
+                    to_version=int(row["version"]),
+                    current_text=current,
+                )
+            except VersionConflictError as exc:
+                raise ValueError(str(exc)) from exc
+            restored = result["restored_text"]
+            if restored:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(restored, encoding="utf-8")
+            elif target.exists():
+                target.unlink()
+            VersionStore(self.db).mark_rolled_back(result["version_id"])
         # A subagent rollback also restores the database row (or renames it
-        # back): the loader reconciles disk -> DB.
+        # back): the loader reconciles disk -> DB. Done outside the lock — it
+        # only reads the file we just wrote and reconciles the DB mirror.
         if artifact_type == "subagent" and self._subagent_loader is not None:
             await asyncio.to_thread(self._subagent_loader.sync)
         return {

--- a/collie-core/collie_core/versions.py
+++ b/collie-core/collie_core/versions.py
@@ -16,11 +16,30 @@ independent of the workspace layout.
 from __future__ import annotations
 
 import difflib
+import threading
 from typing import Any
 
 from collie_core.db import CollieDB
 
-__all__ = ["VersionStore", "VersionConflictError"]
+__all__ = ["VersionStore", "VersionConflictError", "artifact_lock"]
+
+
+# -- per-artifact lock registry ------------------------------------------------
+# Rollback and apply (Gardener/Dream) each do a read-modify-write on the same
+# artifact file from different threads (apply runs via ``asyncio.to_thread``).
+# This shared lock serializes them so a rollback can't clobber a concurrent
+# apply (or vice versa). Keys are ``(artifact_type, artifact_key)``; the
+# registry lives here and is used directly by the apply/rollback handlers in
+# ``ipc/server.py``.
+
+_LOCKS_GUARD = threading.Lock()
+_ARTIFACT_LOCKS: dict[tuple[str, str], threading.Lock] = {}
+
+
+def artifact_lock(artifact_type: str, key: str) -> threading.Lock:
+    """Return the shared per-artifact lock for an artifact type + key."""
+    with _LOCKS_GUARD:
+        return _ARTIFACT_LOCKS.setdefault((artifact_type, key), threading.Lock())
 
 
 class VersionConflictError(Exception):
@@ -37,6 +56,18 @@ def make_diff(before: str, after: str, key: str) -> str:
             tofile=f"{key} (after)",
         )
     )
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize an artifact text for equality comparison.
+
+    Mirrors the gardener/runner apply normalization (a trailing ``\\n`` is
+    always appended) plus CRLF handling: ``\\r\\n`` -> ``\\n`` and trailing
+    newlines stripped. This prevents a whitespace-only difference (e.g. the
+    stored ``after_text`` vs. a manual edit that adds a trailing blank line)
+    from permanently refusing a rollback.
+    """
+    return (text or "").replace("\r\n", "\n").rstrip("\n")
 
 
 class VersionStore:
@@ -107,10 +138,12 @@ class VersionStore:
         * ``current_text`` — the artifact's current content, read by the
           caller before calling. When it differs from the target version's
           ``after_text`` the rollback is refused (never clobber newer
-          owner edits).
+          owner edits). Trailing-newline / CRLF differences are normalized
+          away so a whitespace-only change doesn't permanently block undo.
 
-        The version row is marked ``rolled_back`` and the caller writes the
-        returned ``restored_text`` to the artifact (and re-syncs as needed).
+        The caller writes the returned ``restored_text`` to the artifact (and
+        re-syncs as needed) and then calls :meth:`mark_rolled_back` with the
+        returned ``version_id`` — never *before* the write succeeds.
         """
         rows = self.db.list_artifact_versions(
             artifact_type=artifact_type, artifact_key=key, limit=200
@@ -131,14 +164,13 @@ class VersionStore:
 
         after_text = target.get("after_text") or ""
         current = current_text if current_text is not None else ""
-        if current != after_text:
+        if _normalize_text(current) != _normalize_text(after_text):
             raise VersionConflictError(
                 "That edit has already been changed since — I won't overwrite "
                 "the newer version. Undo the most recent change first."
             )
 
         restored = target.get("before_text") or ""
-        self.db.mark_artifact_rolled_back(str(target["id"]))
         return {
             "version_id": str(target["id"]),
             "artifact_type": artifact_type,
@@ -147,3 +179,13 @@ class VersionStore:
             "restored_text": restored,
             "status": "rolled_back",
         }
+
+    def mark_rolled_back(self, version_id: str) -> None:
+        """Mark a version row ``rolled_back`` (call after writing the file).
+
+        Callers must only invoke this *after* the restored text has been
+        written successfully — marking before the write would leave the row
+        in ``rolled_back`` while the artifact still holds newer content if
+        the write raises.
+        """
+        self.db.mark_artifact_rolled_back(str(version_id))

--- a/collie-core/tests/collie/test_dream_collie.py
+++ b/collie-core/tests/collie/test_dream_collie.py
@@ -332,6 +332,7 @@ async def test_dream_rollback_restores_prior_memory(tmp_path: Path, db: CollieDB
     current = memory_file.read_text(encoding="utf-8")
     result = versions.rollback("memory_dream", "MEMORY.md", current_text=current)
     memory_file.write_text(result["restored_text"], encoding="utf-8")
+    versions.mark_rolled_back(result["version_id"])
     assert memory_file.read_text(encoding="utf-8").strip() == ""
     assert db.list_artifact_versions(artifact_type="memory_dream")[0]["status"] == "rolled_back"
 

--- a/collie-core/tests/collie/test_gardener_mvp.py
+++ b/collie-core/tests/collie/test_gardener_mvp.py
@@ -503,6 +503,7 @@ def test_rollback_restores_prior_text(db: CollieDB, workspace: Path) -> None:
     current = (sub_dir / "helper.md").read_text(encoding="utf-8")
     rollback = versions.rollback("subagent", "helper.md", current_text=current)
     (sub_dir / "helper.md").write_text(rollback["restored_text"], encoding="utf-8")
+    versions.mark_rolled_back(rollback["version_id"])
 
     assert (sub_dir / "helper.md").read_text(encoding="utf-8") == original
     row = db.list_artifact_versions(artifact_type="subagent")[0]

--- a/collie-core/tests/collie/test_versions.py
+++ b/collie-core/tests/collie/test_versions.py
@@ -158,12 +158,15 @@ def test_rollback_restores_before_text(db: CollieDB) -> None:
     result = store.rollback("subagent", "researcher.md", current_text="v2")
     assert result["version"] == 2
     assert result["restored_text"] == "v1"
+    # The caller writes the file *and then* marks the row rolled_back.
+    store.mark_rolled_back(result["version_id"])
     assert db.get_artifact_version(result["version_id"])["status"] == "rolled_back"
 
     # Next rollback targets the remaining applied version.
     result = store.rollback("subagent", "researcher.md", current_text="v1")
     assert result["version"] == 1
     assert result["restored_text"] == ""
+    store.mark_rolled_back(result["version_id"])
 
     with pytest.raises(VersionConflictError):
         store.rollback("subagent", "researcher.md", current_text="anything")
@@ -195,12 +198,38 @@ def test_rollback_targets_specific_version(db: CollieDB) -> None:
     result = store.rollback("agents", "AGENTS.md", current_text="c")
     assert result["version"] == 3
     assert result["restored_text"] == "b"
+    store.mark_rolled_back(result["version_id"])
     result = store.rollback("agents", "AGENTS.md", to_version=2, current_text="b")
     assert result["version"] == 2
     assert result["restored_text"] == "a"
+    store.mark_rolled_back(result["version_id"])
     # Undoing an already-rolled-back version is refused.
     with pytest.raises(VersionConflictError):
         store.rollback("agents", "AGENTS.md", to_version=2, current_text="a")
+
+
+def test_rollback_normalizes_trailing_newlines(db: CollieDB) -> None:
+    store = VersionStore(db)
+    store.snapshot("agents", "AGENTS.md", "old", "new\n")
+    # The apply path (gardener/runner) always appends a trailing "\n" to the
+    # snapshot, but a manual edit may leave a different trailing-newline count.
+    # A whitespace-only trailing-newline difference must not permanently refuse
+    # the rollback (issue #123).
+    result = store.rollback("agents", "AGENTS.md", current_text="new")
+    assert result["version"] == 1
+    assert result["restored_text"] == "old"
+    store.mark_rolled_back(result["version_id"])
+
+    # CRLF in the snapshotted after_text is normalized away too.
+    store.snapshot("agents", "AGENTS.md", "old2", "line one\r\nline two\r\n")
+    result = store.rollback("agents", "AGENTS.md", current_text="line one\nline two\n")
+    assert result["version"] == 2
+    assert result["restored_text"] == "old2"
+
+    # A real content difference is still refused (guard intact).
+    store.snapshot("agents", "AGENTS.md", "old3", "newer")
+    with pytest.raises(VersionConflictError):
+        store.rollback("agents", "AGENTS.md", current_text="something else")
 
 
 # -- subagent loader wiring ------------------------------------------------------
@@ -228,6 +257,7 @@ def test_subagent_edit_versions_and_rollback_restores_file_and_db(
     current = target.read_text(encoding="utf-8")
     result = VersionStore(db).rollback("subagent", filename, current_text=current)
     target.write_text(result["restored_text"], encoding="utf-8")
+    VersionStore(db).mark_rolled_back(result["version_id"])
     loader.sync()
     row = loader.find("Researcher")
     assert row is not None
@@ -240,6 +270,7 @@ def test_subagent_edit_versions_and_rollback_restores_file_and_db(
     assert versions[0]["after_text"] == ""
     result = VersionStore(db).rollback("subagent", filename, current_text="")
     target.write_text(result["restored_text"], encoding="utf-8")
+    VersionStore(db).mark_rolled_back(result["version_id"])
     loader.sync()
     assert target.exists()
     assert loader.find("Researcher") is not None
@@ -274,6 +305,7 @@ def test_profile_edit_versions_memory_md(tmp_path: Path, db: CollieDB) -> None:
         "memory_profile", "MEMORY.md", current_text=versions[0]["after_text"]
     )
     (workspace / "MEMORY.md").write_text(result["restored_text"], encoding="utf-8")
+    VersionStore(db).mark_rolled_back(result["version_id"])
     assert "vegan" not in (workspace / "MEMORY.md").read_text(encoding="utf-8")
 
 
@@ -377,5 +409,49 @@ async def test_ipc_write_file_versions_suggest_apply_path(tmp_path: Path, monkey
         # Non-artifact files are written but not versioned.
         result = await srv._cmd_write_file(conn, {"path": "notes.txt", "content": "hello"})
         assert result["saved"] is True and result["version_id"] is None
+    finally:
+        db.close()
+
+
+async def test_ipc_rollback_write_failure_does_not_mark(tmp_path: Path, monkeypatch) -> None:
+    """If the artifact write raises, the version row stays applied and the file is untouched.
+
+    This proves the mark-after-write ordering: the version row is only marked
+    ``rolled_back`` *after* the restored text lands on disk. A write failure
+    must leave the row applied and the artifact text unchanged (consistent,
+    never desynced) — the issue-#123 desync bug.
+    """
+    monkeypatch.setenv("COLLIE_HOME", str(tmp_path))
+    db = CollieDB(tmp_path / "collie.db")
+    srv = _make_server(tmp_path, db)
+    try:
+        loader: SubagentLoader = srv._test_loader  # type: ignore[attr-defined]
+        created = loader.create("Researcher", "researches", "You research things.")
+        filename = created["filename"]
+        loader.update(created["id"], system_prompt="You research very carefully.")
+        target = tmp_path / "workspace" / "subagents" / filename
+        current = target.read_text(encoding="utf-8")
+        assert "very carefully" in current
+
+        version_id = str(
+            db.list_artifact_versions(artifact_type="subagent", artifact_key=filename, limit=1)[0][
+                "id"
+            ]
+        )
+
+        def boom(*args: Any, **kwargs: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_text", boom)
+
+        conn = _FakeConn()
+        with pytest.raises(OSError, match="disk full"):
+            await srv._cmd_rollback_artifact(conn, {"version_id": version_id})
+
+        # The row is NOT marked rolled_back, and the file still holds the newer
+        # edit — nothing was clobbered or desynced.
+        assert db.get_artifact_version(version_id)["status"] == "applied"
+        assert "very carefully" in target.read_text(encoding="utf-8")
+        assert "You research things." not in target.read_text(encoding="utf-8")
     finally:
         db.close()


### PR DESCRIPTION
## What
Makes artifact version rollback race-safe against concurrent Gardener / Dream applies and eliminates the row/file desync on write failure.

- `collie_core/versions.py`:
  - Added a shared per-artifact lock registry (`artifact_lock(type, key)`) used by rollback *and* apply paths.
  - Added `_normalize_text()` (CRLF→LF, trailing-newline-stripped) so a whitespace-only difference no longer permanently refuses rollback, mirroring gardener/runner normalization.
  - Split `rollback()` so it only validates and returns `restored_text` + `version_id`; the row is marked via a new `mark_rolled_back(version_id)`.
  - `snapshot()` unchanged.
- `collie_core/ipc/server.py`:
  - `_cmd_rollback_artifact` holds the artifact lock across read → validate → write → **mark-after-write**. If the write raises, the row stays `applied` and the file is unchanged — never desynced.
  - `_cmd_apply_gardener_suggestion` / `_cmd_apply_dream_proposal` acquire the same lock inside their `asyncio.to_thread` worker (no `await` inside a lock, avoiding deadlock).
  - `_cmd_write_file` holds the lock for classified workspace artifacts.

## Why
Closes #123: rollback did validate→mark→return, then the *caller* wrote the file. A Gardener/Dream apply landing between read and write could clobber a newer edit; and a write failing after `mark_artifact_rolled_back` left the row saying "undone" while the artifact held newer content (desync). Now the read-validate-write-mark sequence is atomic per artifact and the row is only marked after a successful write.

## Verification
- `pytest tests/collie/test_versions.py tests/collie/test_gardener_mvp.py tests/collie/test_dream_collie.py -q` — **66 passed**.
- `pytest tests/collie/test_ipc.py -q` — **53 passed**.
- `ruff format --check` + `ruff check` on the changed files — clean.
- New tests cover trailing-newline normalization and a write-failure leaving the row `applied` / file unchanged.

Closes #123
