### PR TITLE
fix: count active installs without sign-in or cloud backup

### DIFF
--- a/collie-ui/src/main/cloud-sync.test.ts
+++ b/collie-ui/src/main/cloud-sync.test.ts
@@ -106,9 +106,6 @@ import {
   listSnapshots,
   restoreFromDevice,
   restoreSnapshot,
-  sendHeartbeat,
-  startHeartbeat,
-  stopHeartbeat,
   uploadSnapshot
 } from './cloud-sync'
 import { clearAccountSession, saveAccountSession } from './account-auth'
@@ -448,57 +445,5 @@ describe('supabase REST', () => {
   it('surfaces a friendly error when nothing is there', async () => {
     testState.nextFetchResponse = new Response('[]', { status: 200 })
     await expect(restoreFromDevice('dev-none')).rejects.toThrow(/backup/)
-  })
-})
-
-describe('maker liveness heartbeat', () => {
-  it('PATCHes only presence columns (last_seen, version, platform) when signed in', async () => {
-    signInAs('user-42')
-    const token = makeJwt('user-42')
-    await sendHeartbeat() // loadDeviceIdentity creates sync-device.json on first run
-    const { deviceId } = JSON.parse(
-      readFileSync(join(testState.userData, 'sync-device.json'), 'utf-8')
-    ) as { deviceId: string }
-    const patch = testState.fetches.find((f) => f.init.method === 'PATCH')
-    expect(patch).toBeDefined()
-    const headers = patch!.init.headers as Record<string, string>
-    expect(headers.Authorization).toBe(`Bearer ${token}`)
-    expect(headers.apikey).toBe('test-anon-key')
-    expect(headers.Prefer).toBe('return=representation')
-    expect(patch!.url).toContain(`user_id=eq.user-42`)
-    expect(patch!.url).toContain(`device_id=eq.${deviceId}`)
-    const body = JSON.parse(String(patch!.init.body)) as Record<string, unknown>
-    expect(typeof body.last_seen).toBe('string')
-    expect(body.version).toBe('0.1.0-alpha.7.2')
-    expect(body.platform).toBe(process.platform)
-    expect(typeof body.device_name).toBe('string')
-    // Presence only — the heartbeat never re-sends the snapshot payload, and
-    // the row is identified by the URL filter, not the body.
-    expect(body.payload).toBeUndefined()
-    expect(body.user_id).toBeUndefined()
-    expect(body.device_id).toBeUndefined()
-  })
-
-  it('refuses to heartbeat while signed out', async () => {
-    await expect(sendHeartbeat()).rejects.toThrow(/Sign in/)
-  })
-
-  it('stays quiet on start when sync is OFF', async () => {
-    signInAs('user-42')
-    startHeartbeat()
-    // Give the first async tick time to (should-not) reach the network.
-    await new Promise((resolve) => setTimeout(resolve, 80))
-    expect(testState.fetches.filter((f) => f.init.method === 'PATCH')).toHaveLength(0)
-    stopHeartbeat()
-  })
-
-  it('pings once on start when sync is ON (the opt-in gate)', async () => {
-    signInAs('user-42')
-    testState.toggleValue = true
-    startHeartbeat()
-    await vi.waitFor(() => {
-      expect(testState.fetches.some((f) => f.init.method === 'PATCH')).toBe(true)
-    })
-    stopHeartbeat()
   })
 })

--- a/collie-ui/src/main/cloud-sync.ts
+++ b/collie-ui/src/main/cloud-sync.ts
@@ -27,25 +27,6 @@ import { commandWithCore } from './core-client'
 /** Settings key (local SQLite via the core) for the opt-in toggle. */
 const SYNC_TOGGLE_KEY = 'account.sync_enabled'
 
