### PR TITLE
Add anonymous feedback submission to the desktop sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,9 @@ jobs:
       - name: Unit tests (vitest)
         run: npx vitest run
 
+      - name: Feedback Worker tests
+        run: node --test ../tools/feedback/worker.test.mjs
+
       - name: Build (electron-vite)
         run: npm run build
 
@@ -175,6 +178,9 @@ jobs:
 
       - name: Unit tests (vitest)
         run: npx vitest run
+
+      - name: Feedback Worker tests
+        run: node --test ../tools/feedback/worker.test.mjs
 
       - name: Build (electron-vite)
         run: npm run build

--- a/collie-ui/src/main/feedback.test.ts
+++ b/collie-ui/src/main/feedback.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FEEDBACK_URL, submitFeedback } from './feedback'
+
+const submission = { id: 'b9d6f334-3d32-4d57-87d3-8ed1056ce4b0', message: '  Please add shortcuts.  ' }
+afterEach(() => vi.unstubAllGlobals())
+
+describe('feedback delivery', () => {
+  it('sends only the ID and trimmed message to the fixed endpoint', async () => {
+    const fetcher = vi.fn().mockResolvedValue(Response.json({ ok: true }))
+    vi.stubGlobal('fetch', fetcher)
+    expect(await submitFeedback({ ...submission, email: 'private@example.com', logs: 'private' })).toEqual({ ok: true })
+    expect(fetcher).toHaveBeenCalledWith(FEEDBACK_URL, expect.objectContaining({
+      method: 'POST', redirect: 'error', credentials: 'omit',
+      body: JSON.stringify({ id: submission.id, message: submission.message.trim() })
+    }))
+  })
+
+  it.each([null, {}, { ...submission, id: '../bad' }, { ...submission, message: '  ' },
+    { ...submission, message: 'x'.repeat(4001) }])('rejects malformed IPC payloads', async (value) => {
+    const fetcher = vi.fn()
+    vi.stubGlobal('fetch', fetcher)
+    expect(await submitFeedback(value)).toEqual({ ok: false, error: 'invalid' })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it.each([429, 500, 404])('handles HTTP %s without claiming delivery', async (status) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status })))
+    expect(await submitFeedback(submission)).toEqual({
+      ok: false, error: status === 429 ? 'rate_limited' : 'unavailable'
+    })
+  })
+
+  it('rejects HTML fallback and network failures, and permits retry', async () => {
+    const fetcher = vi.fn().mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(new Response('<html>not deployed</html>'))
+      .mockResolvedValueOnce(Response.json({ ok: false }))
+      .mockResolvedValueOnce(Response.json({ ok: true }))
+    vi.stubGlobal('fetch', fetcher)
+    for (let i = 0; i < 3; i++) expect(await submitFeedback(submission)).toEqual({ ok: false, error: 'unavailable' })
+    expect(await submitFeedback(submission)).toEqual({ ok: true })
+  })
+
+  it('prevents concurrent submissions', async () => {
+    let finish!: (response: Response) => void
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => { finish = resolve })))
+    const first = submitFeedback(submission)
+    expect(await submitFeedback(submission)).toEqual({ ok: false, error: 'rate_limited' })
+    finish(Response.json({ ok: true }))
+    expect(await first).toEqual({ ok: true })
+  })
+})

--- a/collie-ui/src/main/feedback.ts
+++ b/collie-ui/src/main/feedback.ts
@@ -1,0 +1,29 @@
+import { validFeedback, type FeedbackResult } from '../shared/feedback'
+
+// Fixed destination: the renderer cannot supply URLs, recipients, or credentials.
+export const FEEDBACK_URL = 'https://feedback.heycollie.com/api/feedback'
+let sending = false
+
+export async function submitFeedback(value: unknown): Promise<FeedbackResult> {
+  if (!validFeedback(value)) return { ok: false, error: 'invalid' }
+  if (sending) return { ok: false, error: 'rate_limited' }
+  sending = true
+  try {
+    const response = await fetch(FEEDBACK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: value.id, message: value.message.trim() }),
+      signal: AbortSignal.timeout(25_000),
+      redirect: 'error',
+      credentials: 'omit'
+    })
+    if (response.status === 429) return { ok: false, error: 'rate_limited' }
+    if (!response.ok) return { ok: false, error: 'unavailable' }
+    const result = await response.json() as { ok?: unknown }
+    return result.ok === true ? { ok: true } : { ok: false, error: 'unavailable' }
+  } catch {
+    return { ok: false, error: 'unavailable' }
+  } finally {
+    sending = false
+  }
+}

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -32,6 +32,7 @@ import {
 } from './core-client'
 import { startKeychainServer, stopKeychainServer } from './keychain-server'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
