### PR TITLE
fix(win): wire Authenticode update signing + publisher verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,13 @@ name: Release
 # release checks).
 #
 # Signing notes (alpha):
-#  - Windows: the installer is unsigned (no code-signing cert); SmartScreen
-#    may warn. Signing with an EV/OV cert is a follow-up.
+#  - Windows: Authenticode update signing is wired (win.publisherName +
+#    verifyUpdateCodeSignature in collie-ui/electron-builder.yml) and
+#    activates when a code-signing certificate is injected via the
+#    WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD repo secrets (see the
+#    "Expose Windows code-signing certificate" step). Until those secrets are
+#    provisioned the NSIS installer ships unsigned and SmartScreen may warn.
+#    The certificate itself is an ops secret — it is never committed.
 #  - macOS: Developer ID codesign + notarization are SKIPPED for alpha — no
 #    Apple Developer certificate yet (CSC_IDENTITY_AUTO_DISCOVERY=false
 #    below). The app is ad-hoc signed (scripts/adhoc-sign-mac.cjs) so it
@@ -18,9 +23,11 @@ name: Release
 #    $99/yr Apple Developer account + notarytool secrets (APPLE_ID /
 #    APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID) are the follow-up.
 #
-# Secrets: only the automatic secrets.GITHUB_TOKEN is used. No real secrets
-# are referenced or committed; APPLE_* / signing certs are placeholders for
-# future work.
+# Secrets: the automatic secrets.GITHUB_TOKEN is always used. The Windows
+# Authenticode signing cert secret (WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD) is
+# OPTIONAL — read only to sign the Windows installer, and it is never
+# committed. APPLE_* / notarization secrets remain placeholders for future
+# work.
 
 on:
   push:
@@ -126,6 +133,18 @@ jobs:
       # GitHub Release creation. (GITHUB_TOKEN is present on Actions, so
       # electron-builder would otherwise publish from the build jobs.)
       CSC_IDENTITY_AUTO_DISCOVERY: "false" # macOS: unsigned alpha builds
+      # Windows Authenticode signing (issue #59): electron-builder signs the
+      # NSIS installer automatically when the certificate env vars are present.
+      # We promote the repo secrets into job-level env so that (a) a step can
+      # gate on them (GitHub Actions does not allow `secrets` in `if:`) and
+      # (b) electron-builder picks them up on the Windows leg. These are
+      # Windows-SPECIFIC vars: the macOS build reads CSC_LINK only and the
+      # Linux AppImage target uses no code-signing cert, so setting WIN_* here
+      # does NOT activate signing on the other matrix legs. If the secret is
+      # not provisioned the value is an empty string, which electron-builder
+      # treats as "no certificate" -> the artifact stays unsigned (alpha safe).
+      WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+      WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
     defaults:
       run:
         working-directory: collie-ui
@@ -232,6 +251,19 @@ jobs:
           done
           iconutil -c icns icon.iconset -o icon.icns
           rm -rf icon.iconset
+
+      - name: Expose Windows code-signing certificate (Authenticode)
+        # GitHub Actions does not allow `secrets` in `if:` conditions, so the
+        # WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD secrets are promoted to
+        # job-level env above and gated on here. Signing activates once the
+        # certificate secret is added to the repo (Settings -> Secrets and
+        # variables -> Actions); until then this step is skipped and the
+        # Windows installer ships unsigned — alpha updates keep working via
+        # HTTPS + SHA256 (electron-updater skips signature checks without a
+        # publisherName in app-update.yml).
+        if: runner.os == 'Windows' && env.WIN_CSC_LINK != ''
+        run: |
+          echo "Windows code-signing certificate detected — Authenticode signing will activate for the NSIS installer."
 
       - name: Package installer (${{ matrix.flags }})
         run: npx electron-builder ${{ matrix.flags }} --publish never
@@ -343,7 +375,10 @@ jobs:
               Privacy & Security. Notarization needs a $99/yr Apple Developer
               account (APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD /
               APPLE_TEAM_ID secrets) — a follow-up.
-            - **Windows is unsigned**; SmartScreen may warn.
+            - **Windows Authenticode signing is wired** but only activates
+              when the `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` code-signing
+              certificate secret is provisioned for the repo. Until then the
+              installer is unsigned and SmartScreen may warn.
             - Asset provenance is **recorded**: branded art is
               owner-created for Collie (excluded from MIT reuse) and
               third-party marks are nominative-use only, per

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,9 @@ name: Release
 # release checks).
 #
 # Signing notes (alpha):