-/**
- * Maker liveness heartbeat — piggybacks on the opt-in sync toggle. When the
- * user is signed in AND sync is on, the Electron main process PATCHes this
- * device's row in `user_sync_snapshots` with `last_seen` (+ version/platform)
- * every HEARTBEAT_INTERVAL_MS while the app runs.
- *
- * PATCH (not a merge-upsert POST): the row is created once by the baseline
- * `uploadSnapshot` (run before the toggle turns on), so here we update it in
- * place. An UPDATE only overwrites the columns supplied, so `payload` (NOT
- * NULL, must NEVER be re-uploaded) and `created_at` are preserved, and one row
- * per device is guaranteed by the row already existing. A partial merge-upsert
- * POST would 400 (`payload` is NOT NULL with no default) — that's exactly why
- * this is a PATCH.
- * Privacy: reports a device id + version + platform — no content, no
- * conversations, no PII beyond the device name the user already chose. That's
- * why it lives inside the same opt-in toggle as cloud sync.
- */
-export const HEARTBEAT_INTERVAL_MS = 4 * 60_000
-
 /** REST timeout — bounded so a hanging network never hangs the UI. */
 const HTTP_TIMEOUT_MS = 15_000
 
@@ -337,77 +318,6 @@ async function supabaseFetch(
     headers,
     signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
   })