+import { submitFeedback } from './feedback'
 import {
   enableSync,
   getSyncStatus,
@@ -388,6 +389,7 @@ function registerIpc(): void {
   // process (core-client.ts); decrypted secrets never cross into the renderer.
   handle('collie:stored-secret-count', () => listSecretProviders().length)
   handle('account:start-sign-in', () => startAccountSignIn())
+  handle('collie:submit-feedback', (submission: unknown) => submitFeedback(submission))
   handle('account:get-state', () => getAccountState())
   handle('account:sign-out', () => signOut())
   // Account cloud sync (account-cloud-sync.md): per-device snapshots,

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type { FeedbackResult, FeedbackSubmission } from '../shared/feedback'
 
 export type UpdatePhase =
   | 'idle'
@@ -105,6 +106,8 @@ const api = {
     ipcRenderer.invoke('collie:pick-file-access-folders'),
   openExternal: (url: string): Promise<void> =>
     ipcRenderer.invoke('collie:open-external', url),
+  submitFeedback: (submission: FeedbackSubmission): Promise<FeedbackResult> =>
+    ipcRenderer.invoke('collie:submit-feedback', submission),
   thingRead: (conversationId: string, thingId: string): Promise<{ kind: 'text' | 'image'; text?: string; dataUrl?: string }> =>
     ipcRenderer.invoke('collie:thing-read', conversationId, thingId),
   thingOpen: (conversationId: string, thingId: string): Promise<string> =>

--- a/collie-ui/src/renderer/src/components/FeedbackDialog.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/FeedbackDialog.dom.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest'
+import FeedbackDialog from './FeedbackDialog'
+
+let root: Root
+const submitFeedback = vi.fn()
+const onClose = vi.fn()
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  HTMLDialogElement.prototype.showModal = function (): void { this.setAttribute('open', '') }
+})
+beforeEach(() => {
+  submitFeedback.mockReset()
+  onClose.mockReset()
+  Object.defineProperty(window, 'collie', { value: { submitFeedback }, configurable: true })
+  const container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  act(() => root.render(<FeedbackDialog onClose={onClose} />))
+})
+afterEach(() => {
+  act(() => root.unmount())
+  document.body.innerHTML = ''
+})
+function input(value: string): void {
+  const textarea = document.querySelector('textarea')!
+  act(() => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(textarea, value)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+async function send(): Promise<void> {
+  await act(async () => { document.querySelector('form')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })) })
+}
+
+it('offers only a message field and prevents blank submission', async () => {
+  expect(document.querySelector('input')).toBeNull()
+  expect(document.querySelector('textarea')!.maxLength).toBe(4000)
+  input('   ')
+  expect(document.querySelector<HTMLButtonElement>('[type=submit]')!.disabled).toBe(true)
+  await send()
+  expect(submitFeedback).not.toHaveBeenCalled()
+})
+
+it('keeps failed drafts and retries with the same ID before confirming success', async () => {
+  submitFeedback.mockResolvedValueOnce({ ok: false, error: 'unavailable' }).mockResolvedValueOnce({ ok: true })
+  input('Please add keyboard shortcuts.')
+  await send()
+  expect(document.querySelector('textarea')!.value).toBe('Please add keyboard shortcuts.')
+  expect(document.querySelector('[role=alert]')!.textContent).toContain('try again')
+  expect(document.querySelector('[role=status]')).toBeNull()
+  await send()
+  expect(submitFeedback.mock.calls[0][0]).toEqual(submitFeedback.mock.calls[1][0])
+  expect(Object.keys(submitFeedback.mock.calls[0][0]).sort()).toEqual(['id', 'message'])
+  expect(document.querySelector('[role=status]')!.textContent).toContain('has been sent')
+  expect(document.querySelector('textarea')).toBeNull()
+  expect(document.activeElement?.textContent).toBe('Done')
+})
+
+it('uses a new submission ID when the failed draft is edited', async () => {
+  submitFeedback.mockResolvedValue({ ok: false, error: 'rate_limited' })
+  input('First message')
+  await send()
+  expect(document.querySelector('[role=alert]')!.textContent).toContain('wait a minute')
+  input('Changed message')
+  await send()
+  expect(submitFeedback.mock.calls[0][0].id).not.toBe(submitFeedback.mock.calls[1][0].id)
+})
+
+it('blocks duplicate sends and Escape while pending', async () => {
+  let resolve!: (value: { ok: true }) => void
+  submitFeedback.mockReturnValue(new Promise((done) => { resolve = done }))
+  input('Hello team')
+  await send()
+  await send()
+  expect(submitFeedback).toHaveBeenCalledTimes(1)
+  expect(document.querySelector('textarea')!.disabled).toBe(true)
+  act(() => { document.querySelector('dialog')!.dispatchEvent(new Event('cancel', { cancelable: true })) })
+  expect(onClose).not.toHaveBeenCalled()
+  await act(async () => { resolve({ ok: true }) })
+  act(() => { document.querySelector('dialog')!.dispatchEvent(new Event('cancel', { cancelable: true })) })
+  expect(onClose).toHaveBeenCalledTimes(1)
+})
+
+it('preserves text when the bridge rejects', async () => {
+  submitFeedback.mockRejectedValue(new Error('offline'))
+  input('Still here')
+  await send()
+  expect(document.querySelector('textarea')!.value).toBe('Still here')
+  expect(document.querySelector('[role=alert]')).not.toBeNull()
+})

