### PR TITLE
fix(ui): broker core IPC through main — never expose the per-boot token to the renderer

### DIFF
--- a/collie-ui/src/main/core-client.test.ts
+++ b/collie-ui/src/main/core-client.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./python', () => ({
-  coreState: vi.fn(() => ({ state: 'running', port: 3818, token: 'test-token', error: '' }))
+  coreState: vi.fn(() => ({ state: 'running', port: 3818, token: '', error: '' })),
+  ipcToken: 'test-token'
 }))
 
 const loadSecretsMock = vi.fn()

--- a/collie-ui/src/main/core-client.ts
+++ b/collie-ui/src/main/core-client.ts
@@ -10,20 +10,44 @@
  * User-entered keys (typed in Settings) still flow renderer -> main ->
  * core via the existing saveSecret + renderer WS path; those are fresh
  * user input, not stored long-lived secrets.
+ *
+ * #122: the renderer no longer speaks to the core directly. The per-boot
+ * token (ipcToken, from python.ts) lives ONLY here. This module owns ONE
+ * persistent, auto-reconnecting WebSocket to the core and brokers every
+ * renderer command over Electron IPC:
+ *   - coreSend(type, id, payload): routes a command frame to the core and
+ *     resolves with the matching 'ok'/'error' reply for that id.
+ *   - onCoreEvent(listener): receive core-pushed events (ready, thinking,
+ *     delta, message, card, approval_requested, ...) so main can forward
+ *     them to the renderer.
+ * The token is never exposed to the renderer through any of these.
  */
-import { coreState } from './python'
+import { coreState, ipcToken } from './python'
 import { loadSecrets } from './secrets'
 
 const CONNECT_TIMEOUT_MS = 5000
 const COMMAND_TIMEOUT_MS = 10_000
 
+// Reconnect backoff for the broker's persistent socket (matches the renderer
+// transport's old constants so the UX is unchanged).
+const RECONNECT_BASE_DELAY_MS = 1200
+const RECONNECT_MAX_DELAY_MS = 30_000
+const RECONNECT_JITTER_RATIO = 0.2
+const CONNECTION_INTERRUPTED_MESSAGE =
+  "Collie lost the connection before confirming that action. Check its result before trying again."
+
 let pushInFlight = false
+
+/** A core-pushed event frame (any CollieEvent type, loosely typed here). */
+export type CoreEvent = Record<string, unknown>
+/** The core command frame the renderer hands over the IPC bridge. */
+export type CoreCommandFrame = { type: string; id: string; [key: string]: unknown }
 
 function openCoreSocket(timeoutMs = CONNECT_TIMEOUT_MS): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const { port, token } = coreState()
+    const { port } = coreState()
     let settled = false
