### PR TITLE
chore(release): bump to v0.1.0-alpha.7.3

### DIFF
--- a/collie-ui/package-lock.json
+++ b/collie-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.7.2",
+  "version": "0.1.0-alpha.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collie",
-      "version": "0.1.0-alpha.7.2",
+      "version": "0.1.0-alpha.7.3",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.7.2",
+  "version": "0.1.0-alpha.7.3",
   "description": "Your personal AI. With a dog.",
   "main": "./out/main/index.js",
   "author": "Collie",


### PR DESCRIPTION
Version bump for the 2026-08-27 fix batch (PRs #150–#156): renderer-IPC-token, win-authenticode, cloud-sync-transactional, versions-rollback-TOCTOU, account-CSRF-state, keychain-safeStorage, model-not-found-rollback.

- `collie-ui/package.json`: 0.1.0-alpha.7.2 → 0.1.0-alpha.7.3
- `collie-ui/package-lock.json`: sync

Tags `v0.1.0-alpha.7.3` on this tree triggers the release pipeline (qualify → 3 platform builds → draft GitHub Release).