--- a/collie-ui/src/renderer/src/components/FeedbackDialog.tsx
+++ b/collie-ui/src/renderer/src/components/FeedbackDialog.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { FEEDBACK_MAX_LENGTH } from '../../../shared/feedback'
+
+export default function FeedbackDialog({ onClose }: { onClose: () => void }): React.JSX.Element {
+  const dialog = useRef<HTMLDialogElement>(null)
+  const closeButton = useRef<HTMLButtonElement>(null)
+  const inFlight = useRef(false)
+  const submissionId = useRef<string | null>(null)
+  const [message, setMessage] = useState('')
+  const [sending, setSending] = useState(false)
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const previous = document.activeElement as HTMLElement | null
+    dialog.current?.showModal()
+    return () => { previous?.focus() }
+  }, [])
+
+  useEffect(() => {
+    if (sent) closeButton.current?.focus()
+  }, [sent])
+
+  async function send(): Promise<void> {
+    if (inFlight.current || !message.trim()) return
+    inFlight.current = true
+    setSending(true)
+    setError('')
+    try {
+      submissionId.current ??= crypto.randomUUID()
+      const result = await window.collie.submitFeedback({
+        id: submissionId.current,
+        message: message.trim()
+      })
+      if (result.ok) {
+        setMessage('')
+        setSent(true)
+      } else {
+        setError(result.error === 'rate_limited'
+          ? 'Please wait a minute before trying again. Your message is still here.'
+          : "We couldn't confirm delivery. Please try again. Your message is still here.")
+      }
+    } catch {
+      setError("We couldn't confirm delivery. Please try again. Your message is still here.")
+    } finally {
+      inFlight.current = false
+      setSending(false)
+    }
+  }
+
+  return createPortal(
+    <dialog ref={dialog} className="dialog-card feedback-dialog" aria-labelledby="feedback-title"
+      aria-describedby="feedback-description" onCancel={(event) => {
+        event.preventDefault()
+        if (!inFlight.current) onClose()
+      }}>
+      <form onSubmit={(event) => { event.preventDefault(); void send() }}>
+        <h2 id="feedback-title" className="text-lg font-semibold">Submit Feedback</h2>
+        <p id="feedback-description" className="dialog-hint">
+          Tell us what worked, what didn't, or what you'd like next. Only your message is sent to the Collie team.
+        </p>
+        {sent ? <p role="status" className="mt-4">Thanks! Your feedback has been sent.</p> : <>
+          <label className="form-field" htmlFor="feedback-message">Your feedback
+            <textarea id="feedback-message" rows={6} maxLength={FEEDBACK_MAX_LENGTH}
+              value={message} disabled={sending} required
+              onChange={(event) => {
+                setMessage(event.target.value)
+                submissionId.current = null
+                setError('')
+              }} />
+          </label>
+          <p className="dialog-hint">{message.length} / {FEEDBACK_MAX_LENGTH}</p>
+          {error && <p role="alert" className="mt-3 text-sm">{error}</p>}
+        </>}
+        <div className="dialog-actions">
+          <button ref={closeButton} type="button" className="rounded-lg border px-4 py-2 text-sm"
+            disabled={sending} onClick={onClose}>{sent ? 'Done' : 'Cancel'}</button>
+          {!sent && <button type="submit" disabled={sending || !message.trim()}
+            className="rounded-lg bg-black px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">
+            {sending ? 'Sending…' : 'Send'}
+          </button>}
+        </div>
+      </form>
+    </dialog>, document.body
+  )
+}