-}
-
-/* ------------------------------------------------------------------ *
- * Maker liveness heartbeat (starts/stops from main/index.ts)
- * ------------------------------------------------------------------ */
-
-let heartbeatTimer: ReturnType<typeof setInterval> | null = null
-
-/**
- * Send one presence ping for THIS device. Requires a signed-in session (the
- * same one cloud sync uses). PATCHes the device's existing row (created by the
- * baseline upload) with only the presence columns, so the snapshot payload is
- * preserved. The caller gates on the sync toggle; this function does the I/O.
- */
-export async function sendHeartbeat(): Promise<{ lastSeen: string }> {
-  const session = requireSession()
-  const { deviceId, deviceName } = loadDeviceIdentity()
-  const userId = decodeUserId(session.access_token)
-  const path =
-    '/rest/v1/user_sync_snapshots' +
-    `?user_id=eq.${encodeURIComponent(userId)}` +
-    `&device_id=eq.${encodeURIComponent(deviceId)}`
-  const response = await supabaseFetch(path, {
-    method: 'PATCH',
-    session,
-    headers: {
-      Prefer: 'return=representation'
-    },
-    body: JSON.stringify({
-      device_name: deviceName,
-      last_seen: new Date().toISOString(),
-      version: app.getVersion(),
-      platform: process.platform
-    })
-  })
-  if (!response.ok) {
-    throw new Error(`heartbeat failed (${response.status})`)
-  }
-  const rows = (await response.json().catch(() => [])) as Array<{ last_seen?: string }>
-  return { lastSeen: rows?.[0]?.last_seen ?? new Date().toISOString() }
-}
-
-/**
- * Start the background liveness pings. No-ops if already running. Each tick
- * first checks the SAME opt-in gate cloud sync uses (signed in + sync on) and
- * stays completely silent on any failure — telemetry must never surface a
- * spinner, an error, or a network hang in the UI.
- */
-export function startHeartbeat(): void {
-  if (heartbeatTimer) return
-  const tick = (): void => {
-    getSyncStatus()
-      .then((status) => {
-        if (!status.enabled || !status.signedIn) return
-        return sendHeartbeat().catch(() => undefined)
-      })
-      .catch(() => undefined)
-  }
-  // First ping shortly after launch (once the core is up to read the toggle),
-  // then on the steady interval.
-  tick()
-  heartbeatTimer = setInterval(tick, HEARTBEAT_INTERVAL_MS)
-  heartbeatTimer.unref?.()
-}
-
-/** Stop the liveness pings (called on quit; no-op if never started). */
-export function stopHeartbeat(): void {
-  if (heartbeatTimer) {
-    clearInterval(heartbeatTimer)
-    heartbeatTimer = null
-  }
 }
 
 /* ------------------------------------------------------------------ *

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -37,10 +37,9 @@ import {
   getSyncStatus,
   listSnapshots,
   restoreFromDevice,
-  startHeartbeat,
-  stopHeartbeat,
   uploadSnapshot
 } from './cloud-sync'
+import { startHeartbeat, stopHeartbeat } from './install-heartbeat'
 import { autoUpdater } from 'electron-updater'
 import {
   ActiveWorkTracker,
@@ -589,6 +588,8 @@ function isActiveWorkSnapshot(value: unknown): value is ActiveWorkSnapshot {
 }
 
 app.whenReady().then(async () => {
+  // Count launched installs even if onboarding or core startup fails.
+  startHeartbeat()
   // Windows toasts (OS notifications) require an App User Model ID before
   // any notification is created, or they are silently dropped.
   if (process.platform === 'win32') {
@@ -639,11 +640,6 @@ app.whenReady().then(async () => {
       void updates.check()
     }
   }, 15_000)
-
-  // Maker liveness heartbeat: while signed in + sync on, report this device's
-  // presence (id + version + platform) so the founder can see live/active
-  // users. Gated internally on the same opt-in sync toggle; silent on failure.
-  startHeartbeat()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/collie-ui/src/main/install-heartbeat.test.ts
+++ b/collie-ui/src/main/install-heartbeat.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({ directory: '', packaged: true, url: 'https://test.supabase.co' }))
+vi.mock('electron', () => ({ app: {
+  getPath: () => state.directory,
+  getVersion: () => '0.1.0-test',
+  get isPackaged() { return state.packaged }
+} }))
+vi.mock('../shared/account-config', () => ({
+  get SUPABASE_URL() { return state.url }, SUPABASE_ANON_KEY: 'public-key'
+}))
+// Accessing either dependency is a regression: presence must work without them.
+vi.mock('./account-auth', () => { throw new Error('Heartbeat depends on sign-in') })
+vi.mock('./core-client', () => { throw new Error('Heartbeat depends on core settings') })
+import { HEARTBEAT_INTERVAL_MS, sendHeartbeat, startHeartbeat, stopHeartbeat } from './install-heartbeat'
+
+beforeEach(() => {
+  state.directory = mkdtempSync(join(tmpdir(), 'collie-install-'))
+  state.packaged = true
+  state.url = 'https://test.supabase.co'
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })))
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  stopHeartbeat()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  rmSync(state.directory, { recursive: true, force: true })
+})
+
+it('registers a fresh signed-out install with only presence data and public credentials', async () => {
+  await sendHeartbeat()
+  const [url, request] = vi.mocked(fetch).mock.calls[0]
+  expect(url).toBe('https://test.supabase.co/rest/v1/rpc/record_install_heartbeat')
+  expect(request?.method).toBe('POST')
+  expect(request?.headers).toEqual({ apikey: 'public-key', 'Content-Type': 'application/json' })
+  expect(JSON.parse(String(request?.body))).toEqual({
+    p_install_id: readFileSync(join(state.directory, 'install-id'), 'utf8'),
+    p_version: '0.1.0-test', p_platform: process.platform
+  })
+  expect(request?.signal).toBeInstanceOf(AbortSignal)
+})
+
+it('keeps the same identity across repeat sends and scheduler restarts', async () => {
+  startHeartbeat()
+  await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+  stopHeartbeat()
+  startHeartbeat()
+  await vi.advanceTimersByTimeAsync(0)
+  expect(fetch).toHaveBeenCalledTimes(3)
+  const ids = vi.mocked(fetch).mock.calls.map(([, r]) => JSON.parse(String(r?.body)).p_install_id)
+  expect(new Set(ids).size).toBe(1)
+})
+
+it('starts once, retries after failure, and stops on quit', async () => {
+  vi.mocked(fetch).mockRejectedValueOnce(new Error('offline'))
+  startHeartbeat()
+  startHeartbeat()
+  await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+  expect(fetch).toHaveBeenCalledTimes(2)
+  stopHeartbeat()
+  await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS * 2)
+  expect(fetch).toHaveBeenCalledTimes(2)
+})
+
+it('does not overlap requests', async () => {
+  let resolve!: (response: Response) => void
+  vi.mocked(fetch).mockReturnValueOnce(new Promise(r => { resolve = r }))
+  startHeartbeat()
+  await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS * 2)
+  expect(fetch).toHaveBeenCalledTimes(1)
+  resolve(new Response(null, { status: 204 }))
+  await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+  expect(fetch).toHaveBeenCalledTimes(2)
+})
+
+it('does not count development or unconfigured builds', async () => {
+  state.packaged = false
+  startHeartbeat()
+  state.packaged = true
+  state.url = ''
+  startHeartbeat()
+  await sendHeartbeat()
+  expect(fetch).not.toHaveBeenCalled()
+})
+
+it('does not send an unpersisted identity when local storage fails', async () => {
+  const blocker = join(state.directory, 'file')
+  writeFileSync(blocker, '')
+  state.directory = blocker
+  await expect(sendHeartbeat()).rejects.toThrow()
+  expect(fetch).not.toHaveBeenCalled()
+  state.directory = join(blocker, '..')
+})
+
+it('reports HTTP rejection to the scheduler instead of treating it as success', async () => {
+  vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 503 }))
+  await expect(sendHeartbeat()).rejects.toThrow('503')
+})

--- a/collie-ui/src/main/install-heartbeat.ts
+++ b/collie-ui/src/main/install-heartbeat.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from 'crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { app } from 'electron'
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../shared/account-config'
+
+export const HEARTBEAT_INTERVAL_MS = 4 * 60_000
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+let timer: ReturnType<typeof setInterval> | null = null
+let inFlight = false
+
+/** Independent of account identity; never upload names, content, or tokens. */
+function installId(): string {
+  const directory = app.getPath('userData')
+  const file = join(directory, 'install-id')
+  try {
+    const id = readFileSync(file, 'utf8').trim()
+    if (UUID.test(id)) return id
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  const id = randomUUID()
+  mkdirSync(directory, { recursive: true })
+  // Persist before sending: a write failure must not create a new row every tick.
+  writeFileSync(file, id, { encoding: 'utf8', mode: 0o600 })
+  return id
+}
+
+export async function sendHeartbeat(): Promise<void> {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return
+  const response = await fetch(`${SUPABASE_URL.replace(/\/+$/, '')}/rest/v1/rpc/record_install_heartbeat`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      p_install_id: installId(),
+      p_version: app.getVersion(),
+      p_platform: process.platform
+    }),
+    signal: AbortSignal.timeout(15_000)
+  })
+  if (!response.ok) throw new Error(`Install heartbeat failed (${response.status})`)
+}
+
+export function startHeartbeat(): void {
+  // Development runs should not inflate installation counts.
+  if (timer || !app.isPackaged || !SUPABASE_URL || !SUPABASE_ANON_KEY) return
+  const tick = (): void => {
+    if (inFlight) return
+    inFlight = true
+    void sendHeartbeat().catch(() => undefined).finally(() => { inFlight = false })
+  }
+  tick()
+  timer = setInterval(tick, HEARTBEAT_INTERVAL_MS)
+  timer.unref?.()
+}
+
+export function stopHeartbeat(): void {
+  if (timer) clearInterval(timer)
+  timer = null
+}