-    const ws = new WebSocket(`ws://127.0.0.1:${port}`, [`collie-${token}`])
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, [`collie-${ipcToken}`])
     const timer = setTimeout(() => {
       if (settled) return
       settled = true
@@ -142,4 +166,198 @@ export async function commandWithCore(
       // already closed
     }
   }
+}
+
+/**
+ * Persistent, auto-reconnecting, single-socket broker for the core. One
+ * authenticated socket (with the per-boot ipcToken, which stays in main)
+ * serves every renderer command and every core-pushed event. Replies with
+ * an 'ok'/'error' id matching a request resolve that request's promise;
+ * everything else (thinking/delta/message/card/approval, etc.) is fanned
+ * out to the onCoreEvent subscribers so main can forward it to the renderer.
+ */
+class CoreBroker {
+  private socket: WebSocket | null = null
+  private connecting: Promise<WebSocket> | null = null
+  private closed = false
+  private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private readonly pending = new Map<
+    string,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >()
+  private readonly eventListeners = new Set<(event: CoreEvent) => void>()
+
+  onEvent(listener: (event: CoreEvent) => void): () => void {
+    this.eventListeners.add(listener)
+    // Try to bring the socket up so pushed events flow as soon as possible.
+    this.ensureConnected().catch(() => undefined)
+    return () => this.eventListeners.delete(listener)
+  }
+
+  private emit(event: CoreEvent): void {
+    for (const listener of this.eventListeners) listener(event)
+  }
+
+  private ensureConnected(): Promise<WebSocket> {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      return Promise.resolve(this.socket)
+    }
+    if (this.connecting) return this.connecting
+
+    const { port } = coreState()
+    this.connecting = new Promise<WebSocket>((resolve, reject) => {
+      let settled = false
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`, [`collie-${ipcToken}`])
+      const timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        this.connecting = null
+        try {
+          ws.close()
+        } catch {
+          // already closed
+        }
+        reject(new Error('Core connection timed out'))
+      }, CONNECT_TIMEOUT_MS)
+
+      ws.onopen = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        this.connecting = null
+        this.socket = ws
+        this.reconnectAttempts = 0
+        resolve(ws)
+        this.emit({ type: 'connection_opened' })
+      }
+      ws.onmessage = (event) => this.route(event)
+      ws.onclose = () => {
+        if (this.socket === ws) this.socket = null
+        if (this.connecting) return
+        this.failPending(new Error(CONNECTION_INTERRUPTED_MESSAGE))
+        this.scheduleReconnect()
+      }
+      ws.onerror = () => {
+        // Reject the in-flight connect promptly (don't wait for the timeout)
+        // and let onclose drive the reconnect backoff.
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        this.connecting = null
+        try {
+          ws.close()
+        } catch {
+          // already closed
+        }
+        reject(new Error('Could not connect to the core'))
+      }
+    })
+    return this.connecting
+  }
+
+  private route(event: MessageEvent): void {
+    let frame: CoreEvent | null = null
+    try {
+      frame = JSON.parse(String(event.data)) as CoreEvent
+    } catch {
+      return
+    }
+    if (!frame) return
+    const id = typeof frame.id === 'string' ? frame.id : undefined
+    const type = frame.type
+    if (id && (type === 'ok' || type === 'error')) {
+      const promise = this.pending.get(id)
+      if (promise) {
+        this.pending.delete(id)
+        if (type === 'ok') promise.resolve(frame.data)
+        else {
+          const detail =
+            typeof frame.message === 'string'
+              ? frame.message
+              : typeof frame.detail === 'string'
+                ? frame.detail
+                : 'Core command failed'
+          promise.reject(new Error(detail))
+        }
+      }
+      // Command replies are consumed by the caller — never fanned out, even
+      // when no caller is waiting (mirrors the old renderer transport).
+      return
+    }
+    this.emit(frame)
+  }
+
+  /** Send a command frame and resolve with its 'ok'/'error' reply. */
+  async send(type: string, id: string, payload: Record<string, unknown>): Promise<unknown> {
+    const ws = await this.ensureConnected()
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      try {
+        ws.send(JSON.stringify({ type, id, ...payload }))
+      } catch (error) {
+        this.pending.delete(id)
+        reject(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+  }
+
+  private failPending(error: Error): void {
+    const requests = [...this.pending.values()]
+    this.pending.clear()
+    for (const request of requests) request.reject(error)
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed || this.retryTimer) return
+    const exponentialDelay = Math.min(
+      RECONNECT_MAX_DELAY_MS,
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts
+    )
+    this.reconnectAttempts += 1
+    const jitter = 1 - RECONNECT_JITTER_RATIO + Math.random() * RECONNECT_JITTER_RATIO * 2
+    const delayMs = Math.min(RECONNECT_MAX_DELAY_MS, Math.round(exponentialDelay * jitter))
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null
+      this.ensureConnected().catch(() => undefined)
+    }, delayMs)
+  }
+
+  stop(): void {
+    this.closed = true
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+    this.failPending(new Error('Core connection closed'))
+    if (this.socket) {
+      try {
+        this.socket.close()
+      } catch {
+        // already closed
+      }
+      this.socket = null
+    }
+  }
+}
+
+const coreBroker = new CoreBroker()
+
+/** Send one renderer command to the core and await its reply. */
+export function coreSend(frame: CoreCommandFrame): Promise<unknown> {
+  const { type, id, ...payload } = frame
+  if (typeof type !== 'string' || typeof id !== 'string') {
+    return Promise.reject(new Error('Malformed core command frame'))
+  }
+  return coreBroker.send(type, id, payload)
+}
+
+/** Subscribe to core-pushed events (returns an unsubscribe). */
+export function onCoreEvent(listener: (event: CoreEvent) => void): () => void {
+  return coreBroker.onEvent(listener)
+}
+
+/** Cleanly tear the broker down (app quit / core shutdown). */
+export function stopCoreBroker(): void {
+  coreBroker.stop()
 }

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -23,7 +23,13 @@ import {
   secureStorageAvailable,
   stageSecretChange
 } from './secrets'
-import { pushStoredSecretsToCore } from './core-client'
+import {
+  coreSend,
+  onCoreEvent,
+  pushStoredSecretsToCore,
+  stopCoreBroker,
+  type CoreCommandFrame
+} from './core-client'
 import { startKeychainServer, stopKeychainServer } from './keychain-server'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
 import {
@@ -353,6 +359,11 @@ function registerIpc(): void {
   }
 
   handle('collie:core-state', () => coreState())
+  // #122: the renderer no longer holds the per-boot token or opens its own
+  // socket to the core. Every command is relayed here, over main's single
+  // authenticated connection (core-client.ts CoreBroker), guarded by the
+  // exact renderer-URL sender check.
+  handle('collie:core-send', (frame: CoreCommandFrame): Promise<unknown> => coreSend(frame))
   handle('collie:secure-storage-status', () => ({
     available: secureStorageAvailable(),
     platform: process.platform
@@ -583,6 +594,15 @@ app.whenReady().then(async () => {
   }
   registerIpc()
   createWindow()
+  // #122: forward every core-pushed event (ready/delta/message/card/
+  // approval_*, connection_opened, ...) to the app's own renderer. The
+  // renderer no longer opens a socket to the core, so this is the only
+  // path by which it learns about core activity.
+  onCoreEvent((event) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('collie:core-event', event)
+    }
+  })
   createTray()
   updates.onStatus((status) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -636,6 +656,7 @@ app.on('before-quit', () => {
 
 app.on('will-quit', () => {
   stopCore()
+  stopCoreBroker()
   stopPet()
   stopKeychainServer()
 })

--- a/collie-ui/src/main/python.ts
+++ b/collie-ui/src/main/python.ts
@@ -14,9 +14,11 @@ import {
 
 const IPC_PORT = Number(process.env.COLLIE_IPC_PORT || 3818)
 
-// Per-boot secret handed to the core out-of-band; the renderer presents it
-// as the WebSocket subprotocol so no other local process can drive the core.
-const ipcToken = randomBytes(32).toString('hex')
+// Per-boot secret handed to the core out-of-band. It lives ONLY here in the
+// main process — it is used to spawn the core (env) and to authenticate the
+// main-process broker's WebSocket (core-client.ts). It is NEVER sent to the
+// renderer, so no renderer compromise can open a socket that drives the core.
+export const ipcToken = randomBytes(32).toString('hex')
 
 let child: ChildProcess | null = null
 let state: 'stopped' | 'starting' | 'running' | 'failed' = 'stopped'
@@ -43,10 +45,14 @@ const restartBudget = new RestartBudget(MAX_ABNORMAL_EXITS, HEALTHY_WINDOW_MS)
 export function coreState(): {
   state: string
   port: number
+  /** Redacted — the per-boot token never leaves the main process. */
   token: string
   error: string
 } {
-  return { state, port: readyPort ?? IPC_PORT, token: ipcToken, error: lastError }
+  // The token field is kept for shape compatibility (preload + renderer
+  // mocks reference it), but it is ALWAYS empty here. The real ipcToken lives
+  // only in the main process and is consumed by core-client.ts's broker.
+  return { state, port: readyPort ?? IPC_PORT, token: '', error: lastError }
 }
 
 function bundledPythonCandidates(): string[] {

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -67,6 +67,18 @@ export interface InstallResult {
 const api = {
   coreState: (): Promise<{ state: string; port: number; token: string; error: string }> =>
     ipcRenderer.invoke('collie:core-state'),
+  // #122: renderer -> main -> core command relay. The renderer builds a
+  // { type, id, ...payload } frame; main authenticates it against the
+  // per-boot token (which stays in main) and returns the core's reply.
+  coreSend: (frame: Record<string, unknown>): Promise<unknown> =>
+    ipcRenderer.invoke('collie:core-send', frame),
+  // #122: main forwards core-pushed events to the renderer (the renderer no
+  // longer opens its own socket). Returns an unsubscribe.
+  onCoreEvent: (listener: (event: unknown) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, event: unknown): void => listener(event)
+    ipcRenderer.on('collie:core-event', handler)
+    return () => ipcRenderer.removeListener('collie:core-event', handler)
+  },
   secureStorageStatus: (): Promise<{ available: boolean; platform: string }> =>
     ipcRenderer.invoke('collie:secure-storage-status'),
   saveSecret: (provider: string, key: string): Promise<boolean> =>

--- a/collie-ui/src/renderer/src/App.tsx
+++ b/collie-ui/src/renderer/src/App.tsx
@@ -54,11 +54,12 @@ export default function App(): React.JSX.Element {
     })
 
     const boot = async (): Promise<void> => {
-      // The core binds its own port and issues a per-boot token; learn both
-      // from the main process before speaking to the socket.
+      // The core binds its own port; learn it from the main process. The
+      // per-boot token is handled entirely in main (core-client.ts broker) —
+      // it is never handed to the renderer.
       try {
         const core = await window.collie?.coreState()
-        if (core) collieClient.applyEndpoint(core.port, core.token)
+        if (core) collieClient.applyEndpoint(core.port)
       } catch {
         // main process unavailable — keep the default endpoint
       }

--- a/collie-ui/src/renderer/src/lib/ipc.test.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.test.ts
@@ -32,8 +32,9 @@ describe('CollieClient bridge transport (#122)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('fails closed while the bridge has not been connected', async () => {
-    installBridge()
+  it('fails closed when the bridge is unavailable', async () => {
+    // No window.collie bridge installed — commands cannot be relayed to the
+    // core, so the client fails closed (CORE_RESTARTING) rather than hang.
     const client = new CollieClient(4321)
 
     const reply = client.command('toggle_automation', {
@@ -57,7 +58,8 @@ describe('CollieClient bridge transport (#122)', () => {
     client.connect()
 
     expect(bridge.onCoreEvent).toHaveBeenCalledTimes(1)
-    expect(client.connected).toBe(true)
+    // `connected` only flips once the broker reports a real core socket.
+    expect(client.connected).toBe(false)
 
     bridge.coreSend.mockResolvedValueOnce({ configured: false })
     const reply = client.command<{ configured: boolean }>('get_status')
@@ -72,14 +74,21 @@ describe('CollieClient bridge transport (#122)', () => {
     expect(bridge.unsubscribe).toHaveBeenCalled()
   })
 
-  it('emits connection_opened to listeners when the bridge goes live', () => {
-    installBridge()
+  it('emits connection_opened to listeners only when the broker reports the core socket open', () => {
+    const bridge = installBridge()
     const client = new CollieClient(4321)
     const listener = vi.fn()
     client.on(listener)
 
     client.connect()
+    // Not emitted at connect() time — the broker must actually reach the core.
+    expect(listener).not.toHaveBeenCalledWith({ type: 'connection_opened' })
+    expect(client.connected).toBe(false)
+
+    // The broker's core socket opens.
+    bridge.listener?.({ type: 'connection_opened' })
     expect(listener).toHaveBeenCalledWith({ type: 'connection_opened' })
+    expect(client.connected).toBe(true)
     client.close()
   })
 

--- a/collie-ui/src/renderer/src/lib/ipc.test.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.test.ts
@@ -1,68 +1,39 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CollieClient } from './ipc'
 
-class FakeWebSocket {
-  static readonly CONNECTING = 0
-  static readonly OPEN = 1
-  static readonly CLOSED = 3
-  static instances: FakeWebSocket[] = []
-
-  readyState = FakeWebSocket.CONNECTING
-  onopen: (() => void) | null = null
-  onmessage: ((event: { data: string }) => void) | null = null
-  onclose: (() => void) | null = null
-  onerror: (() => void) | null = null
-  send = vi.fn()
-
-  constructor(readonly url: string) {
-    FakeWebSocket.instances.push(this)
-  }
-
-  open(): void {
-    this.readyState = FakeWebSocket.OPEN
-    this.onopen?.()
-  }
-
-  close(): void {
-    this.readyState = FakeWebSocket.CLOSED
-    this.onclose?.()
-  }
+interface BridgeMock {
+  coreSend: ReturnType<typeof vi.fn>
+  onCoreEvent: ReturnType<typeof vi.fn>
+  listener: ((event: unknown) => void) | null
+  unsubscribe: ReturnType<typeof vi.fn>
 }
 
-describe('CollieClient connection startup', () => {
+/** Install a fake preload bridge (window.collie) and expose its handlers. */
+function installBridge(): BridgeMock {
+  const bridge: BridgeMock = {
+    coreSend: vi.fn(async () => ({})),
+    onCoreEvent: vi.fn(),
+    listener: null,
+    unsubscribe: vi.fn()
+  }
+  bridge.onCoreEvent.mockImplementation((listener: (event: unknown) => void) => {
+    bridge.listener = listener
+    return bridge.unsubscribe
+  })
+  vi.stubGlobal('window', {
+    collie: { coreSend: bridge.coreSend, onCoreEvent: bridge.onCoreEvent }
+  })
+  return bridge
+}
+
+describe('CollieClient bridge transport (#122)', () => {
   afterEach(() => {
-    FakeWebSocket.instances = []
     vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
-  it('reuses an in-flight socket and sends a connected command once', async () => {
-    vi.stubGlobal('WebSocket', FakeWebSocket)
-    const client = new CollieClient(4321)
-
-    client.connect()
-    client.connect()
-
-    expect(FakeWebSocket.instances).toHaveLength(1)
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
-    const reply = client.command<{ configured: boolean }>('get_status')
-    expect(socket.send).toHaveBeenCalledTimes(1)
-
-    const request = JSON.parse(socket.send.mock.calls[0][0] as string)
-    socket.onmessage?.({
-      data: JSON.stringify({
-        id: request.id,
-        type: 'ok',
-        data: { configured: false }
-      })
-    })
-    await expect(reply).resolves.toEqual({ configured: false })
-    client.close()
-  })
-
-  it('fails closed while disconnected and never replays the command after reconnect', async () => {
-    vi.stubGlobal('WebSocket', FakeWebSocket)
+  it('fails closed while the bridge has not been connected', async () => {
+    installBridge()
     const client = new CollieClient(4321)
 
     const reply = client.command('toggle_automation', {
@@ -76,155 +47,143 @@ describe('CollieClient connection startup', () => {
         message: "Collie's engine is restarting. Try again in a moment."
       })
     )
-
-    client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
-    expect(socket.send).not.toHaveBeenCalled()
-    client.close()
   })
 
-  it('rejects in-flight commands and clears their timers when the socket closes', async () => {
-    vi.useFakeTimers()
-    vi.stubGlobal('WebSocket', FakeWebSocket)
+  it('connects idempotently, subscribes once, and relays a command frame', async () => {
+    const bridge = installBridge()
     const client = new CollieClient(4321)
-    client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
-
-    const reply = client.chat(null, 'Do this once')
-    expect(socket.send).toHaveBeenCalledOnce()
-    expect(vi.getTimerCount()).toBe(1)
-    socket.close()
-
-    await expect(reply).rejects.toEqual(
-      expect.objectContaining({
-        name: 'CollieConnectionError',
-        code: 'CONNECTION_INTERRUPTED',
-        message:
-          'Collie lost the connection before confirming that action. Check its result before trying again.'
-      })
-    )
-    // Only the reconnect timer remains; the 120-second command timer is gone.
-    expect(vi.getTimerCount()).toBe(1)
 
     client.connect()
-    const replacement = FakeWebSocket.instances[1]
-    replacement.open()
-    expect(replacement.send).not.toHaveBeenCalled()
+    client.connect()
+
+    expect(bridge.onCoreEvent).toHaveBeenCalledTimes(1)
+    expect(client.connected).toBe(true)
+
+    bridge.coreSend.mockResolvedValueOnce({ configured: false })
+    const reply = client.command<{ configured: boolean }>('get_status')
+
+    expect(bridge.coreSend).toHaveBeenCalledTimes(1)
+    const frame = bridge.coreSend.mock.calls[0][0] as Record<string, unknown>
+    expect(frame).toMatchObject({ type: 'get_status', id: 'c1' })
+    await expect(reply).resolves.toEqual({ configured: false })
+
     client.close()
-    expect(vi.getTimerCount()).toBe(0)
-    vi.useRealTimers()
+    expect(client.connected).toBe(false)
+    expect(bridge.unsubscribe).toHaveBeenCalled()
   })
 
-  it('cleans up timed-out commands without leaking their late reply to listeners', async () => {
-    vi.useFakeTimers()
-    vi.stubGlobal('WebSocket', FakeWebSocket)
+  it('emits connection_opened to listeners when the bridge goes live', () => {
+    installBridge()
+    const client = new CollieClient(4321)
+    const listener = vi.fn()
+    client.on(listener)
+
+    client.connect()
+    expect(listener).toHaveBeenCalledWith({ type: 'connection_opened' })
+    client.close()
+  })
+
+  it('fans core-pushed events out to subscribed listeners', () => {
+    const bridge = installBridge()
     const client = new CollieClient(4321)
     const listener = vi.fn()
     client.on(listener)
     client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
 
+    bridge.listener?.({ type: 'thinking', state: 'working', phrase: 'going', pet_animation: 'walking' })
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'thinking', phrase: 'going' })
+    )
+
+    client.close()
+  })
+
+  it('rejects in-flight commands when the client is closed', async () => {
+    const bridge = installBridge()
+    const client = new CollieClient(4321)
+    client.connect()
+
+    let settle!: (value: unknown) => void
+    bridge.coreSend.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve
+        })
+    )
+    const reply = client.chat(null, 'Do this once')
+
+    client.close()
+    await expect(reply).rejects.toEqual(
+      expect.objectContaining({
+        name: 'CollieConnectionError',
+        code: 'CONNECTION_CLOSED',
+        message: "Collie's engine connection closed."
+      })
+    )
+    // The late core reply must not resolve the already-rejected command.
+    settle({ conversation_id: 'conversation-1' })
+  })
+
+  it('cleans up timed-out commands without leaking their late reply to listeners', async () => {
+    const bridge = installBridge()
+    vi.useFakeTimers()
+    const client = new CollieClient(4321)
+    const listener = vi.fn()
+    client.on(listener)
+    client.connect()
+
+    // Hold the bridge reply open so the caller's timeout fires first.
+    bridge.coreSend.mockImplementation(() => new Promise(() => undefined))
     const reply = client.command('get_status', {}, 50)
-    const request = JSON.parse(socket.send.mock.calls[0][0] as string)
     const rejected = expect(reply).rejects.toThrow('Collie took too long to answer.')
     await vi.advanceTimersByTimeAsync(50)
     await rejected
 
-    socket.onmessage?.({
-      data: JSON.stringify({ id: request.id, type: 'error', message: 'late reply' })
+    // A late reply that arrives over the event channel is never fanned out.
+    bridge.listener?.({
+      id: 'c1',
+      type: 'error',
+      message: 'late reply'
     })
     expect(listener).not.toHaveBeenCalledWith(
-      expect.objectContaining({ id: request.id, type: 'error' })
+      expect.objectContaining({ id: 'c1', type: 'error' })
     )
     client.close()
-  })
-
-  it('backs reconnects off exponentially, caps the delay, and resets after open', async () => {
-    vi.useFakeTimers()
-    vi.stubGlobal('WebSocket', FakeWebSocket)
-    const client = new CollieClient(4321, null, () => 0.5)
-    client.connect()
-    FakeWebSocket.instances[0].open()
-    FakeWebSocket.instances[0].close()
-
-    const delays = [1200, 2400, 4800, 9600, 19_200, 30_000, 30_000]
-    for (const [index, delay] of delays.entries()) {
-      const before = FakeWebSocket.instances.length
-      await vi.advanceTimersByTimeAsync(delay - 1)
-      expect(FakeWebSocket.instances).toHaveLength(before)
-      await vi.advanceTimersByTimeAsync(1)
-      expect(FakeWebSocket.instances).toHaveLength(before + 1)
-      if (index < delays.length - 1) FakeWebSocket.instances.at(-1)!.close()
-    }
-
-    const recovered = FakeWebSocket.instances.at(-1)!
-    recovered.open()
-    recovered.close()
-    const beforeReset = FakeWebSocket.instances.length
-    await vi.advanceTimersByTimeAsync(1199)
-    expect(FakeWebSocket.instances).toHaveLength(beforeReset)
-    await vi.advanceTimersByTimeAsync(1)
-    expect(FakeWebSocket.instances).toHaveLength(beforeReset + 1)
-    client.close()
-  })
-
-  it('applies deterministic jitter to the reconnect delay', async () => {
-    vi.useFakeTimers()
-    vi.stubGlobal('WebSocket', FakeWebSocket)
-    const client = new CollieClient(4321, null, () => 0)
-    client.connect()
-    FakeWebSocket.instances[0].open()
-    FakeWebSocket.instances[0].close()
-
-    await vi.advanceTimersByTimeAsync(959)
-    expect(FakeWebSocket.instances).toHaveLength(1)
-    await vi.advanceTimersByTimeAsync(1)
-    expect(FakeWebSocket.instances).toHaveLength(2)
-    client.close()
+    vi.useRealTimers()
   })
 
   it('sends Change plan with the generated authenticated envelope id intact', async () => {
-    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const bridge = installBridge()
     const client = new CollieClient(4321)
     client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
+
+    bridge.coreSend.mockResolvedValueOnce({
+      requested: true,
+      conversation_id: 'conversation-1',
+      run_id: 'run-1',
+      plan_id: 'plan-1',
+      plan_version: 1,
+      execution_mode: 'plan',
+      status: 'pending_safe_boundary'
+    })
     const reply = client.changePlan('conversation-1', 'run-1')
-    const request = JSON.parse(socket.send.mock.calls[0][0] as string)
-    expect(request).toMatchObject({
+    const frame = bridge.coreSend.mock.calls[0][0] as Record<string, unknown>
+    expect(frame).toMatchObject({
       type: 'change_plan',
       id: 'c1',
       conversation_id: 'conversation-1',
       run_id: 'run-1'
-    })
-    socket.onmessage?.({
-      data: JSON.stringify({
-        id: request.id,
-        type: 'ok',
-        data: {
-          requested: true,
-          conversation_id: 'conversation-1',
-          run_id: 'run-1',
-          plan_id: 'plan-1',
-          plan_version: 1,
-          execution_mode: 'plan',
-          status: 'pending_safe_boundary'
-        }
-      })
     })
     await expect(reply).resolves.toMatchObject({ requested: true, status: 'pending_safe_boundary' })
     client.close()
   })
 
   it('sends execute mode and the explicit file-access scope with chat', async () => {
-    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const bridge = installBridge()
     const client = new CollieClient(4321)
     client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
+
+    bridge.coreSend.mockResolvedValueOnce({ conversation_id: 'conversation-1' })
     const reply = client.chat(
       null,
       'Organize these files',
@@ -233,8 +192,8 @@ describe('CollieClient connection startup', () => {
       'C:\\Selected',
       { mode: 'chosen_folders', roots: ['C:\\First', 'C:\\Second'] }
     )
-    const request = JSON.parse(socket.send.mock.calls[0][0] as string)
-    expect(request).toMatchObject({
+    const frame = bridge.coreSend.mock.calls[0][0] as Record<string, unknown>
+    expect(frame).toMatchObject({
       type: 'chat',
       execution_mode: 'execute',
       project_path: 'C:\\Selected',
@@ -243,42 +202,32 @@ describe('CollieClient connection startup', () => {
         roots: ['C:\\First', 'C:\\Second']
       }
     })
-    socket.onmessage?.({
-      data: JSON.stringify({
-        id: request.id,
-        type: 'ok',
-        data: { conversation_id: 'conversation-1' }
-      })
-    })
     await expect(reply).resolves.toEqual({ conversation_id: 'conversation-1' })
     client.close()
   })
 
   it('keeps General Chat narrow when no selected folder exists', async () => {
-    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const bridge = installBridge()
     const client = new CollieClient(4321)
     client.connect()
-    const socket = FakeWebSocket.instances[0]
-    socket.open()
+
+    bridge.coreSend.mockResolvedValueOnce({ conversation_id: 'conversation-1' })
     const reply = client.chat(null, 'Hello')
-    const request = JSON.parse(socket.send.mock.calls[0][0] as string)
-    expect(request.execution_mode).toBe('execute')
-    expect(request).toMatchObject({
+    const frame = bridge.coreSend.mock.calls[0][0] as Record<string, unknown>
+    expect(frame.execution_mode).toBe('execute')
+    expect(frame).toMatchObject({
       file_access_scope: { mode: 'selected_folder' }
     })
-    expect(request).not.toHaveProperty('project_path')
-    socket.onmessage?.({
-      data: JSON.stringify({
-        id: request.id,
-        type: 'ok',
-        data: { conversation_id: 'conversation-1' }
-      })
-    })
+    // The wire (JSON.stringify, as main's broker does) drops the undefined
+    // project_path — General Chat stays narrow.
+    const wire = JSON.parse(JSON.stringify(frame))
+    expect(wire).not.toHaveProperty('project_path')
     await expect(reply).resolves.toEqual({ conversation_id: 'conversation-1' })
     client.close()
   })
 
   it('gives getSubagentActivity a short default timeout for 2 s polls', async () => {
+    installBridge()
     const client = new CollieClient(4321)
     const commandSpy = vi
       .spyOn(client, 'command')
@@ -286,5 +235,14 @@ describe('CollieClient connection startup', () => {
     void client.getSubagentActivity()
     expect(commandSpy).toHaveBeenCalledWith('get_subagent_activity', {}, 5_000)
     commandSpy.mockRestore()
+  })
+
+  it('applies the endpoint port without a token argument', () => {
+    installBridge()
+    const client = new CollieClient(3818)
+    client.applyEndpoint(4321)
+    // applyEndpoint is a no-op for the bridge (main owns the port), but must
+    // accept a bare port number without a token argument.
+    expect(client.connected).toBe(false)
   })
 })

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -517,12 +517,7 @@ export type CollieEvent =
 
 type Listener = (event: CollieEvent) => void
 
-const RECONNECT_BASE_DELAY_MS = 1200
-const RECONNECT_MAX_DELAY_MS = 30_000
-const RECONNECT_JITTER_RATIO = 0.2
 const CORE_RESTARTING_MESSAGE = "Collie's engine is restarting. Try again in a moment."
-const CONNECTION_INTERRUPTED_MESSAGE =
-  "Collie lost the connection before confirming that action. Check its result before trying again."
 
 type CollieConnectionErrorCode =
   | 'CORE_RESTARTING'
@@ -545,132 +540,79 @@ interface PendingRequest {
 }
 
 export class CollieClient {
-  private ws: WebSocket | null = null
-  private url: string
-  private token: string | null = null
+  // #122: the renderer no longer opens a WebSocket to the core. The main
+  // process owns the single authenticated socket (core-client.ts broker) and
+  // relays commands over Electron IPC (window.collie.coreSend) and pushes
+  // core events back (window.collie.onCoreEvent). The per-boot token never
+  // reaches this process.
   private listeners = new Set<Listener>()
   private pending = new Map<string, PendingRequest>()
-  private retryTimer: ReturnType<typeof setTimeout> | null = null
-  private reconnectAttempts = 0
   private seq = 0
   private closed = false
+  private port = 3818
+  private coreEventsUnsub: (() => void) | null = null
   connected = false
 
   constructor(
     port = 3818,
-    token?: string | null,
-    private readonly random: () => number = Math.random
+    _token?: string | null,
+    private readonly _random: () => number = Math.random
   ) {
-    this.url = `ws://127.0.0.1:${port}`
-    this.token = token || null
+    this.port = port
   }
 
-  /** Re-point at the core's actual port/token (from main-process coreState). */
-  applyEndpoint(port: number, token?: string | null): void {
-    this.url = `ws://127.0.0.1:${port}`
-    this.token = token || null
-    if (this.ws) {
-      const socket = this.ws
-      this.ws = null
-      this.connected = false
-      this.failPending(
-        new CollieConnectionError(CONNECTION_INTERRUPTED_MESSAGE, 'CONNECTION_INTERRUPTED')
-      )
-      socket.close()
-    }
+  /**
+   * Re-point at the core's actual port. The token argument is deliberately
+   * dropped — the renderer never learns it (it lives in main only).
+   */
+  applyEndpoint(port: number): void {
+    if (typeof port === 'number' && Number.isFinite(port)) this.port = port
   }
 
+  /** Make the bridge the renderer's transport. Idempotent; no socket to open. */
   connect(): void {
     if (this.closed) return
-    if (
-      this.ws &&
-      (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)
-    ) {
-      return
-    }
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer)
-      this.retryTimer = null
-    }
-    let socket: WebSocket
-    try {
-      socket = this.token
-        ? new WebSocket(this.url, [`collie-${this.token}`])
-        : new WebSocket(this.url)
-      this.ws = socket
-    } catch {
-      this.retry()
-      return
-    }
-    socket.onopen = () => {
-      if (this.ws !== socket) return
-      this.connected = true
-      this.reconnectAttempts = 0
-      for (const listener of this.listeners) listener({ type: 'connection_opened' })
-    }
-    socket.onmessage = (e) => {
-      let event: CollieEvent
-      try {
-        event = JSON.parse(String(e.data)) as CollieEvent
-      } catch {
-        return
-      }
-      const id = 'id' in event ? (event.id as string | undefined) : undefined
-      if (id && (event.type === 'ok' || event.type === 'error')) {
-        this.pending.get(id)?.settle(event)
-        // Command replies (ok AND error) are consumed by the caller — never
-        // fanned out to listeners, even if the caller already timed out.
-        return
-      }
-      for (const listener of this.listeners) listener(event)
-    }
-    socket.onclose = () => {
-      if (this.ws !== socket) return
-      this.ws = null
-      this.connected = false
-      this.failPending(
-        new CollieConnectionError(CONNECTION_INTERRUPTED_MESSAGE, 'CONNECTION_INTERRUPTED')
+    if (this.connected) return
+    this.connected = true
+    const bridge = this.bridge()
+    if (!this.coreEventsUnsub && bridge) {
+      this.coreEventsUnsub = bridge.onCoreEvent((event) =>
+        this.dispatch(event as CollieEvent)
       )
-      this.retry()
     }
-    socket.onerror = () => {
-      socket.close()
-    }
-  }
-
-  private retry(): void {
-    if (this.closed || this.retryTimer) return
-    const exponentialDelay = Math.min(
-      RECONNECT_MAX_DELAY_MS,
-      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts
-    )
-    this.reconnectAttempts += 1
-    const jitter = 1 - RECONNECT_JITTER_RATIO + this.random() * RECONNECT_JITTER_RATIO * 2
-    const delayMs = Math.min(RECONNECT_MAX_DELAY_MS, Math.round(exponentialDelay * jitter))
-    this.retryTimer = setTimeout(() => {
-      this.retryTimer = null
-      this.connect()
-    }, delayMs)
+    // Bridge is live — surface the connection_opened event exactly as the old
+    // WebSocket transport did, so consumers that hydrate on it keep working.
+    for (const listener of this.listeners) listener({ type: 'connection_opened' })
   }
 
   close(): void {
     this.closed = true
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer)
-      this.retryTimer = null
-    }
-    const socket = this.ws
-    this.ws = null
     this.connected = false
+    if (this.coreEventsUnsub) {
+      this.coreEventsUnsub()
+      this.coreEventsUnsub = null
+    }
     this.failPending(
       new CollieConnectionError("Collie's engine connection closed.", 'CONNECTION_CLOSED')
     )
-    socket?.close()
   }
 
   on(listener: Listener): () => void {
     this.listeners.add(listener)
     return () => this.listeners.delete(listener)
+  }
+
+  /** Fan out a core event to listeners (and settle any matching reply). */
+  private dispatch(event: CollieEvent): void {
+    const id = 'id' in event ? (event.id as string | undefined) : undefined
+    if (id && (event.type === 'ok' || event.type === 'error')) {
+      // Replies are normally consumed by the command() promise (via the
+      // bridge). If one still arrives here, settle the waiting request and
+      // never fan it out to listeners — even if the caller timed out.
+      this.pending.get(id)?.settle(event)
+      return
+    }
+    for (const listener of this.listeners) listener(event)
   }
 
   private failPending(error: Error): void {
@@ -679,18 +621,32 @@ export class CollieClient {
     for (const request of pending) request.fail(error)
   }
 
+  /** Resolve the preload IPC bridge (absent in non-browser test environments). */
+  private bridge(): Window['collie'] | undefined {
+    return typeof window !== 'undefined' ? window.collie : undefined
+  }
+
+  /** Relay one command frame to the core via main's guarded IPC bridge. */
+  private send(frame: Record<string, unknown>): Promise<unknown> {
+    const bridge = this.bridge()
+    if (!bridge?.coreSend) {
+      return Promise.reject(new CollieConnectionError())
+    }
+    return bridge.coreSend(frame)
+  }
+
   /** Fire a command and await its ok/error reply. */
   command<T = Record<string, unknown>>(
     type: string,
     payload: Record<string, unknown> = {},
     timeoutMs = 120_000
   ): Promise<T> {
-    const socket = this.ws
-    if (!this.connected || !socket || socket.readyState !== WebSocket.OPEN) {
+    if (!this.connected) {
       return Promise.reject(new CollieConnectionError())
     }
 
     const id = `c${++this.seq}`
+    const frame = { type, id, ...payload }
     return new Promise<T>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null
       let settled = false
@@ -714,12 +670,13 @@ export class CollieClient {
         pending.fail(new Error('Collie took too long to answer.'))
       }, timeoutMs)
       this.pending.set(id, pending)
-      try {
-        socket.send(JSON.stringify({ type, id, ...payload }))
-      } catch {
-        pending.fail(new CollieConnectionError())
-        socket.close()
-      }
+      this.send(frame).then(
+        (data) => finish(() => resolve(data as T)),
+        (error) =>
+          finish(() =>
+            reject(error instanceof Error ? error : new Error(String(error)))
+          )
+      )
     })
   }
 

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -572,17 +572,19 @@ export class CollieClient {
   /** Make the bridge the renderer's transport. Idempotent; no socket to open. */
   connect(): void {
     if (this.closed) return
-    if (this.connected) return
-    this.connected = true
+    // Subscribe to the main-process broker's event stream. Real core
+    // reachability is reported by the broker (it emits connection_opened /
+    // ready only once its socket to the core is actually open), so this
+    // method does NOT flip `connected` itself. That keeps the boot probe's
+    // offline screen honest: a core that never starts never emits
+    // connection_opened, so `connected` stays false and the user sees the
+    // Offline screen rather than a dead-ende Welcome screen.
     const bridge = this.bridge()
     if (!this.coreEventsUnsub && bridge) {
       this.coreEventsUnsub = bridge.onCoreEvent((event) =>
         this.dispatch(event as CollieEvent)
       )
     }
-    // Bridge is live — surface the connection_opened event exactly as the old
-    // WebSocket transport did, so consumers that hydrate on it keep working.
-    for (const listener of this.listeners) listener({ type: 'connection_opened' })
   }
 
   close(): void {
@@ -611,6 +613,11 @@ export class CollieClient {
       // never fan it out to listeners — even if the caller timed out.
       this.pending.get(id)?.settle(event)
       return
+    }
+    // The broker only emits connection_opened / ready once its socket to the
+    // core is genuinely open — that is the moment we are connected.
+    if (event.type === 'connection_opened' || event.type === 'ready') {
+      this.connected = true
     }
     for (const listener of this.listeners) listener(event)
   }
@@ -641,8 +648,14 @@ export class CollieClient {
     payload: Record<string, unknown> = {},
     timeoutMs = 120_000
   ): Promise<T> {
-    if (!this.connected) {
-      return Promise.reject(new CollieConnectionError())
+    // The renderer no longer holds a WebSocket; main's broker connects to the
+    // core on demand. Fail closed only when the client (or the bridge) is
+    // gone — relaying is otherwise always attempted, so a healthy core is
+    // reached even before a `connection_opened` arrives.
+    if (this.closed) {
+      return Promise.reject(
+        new CollieConnectionError("Collie's engine connection closed.", 'CONNECTION_CLOSED')
+      )
     }
 
     const id = `c${++this.seq}`


### PR DESCRIPTION
## What
Keeps the per-boot core IPC token out of the renderer by having **main** own the single authenticated core WebSocket and broker all renderer traffic over guarded Electron IPC.

- `main/python.ts` — `coreState()` no longer returns the token (always `''`); `ipcToken` is now main-only (`export`), used to spawn the core and to open the broker socket.
- `main/core-client.ts` — new persistent, auto-reconnecting `CoreBroker` owning one authenticated socket: `coreSend(type,id,payload)` resolves the matching ok/error reply; `onCoreEvent` fans core-pushed events (ready/delta/message/card/approval_*/connection_opened, …) back to main.
- `main/index.ts` — `ipcMain.handle('collie:core-send', …)` (sender-guarded via the exact renderer-URL check, same as every other handler) relays renderer frames; broker events are forwarded via `webContents.send('collie:core-event', …)`; the broker is torn down on quit.
- `preload/index.ts` — exposes `coreSend(frame)` and `onCoreEvent(listener)` (with unsubscribe).
- `renderer/src/lib/ipc.ts` — `CollieClient` now uses the bridge (no `WebSocket`, no token). The full public API, `.command('<kind>')` call sites, `CollieEvent` dispatch, `on()`, `close()`, and `applyEndpoint(port)` are preserved.
- `renderer/src/App.tsx` — `applyEndpoint(core.port)` (no token arg).

## Why
Closes the critical boundary-collapse in #122. The privileged token (which "no other local process can drive the core") was handed to the least-trusted process; any renderer XSS/pollution could open its own `ws://127.0.0.1:3818` socket and invoke the privileged surface (`resolve_approval`, `write_file`, `set_api_key`, `clear_all_data`, `approve_pairing`). Now the token lives only in main, and the renderer can only reach the core through main's guarded IPC.

## Review correction applied
The initial implementation regressed offline detection: `connect()` set `connected=true` unconditionally, so a core that never started settled on the **Welcome** screen instead of the **Offline** screen (the boot probe uses `connected` to tell them apart). Fixed so `connected` flips true only when the broker reports the core socket is genuinely open (`connection_opened` / `ready`), and `command()` relays whenever the bridge exists (main's broker connects on demand) instead of gating on `connected`.

## Verification
- `npx vitest run` (full suite) — **64 files / 443 tests passed**.
- `npm run typecheck` — clean.
- `tests/collie/test_ipc_contract.py` — **3 passed** (the drift guard that scans `collie-ui/src` for `.command('kind')` literals still holds — no command kinds removed).

Closes #122