--- a/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
@@ -109,6 +109,7 @@ function renderSidebar(options: SidebarTestOptions = {}): HTMLElement {
 }
 
 beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function (): void { this.setAttribute('open', '') }
   ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
     .IS_REACT_ACT_ENVIRONMENT = true
 })
@@ -117,6 +118,19 @@ beforeEach(() => {
   localStorage.clear()
   searchMessages.mockReset()
   searchMessages.mockResolvedValue({ results: [] })
+})
+
+it('opens feedback from the collapsed sidebar and returns focus on cancel', () => {
+  localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, '1')
+  const container = renderSidebar()
+  const button = container.querySelector<HTMLButtonElement>('[aria-label="Submit Feedback"]')!
+  expect(container.querySelector('aside')!.classList.contains('is-collapsed')).toBe(true)
+  act(() => { button.focus(); button.click() })
+  expect(document.querySelector('dialog[open]')).not.toBeNull()
+  const cancel = Array.from(document.querySelectorAll('dialog button')).find((item) => item.textContent === 'Cancel') as HTMLButtonElement
+  act(() => cancel.click())
+  expect(document.querySelector('dialog')).toBeNull()
+  expect(document.activeElement).toBe(button)
 })
 
 afterEach(() => {

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   type AppView
 } from '../lib/navigation'
 import CollieFace from './CollieFace'
+import FeedbackDialog from './FeedbackDialog'
 
 interface Props {
   conversations: Conversation[]
@@ -59,6 +60,7 @@ export default function Sidebar({
   onAddProject
 }: Props): React.JSX.Element {
   const [query, setQuery] = useState('')
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [collapsed, setCollapsed] = useState<boolean>(() =>
     typeof localStorage === 'undefined' ? false : readSidebarCollapsed(localStorage)
@@ -416,6 +418,12 @@ export default function Sidebar({
       </nav>
 
       <div className="sidebar-footer">
+        <button type="button" onClick={() => setFeedbackOpen(true)}
+          className="sidebar-footer-row mx-4 mb-2 flex items-center gap-2 px-3 py-2.5 text-sm transition"
+          title="Submit Feedback" aria-label="Submit Feedback" aria-haspopup="dialog">
+          <MessageCircle size={16} aria-hidden="true" />
+          <span>Submit Feedback</span>
+        </button>
         <button
           type="button"
           onClick={toggleCollapsed}
@@ -436,6 +444,7 @@ export default function Sidebar({
           <span>{t('sidebar.settings')}</span>
         </button>
       </div>
+      {feedbackOpen && <FeedbackDialog onClose={() => setFeedbackOpen(false)} />}
     </aside>
   )
 }

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -942,6 +942,9 @@ button {
 .form-field textarea:focus { border-color: #8f928d; }
 .dialog-hint { margin: 10px 0 0; color: var(--muted); font-size: var(--collie-min-font-size); }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; }
+.feedback-dialog { margin: auto; max-height: calc(100vh - 48px); overflow-y: auto; color: var(--ink); }
+.feedback-dialog::backdrop { background: rgba(10, 11, 12, 0.45); backdrop-filter: blur(5px); }
+.feedback-dialog textarea { resize: vertical; min-height: 120px; }
 
 @media (max-width: 900px) {
   .detail-grid { grid-template-columns: 1fr; }

--- a/collie-ui/src/shared/feedback.ts
+++ b/collie-ui/src/shared/feedback.ts
@@ -1,0 +1,19 @@
+export const FEEDBACK_MAX_LENGTH = 4000
+
+export interface FeedbackSubmission {
+  id: string
+  message: string
+}
+
+export type FeedbackResult =
+  | { ok: true }
+  | { ok: false; error: 'invalid' | 'rate_limited' | 'unavailable' }
+
+export function validFeedback(value: unknown): value is FeedbackSubmission {
+  if (!value || typeof value !== 'object') return false
+  const { id, message } = value as Partial<FeedbackSubmission>
+  return typeof id === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id) &&
+    typeof message === 'string' && message.trim().length > 0 &&
+    message.length <= FEEDBACK_MAX_LENGTH
+}

--- a/collie-ui/tsconfig.web.json
+++ b/collie-ui/tsconfig.web.json
@@ -15,5 +15,5 @@
       "@/*": ["./src/renderer/src/*"]
     }
   },
-  "include": ["src/renderer/src/**/*", "src/preload/index.d.ts"]
+  "include": ["src/renderer/src/**/*", "src/preload/index.d.ts", "src/shared/feedback.ts"]
 }

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -74,6 +74,14 @@ are not part of this public source tree.
 - `scripts/` contains staging, packaging, smoke, and release verification.
 - `electron-builder.yml` defines Windows artifact composition.
 
+### Feedback intake: `tools/feedback/`
+
+The desktop's guarded feedback IPC sends only the user's message and a random
+submission ID to a dedicated Cloudflare Worker. The Worker stores feedback in
+the existing Supabase project and notifies the team through Resend; server
+credentials remain in Worker secrets. See [in-app feedback](product/feedback.md)
+for deployment ownership and the live verification gate.
+
 ## Primary data flow
 
 ```text

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -13,9 +13,9 @@
 
 - Core Python files: **522**
 - Core Python test files: **238**
-- Desktop TypeScript/TSX files: **177**
-- Desktop test files: **64**
-- Active Markdown docs: **34**
+- Desktop TypeScript/TSX files: **182**
+- Desktop test files: **66**
+- Active Markdown docs: **35**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,0 +1,60 @@
+# In-app feedback
+
+**Status:** implemented; backend provisioning and live inbox verification required before release.
+
+The desktop sidebar has a **Submit Feedback** button, including when collapsed.
+It opens a keyboard-accessible dialog with one message field and Send. No account
+or email address is required. Only the typed text and a random submission ID leave
+the app; conversations, logs, device identifiers, and account details are excluded.
+The message limit is 4,000 characters. A failed send keeps the draft in the open
+dialog. Cancel discards the draft; drafts are not saved to disk.
+
+The guarded Electron bridge submits to
+`https://feedback.heycollie.com/api/feedback`. The renderer cannot choose the
+destination or email recipient. The Cloudflare Worker in `tools/feedback/` stores
+the message in a private Supabase table, then sends a plain-text team notification
+via Resend. Success means the row was saved and Resend accepted the notification;
+it does not prove delivery to the mailbox. A mail failure leaves the row available
+in Supabase and returns an error so the user can retry. Repeated sends of the same
+unchanged draft reuse the submission ID: database writes are deduplicated, and
+Resend deduplicates notifications within its 24-hour idempotency window.
+
+## Provisioning and release gate
+
+This is a dedicated API Worker in the existing Cloudflare account; the website
+repository and website Worker do not need changes. The app and this service are
+reviewed together in the main app repository, but deployed separately.
+
+1. Review and run `tools/feedback/schema.sql` once in the existing Supabase
+   project. It enables RLS and denies both anonymous and authenticated client
+   access. Confirm both roles cannot select or insert; the server role can.
+2. Use Wrangler from `tools/feedback/` (`npx wrangler@4.92.0`). Verify the
+   configured rate-limit namespace is unused or allocate another namespace.
+   The binding limits each IP to three requests per minute per Cloudflare
+   location; this is approximate abuse control, not a global quota.
+3. Configure Worker secrets with `wrangler secret put`: `SUPABASE_URL`,
+   `SUPABASE_SECRET_KEY` (server secret key or legacy service-role key),
+   `RESEND_API_KEY`, `FEEDBACK_FROM` (verified sender), and `FEEDBACK_TO`
+   (team inbox). Never put these in the desktop build or committed files.
+4. Deploy with `npx wrangler@4.92.0 deploy --config wrangler.jsonc`. This creates
+   the `feedback.heycollie.com` custom domain on the existing Cloudflare zone.
+5. From a preview/packaged app, submit a test message and confirm one database
+   row and one email, then check offline failure/retry and collapsed navigation.
+   Do not release the desktop feature until this live check passes.
+
+The endpoint fails closed when secrets or rate limiting are unavailable. IPs
+are used transiently by the Cloudflare limiter and are not stored in the feedback
+table. Hosting providers may retain normal infrastructure request logs. The
+service has no public read endpoint and no user-controlled recipient. Restrict
+team access to feedback, and handle deletion/retention through Supabase and the
+team mailbox under the product's privacy policy.
+
+## Local checks
+
+Run `node --test tools/feedback/worker.test.mjs` from the repository root. In
+`collie-ui/`, run the feedback/sidebar tests, `npm run typecheck`, and
+`npm run build`. Worker tests use mocked upstreams and do not send real email.
+
+References: [Cloudflare rate limiting](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/),
+[Supabase API access](https://supabase.com/docs/guides/api/securing-your-api),
+[Resend send API](https://resend.com/docs/api-reference/emails/send-email).

--- a/tools/feedback/schema.sql
+++ b/tools/feedback/schema.sql
@@ -1,0 +1,12 @@
+-- Bootstrap once in the existing Supabase project before deploying the Worker.
+-- No client (including signed-in app users) can read or write this table.
+begin;
+create table public.app_feedback (
+  id uuid primary key,
+  message text not null check (char_length(btrim(message)) between 1 and 4000),
+  created_at timestamptz not null default now()
+);
+alter table public.app_feedback enable row level security;
+revoke all on public.app_feedback from public, anon, authenticated;
+grant select, insert on public.app_feedback to service_role;
+commit;

--- a/tools/feedback/worker.mjs
+++ b/tools/feedback/worker.mjs
@@ -1,0 +1,109 @@
+const MAX_BODY_BYTES = 32_768
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function json(body, status = 200) {
+  return Response.json(body, { status, headers: {
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+    ...(status === 429 ? { 'Retry-After': '60' } : {})
+  } })
+}
+
+async function readBody(request) {
+  if (!request.body) return null
+  const reader = request.body.getReader()
+  const chunks = []
+  let size = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size += value.byteLength
+      if (size > MAX_BODY_BYTES) {
+        await reader.cancel()
+        return null
+      }
+      chunks.push(value)
+    }
+    const bytes = new Uint8Array(size)
+    let offset = 0
+    for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.length }
+    return JSON.parse(new TextDecoder().decode(bytes))
+  } catch {
+    return null
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+// Public, anonymous intake. All privileged credentials remain in Worker secrets.
+export default {
+  async fetch(request, env) {
+    if (new URL(request.url).pathname !== '/api/feedback') return json({ ok: false }, 404)
+    if (request.method !== 'POST') return json({ ok: false }, 405)
+    if (request.headers.get('content-type')?.split(';')[0].trim() !== 'application/json') {
+      return json({ ok: false }, 415)
+    }
+    const ip = request.headers.get('CF-Connecting-IP')
+    if (!ip || !env.FEEDBACK_RATE_LIMITER || !env.SUPABASE_URL ||
+        !env.SUPABASE_SECRET_KEY || !env.RESEND_API_KEY || !env.FEEDBACK_TO || !env.FEEDBACK_FROM) {
+      return json({ ok: false }, 503)
+    }
+    try {
+      // Fail closed: an unavailable limiter must not turn into an open mail relay.
+      const { success } = await env.FEEDBACK_RATE_LIMITER.limit({ key: ip })
+      if (!success) return json({ ok: false }, 429)
+      const body = await readBody(request)
+      if (!body || typeof body.id !== 'string' || !UUID.test(body.id) ||
+          typeof body.message !== 'string' || !body.message.trim() || body.message.length > 4000) {
+        return json({ ok: false }, 400)
+      }
+      const id = body.id.toLowerCase()
+      const message = body.message.trim()
+      const base = new URL(env.SUPABASE_URL)
+      if (base.protocol !== 'https:' || base.username || base.password) return json({ ok: false }, 503)
+      const endpoint = new URL('/rest/v1/app_feedback', base)
+      const headers = { apikey: env.SUPABASE_SECRET_KEY, 'Content-Type': 'application/json' }
+      // Legacy service_role keys additionally require the bearer header.
+      if (!env.SUPABASE_SECRET_KEY.startsWith('sb_secret_')) {
+        headers.Authorization = `Bearer ${env.SUPABASE_SECRET_KEY}`
+      }
+      const stored = await fetch(endpoint, {
+        method: 'POST', headers: { ...headers, Prefer: 'return=minimal' },
+        body: JSON.stringify({ id, message }), redirect: 'error', signal: AbortSignal.timeout(8000)
+      })
+      if (stored.status === 409) {
+        // A retry must use the original content. Never overwrite an accepted message.
+        endpoint.search = new URLSearchParams({ id: `eq.${id}`, select: 'message' }).toString()
+        const existing = await fetch(endpoint, {
+          headers, redirect: 'error', signal: AbortSignal.timeout(8000)
+        })
+        if (!existing.ok) return json({ ok: false }, 503)
+        const rows = await existing.json()
+        if (!Array.isArray(rows) || rows.length !== 1 || rows[0].message !== message) {
+          return json({ ok: false }, 409)
+        }
+      } else if (!stored.ok) {
+        return json({ ok: false }, 503)
+      }
+      const emailed = await fetch('https://api.resend.com/emails', {
+        method: 'POST', redirect: 'error', signal: AbortSignal.timeout(8000),
+        headers: {
+          Authorization: `Bearer ${env.RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+          'Idempotency-Key': `feedback/${id}`
+        },
+        body: JSON.stringify({
+          from: env.FEEDBACK_FROM, to: [env.FEEDBACK_TO],
+          subject: 'New Collie feedback', text: message
+        })
+      })
+      // Database save alone is insufficient: the inbox notification must be accepted too.
+      if (!emailed.ok) return json({ ok: false }, 503)
+      return json({ ok: true })
+    } catch {
+      // Never log user text, addresses, IPs, provider responses, or credentials.
+      return json({ ok: false }, 503)
+    }
+  }
+}

--- a/tools/feedback/worker.test.mjs
+++ b/tools/feedback/worker.test.mjs
@@ -1,0 +1,99 @@
+import { test, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import worker from './worker.mjs'
+
+const originalFetch = globalThis.fetch
+afterEach(() => { globalThis.fetch = originalFetch })
+const body = { id: 'b9d6f334-3d32-4d57-87d3-8ed1056ce4b0', message: 'Please add shortcuts.' }
+const env = () => ({
+  FEEDBACK_RATE_LIMITER: { limit: async () => ({ success: true }) },
+  SUPABASE_URL: 'https://example.supabase.co', SUPABASE_SECRET_KEY: 'sb_secret_test',
+  RESEND_API_KEY: 'test', FEEDBACK_FROM: 'Collie <hello@example.com>', FEEDBACK_TO: 'team@example.com'
+})
+const request = (payload = body) => new Request('https://feedback.heycollie.com/api/feedback', {
+  method: 'POST', headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': '192.0.2.1' },
+  body: JSON.stringify(payload)
+})
+
+test('stores privately, then sends plain text to the configured inbox', async () => {
+  const calls = []
+  globalThis.fetch = async (url, options) => { calls.push([String(url), options]); return Response.json({ id: 'accepted' }) }
+  const response = await worker.fetch(request({ ...body, email: 'ignored', to: 'attacker', logs: 'ignored' }), env())
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), { ok: true })
+  assert.deepEqual(JSON.parse(calls[0][1].body), body)
+  assert.equal(calls[0][1].headers.apikey, 'sb_secret_test')
+  assert.deepEqual(JSON.parse(calls[1][1].body), {
+    from: 'Collie <hello@example.com>', to: ['team@example.com'], subject: 'New Collie feedback', text: body.message
+  })
+  assert.equal(calls[1][1].headers['Idempotency-Key'], `feedback/${body.id}`)
+})
+
+test('fails closed with missing configuration, missing IP, or unavailable limiter', async () => {
+  globalThis.fetch = () => { throw new Error('must not send') }
+  assert.equal((await worker.fetch(request(), {})).status, 503)
+  const noIp = request(); noIp.headers.delete('CF-Connecting-IP')
+  assert.equal((await worker.fetch(noIp, env())).status, 503)
+  const unavailable = env(); unavailable.FEEDBACK_RATE_LIMITER.limit = async () => { throw new Error('down') }
+  assert.equal((await worker.fetch(request(), unavailable)).status, 503)
+})
+
+test('rate limits before storing or mailing', async () => {
+  let called = false
+  globalThis.fetch = async () => { called = true }
+  const limited = env(); limited.FEEDBACK_RATE_LIMITER.limit = async () => ({ success: false })
+  const result = await worker.fetch(request(), limited)
+  assert.equal(result.status, 429)
+  assert.equal(result.headers.get('Retry-After'), '60')
+  assert.equal(called, false)
+})
+
+test('rejects blank, oversized, malformed and unbounded bodies', async () => {
+  for (const payload of [null, {}, { ...body, id: 'bad' }, { ...body, message: ' \n ' },
+    { ...body, message: 'x'.repeat(4001) }, { ...body, extra: 'x'.repeat(33_000) }]) {
+    assert.equal((await worker.fetch(request(payload), env())).status, 400)
+  }
+  const malformed = new Request(request(), { body: '{' })
+  assert.equal((await worker.fetch(malformed, env())).status, 400)
+})
+
+test('never sends email when persistence fails', async () => {
+  let calls = 0
+  globalThis.fetch = async () => { calls++; return new Response('', { status: 500 }) }
+  assert.equal((await worker.fetch(request(), env())).status, 503)
+  assert.equal(calls, 1)
+})
+
+test('failed email is reported as a retryable failure; retry keeps original ID and content', async () => {
+  const responses = [new Response('', { status: 201 }), new Response('', { status: 500 }),
+    new Response('', { status: 409 }), Response.json([{ message: body.message }]), Response.json({ id: 'mail' })]
+  const mailKeys = []
+  globalThis.fetch = async (url, options) => {
+    if (String(url).includes('resend.com')) mailKeys.push(options.headers['Idempotency-Key'])
+    return responses.shift()
+  }
+  assert.equal((await worker.fetch(request(), env())).status, 503)
+  assert.equal((await worker.fetch(request(), env())).status, 200)
+  assert.deepEqual(mailKeys, [`feedback/${body.id}`, `feedback/${body.id}`])
+})
+
+test('rejects reuse of an ID with different content without sending mail', async () => {
+  let count = 0
+  globalThis.fetch = async () => ++count === 1
+    ? new Response('', { status: 409 }) : Response.json([{ message: 'original message' }])
+  assert.equal((await worker.fetch(request(), env())).status, 409)
+  assert.equal(count, 2)
+})
+
+test('upstream exceptions return a generic response', async () => {
+  globalThis.fetch = async () => { throw new Error('secret data') }
+  const response = await worker.fetch(request(), env())
+  assert.equal(response.status, 503)
+  assert.equal((await response.text()).includes('secret'), false)
+})
+
+test('does not expose a read endpoint or accept browser form posts', async () => {
+  assert.equal((await worker.fetch(new Request('https://feedback.heycollie.com/api/feedback'), env())).status, 405)
+  const form = request(); form.headers.set('Content-Type', 'text/plain')
+  assert.equal((await worker.fetch(form, env())).status, 415)
+})

--- a/tools/feedback/wrangler.jsonc
+++ b/tools/feedback/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "name": "collie-feedback",
+  "main": "worker.mjs",
+  "compatibility_date": "2026-09-05",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [{ "pattern": "feedback.heycollie.com", "custom_domain": true }],
+  "ratelimits": [{
+    "name": "FEEDBACK_RATE_LIMITER",
+    "namespace_id": "1001",
+    "simple": { "limit": 3, "period": 60 }
+  }]
+}


### PR DESCRIPTION
Adds a Submit Feedback button above Settings in the desktop sidebar, including its collapsed state. Users type a message and press Send, with no email address or account required. Failed requests preserve the draft, retries reuse the submission ID, and the keyboard-accessible dialog confirms successful submission.

The guarded Electron bridge posts only the message and a random ID to a dedicated Cloudflare Worker at feedback.heycollie.com. The Worker stores submissions in the existing Supabase project and sends a plain-text notification to a server-configured team inbox via Resend. It enforces payload limits and per-IP rate limits, keeps credentials server-side, and denies client access to the feedback table. The schema bootstrap is isolated in its own commit. No website repository changes or new desktop dependencies are needed.

Validation:
- Desktop suite: 466 passed, 1 existing skipped test; focused dialog/sidebar checks passed again after the final accessibility adjustment.
- Feedback Worker: 9 tests passed, added to Linux and Windows CI.
- TypeScript checks and production build passed.
- Cloudflare Wrangler 4.92.0 deployment dry run passed.
- Browser preview verified production styles, collapsed navigation, initial and restored keyboard focus, typed input, and confirmation using mocked delivery.
- Documentation snapshot and git whitespace checks passed.

Before releasing this feature, follow docs/product/feedback.md: provision tools/feedback/schema.sql in the existing Supabase project, configure the Worker secrets and confirmed team inbox, deploy the custom domain, and verify a real submission reaches both the private table and inbox. No live database, hosting, or email changes were made in this PR task; live RLS and inbox verification remain pending. Resend retry deduplication covers its 24-hour idempotency window, and its acceptance response is not proof of mailbox delivery.