--- a/collie-ui/src/renderer/src/components/settings/AccountTab.tsx
+++ b/collie-ui/src/renderer/src/components/settings/AccountTab.tsx
@@ -293,7 +293,7 @@ export default function AccountTab(): React.JSX.Element {
         <>
           <p className="settings-lead">
             One click with your email — a browser window opens, you tap the
-            link, and you're back. No password to remember, and no data leaves
+            link, and you're back. No password to remember. Your chats stay on
             this computer. Don't have an account yet? This creates one and
             holds your spot on the early-access list.
           </p>
@@ -307,6 +307,12 @@ export default function AccountTab(): React.JSX.Element {
           </button>
         </>
       )}
+      <p className="settings-lead">
+        To count active installs, Collie sends a random install ID, app version,
+        and operating system at launch and every four minutes while running,
+        even when signed out or backup is off. This contains no chats, files,
+        email address, or API keys.
+      </p>
       {(error || notice) && (
         <p className="inline-notice" role="status">
           {error || notice}

--- a/docs/engineering/architecture/account-cloud-sync.md
+++ b/docs/engineering/architecture/account-cloud-sync.md
@@ -83,15 +83,11 @@ create policy "own rows only"
 
 ### §4b. Maker liveness view (owner-only, not client-facing)
 
-The heartbeat is a **PATCH** of `last_seen`/`version`/`platform` on the
-device's existing row, gated on the same opt-in sync toggle (signed in + sync
-on). It reports a device id + version + platform only — no content, no
-conversations. The founder reads presence with the service role
-(`tools/device_liveness.py`), which bypasses RLS:
-
-- **live now** = `last_seen > now() - interval '10 minutes'`
-- **active 24h** = `last_seen > now() - interval '24 hours'`
-- plus a version/platform spread so update adoption is visible.
+Install presence is now independent of cloud sync and accounts. See
+[install heartbeat](install-heartbeat.md) for the anonymous write API,
+count definitions, privacy disclosure, and deployment order. Older clients
+PATCH the legacy presence columns on their existing snapshot; that only
+covers signed-in users with sync enabled and is not an installation count.
 
 - One row per (user, device): the app **upserts** on `(user_id, device_id)`.
 - RLS: every operation scoped to `auth.uid()`; anon key only, no service role

--- a/docs/engineering/architecture/install-heartbeat.md
+++ b/docs/engineering/architecture/install-heartbeat.md
@@ -1,0 +1,56 @@
+# Install heartbeat
+
+**Status:** implemented; deploy the migration before releasing the desktop change.
+
+Packaged Collie sends a presence ping on launch and every four minutes while
+running, independently of sign-in, cloud backup, onboarding, and the Python
+core. Development and unconfigured builds do not ping. Failed requests time
+out after 15 seconds and retry on the next interval without blocking the UI.
+
+`collie-ui/src/main/install-heartbeat.ts` persists a random UUID in
+`userData/install-id` before sending anything. It survives app upgrades,
+sign-in/out, and scheduler restarts. Clearing userData creates a new identity.
+If it cannot persist the ID, it does not send a temporary identity. The ID is
+separate from cloud backup device/account identities.
+
+The request contains only that ID, version, and platform. It sends the public
+API key, never an account access token, device name, email, or user content.
+Account settings disclose this default behavior; turning backup off does not
+disable presence. Network infrastructure still sees the originating IP address;
+the presence table does not store it.
+
+## Storage and access
+
+`record_install_heartbeat` is an intentionally unauthenticated RPC. Its
+invoker wrapper calls a narrow definer function in the unexposed `install_presence_private`
+schema, with an empty search path and explicit grants. It can only upsert
+presence fields in `install_heartbeats`; it cannot read presence or access
+account backups. RLS is enabled, with no client table privileges/policies.
+The service role can read reports. Timestamps are assigned by the server;
+first_seen is preserved on repeat pings. Version/platform inputs are bounded.
+
+Anonymous clients can fabricate IDs, so counts are operational estimates, not
+verified people or billing/security signals. Protect the endpoint with gateway
+rate limits if abuse occurs. Never expose the install_presence_private schema through the Data API.
+
+## Counting and rollout
+
+1. Apply `supabase/migrations/20260905060526_install_heartbeat.sql` to the same
+   Supabase project used by the release's public account configuration.
+2. Run `supabase/tests/install_heartbeat.sql` against a test database with the
+   migration applied. It rolls back its fixtures and checks anonymous writes,
+   deduplication, timestamps, validation, and denied direct access.
+3. Verify a POST to `/rest/v1/rpc/record_install_heartbeat` with the release
+   publishable key in `apikey`, and no Authorization header. Confirm the row
+   through an owner connection. Do not use a publishable key as a Bearer JWT.
+4. Release the desktop app. Existing installations only start reporting once
+   they update and launch; no historical counts can be recovered from this fix.
+5. Run `python tools/device_liveness.py` with owner credentials as documented
+   in that tool. It pages through all install rows, including server-limited
+   short pages, without downloading backups or account information.
+
+Total = launched install IDs ever received; live = seen within ten minutes;
+active today = seen within 24 hours. One person can have several installs.
+An installer that is downloaded but never launched cannot report, and offline
+or blocked requests are absent until a later successful ping. Legacy snapshot
+presence is not added to the new totals because that would double count.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -13,9 +13,9 @@
 
 - Core Python files: **522**
 - Core Python test files: **238**
-- Desktop TypeScript/TSX files: **177**
-- Desktop test files: **64**
-- Active Markdown docs: **34**
+- Desktop TypeScript/TSX files: **179**
+- Desktop test files: **65**
+- Active Markdown docs: **35**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups

--- a/supabase/migrations/20260905060526_install_heartbeat.sql
+++ b/supabase/migrations/20260905060526_install_heartbeat.sql
@@ -1,0 +1,33 @@
+-- Presence is separate from account backups. No account/content/name is stored.
+create table public.install_heartbeats (
+  install_id uuid primary key,
+  first_seen timestamptz not null default now(),
+  last_seen timestamptz not null default now(),
+  version text not null check (length(version) between 1 and 64),
+  platform text not null check (platform in ('win32', 'darwin', 'linux'))
+);
+create index install_heartbeats_last_seen_idx on public.install_heartbeats (last_seen);
+alter table public.install_heartbeats enable row level security;
+revoke all on public.install_heartbeats from public, anon, authenticated;
+grant select on public.install_heartbeats to service_role;
+
+-- The intentionally anonymous write API cannot read rows, set timestamps, or
+-- touch backups. Keep elevated execution in an unexposed schema.
+create schema install_presence_private;
+grant usage on schema install_presence_private to anon, authenticated;
+create function install_presence_private.record_install_heartbeat(p_install_id uuid, p_version text, p_platform text)
+returns void language sql security definer set search_path = '' as $$
+  insert into public.install_heartbeats (install_id, version, platform)
+  values (p_install_id, p_version, p_platform)
+  on conflict (install_id) do update
+    set last_seen = now(), version = excluded.version, platform = excluded.platform;
+$$;
+revoke all on function install_presence_private.record_install_heartbeat(uuid, text, text) from public;
+grant execute on function install_presence_private.record_install_heartbeat(uuid, text, text) to anon, authenticated;
+
+create function public.record_install_heartbeat(p_install_id uuid, p_version text, p_platform text)
+returns void language sql security invoker set search_path = '' as $$
+  select install_presence_private.record_install_heartbeat(p_install_id, p_version, p_platform);
+$$;
+revoke all on function public.record_install_heartbeat(uuid, text, text) from public;
+grant execute on function public.record_install_heartbeat(uuid, text, text) to anon, authenticated;

--- a/supabase/tests/install_heartbeat.sql
+++ b/supabase/tests/install_heartbeat.sql
@@ -1,0 +1,39 @@
+begin;
+set local role anon;
+select public.record_install_heartbeat('b9d4991a-47cb-4eb4-9556-cf5b324aa076', 'test-1', 'win32');
+reset role;
+update public.install_heartbeats set first_seen = now() - interval '1 day', last_seen = now() - interval '1 day'
+  where install_id = 'b9d4991a-47cb-4eb4-9556-cf5b324aa076';
+set local role anon;
+select public.record_install_heartbeat('b9d4991a-47cb-4eb4-9556-cf5b324aa076', 'test-2', 'linux');
+do $$ begin
+  begin
+    perform * from public.install_heartbeats;
+    raise exception 'Anonymous read unexpectedly allowed';
+  exception when insufficient_privilege then null; end;
+  begin
+    delete from public.install_heartbeats;
+    raise exception 'Anonymous delete unexpectedly allowed';
+  exception when insufficient_privilege then null; end;
+  begin
+    update public.install_heartbeats set version = 'forged';
+    raise exception 'Anonymous update unexpectedly allowed';
+  exception when insufficient_privilege then null; end;
+  begin
+    perform public.record_install_heartbeat('b9d4991a-47cb-4eb4-9556-cf5b324aa076', repeat('x', 65), 'win32');
+    raise exception 'Unbounded version unexpectedly accepted';
+  exception when check_violation then null; end;
+  begin
+    perform public.record_install_heartbeat('b9d4991a-47cb-4eb4-9556-cf5b324aa076', 'test', 'invalid');
+    raise exception 'Invalid platform unexpectedly accepted';
+  exception when check_violation then null; end;
+end $$;
+reset role;
+do $$ begin
+  assert (select count(*) = 1 from public.install_heartbeats where install_id = 'b9d4991a-47cb-4eb4-9556-cf5b324aa076');
+  assert (select version = 'test-2' and platform = 'linux' and first_seen = now() - interval '1 day' and last_seen = now()
+    from public.install_heartbeats where install_id = 'b9d4991a-47cb-4eb4-9556-cf5b324aa076');
+end $$;
+set local role service_role;
+select count(*) from public.install_heartbeats;
+rollback;

--- a/tools/device_liveness.py
+++ b/tools/device_liveness.py
@@ -2,15 +2,10 @@
 """
 Collie — maker-side device liveness view.
 
-Who is using Collie, and are they live right now? This is the FOUNDER's
-ops tool (not a product feature). It reads the `user_sync_snapshots` table —
-the same opt-in cloud-sync rows the app owns — and reports presence from the
-`last_seen` / `version` / `platform` columns the client heartbeats.
-
-Privacy note: only devices whose user signed in AND turned on sync appear here.
-The heartbeat carries a device id + version + platform only (no content, no
-conversations). This whole view is data the users already volunteered to send
-by enabling sync — there is no covert telemetry.
+Counts launched installations, including signed-out users. Reads only random
+install IDs, version, platform, and server-recorded last_seen timestamps from
+install_heartbeats. These are installations, not unique people. Older builds
+and installations that never launch or cannot reach the service are absent.
 
 Usage:
     python3 tools/device_liveness.py                # reads ~/.collie-supabase.env
@@ -54,20 +49,27 @@ def load_config():
 
 def fetch_devices(url, key):
     """Pull the presence columns for every device row (service key = admin)."""
-    params = (
-        "device_name,version,platform,last_seen"
-        "&order=last_seen.desc.nullsfirst&limit=10000"
-    )
-    req = urllib.request.Request(
-        f"{url}/rest/v1/user_sync_snapshots?select={params}",
-        headers={"apikey": key, "Authorization": f"Bearer {key}",
-                 "Accept": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as err:
-        sys.exit(f"Supabase error {err.code}: {err.read().decode()[:300]}")
+    rows = []
+    after = None
+    while True:
+        params = "install_id,version,platform,last_seen&order=install_id.asc&limit=500"
+        if after:
+            params += f"&install_id=gt.{after}"
+        req = urllib.request.Request(
+            f"{url}/rest/v1/install_heartbeats?select={params}",
+            headers={"apikey": key, "Authorization": f"Bearer {key}",
+                     "Accept": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                page = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as err:
+            sys.exit(f"Supabase error {err.code}: {err.read().decode()[:300]}")
+        if not page:
+            return rows
+        rows.extend(page)
+        # Continue even with a short page: the server may cap below our limit.
+        after = page[-1]["install_id"]
 
 
 def parse(ts):
@@ -93,23 +95,23 @@ def main():
         total += 1
         if seen and (now - seen).total_seconds() <= LIVE_WINDOW_MIN * 60:
             live += 1
-            live_rows.append((row.get("device_name") or "Unknown", row.get("version"),
+            live_rows.append((row.get("install_id", "Unknown")[:8], row.get("version"),
                               row.get("platform"), seen))
         if seen and (now - seen).total_seconds() <= ACTIVE_WINDOW_HRS * 3600:
             active += 1
-            active_rows.append((row.get("device_name") or "Unknown", row.get("version"),
+            active_rows.append((row.get("install_id", "Unknown")[:8], row.get("version"),
                                 row.get("platform"), seen))
             key = (row.get("version") or "unknown", row.get("platform") or "unknown")
             spread[key] = spread.get(key, 0) + 1
 
     has_rows = total > 0
-    print("COLLIE DEVICE LIVENESS")
+    print("COLLIE INSTALL LIVENESS")
     print("=" * 52)
-    print(f"devices on record (sync-opted-in): {total}")
+    print(f"launched installs on record: {total}")
     print(f"live right now (last_seen <= {LIVE_WINDOW_MIN}m): {live}")
     print(f"active last {ACTIVE_WINDOW_HRS}h:               {active}")
     if not has_rows:
-        print("\n(nothing yet — devices appear once a signed-in + syncing user")
+        print("\n(nothing yet — devices appear once a user")
         print(" runs a build with the heartbeat wired in and it pings.)")
         return
 

--- a/tools/test_device_liveness.py
+++ b/tools/test_device_liveness.py
@@ -1,0 +1,27 @@
+import io
+import json
+import unittest
+from unittest.mock import patch
+
+from device_liveness import fetch_devices
+
+
+class DeviceLivenessTests(unittest.TestCase):
+    def test_pages_past_server_limit_without_reading_backups(self):
+        pages = [[{"install_id": "a"}], [{"install_id": "b"}], []]
+        with patch("urllib.request.urlopen", side_effect=[
+            io.BytesIO(json.dumps(page).encode()) for page in pages
+        ]) as request:
+            self.assertEqual(fetch_devices("https://example.test", "test-key"), [
+                {"install_id": "a"}, {"install_id": "b"}
+            ])
+        urls = [call.args[0].full_url for call in request.call_args_list]
+        self.assertEqual(len(urls), 3)
+        self.assertTrue(all("/install_heartbeats?" in url for url in urls))
+        self.assertIn("install_id=gt.a", urls[1])
+        self.assertIn("install_id=gt.b", urls[2])
+        self.assertTrue(all("payload" not in url and "device_name" not in url for url in urls))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Collie's existing heartbeat required sign-in, cloud sync enabled, and an existing backup row. This missed signed-out installs and users who never enabled backup.

This change registers a launched packaged install immediately and every four minutes with a persistent random install ID, version, and platform. It runs before core startup and independently of accounts/backups, retries quietly after failures, and excludes development builds. Account settings disclose the traffic. The owner reporting tool now counts install presence and paginates past server row limits.

The database migration is a separate commit. It adds a write-only anonymous RPC with server timestamps, bounded inputs, and a private definer implementation. Clients cannot directly read or modify the presence table; no account credentials, content, or device names are sent.

Validation:
- Reproduced the original signed-out failure before changing the implementation.
- Desktop suite: 452 passed, 1 skipped; typecheck and production build passed.
- PostgreSQL migration and regression SQL passed in an isolated PGlite instance: deduplication, first_seen preservation, last_seen refresh, input validation, denied anonymous reads/updates/deletes, service-role reads.
- Python reporting pagination regression passed; repository snapshot check and git diff check passed.

Rollout: apply the included migration to Collie's Supabase project before releasing the updated app, then verify the public REST RPC with the release publishable key. Production deployment was not performed: the connected Supabase account does not expose Collie's project. Counts begin when updated installations launch and reach the endpoint; they represent installations, not unique people, and anonymous submissions are not abuse-proof. Legacy backup presence is deliberately not added to the totals to avoid double counting.
