### PR TITLE
docs: refresh SECURITY.md alpha risks + README alpha badge to alpha.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ No prompt engineering. No forced subscription.
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow" alt="License: MIT"></a>
   <a href="https://github.com/FoxRick/Collie/releases"><img src="https://img.shields.io/badge/Platform-Windows%2011%20x64-0078d6" alt="Platform: Windows 11 x64"></a>
-  <a href="https://github.com/FoxRick/Collie/tree/v0.1.0-alpha.7.1"><img src="https://img.shields.io/badge/Alpha-v0.1.0--alpha.7.1-purple" alt="Alpha: v0.1.0-alpha.7.1"></a>
+  <a href="https://github.com/FoxRick/Collie/tree/v0.1.0-alpha.7.3"><img src="https://img.shields.io/badge/Alpha-v0.1.0--alpha.7.3-purple" alt="Alpha: v0.1.0-alpha.7.3"></a>
   <a href="https://github.com/FoxRick/Collie/actions/workflows/ci.yml"><img src="https://github.com/FoxRick/Collie/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="https://heycollie.com"><img src="https://img.shields.io/badge/Website-heycollie.com-2ea44f" alt="heycollie.com"></a>
   <a href="https://github.com/FoxRick/Collie"><img src="https://img.shields.io/github/stars/FoxRick/Collie" alt="GitHub stars"></a>
@@ -203,7 +203,7 @@ runs from source on Linux for development; macOS is not supported). You need
 Python 3.12, Node.js, and npm:
 
 > Versioning note: the repo carries two versions that move independently —
-> the desktop app (`collie-ui/package.json`, e.g. `0.1.0-alpha.7.1`) and the
+> the desktop app (`collie-ui/package.json`, e.g. `0.1.0-alpha.7.3`) and the
 > Python core (`collie-core/pyproject.toml`, e.g. `0.2.2`). A release tag
 > tracks the app version.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,12 +58,13 @@ not warrant the same priority.
 
 ## Limits and known alpha risks
 
-Collie is pre-release software. It currently has no enabled external OAuth
-connectors and no public installer. The application sends a request's relevant
-content to the model provider a user chooses; provider data handling is an
-external trust boundary. Windows release signing, a clean-account installation
-rehearsal, release artifact validation, and support/security routing are
-tracked release gates, not completed assurances.
+Collie is pre-release software. Its connectors and the optional Collie account
+sign-in (hosted by Supabase, identity only) are live in alpha but provided on a
+best-effort basis, and there is no public installer yet. The application sends
+a request's relevant content to the model provider a user chooses; provider
+data handling is an external trust boundary. Windows release signing, a
+clean-account installation rehearsal, release artifact validation, and
+support/security routing are tracked release gates, not completed assurances.
 
 ## Security development expectations
 


### PR DESCRIPTION
## What
Refresh two stale docs to match current product state (app now `0.1.0-alpha.7.3`):

- **SECURITY.md** — `Limits and known alpha risks` said *"no enabled external OAuth connectors"*, which now contradicts the README (five connectors — Notion, Linear, Todoist, Atlassian, Airtable — plus the optional Supabase-hosted Collie account sign-in are live in alpha). Kept the accurate *"no public installer yet"*.
- **README.md** — alpha badge and versioning-note example bumped `7.1` → `7.3`.

## Why
These are the only two files in the set that were genuinely out of date; the rest of the docs (AGENTS.md, CONTRIBUTING.md, NOTICE.md, LICENSE, start-collie.bat, supabase/migrations) reviewed clean.