### PR TITLE
feat: device liveness heartbeat + maker live-user view

### DIFF
--- a/collie-ui/src/main/cloud-sync.test.ts
+++ b/collie-ui/src/main/cloud-sync.test.ts
@@ -18,7 +18,10 @@ const testState = vi.hoisted(() => {
 })
 
 vi.mock('electron', () => ({
-  app: { getPath: () => testState.userData },
+  app: {
+    getPath: () => testState.userData,
+    getVersion: () => '0.1.0-alpha.7.2'
+  },
   safeStorage: {
     isEncryptionAvailable: () => true,
     getSelectedStorageBackend: () => 'gnome_libsecret',
@@ -103,6 +106,9 @@ import {
   listSnapshots,
   restoreFromDevice,
   restoreSnapshot,
+  sendHeartbeat,
+  startHeartbeat,
+  stopHeartbeat,
   uploadSnapshot
 } from './cloud-sync'
 import { clearAccountSession, saveAccountSession } from './account-auth'
@@ -442,5 +448,57 @@ describe('supabase REST', () => {
   it('surfaces a friendly error when nothing is there', async () => {
     testState.nextFetchResponse = new Response('[]', { status: 200 })
     await expect(restoreFromDevice('dev-none')).rejects.toThrow(/backup/)
+  })
+})
+
+describe('maker liveness heartbeat', () => {
+  it('PATCHes only presence columns (last_seen, version, platform) when signed in', async () => {
+    signInAs('user-42')
+    const token = makeJwt('user-42')
+    await sendHeartbeat() // loadDeviceIdentity creates sync-device.json on first run
+    const { deviceId } = JSON.parse(
+      readFileSync(join(testState.userData, 'sync-device.json'), 'utf-8')
+    ) as { deviceId: string }
+    const patch = testState.fetches.find((f) => f.init.method === 'PATCH')
+    expect(patch).toBeDefined()
+    const headers = patch!.init.headers as Record<string, string>
+    expect(headers.Authorization).toBe(`Bearer ${token}`)
+    expect(headers.apikey).toBe('test-anon-key')
+    expect(headers.Prefer).toBe('return=representation')
+    expect(patch!.url).toContain(`user_id=eq.user-42`)
+    expect(patch!.url).toContain(`device_id=eq.${deviceId}`)
+    const body = JSON.parse(String(patch!.init.body)) as Record<string, unknown>
+    expect(typeof body.last_seen).toBe('string')
+    expect(body.version).toBe('0.1.0-alpha.7.2')
+    expect(body.platform).toBe(process.platform)
+    expect(typeof body.device_name).toBe('string')
+    // Presence only — the heartbeat never re-sends the snapshot payload, and
+    // the row is identified by the URL filter, not the body.
+    expect(body.payload).toBeUndefined()
+    expect(body.user_id).toBeUndefined()
+    expect(body.device_id).toBeUndefined()
+  })
+
+  it('refuses to heartbeat while signed out', async () => {
+    await expect(sendHeartbeat()).rejects.toThrow(/Sign in/)
+  })
+
+  it('stays quiet on start when sync is OFF', async () => {
+    signInAs('user-42')
+    startHeartbeat()
+    // Give the first async tick time to (should-not) reach the network.
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(testState.fetches.filter((f) => f.init.method === 'PATCH')).toHaveLength(0)
+    stopHeartbeat()
+  })
+
+  it('pings once on start when sync is ON (the opt-in gate)', async () => {
+    signInAs('user-42')
+    testState.toggleValue = true
+    startHeartbeat()
+    await vi.waitFor(() => {
+      expect(testState.fetches.some((f) => f.init.method === 'PATCH')).toBe(true)
+    })
+    stopHeartbeat()
   })
 })

--- a/collie-ui/src/main/cloud-sync.ts
+++ b/collie-ui/src/main/cloud-sync.ts
@@ -27,6 +27,25 @@ import { commandWithCore } from './core-client'
 /** Settings key (local SQLite via the core) for the opt-in toggle. */
 const SYNC_TOGGLE_KEY = 'account.sync_enabled'
 
+/**
+ * Maker liveness heartbeat — piggybacks on the opt-in sync toggle. When the
+ * user is signed in AND sync is on, the Electron main process PATCHes this
+ * device's row in `user_sync_snapshots` with `last_seen` (+ version/platform)
+ * every HEARTBEAT_INTERVAL_MS while the app runs.
+ *
+ * PATCH (not a merge-upsert POST): the row is created once by the baseline
+ * `uploadSnapshot` (run before the toggle turns on), so here we update it in
+ * place. An UPDATE only overwrites the columns supplied, so `payload` (NOT
+ * NULL, must NEVER be re-uploaded) and `created_at` are preserved, and one row
+ * per device is guaranteed by the row already existing. A partial merge-upsert
+ * POST would 400 (`payload` is NOT NULL with no default) — that's exactly why
+ * this is a PATCH.
+ * Privacy: reports a device id + version + platform — no content, no
+ * conversations, no PII beyond the device name the user already chose. That's
+ * why it lives inside the same opt-in toggle as cloud sync.
+ */
+export const HEARTBEAT_INTERVAL_MS = 4 * 60_000
+
 const SYNCED_FILES = ['AGENTS.md', 'VISION.md'] as const
 
 /** REST timeout — bounded so a hanging network never hangs the UI. */
@@ -320,6 +339,77 @@ async function supabaseFetch(
     headers,
     signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
   })
+}
+
+/* ------------------------------------------------------------------ *
+ * Maker liveness heartbeat (starts/stops from main/index.ts)
+ * ------------------------------------------------------------------ */
+
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * Send one presence ping for THIS device. Requires a signed-in session (the
+ * same one cloud sync uses). PATCHes the device's existing row (created by the
+ * baseline upload) with only the presence columns, so the snapshot payload is
+ * preserved. The caller gates on the sync toggle; this function does the I/O.
+ */
+export async function sendHeartbeat(): Promise<{ lastSeen: string }> {
+  const session = requireSession()
+  const { deviceId, deviceName } = loadDeviceIdentity()
+  const userId = decodeUserId(session.access_token)
+  const path =
+    '/rest/v1/user_sync_snapshots' +
+    `?user_id=eq.${encodeURIComponent(userId)}` +
+    `&device_id=eq.${encodeURIComponent(deviceId)}`
+  const response = await supabaseFetch(path, {
+    method: 'PATCH',
+    session,
+    headers: {
+      Prefer: 'return=representation'
+    },
+    body: JSON.stringify({
+      device_name: deviceName,
+      last_seen: new Date().toISOString(),
+      version: app.getVersion(),
+      platform: process.platform
+    })
+  })
+  if (!response.ok) {
+    throw new Error(`heartbeat failed (${response.status})`)
+  }
+  const rows = (await response.json().catch(() => [])) as Array<{ last_seen?: string }>
+  return { lastSeen: rows?.[0]?.last_seen ?? new Date().toISOString() }
+}
+
+/**
+ * Start the background liveness pings. No-ops if already running. Each tick
+ * first checks the SAME opt-in gate cloud sync uses (signed in + sync on) and
+ * stays completely silent on any failure — telemetry must never surface a
+ * spinner, an error, or a network hang in the UI.
+ */
+export function startHeartbeat(): void {
+  if (heartbeatTimer) return
+  const tick = (): void => {
+    getSyncStatus()
+      .then((status) => {
+        if (!status.enabled || !status.signedIn) return
+        return sendHeartbeat().catch(() => undefined)
+      })
+      .catch(() => undefined)
+  }
+  // First ping shortly after launch (once the core is up to read the toggle),
+  // then on the steady interval.
+  tick()
+  heartbeatTimer = setInterval(tick, HEARTBEAT_INTERVAL_MS)
+  heartbeatTimer.unref?.()
+}
+
+/** Stop the liveness pings (called on quit; no-op if never started). */
+export function stopHeartbeat(): void {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer)
+    heartbeatTimer = null
+  }
 }
 
 /* ------------------------------------------------------------------ *

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -33,11 +33,13 @@ import {
 import { startKeychainServer, stopKeychainServer } from './keychain-server'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
 import {
- enableSync,
- getSyncStatus,
- listSnapshots,
- restoreFromDevice,
- uploadSnapshot
+  enableSync,
+  getSyncStatus,
+  listSnapshots,
+  restoreFromDevice,
+  startHeartbeat,
+  stopHeartbeat,
+  uploadSnapshot
 } from './cloud-sync'
 import { autoUpdater } from 'electron-updater'
 import {
@@ -638,6 +640,11 @@ app.whenReady().then(async () => {
     }
   }, 15_000)
 
+  // Maker liveness heartbeat: while signed in + sync on, report this device's
+  // presence (id + version + platform) so the founder can see live/active
+  // users. Gated internally on the same opt-in sync toggle; silent on failure.
+  startHeartbeat()
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
     else mainWindow?.show()
@@ -655,6 +662,7 @@ app.on('before-quit', () => {
 })
 
 app.on('will-quit', () => {
+  stopHeartbeat()
   stopCore()
   stopCoreBroker()
   stopPet()

--- a/docs/engineering/architecture/account-cloud-sync.md
+++ b/docs/engineering/architecture/account-cloud-sync.md
@@ -61,7 +61,13 @@ create table if not exists public.user_sync_snapshots (
   device_id text not null,            -- stable random id, generated per install
   device_name text not null,          -- user-readable, e.g. "Rick's laptop"
   payload jsonb not null,             -- §3 shape
-  created_at timestamptz not null default now()
+  created_at timestamptz not null default now(),
+  -- Maker liveness columns (see §4b): PATCHed by the heartbeat, never in the
+  -- snapshot payload. `payload` stays NOT NULL with no default — the heartbeat
+  -- therefore PATCHes, it does NOT merge-upsert (a partial upsert would 400).
+  last_seen timestamptz,              -- last heartbeat ("live" = within ~10m)
+  version text,                       -- app version at heartbeat
+  platform text                       -- process.platform (win32/darwin/linux)
 );
 create index if not exists user_sync_snapshots_user_idx
   on public.user_sync_snapshots (user_id, created_at desc);
@@ -74,6 +80,18 @@ create policy "own rows only"
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
 ```
+
+### §4b. Maker liveness view (owner-only, not client-facing)
+
+The heartbeat is a **PATCH** of `last_seen`/`version`/`platform` on the
+device's existing row, gated on the same opt-in sync toggle (signed in + sync
+on). It reports a device id + version + platform only — no content, no
+conversations. The founder reads presence with the service role
+(`tools/device_liveness.py`), which bypasses RLS:
+
+- **live now** = `last_seen > now() - interval '10 minutes'`
+- **active 24h** = `last_seen > now() - interval '24 hours'`
+- plus a version/platform spread so update adoption is visible.
 
 - One row per (user, device): the app **upserts** on `(user_id, device_id)`.
 - RLS: every operation scoped to `auth.uid()`; anon key only, no service role

--- a/tools/device_liveness.py
+++ b/tools/device_liveness.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Collie — maker-side device liveness view.
+
+Who is using Collie, and are they live right now? This is the FOUNDER's
+ops tool (not a product feature). It reads the `user_sync_snapshots` table —
+the same opt-in cloud-sync rows the app owns — and reports presence from the
+`last_seen` / `version` / `platform` columns the client heartbeats.
+
+Privacy note: only devices whose user signed in AND turned on sync appear here.
+The heartbeat carries a device id + version + platform only (no content, no
+conversations). This whole view is data the users already volunteered to send
+by enabling sync — there is no covert telemetry.
+
+Usage:
+    python3 tools/device_liveness.py                # reads ~/.collie-supabase.env
+    SUPABASE_URL=... SUPABASE_SERVICE_KEY=... python3 tools/device_liveness.py
+
+Output is plain text, sorted so it's easy to skim in a terminal or paste into
+a message. All timestamps are UTC.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+LIVE_WINDOW_MIN = 10          # "live now" = last_seen within this many minutes
+ACTIVE_WINDOW_HRS = 24        # "active today" = last_seen within this many hours
+
+
+def load_config():
+    """URL + service key from env, falling back to ~/.collie-supabase.env."""
+    env = dict(os.environ)
+    if "SUPABASE_URL" not in env or "SUPABASE_SERVICE_KEY" not in env:
+        path = os.path.expanduser("~/.collie-supabase.env")
+        if os.path.exists(path):
+            with open(path) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if "=" in line and not line.startswith("#"):
+                        k, v = line.split("=", 1)
+                        env.setdefault(k.strip(), v.strip())
+    url = env.get("SUPABASE_URL", "").rstrip("/")
+    key = env.get("SUPABASE_SERVICE_KEY", "")
+    if not url or not key:
+        sys.exit(
+            "Missing SUPABASE_URL / SUPABASE_SERVICE_KEY (env or "
+            "~/.collie-supabase.env)."
+        )
+    return url, key
+
+
+def fetch_devices(url, key):
+    """Pull the presence columns for every device row (service key = admin)."""
+    params = (
+        "device_name,version,platform,last_seen"
+        "&order=last_seen.desc.nullsfirst&limit=10000"
+    )
+    req = urllib.request.Request(
+        f"{url}/rest/v1/user_sync_snapshots?select={params}",
+        headers={"apikey": key, "Authorization": f"Bearer {key}",
+                 "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as err:
+        sys.exit(f"Supabase error {err.code}: {err.read().decode()[:300]}")
+
+
+def parse(ts):
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def main():
+    url, key = load_config()
+    rows = fetch_devices(url, key)
+    now = datetime.now(timezone.utc)
+
+    live, active, total = 0, 0, 0
+    live_rows, active_rows = [], []
+    spread = {}
+
+    for row in rows:
+        seen = parse(row.get("last_seen"))
+        total += 1
+        if seen and (now - seen).total_seconds() <= LIVE_WINDOW_MIN * 60:
+            live += 1
+            live_rows.append((row.get("device_name") or "Unknown", row.get("version"),
+                              row.get("platform"), seen))
+        if seen and (now - seen).total_seconds() <= ACTIVE_WINDOW_HRS * 3600:
+            active += 1
+            active_rows.append((row.get("device_name") or "Unknown", row.get("version"),
+                                row.get("platform"), seen))
+            key = (row.get("version") or "unknown", row.get("platform") or "unknown")
+            spread[key] = spread.get(key, 0) + 1
+
+    has_rows = total > 0
+    print("COLLIE DEVICE LIVENESS")
+    print("=" * 52)
+    print(f"devices on record (sync-opted-in): {total}")
+    print(f"live right now (last_seen <= {LIVE_WINDOW_MIN}m): {live}")
+    print(f"active last {ACTIVE_WINDOW_HRS}h:               {active}")
+    if not has_rows:
+        print("\n(nothing yet — devices appear once a signed-in + syncing user")
+        print(" runs a build with the heartbeat wired in and it pings.)")
+        return
+
+    print("\nLIVE NOW (device | version | platform | last_seen UTC):")
+    if not live_rows:
+        print("  none")
+    for name, ver, plat, seen in sorted(live_rows, key=lambda r: r[3], reverse=True):
+        print(f"  {name:24s} {str(ver):12s} {str(plat):10s} {seen:%H:%M:%S}")
+
+    print(f"\nACTIVE {ACTIVE_WINDOW_HRS}h VERSION SPREAD:")
+    if not spread:
+        print("  none")
+    for (ver, plat), count in sorted(spread.items(), key=lambda kv: kv[1], reverse=True):
+        print(f"  {str(ver):12s} {str(plat):14s} {count} device(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why
Gives the founder a **live-user view** — "how many people are using Collie right now?" — without breaking Collie's local-first / privacy promise.

Today there was **zero telemetry**: the only phone-home was a one-time update check (the GitHub feed logs nothing for us), and `user_sync_snapshots` was opt-in + only uploaded on backup/sign-in (not a heartbeat), so a live count was impossible.

## How it works
- **Heartbeat** (`collie-ui/src/main/cloud-sync.ts`): while signed in **and** sync is ON, the Electron main process **PATCHes** the device's own `user_sync_snapshots` row with `last_seen` + `version` + `platform` every 4 min. Started at launch, stopped on quit (`main/index.ts`). Fully silent on failure (never surfaces an error/spinner/hang in the UI).
- **The view** (`tools/device_liveness.py`): owner-only (service-role) helper that prints **live-now** (≤10 min), **active 24h**, and the **version/platform spread** so update adoption is visible.

```
python3 tools/device_liveness.py
```

## Why PATCH, not a merge-upsert POST
`payload` is `NOT NULL` with no default. A partial-column `merge-duplicates` upsert **400s against the real table** (Postgres can't build even the conflict-routed INSERT without it). The heartbeat must *never* re-upload the payload, so it's an in-place **PATCH** on the row the baseline `uploadSnapshot` already creates — which preserves `payload` by design and guarantees one row per device.

## Privacy (matches the product promise)
Opt-in only. Only **signed-in + sync-enabled** devices report. The heartbeat carries a device id + version + platform — **no content, no conversations, no secrets**. Verified live end-to-end (baseline POST → heartbeat PATCH → payload preserved, `last_seen` updated, one row/device, cleaned up to 0 rows).

## Test plan
- [x] 450/450 tests pass (4 new heartbeat tests)
- [x] `tsc --noEmit -p tsconfig.node.json` clean
- [x] Live-Supabase migration applied (`last_seen`, `version`, `platform` on `user_sync_snapshots`)
- [x] Heartbeat path validated against the live DB

## Follow-ups (not in this PR)
- Option B: log every update-check to capture non-syncing users (true install base).
- The view is currently **0 devices** by design — it populates once a build with the heartbeat ships to a signed-in + syncing user.

Spec updated: `docs/engineering/architecture/account-cloud-sync.md` §4b documents the liveness columns + view.
