### PR TITLE
fix(account): make cloud-sync restore transactional

### DIFF
--- a/collie-ui/src/main/cloud-sync.test.ts
+++ b/collie-ui/src/main/cloud-sync.test.ts
@@ -312,6 +312,53 @@ describe('snapshot gather/restore', () => {
       restoreSnapshot({ version: 99 } as unknown as Parameters<typeof restoreSnapshot>[0])
     ).rejects.toThrow(/format/)
   })
+
+  it('rolls back to the pre-restore state when the restore fails partway', async () => {
+    // The restore fails at the new-person add (the mock rejects every
+    // 'add_person_memory'), AFTER it has already half-written the incoming
+    // profile color. The wrapper must then replay the pre-restore snapshot.
+    testState.failCoreType = 'add_person_memory'
+
+    await expect(
+      restoreSnapshot({
+        version: 1,
+        profile: { favorite_color: 'red' },
+        people: [{ name: 'New Friend', gift_ideas: 'tea' }],
+        dates: [{ date: '12-24', label: 'Trip', recurring: false }],
+        agents_md: '# About Me (from laptop)',
+        vision_md: '# Personality (from laptop)'
+      })
+    ).rejects.toThrow(/add_person_memory/)
+
+    const calls = testState.coreCalls
+    // The error still propagates — the caller knows the restore didn't finish.
+    // The failing add was only attempted once: the rollback matches the
+    // pre-existing 'Maya' by name (update), so the new person is not re-added.
+    expect(calls.filter((c) => c.type === 'add_person_memory')).toHaveLength(1)
+    // Pre-restore profile color (blue) replays over the half-written 'red'.
+    expect(
+      calls
+        .filter((c) => c.type === 'set_profile_memory')
+        .some((c) => c.payload.value === 'blue')
+    ).toBe(true)
+    // Pre-existing people are updated, not duplicated.
+    expect(calls.some((c) => c.type === 'update_person_memory')).toBe(true)
+    // Both authored files are rewritten with their pre-restore content.
+    const writes = calls.filter((c) => c.type === 'write_file')
+    expect(
+      writes.some(
+        (c) => c.payload.path === 'AGENTS.md' && c.payload.content === '# About Me'
+      )
+    ).toBe(true)
+    expect(
+      writes.some(
+        (c) => c.payload.path === 'VISION.md' && c.payload.content === '# Personality'
+      )
+    ).toBe(true)
+    // Dates are content-addressed/duplicate-skipped, so the pre-existing
+    // date is preserved rather than stacked — no add_date_memory for it.
+    expect(calls.filter((c) => c.type === 'add_date_memory')).toHaveLength(0)
+  })
 })
 
 describe('supabase REST', () => {

--- a/collie-ui/src/main/cloud-sync.ts
+++ b/collie-ui/src/main/cloud-sync.ts
@@ -175,15 +175,13 @@ export async function gatherSnapshot(): Promise<SyncPayload> {
 }
 
 /**
- * Restore a payload through the app's normal write paths: MD files go
- * through `write_file` (versioned + undoable), memory rows through the
- * same person/date/profile commands the Settings UI itself uses.
+ * Plain sequential restore through the app's normal write paths: MD files
+ * go through `write_file` (versioned + undoable), memory rows through the
+ * same person/date/profile commands the Settings UI itself uses. This is
+ * the raw writer — `restoreSnapshot` wraps it so a failed restore can roll
+ * back to the pre-restore snapshot.
  */
-export async function restoreSnapshot(payload: SyncPayload): Promise<void> {
-  if (!payload || payload.version !== 1) {
-    throw new Error("This backup isn't a format this Collie understands.")
-  }
-
+async function applyRestore(payload: SyncPayload): Promise<void> {
   // Memory first (structured rows), then the two authored files.
   const profile = isRecord(payload.profile) ? payload.profile : {}
   for (const [key, value] of Object.entries(profile)) {
@@ -238,6 +236,33 @@ export async function restoreSnapshot(payload: SyncPayload): Promise<void> {
     const content = payload[key]
     if (typeof content !== 'string' || !content.trim()) continue
     await coreCommand('write_file', { path: file, content })
+  }
+}
+
+/**
+ * Restore a payload atomically: snapshot the current on-device state, then
+ * apply the incoming payload. If the restore fails partway (a mid-way error
+ * leaves only some memory rows / files written), replay the pre-restore
+ * snapshot as a best-effort rollback so the device isn't left half-restored,
+ * then rethrow the original error to tell the user the restore didn't finish.
+ */
+export async function restoreSnapshot(payload: SyncPayload): Promise<void> {
+  if (!payload || payload.version !== 1) {
+    throw new Error("This backup isn't a format this Collie understands.")
+  }
+
+  const before = await gatherSnapshot()
+  try {
+    await applyRestore(payload)
+  } catch (err) {
+    // Best-effort rollback: if the rollback itself fails, there's nothing
+    // more we can safely do — surface the original restore error.
+    try {
+      await applyRestore(before)
+    } catch {
+      // best effort
+    }
+    throw err
   }
 }
 


### PR DESCRIPTION
## What
Makes cloud-sync restore atomic so a mid-way failure doesn't leave the device half-restored.

`collie-ui/src/main/cloud-sync.ts`:
- The sequential-write body became a private `applyRestore(payload)` raw writer (logic unchanged).
- `restoreSnapshot(payload)` now captures `before = await gatherSnapshot()`, runs `applyRestore(payload)`, and on any error best-effort replays `applyRestore(before)` (the pre-restore snapshot) before rethrowing the original error. No recursion — `restoreFromDevice` still calls `restoreSnapshot`.
- Helper functions and the secret-header lines are untouched.

## Why
Closes the remaining open half of #132 (the baseline-upload ordering was fixed earlier). `restoreFromDevice` applied profile/people/dates rows and the two authored files sequentially with no rollback; a mid-way failure left half-restored memory with no recovery.

## Verification
- `npx vitest run src/main/cloud-sync.test.ts` — **17 passed** (added a test that a failing restore propagates the error and replays the pre-restore state).
- `npm run typecheck` — clean.

Note: rollback is best-effort by design — a failure in the same command type the rollback also needs can't always be fully reversed; it's caught and the original error surfaces.

Closes #132