-#  - Windows: Authenticode update signing is wired (win.publisherName +
-#    verifyUpdateCodeSignature in collie-ui/electron-builder.yml) and
+#  - Windows: Authenticode update signing is wired (win.verifyUpdateCodeSignature
+#    in collie-ui/electron-builder.yml; electron-builder derives the
+#    publisherName electron-updater verifies against from the signing cert) and
 #    activates when a code-signing certificate is injected via the
 #    WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD repo secrets (see the
 #    "Expose Windows code-signing certificate" step). Until those secrets are

--- a/collie-core/SECURITY.md
+++ b/collie-core/SECURITY.md
@@ -20,6 +20,24 @@ Security fixes are assessed for the current Collie alpha release. Alpha builds
 are unsigned while the release program is being established; download them only
 from the Collie GitHub Releases page and verify the published checksum.
 
+### Update signature verification (Windows)
+
+Windows update signing + publisher verification is wired (issue #59): the
+packaged installer is Authenticode-signed and electron-updater verifies an
+available update's signature against `win.publisherName` **when the build was
+produced with a code-signing certificate**. The certificate is injected at
+release time from the `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` repo secrets
+(see `.github/workflows/release.yml`). Until that secret is provisioned by a
+maintainer:
+
+- Windows installers ship **unsigned** (SmartScreen may warn), and
+- electron-updater performs **no** signature check — updates are trusted via
+  the HTTPS feed's SHA256 hashes.
+
+Once the certificate is provisioned, published Windows updates are
+Authenticode-signed and publisher-verified before install. The certificate
+itself is an ops secret and is never committed to the repository.
+
 ## Keeping Collie data safe
 
 - Collie stores its local database under the user's Collie data directory.
@@ -46,4 +64,4 @@ Collie includes adapted code from
 vendored `nanobot` Python namespace remains for compatibility. See `LICENSE`
 and `THIRD_PARTY_NOTICES.md` for the applicable notices.
 
-**Last updated:** 2026-07-29
+**Last updated:** 2026-08-27

--- a/collie-core/SECURITY.md
+++ b/collie-core/SECURITY.md
@@ -24,8 +24,10 @@ from the Collie GitHub Releases page and verify the published checksum.
 
 Windows update signing + publisher verification is wired (issue #59): the
 packaged installer is Authenticode-signed and electron-updater verifies an
-available update's signature against `win.publisherName` **when the build was
-produced with a code-signing certificate**. The certificate is injected at
+available update's signature against the publisher name written into the
+installed app's `app-update.yml` (derived from the certificate's subject)
+**when the build was produced with a code-signing certificate**. The
+certificate is injected at
 release time from the `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` repo secrets
 (see `.github/workflows/release.yml`). Until that secret is provisioned by a
 maintainer:

--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -23,6 +23,25 @@ win:
       arch:
         - x64
   artifactName: Collie-Setup-${version}.exe
+  # Authenticode update signing + publisher verification (issue #59).
+  # publisherName is the stable subject this org's code-signing certificate
+  # should carry. When a certificate IS present on the build (CSC_LINK /
+  # WIN_CSC_LINK, injected by the CI workflow from a repo secret),
+  # electron-builder signs the installer AND writes the certificate's
+  # subject/common name into the installed app's update config
+  # (app-update.yml), which makes electron-updater verify an available
+  # update's Authenticode signature before applying it (see
+  # verifyUpdateCodeSignature below). With NO certificate on the build, no
+  # publisherName lands in app-update.yml, so electron-updater keeps relying
+  # on HTTPS + the feed's SHA256 hashes — unsigned alpha builds remain
+  # installable. NOTE: the certificate's Subject common name should match
+  # this value so the publisher metadata and the verified identity align.
+  publisherName: Collie (heycollie.com)
+  # Explicit (matches the default): verify an available update's Authenticode
+  # signature against the publisher name before installing. Only effective
+  # when the build is actually signed (cert present); otherwise it is a
+  # no-op, so unsigned alpha builds are NOT blocked.
+  verifyUpdateCodeSignature: true
 nsis:
   # Friendly assisted wizard for nontechnical users: Welcome -> Install mode
   # (per-user recommended, no admin prompt) -> Location (custom only) ->

--- a/collie-ui/electron-builder.yml
+++ b/collie-ui/electron-builder.yml
@@ -24,23 +24,23 @@ win:
         - x64
   artifactName: Collie-Setup-${version}.exe
   # Authenticode update signing + publisher verification (issue #59).
-  # publisherName is the stable subject this org's code-signing certificate
-  # should carry. When a certificate IS present on the build (CSC_LINK /
+  # When a code-signing certificate is present on the build (CSC_LINK /
   # WIN_CSC_LINK, injected by the CI workflow from a repo secret),
-  # electron-builder signs the installer AND writes the certificate's
+  # electron-builder signs the NSIS installer AND writes the certificate's
   # subject/common name into the installed app's update config
-  # (app-update.yml), which makes electron-updater verify an available
-  # update's Authenticode signature before applying it (see
-  # verifyUpdateCodeSignature below). With NO certificate on the build, no
-  # publisherName lands in app-update.yml, so electron-updater keeps relying
-  # on HTTPS + the feed's SHA256 hashes — unsigned alpha builds remain
-  # installable. NOTE: the certificate's Subject common name should match
-  # this value so the publisher metadata and the verified identity align.
-  publisherName: Collie (heycollie.com)
-  # Explicit (matches the default): verify an available update's Authenticode
-  # signature against the publisher name before installing. Only effective
-  # when the build is actually signed (cert present); otherwise it is a
-  # no-op, so unsigned alpha builds are NOT blocked.
+  # (app-update.yml) as the publisherName that electron-updater uses to
+  # verify an available update's Authenticode signature before applying it.
+  # With NO certificate on the build nothing is signed, no publisherName
+  # lands in app-update.yml, and electron-updater relies on HTTPS + the
+  # feed's SHA256 hashes — unsigned alpha builds remain installable.
+  # NOTE: the certificate's Subject common name is what becomes the verified
+  # publisher, so it should carry the identity users trust (e.g. the org
+  # name). `publisherName` must NOT be set as a `win` key here — the schema
+  # is strict (additionalProperties: false) and it would fail the build.
+  # Explicit (matches the electron-builder default): verify an available
+  # update's Authenticode signature against the publisher before installing.
+  # Only effective when the build is actually signed (cert present);
+  # otherwise it is a no-op, so unsigned alpha builds are NOT blocked.
   verifyUpdateCodeSignature: true
 nsis:
   # Friendly assisted wizard for nontechnical users: Welcome -> Install mode

--- a/collie-ui/src/main/updater-controller.ts
+++ b/collie-ui/src/main/updater-controller.ts
@@ -109,6 +109,16 @@ export class UpdateController {
     updater.allowPrerelease = true
     updater.channel = 'alpha'
 
+    // Windows updates: when the published NSIS build was produced with a
+    // code-signing certificate (see collie-ui/electron-builder.yml
+    // win.publisherName + win.verifyUpdateCodeSignature), electron-updater
+    // verifies the downloaded update's Authenticode signature against the
+    // publisher before applying it, and rejects a mismatch. When the build
+    // ships unsigned (no cert on the CI runner, as in current alpha) that
+    // publisherName is absent from the installed update config, so signature
+    // verification is skipped and updates proceed via the HTTPS feed + SHA256
+    // hashes. No behavior change in this controller either way.
+
     updater.on('checking-for-update', () => this.setStatus({ phase: 'checking' }))
     updater.on('update-available', (info: UpdateInfo) =>
       this.setStatus({ phase: 'available', availableVersion: info.version })

--- a/docs/operations/release/installer-ux.md
+++ b/docs/operations/release/installer-ux.md
@@ -75,10 +75,17 @@ original setup are kept).
 Windows update signing + publisher verification is wired (issue #59) in
 `collie-ui/electron-builder.yml`:
 
-- `win.publisherName: Collie (heycollie.com)` — the stable subject the
-  code-signing certificate should carry.
 - `win.verifyUpdateCodeSignature: true` — verify an available update's
-  Authenticode signature against the publisher before applying it.
+  Authenticode signature against the publisher (the electron-builder default is
+  `true`; declared explicitly here). It only takes effect when the build is
+  actually signed.
+- `win.publisherName` is intentionally **not** set as a config key — the `win`
+  schema is strict (`additionalProperties: false`) and would reject it and fail
+  the build. Instead, electron-builder derives the publisher name from the
+  code-signing certificate's subject and writes it into the installed app's
+  `app-update.yml`; electron-updater verifies the update's signature against
+  that publisher. The certificate's Subject common name should be the trusted
+  identity (e.g. the org/product name).
 
 electron-builder signs the NSIS installer automatically when a code-signing
 certificate is present on the build (`CSC_LINK` / `WIN_CSC_LINK` +

--- a/docs/operations/release/installer-ux.md
+++ b/docs/operations/release/installer-ux.md
@@ -70,8 +70,40 @@ original setup are kept).
    profile and walk all five pages; verify no UAC prompt appears and that
    unchecking the desktop checkbox leaves no desktop icon after install.
 
+## Authenticode update signing
+
+Windows update signing + publisher verification is wired (issue #59) in
+`collie-ui/electron-builder.yml`:
+
+- `win.publisherName: Collie (heycollie.com)` — the stable subject the
+  code-signing certificate should carry.
+- `win.verifyUpdateCodeSignature: true` — verify an available update's
+  Authenticode signature against the publisher before applying it.
+
+electron-builder signs the NSIS installer automatically when a code-signing
+certificate is present on the build (`CSC_LINK` / `WIN_CSC_LINK` +
+`CSC_KEY_PASSWORD` / `WIN_CSC_KEY_PASSWORD`). `.github/workflows/release.yml`
+promotes the `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` repo secrets to the
+Windows build job's env so signing activates **only when a maintainer
+provisions the certificate** (Settings → Secrets and variables → Actions).
+When no certificate is present those env values are empty, which
+electron-builder treats as "no certificate", so:
+
+- the installer ships **unsigned** (SmartScreen may warn), and
+- no `publisherName` is written to the installed app's `app-update.yml`, so
+  electron-updater **skips** signature verification and updates are delivered
+  over HTTPS with SHA256 feed hashes (the same as before).
+
+Once the certificate is provisioned, the installed app carries a
+`publisherName`, electron-updater verifies an available update's signature
+against it, and signed alpha builds remain installable and publisher-verified.
+
+The certificate itself is an ops secret — it is never committed to the repo.
+
 ## Follow-ups (not in this change)
 
-- Code signing + SmartScreen reputation (an unsigned alpha triggers
-  "Windows protected your PC").
+- SmartScreen reputation for unsigned builds ("Windows protected your PC") —
+  resolved only once a code-signing certificate is provisioned, and
+  Reputation/visibility may need time to build after the first signed
+  release.
 - First-run in-app welcome flow (the natural next step after setup).


### PR DESCRIPTION
## What
Wires Windows Authenticode update signing + publisher verification for the in-app updater.

- `collie-ui/electron-builder.yml` — added `win.verifyUpdateCodeSignature: true` (valid electron-builder key; explicitly declares the default) so electron-updater verifies an available update's Authenticode signature against the publisher. Greenfield analysis confirmed `win.publisherName` is **not** a valid `win` key (the schema is strict, `additionalProperties: false` — it would fail the build), so it is deliberately not set.
- `.github/workflows/release.yml` — promoted the `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` repo secrets to job-level env (Windows-leg only: `WIN_*` so the macOS `CSC_LINK` leg and the Linux AppImage leg are unaffected) and added a gated "Expose Windows code-signing certificate" step.
- `collie-ui/src/main/updater-controller.ts` — comment-only (no behavior change) documenting the verification path.
- `docs/operations/release/installer-ux.md` + `collie-core/SECURITY.md` — documented the mechanism honestly.

## Why
Closes the supply-chain gap in #59: unsigned Windows updates were trusted via the release feed + SHA512 hashes. With signing wired, when the code-signing cert is present on the build, electron-builder signs the NSIS installer and writes the cert's subject into the installed app's `app-update.yml`; electron-updater verifies an available update's signature against that publisher before installing.

## Verification
- `electron-builder.yml` and `release.yml` both parse as valid YAML.
- `verifyUpdateCodeSignature` confirmed as a real key in `app-builder-lib/scheme.json` → `definitions.WindowsConfiguration.properties`.
- Could **not** run a real signed Windows build/install here (no cert, no Windows runner) — integration is validated at config/workflow/YAML level only.

## ⚠ Honest caveat (important)
The certificate is an **ops prerequisite**, not code. Signing activates only once the owner adds the `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` secrets (Settings → Secrets and variables → Actions). Until then, Windows installers still ship unsigned and updates fall back to HTTPS + SHA256 (alpha stays installable). The cert's Subject common name should be the trusted publisher identity.

Closes #59
