### PR TITLE
fix: responsive chat streaming and immediate answer completion

### DIFF
--- a/collie-ui/scripts/verify-chat-stream.cjs
+++ b/collie-ui/scripts/verify-chat-stream.cjs
@@ -1,0 +1,147 @@
+// Run after npm run build: electron scripts/verify-chat-stream.cjs
+// Exercises the actual renderer with synthetic core events, never user data.
+const { app, BrowserWindow } = require('electron')
+const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { join, resolve } = require('node:path')
+const assert = require('node:assert/strict')
+const temporary = mkdtempSync(join(tmpdir(), 'collie-chat-qa-'))
+app.setPath('userData', join(temporary, 'profile'))
+const preload = join(temporary, 'preload.cjs')
+writeFileSync(preload, `
+  sessionStorage.setItem('collie.ui-ux-preview', '1')
+  let listener = () => {}
+  window.chatFixture = { emit: event => listener(event) }
+  window.collie = {
+    onCoreEvent: callback => { listener = callback; return () => {} },
+    coreState: async () => ({}),
+    coreSend: async frame => {
+      if (frame.type === 'chat') {
+        setTimeout(() => listener({type: 'message', conversation_id: 'qa', message: {
+          id: 'user', conversation_id: 'qa', role: 'user', content: frame.content,
+          created_at: '2026-09-05T00:00:00Z'
+        }}), 0)
+        return {conversation_id: 'qa'}
+      }
+      return { conversations: [], messages: [], settings: {}, commands: [], agents: [],
+        skills: [], approvals: [], things: [], task: null, active_agents: [], recent_agents: [] }
+    },
+    updateActiveWork: async () => {}, petCommand: async () => {},
+    storedSecretCount: async () => 0, onNavigate: () => () => {},
+    onUpdateState: () => () => {}, getUpdateState: async () => ({})
+  }
+`)
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+app.whenReady().then(async () => {
+  const window = new BrowserWindow({ width: 1120, height: 780, show: false,
+    webPreferences: { preload, contextIsolation: false, sandbox: false, backgroundThrottling: false, offscreen: true } })
+  const errors = []
+  window.webContents.on('console-message', (event) => {
+    if (event.level === 'error') { errors.push(event.message); console.error(event.message) }
+  })
+  const evaluate = code => window.webContents.executeJavaScript(code)
+  const emit = event => evaluate(`window.chatFixture.emit(${JSON.stringify(event)})`)
+  const output = process.env.COLLIE_CHAT_QA_OUTPUT
+  async function screenshot(name) {
+    if (!output) return
+    mkdirSync(resolve(output), { recursive: true })
+    writeFileSync(join(resolve(output), name + '.png'), (await window.webContents.capturePage()).toPNG())
+  }
+  try {
+    await window.loadFile(join(__dirname, '../out/renderer/index.html'))
+    await wait(600)
+    await evaluate(`(() => {
+      const input = document.querySelector('textarea')
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(input, 'Explain a calm chat experience')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })()`)
+    await wait(50)
+    await evaluate(`document.querySelector('button[aria-label="Send message"]').click()`)
+    await wait(100)
+    await emit({ type: 'thinking', conversation_id: 'qa', state: 'processing', phrase: 'Thinking through your task…', pet_animation: 'working' })
+    await wait(100)
+    await screenshot('thinking')
+    let answer = '## A calmer conversation\n\n' + 'Keep the answer readable and the composer responsive. '.repeat(170)
+    await emit({ type: 'delta', conversation_id: 'qa', text: answer })
+    await wait(200)
+    const streamedCharacters = await evaluate(`document.querySelector('[role="log"]').textContent.length`)
+    await screenshot('streaming')
+    if (!process.env.COLLIE_CHAT_QA_BASELINE) {
+      await evaluate(`(() => {
+        const transcript = document.querySelector('.chat-transcript')
+        transcript.dispatchEvent(new WheelEvent('wheel', { deltaY: -1000, bubbles: true }))
+        transcript.scrollTop = 0
+        transcript.dispatchEvent(new Event('scroll'))
+      })()`)
+      await wait(50)
+      const extra = '\n\nKeep the reader in control.'
+      answer += extra
+      await emit({ type: 'delta', conversation_id: 'qa', text: extra })
+      await evaluate(`(() => {
+        const input = document.querySelector('textarea')
+        Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(input, 'Keep this draft while streaming')
+        input.dispatchEvent(new Event('input', {bubbles: true}))
+      })()`)
+      await wait(100)
+      assert.equal(await evaluate(`document.querySelector('.chat-transcript').scrollTop`), 0, 'Streaming must respect scroll-back')
+      assert.equal(await evaluate(`document.querySelector('.composer-send').disabled`), false, 'Composer must accept input while streaming')
+      const jumpVisible = await evaluate(`(() => {
+        const button = document.querySelector('.chat-jump-latest')
+        const rect = button?.getBoundingClientRect()
+        return !!rect && rect.top > 0 && rect.bottom < innerHeight
+      })()`)
+      assert.ok(jumpVisible, 'Jump to latest must be visible while reading older text')
+      await screenshot('scroll-back')
+    }
+    const started = Date.now()
+    await emit({ type: 'message', conversation_id: 'qa', message: {
+      id: 'answer', conversation_id: 'qa', role: 'assistant', content: answer, created_at: '2026-09-05T00:00:01Z'
+    } })
+    await emit({ type: 'thinking', conversation_id: 'qa', state: 'done', phrase: 'All done!', pet_animation: 'happy' })
+    await wait(100)
+    const finalCharacters = await evaluate(`document.querySelector('[role="log"]').textContent.length`)
+    await screenshot('completed')
+    console.log(JSON.stringify({ answerCharacters: answer.length, streamedCharacters, finalCharacters, completionCheckMs: Date.now() - started, errors }))
+    if (!process.env.COLLIE_CHAT_QA_BASELINE) {
+      assert.ok(finalCharacters >= answer.length - 5, 'Final answer must render without a reveal backlog')
+      assert.equal(await evaluate(`document.querySelectorAll('.collie-thinking').length`), 0)
+      await evaluate(`document.querySelector('.chat-jump-latest').click()`)
+      await wait(50)
+      assert.ok(await evaluate(`(() => { const e = document.querySelector('.chat-transcript'); return e.scrollHeight - e.scrollTop - e.clientHeight < 96 })()`))
+      assert.equal(await evaluate(`document.querySelector('textarea').value`), 'Keep this draft while streaming')
+      // Inspect a compact mixed-Markdown answer at desktop and narrow widths.
+      await emit({ type: 'message', conversation_id: 'qa', message: {
+        id: 'answer', conversation_id: 'qa', role: 'assistant',
+        content: '## A calmer conversation\n\nHere is what changed:\n\n- **Faster answers:** completed text appears immediately.\n- **Clear progress:** a compact status shows what is happening.\n- **Your place stays put:** scroll back, then use Jump to latest.\n\nYou can keep typing while Collie works.',
+        created_at: '2026-09-05T00:00:01Z'
+      } })
+      await wait(500)
+      await screenshot('desktop-dark')
+      await evaluate(`document.documentElement.classList.remove('dark')`)
+      window.setSize(860, 720)
+      await wait(200)
+      await screenshot('narrow-light')
+      assert.ok(await evaluate(`document.documentElement.scrollWidth <= innerWidth`), 'No horizontal page overflow')
+      await emit({ type: 'thinking', conversation_id: 'qa', state: 'processing', phrase: 'Checking the next step…', pet_animation: 'working' })
+      await emit({ type: 'delta', conversation_id: 'qa', text: 'A second response '.repeat(300) })
+      await wait(50)
+      await evaluate(`document.querySelector('button[aria-label="Stop response"]').click()`)
+      await wait(50)
+      const stopped = await evaluate(`document.querySelector('[role="log"]').textContent`)
+      await wait(200)
+      assert.equal(await evaluate(`document.querySelector('[role="log"]').textContent`), stopped, 'Stop must cancel the presentation timer')
+      assert.equal(await evaluate(`document.querySelector('button[aria-label="Stop response"]')`), null)
+      await evaluate(`Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'New chat').click()`)
+      await wait(100)
+      await emit({ type: 'delta', conversation_id: 'qa', text: 'Background text must stay out.' })
+      await wait(100)
+      assert.equal(await evaluate(`document.querySelector('[role="log"]').textContent`), '')
+      assert.deepEqual(errors, [])
+      console.log('PASS: completion, scroll-back, jump to latest, typing, stop, conversation isolation, dark/light layouts')
+    }
+  } finally {
+    window.destroy()
+  }
+}).then(() => app.exit(0), error => { console.error(error); app.exit(1) })
+process.on('exit', () => { try { rmSync(temporary, { recursive: true, force: true }) } catch {} })
+

--- a/collie-ui/src/renderer/src/components/MessageBubble.skeleton.test.tsx
+++ b/collie-ui/src/renderer/src/components/MessageBubble.skeleton.test.tsx
@@ -25,27 +25,23 @@ afterEach(() => {
   document.body.replaceChildren()
 })
 
-describe('MessageBubble streaming skeleton frame', () => {
-  it('shows placeholder lines while the first tokens are still on their way', () => {
+describe('MessageBubble streaming presentation', () => {
+  it('keeps an accessible busy state without animated placeholder lines', () => {
     const container = render(<MessageBubble role="assistant" content="" streaming />)
     const skeleton = container.querySelector('.collie-skeleton')
-    expect(skeleton).not.toBeNull()
-    expect(skeleton?.classList.contains('collie-skeleton--active')).toBe(true)
-    expect(skeleton?.querySelectorAll('.collie-skeleton-line')).toHaveLength(3)
-    expect(skeleton?.getAttribute('aria-hidden')).toBe('true')
+    expect(skeleton).toBeNull()
     expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBe('true')
   })
 
-  it('keeps a short streamed answer inside the same active frame', () => {
+  it('renders short answers without overlapping placeholders', () => {
     const container = render(<MessageBubble role="assistant" content="Sure — on it." streaming />)
     const skeleton = container.querySelector('.collie-skeleton')
-    expect(skeleton).not.toBeNull()
-    expect(skeleton?.classList.contains('collie-skeleton--active')).toBe(true)
+    expect(skeleton).toBeNull()
     expect(container.textContent).toContain('Sure — on it.')
     expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBe('true')
   })
 
-  it('fades the placeholder lines once real text fills the card', () => {
+  it('renders long answers without placeholder animations', () => {
     const container = render(
       <MessageBubble
         role="assistant"
@@ -54,9 +50,7 @@ describe('MessageBubble streaming skeleton frame', () => {
       />
     )
     const skeleton = container.querySelector('.collie-skeleton')
-    expect(skeleton).not.toBeNull()
-    expect(skeleton?.classList.contains('collie-skeleton--settled')).toBe(true)
-    expect(skeleton?.classList.contains('collie-skeleton--active')).toBe(false)
+    expect(skeleton).toBeNull()
   })
 
   it('streams markdown into the same card while the frame is up', () => {

--- a/collie-ui/src/renderer/src/components/MessageBubble.tsx
+++ b/collie-ui/src/renderer/src/components/MessageBubble.tsx
@@ -22,12 +22,6 @@ interface Props {
   taskState?: TaskState | null
 }
 
-// While an answer is streaming, the assistant card shows a quiet skeleton
-// frame (placeholder lines) so the chat never looks stalled. As soon as the
-// streamed text crosses this length the placeholder lines fade out and the
-// stream keeps filling the same card — the frame itself never disappears.
-const STREAM_SKELETON_MAX_CHARS = 48
-
 const PREVIEWABLE_IMAGE_TYPES = new Set([
   'image/png',
   'image/jpeg',
@@ -48,9 +42,8 @@ function MessageBubble({ role, content, streaming, settled = true, cardType, car
   const returnFocusRef = useRef<HTMLButtonElement | null>(null)
   const isUser = role === 'user'
   const visibleContent = isUser ? content : visibleStreamText(content)
-  const takeaway = useMemo(() => buildTakeawayDigest(content), [content])
+  const takeaway = useMemo(() => settled && !streaming ? buildTakeawayDigest(content) : null, [content, settled, streaming])
   const writing = Boolean(streaming && !isUser)
-  const skeletonActive = writing && visibleContent.trim().length < STREAM_SKELETON_MAX_CHARS
   // Before the first streamed token lands, the bubble shows a clear
   // "Collie is thinking…" cue (animated dots + label) so the frame is never
   // an empty, shapeless strip.
@@ -128,16 +121,6 @@ function MessageBubble({ role, content, streaming, settled = true, cardType, car
                 <i />
               </span>
               <span>{t('chat.thinking')}</span>
-            </div>
-          )}
-          {writing && (
-            <div
-              className={`collie-skeleton ${skeletonActive ? 'collie-skeleton--active' : 'collie-skeleton--settled'} ${thinking ? 'collie-skeleton--below-thinking' : ''}`}
-              aria-hidden="true"
-            >
-              <span className="collie-skeleton-line" />
-              <span className="collie-skeleton-line" />
-              <span className="collie-skeleton-line" />
             </div>
           )}
         </div>

--- a/collie-ui/src/renderer/src/components/MessageList.test.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.test.tsx
@@ -44,30 +44,36 @@ describe('MessageList streaming output', () => {
 
     act(() => root.render(<MessageList messages={[]} streamText="Second frame" />))
     expect(scrollIntoView).toHaveBeenCalledTimes(callsBeforeUpdate)
+    const jump = container.querySelector<HTMLButtonElement>('.chat-jump-latest')
+    expect(jump?.textContent).toContain('Jump to latest')
+    act(() => jump?.click())
+    expect(scrollIntoView).toHaveBeenCalledTimes(callsBeforeUpdate + 1)
+    act(() => root.render(<MessageList messages={[]} streamText="Third frame" />))
+    expect(scrollIntoView).toHaveBeenCalledTimes(callsBeforeUpdate + 2)
 
     act(() => root.unmount())
   })
 
-  it('holds the writing frame on the live bubble before the first token arrives', () => {
+  it('shows a compact activity status without an empty answer before the first token', () => {
     const container = document.createElement('div')
     const root = createRoot(container)
 
     act(() => root.render(<MessageList messages={[]} streamText="" streaming />))
-    expect(container.querySelector('.collie-skeleton--active')).not.toBeNull()
-    expect(container.querySelector('.message-bubble')?.getAttribute('aria-busy')).toBe('true')
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('thinking')
+    expect(container.querySelector('.message-bubble')).toBeNull()
 
     act(() => root.unmount())
   })
 
-  it('streams the first tokens into the same live bubble without a gap', () => {
+  it('replaces activity with the answer as soon as text arrives', () => {
     const container = document.createElement('div')
     const root = createRoot(container)
 
     act(() => root.render(<MessageList messages={[]} streamText="" streaming />))
-    const bubble = container.querySelector('.message-bubble')
 
     act(() => root.render(<MessageList messages={[]} streamText="Hello there" streaming />))
-    expect(container.querySelector('.message-bubble')).toBe(bubble)
+    expect(container.querySelector('.message-bubble')).not.toBeNull()
+    expect(container.querySelector('[role="status"]')).toBeNull()
     expect(container.textContent).toContain('Hello there')
 
     act(() => root.unmount())
@@ -78,10 +84,10 @@ describe('MessageList streaming output', () => {
     const root = createRoot(container)
 
     act(() => root.render(<MessageList messages={[]} streamText="Done" streaming />))
-    expect(container.querySelector('.collie-skeleton')).not.toBeNull()
+    expect(container.querySelector('.message-bubble')).not.toBeNull()
 
     act(() => root.render(<MessageList messages={[]} streamText="" />))
-    expect(container.querySelector('.collie-skeleton')).toBeNull()
+    expect(container.querySelector('.message-bubble')).toBeNull()
 
     act(() => root.unmount())
   })

--- a/collie-ui/src/renderer/src/components/MessageList.test.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.test.tsx
@@ -54,6 +54,33 @@ describe('MessageList streaming output', () => {
     act(() => root.unmount())
   })
 
+  it('keeps following paused after a small upward scroll and resumes at the bottom', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView)
+    scrollIntoView.mockClear()
+    act(() => root.render(<MessageList messages={[]} streamText="First frame" />))
+    const scroller = container.firstElementChild as HTMLDivElement
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 1_000 },
+      clientHeight: { configurable: true, value: 300 },
+      scrollTop: { configurable: true, value: 700, writable: true }
+    })
+    act(() => scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -40 })))
+    scroller.scrollTop = 660
+    act(() => scroller.dispatchEvent(new Event('scroll', { bubbles: true })))
+    const callsBeforeUpdate = scrollIntoView.mock.calls.length
+    act(() => root.render(<MessageList messages={[]} streamText="Second frame" />))
+    expect(scrollIntoView).toHaveBeenCalledTimes(callsBeforeUpdate)
+    expect(container.querySelector('.chat-jump-latest')).not.toBeNull()
+    scroller.scrollTop = 700
+    act(() => scroller.dispatchEvent(new Event('scroll', { bubbles: true })))
+    act(() => root.render(<MessageList messages={[]} streamText="Third frame" />))
+    expect(scrollIntoView).toHaveBeenCalledTimes(callsBeforeUpdate + 1)
+    expect(container.querySelector('.chat-jump-latest')).toBeNull()
+    act(() => root.unmount())
+  })
+
   it('shows a compact activity status without an empty answer before the first token', () => {
     const container = document.createElement('div')
     const root = createRoot(container)

--- a/collie-ui/src/renderer/src/components/MessageList.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.tsx
@@ -57,7 +57,7 @@ function MessageList({ messages, streamText, streaming = false, activityLabel, c
         const element = scrollRef.current
         if (!element) return
         shouldFollowRef.current =
-          element.scrollHeight - element.scrollTop - element.clientHeight < 96
+          element.scrollHeight - element.scrollTop - element.clientHeight <= 1
         setFollowing(shouldFollowRef.current)
       }}
     >

--- a/collie-ui/src/renderer/src/components/MessageList.tsx
+++ b/collie-ui/src/renderer/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { memo, useLayoutEffect, useRef, useState } from 'react'
 import type { CollieMessage } from '../lib/ipc'
 import { useT } from '../lib/i18n'
 import MessageBubble from './MessageBubble'
@@ -8,33 +8,27 @@ interface Props {
   messages: CollieMessage[]
   streamText: string
   streaming?: boolean
+  activityLabel?: string
   cardPreview?: { card_type: string; card_data: Record<string, unknown> } | null
 }
 
 // Long conversations render in windows so the DOM stays light (Step 49).
 const WINDOW_SIZE = 100
 
-export default function MessageList({ messages, streamText, streaming = false, cardPreview }: Props): React.JSX.Element {
+function MessageList({ messages, streamText, streaming = false, activityLabel, cardPreview }: Props): React.JSX.Element {
   const endRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const shouldFollowRef = useRef(true)
   const [visibleCount, setVisibleCount] = useState(WINDOW_SIZE)
+  const [following, setFollowing] = useState(true)
   const lastId = messages.length > 0 ? messages[messages.length - 1].id : ''
   const t = useT()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (shouldFollowRef.current) {
-      endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
-    }
-  }, [lastId])
-
-  useEffect(() => {
-    // Repeated smooth-scroll animations fight each other while text streams.
-    // Following the paced reveal directly keeps the viewport visually stable.
-    if (streamText && shouldFollowRef.current) {
       endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
     }
-  }, [streamText])
+  }, [lastId, messages, streamText, streaming, cardPreview])
 
   const visibleStream = stableMarkdownStreamText(visibleStreamText(streamText))
   const hidden = Math.max(0, messages.length - visibleCount)
@@ -43,12 +37,28 @@ export default function MessageList({ messages, streamText, streaming = false, c
   return (
     <div
       ref={scrollRef}
-      className="flex-1 overflow-y-auto px-4 py-4"
+      className="chat-transcript flex-1 overflow-y-auto px-4 py-4"
+      tabIndex={0}
+      aria-label="Chat history"
+      onWheel={(event) => {
+        // Pause before the next text paint, not after its resulting scroll event.
+        if (event.deltaY < 0) {
+          shouldFollowRef.current = false
+          setFollowing(false)
+        }
+      }}
+      onKeyDown={(event) => {
+        if (['ArrowUp', 'PageUp', 'Home'].includes(event.key)) {
+          shouldFollowRef.current = false
+          setFollowing(false)
+        }
+      }}
       onScroll={() => {
         const element = scrollRef.current
         if (!element) return
         shouldFollowRef.current =
           element.scrollHeight - element.scrollTop - element.clientHeight < 96
+        setFollowing(shouldFollowRef.current)
       }}
     >
       <div
@@ -77,7 +87,7 @@ export default function MessageList({ messages, streamText, streaming = false, c
             taskState={msg.task_state}
           />
         ))}
-        {(visibleStream || streaming) && (
+        {(visibleStream || cardPreview) && (
           <MessageBubble
             role="assistant"
             content={visibleStream}
@@ -87,8 +97,23 @@ export default function MessageList({ messages, streamText, streaming = false, c
             cardData={cardPreview?.card_data ?? null}
           />
         )}
+        {streaming && !visibleStream && (
+          <div className="chat-activity collie-thinking" role="status">
+            <span className="collie-thinking-dots" aria-hidden="true"><i /><i /><i /></span>
+            <span>{activityLabel || t('chat.thinking')}</span>
+          </div>
+        )}
         <div ref={endRef} />
       </div>
+      {!following && (
+        <button type="button" className="chat-jump-latest" onClick={() => {
+          shouldFollowRef.current = true
+          setFollowing(true)
+          endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
+        }}>↓ Jump to latest</button>
+      )}
     </div>
   )
 }
+
+export default memo(MessageList)

--- a/collie-ui/src/renderer/src/lib/stream.test.ts
+++ b/collie-ui/src/renderer/src/lib/stream.test.ts
@@ -127,6 +127,17 @@ describe('stableMarkdownStreamText', () => {
 })
 
 describe('nextStreamReveal', () => {
+  it('catches up with a large burst in under one second of display ticks', () => {
+    const content = 'A large provider burst. '.repeat(400)
+    let displayed = ''
+    for (let frame = 0; frame < 30; frame += 1) displayed = nextStreamReveal(displayed, content)
+    expect(displayed).toBe(content)
+  })
+
+  it('never cuts an emoji in half at the reveal boundary', () => {
+    expect(nextStreamReveal('', 'Hi 🐶 there', 4)).toBe('Hi 🐶')
+  })
+
   it('reveals ordinary text at a bounded cadence without losing content', () => {
     const content = 'A smooth complete response'
     let displayed = ''

--- a/collie-ui/src/renderer/src/lib/stream.ts
+++ b/collie-ui/src/renderer/src/lib/stream.ts
@@ -197,7 +197,7 @@ export function stableMarkdownStreamText(content: string): string {
 export function nextStreamReveal(
   displayed: string,
   content: string,
-  maxCharacters = 18
+  maxCharacters?: number
 ): string {
   const target = visibleStreamText(content)
   if (target === displayed) return target
@@ -205,5 +205,11 @@ export function nextStreamReveal(
   const sharedLimit = Math.min(displayed.length, target.length)
   while (shared < sharedLimit && displayed[shared] === target[shared]) shared += 1
   const start = shared === displayed.length ? displayed.length : shared
-  return target.slice(0, start + Math.max(1, maxCharacters))
+  // Catch up after provider bursts instead of adding seconds of fake latency.
+  // Explicit limits remain useful for callers that need a fixed reveal size.
+  const step = maxCharacters ?? Math.max(18, Math.ceil((target.length - start) / 4))
+  let end = start + Math.max(1, step)
+  // Never split a UTF-16 surrogate pair (emoji and many non-Latin characters).
+  if (end < target.length && /[\uD800-\uDBFF]/.test(target[end - 1])) end += 1
+  return target.slice(0, end)
 }

--- a/collie-ui/src/renderer/src/screens/ChatScreen.ordering.test.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.ordering.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AttachmentDraft, CollieEvent, CollieMessage, TaskState } from '../lib/ipc'
 
 interface ChatInputProps {
+  onStop: () => void
+  busy: boolean
   onSend: (text: string, attachments: AttachmentDraft[]) => Promise<boolean>
   onProjectChange: (path: string) => void
   taskProgress?: TaskState | null
@@ -76,8 +78,8 @@ vi.mock('./SkillsScreen', () => ({ default: () => null }))
 vi.mock('./RoutinesScreen', () => ({ default: () => null }))
 vi.mock('./ConnectorsScreen', () => ({ default: () => null }))
 vi.mock('../components/MessageList', () => ({
-  default: ({ messages, streaming }: { messages: CollieMessage[]; streaming: boolean }) => (
-    <ol data-streaming={String(streaming)}>
+  default: ({ messages, streaming, streamText }: { messages: CollieMessage[]; streaming: boolean; streamText: string }) => (
+    <ol data-streaming={String(streaming)} data-stream-text={streamText}>
       {messages.map((message) => (
         <li data-message={`${message.role}:${message.id}`} key={message.id}>
           {message.content}
@@ -134,6 +136,47 @@ describe('ChatScreen paced assistant completion order', () => {
   afterEach(() => {
     act(() => root.unmount())
     vi.useRealTimers()
+  })
+
+  it('shows the entire final answer immediately, even with a large reveal backlog', async () => {
+    const emit = hooks.listener()
+    await act(async () => emit({ type: 'message', conversation_id: conversationId,
+      message: message('user-1', 'user', 'Explain this') }))
+    const answer = message('answer', 'assistant', 'A complete answer. '.repeat(500))
+    act(() => emit({ type: 'delta', conversation_id: conversationId, text: answer.content }))
+    await act(async () => emit({ type: 'message', conversation_id: conversationId, message: answer }))
+    expect(container.querySelector('[data-message="assistant:answer"]')?.textContent).toBe(answer.content)
+    expect(container.querySelector('ol')?.dataset.streaming).toBe('false')
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+    expect(container.querySelector('[data-message="assistant:answer"]')?.textContent).toBe(answer.content)
+    expect(container.querySelector('ol')?.dataset.streamText).toBe('')
+  })
+
+  it('stops revealing buffered text when Stop is acknowledged', async () => {
+    hooks.client.stopConversation.mockResolvedValue({ cancelled_subagents: 0 })
+    const emit = hooks.listener()
+    await act(async () => emit({ type: 'message', conversation_id: conversationId,
+      message: message('user-stop', 'user', 'Start') }))
+    act(() => emit({ type: 'delta', conversation_id: conversationId, text: 'Working '.repeat(500) }))
+    expect(hooks.chatInput().busy).toBe(true)
+    await act(async () => vi.advanceTimersByTimeAsync(32))
+    const partial = container.querySelector('ol')?.dataset.streamText
+    await act(async () => hooks.chatInput().onStop())
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+    expect(container.querySelector('ol')?.dataset.streamText).toBe(partial)
+    expect(container.querySelector('ol')?.dataset.streaming).toBe('false')
+    expect(hooks.chatInput().busy).toBe(false)
+  })
+
+  it('clears a stale reveal timer when the core restarts', async () => {
+    const emit = hooks.listener()
+    await act(async () => emit({ type: 'message', conversation_id: conversationId,
+      message: message('user-restart', 'user', 'Start') }))
+    act(() => emit({ type: 'delta', conversation_id: conversationId, text: 'Old stream'.repeat(500) }))
+    await act(async () => emit({ type: 'ready', protocol: 1, phrase: 'Ready' }))
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+    expect(container.querySelector('ol')?.dataset.streamText).toBe('')
+    expect(container.querySelector('ol')?.dataset.streaming).toBe('false')
   })
 
   it('keeps a completed assistant turn above a later user turn while its text catches up', async () => {

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { startTransition, useCallback, useEffect, useRef, useState } from 'react'
 import {
   collieClient,
   type AttachmentDraft,
@@ -29,7 +29,7 @@ import SkillsScreen from './SkillsScreen'
 import RoutinesScreen from './RoutinesScreen'
 import ConnectorsScreen from './ConnectorsScreen'
 import type { AppView } from '../lib/navigation'
-import { mergeStreamDelta, nextStreamReveal, shouldResetStreamDisplay, visibleStreamText } from '../lib/stream'
+import { mergeStreamDelta, nextStreamReveal, visibleStreamText } from '../lib/stream'
 import ApprovalSheet from '../components/approvals/ApprovalSheet'
 import { isTaskTerminal } from '../components/tasks/TaskProgress'
 import {
@@ -173,8 +173,6 @@ export default function ChatScreen({
   const streamRef = useRef('')
   const streamDisplayRef = useRef('')
   const streamTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pendingAssistantRef = useRef<CollieMessage | null>(null)
-  const finalizePendingRef = useRef<(() => void) | null>(null)
   const loadTokenRef = useRef(0)
   const taskSnapshotGenerationRef = useRef<Record<string, number>>({})
   activeIdRef.current = activeId
@@ -192,24 +190,12 @@ export default function ChatScreen({
     const reveal = () => {
       const next = nextStreamReveal(streamDisplayRef.current, streamRef.current)
       streamDisplayRef.current = next
-      const pending = pendingAssistantRef.current
-      if (pending && activeIdRef.current === pending.conversation_id) {
-        // Once the terminal event arrives, its place in the transcript is
-        // fixed. Continue revealing into that reserved bubble so a later user
-        // event cannot jump ahead of the paced assistant response.
-        setMessages((previous) =>
-          previous.map((item) => item.id === pending.id ? { ...item, content: next } : item)
-        )
-        setStreamText('')
-      } else {
-        setStreamText(next)
-      }
+      startTransition(() => setStreamText(next))
 
       if (next !== visibleStreamText(streamRef.current)) {
         streamTimerRef.current = setTimeout(reveal, 32)
       } else {
         streamTimerRef.current = null
-        finalizePendingRef.current?.()
       }
     }
 
@@ -272,34 +258,6 @@ export default function ChatScreen({
     }
   }, [])
 
-  const finalizePendingAssistant = useCallback(() => {
-    const msg = pendingAssistantRef.current
-    if (!msg || activeIdRef.current !== msg.conversation_id) return
-    pendingAssistantRef.current = null
-    setMessages((previous) => {
-      const existing = previous.findIndex((item) => item.id === msg.id)
-      if (existing === -1) return [...previous, msg]
-      const next = [...previous]
-      next[existing] = msg
-      return next
-    })
-    streamRef.current = ''
-    streamDisplayRef.current = ''
-    setStreamText('')
-    setCardPreview(null)
-    setPortraitThinking({
-      state: 'done',
-      phrase: 'Done — that was a good one.',
-      pet_animation: 'happy'
-    })
-    if (!document.hasFocus()) {
-      void window.collie?.petCommand('status:happy|Finished. Your result is ready in Collie.')
-    }
-    void refreshRuntimeStatus()
-    void refreshCommandCatalog()
-  }, [refreshCommandCatalog, refreshRuntimeStatus])
-  finalizePendingRef.current = finalizePendingAssistant
-
   const rememberProject = useCallback((path: string) => {
     setCurrentProject(path)
     if (!path) return
@@ -327,7 +285,6 @@ export default function ChatScreen({
     setThingsUnseen(new Set())
     streamRef.current = ''
     streamDisplayRef.current = ''
-    pendingAssistantRef.current = null
     stopStreamReveal()
     if (projectPath !== undefined) rememberProject(projectPath || '')
     if (!id) {
@@ -412,8 +369,6 @@ export default function ChatScreen({
 
   useEffect(() => () => {
     stopStreamReveal()
-    pendingAssistantRef.current = null
-    finalizePendingRef.current = null
   }, [stopStreamReveal])
 
   useEffect(() => {
@@ -456,6 +411,12 @@ export default function ChatScreen({
           void refreshApprovalPreset()
           setThinkingMap({})
           setStreaming(false)
+          stopStreamReveal()
+          streamRef.current = ''
+          streamDisplayRef.current = ''
+          setStreamText('')
+          setCardPreview(null)
+          setPortraitThinking(null)
           if (current) {
             collieClient
               .getMessages(current)
@@ -604,36 +565,23 @@ export default function ChatScreen({
             })
           }
           if (msg.role === 'assistant' && isCurrentConversationEvent(msg.conversation_id, current)) {
-            pendingAssistantRef.current = msg
-            // The turn's final text is reserved and revealed in the
-            // transcript — the live stream card hands over to it.
+            // The delivered message is authoritative: never queue a completed
+            // answer behind the presentation timer.
+            stopStreamReveal()
+            streamRef.current = ''
+            streamDisplayRef.current = ''
+            setStreamText('')
             setStreaming(false)
-            // A mid-turn steer delivers the superseded answer as its own
-            // message; the follow-up response then covers only the tail of
-            // the accumulated stream. Reveal that bubble from scratch instead
-            // of rewinding the already-delivered text.
-            if (shouldResetStreamDisplay(streamRef.current, msg.content)) {
-              streamDisplayRef.current = ''
-            }
-            // Reserve the assistant turn as soon as it is complete. The
-            // reveal timer replaces this provisional content in place, rather
-            // than appending after newer user turns.
-            const displayedContent = streamDisplayRef.current
+            setCardPreview(null)
             setMessages((previous) => {
               const existing = previous.findIndex((item) => item.id === msg.id)
-              const reserved = { ...msg, content: displayedContent }
-              if (existing === -1) return [...previous, reserved]
+              if (existing === -1) return [...previous, msg]
               const next = [...previous]
-              next[existing] = reserved
+              next[existing] = msg
               return next
             })
-            setStreamText('')
-            if (streamRef.current || streamDisplayRef.current) {
-              streamRef.current = msg.content
-              scheduleStreamReveal()
-            } else {
-              finalizePendingAssistant()
-            }
+            void refreshRuntimeStatus()
+            void refreshCommandCatalog()
             void refreshConversations()
             break
           }
@@ -675,11 +623,6 @@ export default function ChatScreen({
             streamRef.current = ''
             streamDisplayRef.current = ''
             setStreaming(false)
-            const pending = pendingAssistantRef.current
-            pendingAssistantRef.current = null
-            if (pending) {
-              setMessages((previous) => previous.filter((item) => item.id !== pending.id))
-            }
             setErrorText(event.message)
             setStreamText('')
             setCardPreview(null)
@@ -712,7 +655,7 @@ export default function ChatScreen({
       }
     })
     return off
-  }, [applyTaskSnapshot, finalizePendingAssistant, hydrateActiveTask, onNavigate, refreshApprovalPreset, refreshCommandCatalog, refreshConversations, refreshRuntimeStatus, scheduleStreamReveal, stopStreamReveal])
+  }, [applyTaskSnapshot, hydrateActiveTask, onNavigate, refreshApprovalPreset, refreshCommandCatalog, refreshConversations, refreshRuntimeStatus, scheduleStreamReveal, stopStreamReveal])
 
   const activeThinking: ThinkingState | null = activeId
     ? (thinkingMap[activeId] ?? null)
@@ -726,7 +669,7 @@ export default function ChatScreen({
   const activeTiming = activeId ? taskTimings[activeId] : undefined
   const activeTask = activeId ? tasksByConversation[activeId] : undefined
   const taskIsActive = activeTask ? !isTaskTerminal(activeTask) : false
-  const isWorkActive = activeThinking !== null || activeAgents.length > 0 || taskIsActive
+  const isWorkActive = streaming || activeThinking !== null || activeAgents.length > 0 || taskIsActive
   const activeAgentsCount = runtimeStatus.active_agents?.length ?? 0
   const thinkingCount = Object.keys(thinkingMap).length
 
@@ -780,6 +723,10 @@ export default function ChatScreen({
         phrase: 'Thinking through your task…',
         pet_animation: 'working'
       })
+      stopStreamReveal()
+      streamRef.current = ''
+      streamDisplayRef.current = ''
+      setStreamText('')
       setStreaming(true)
       try {
         const { conversation_id, command_handled } = await collieClient.chat(
@@ -825,7 +772,8 @@ export default function ChatScreen({
       isWorkActive,
       openConversation,
       refreshCommandCatalog,
-      refreshConversations
+      refreshConversations,
+      stopStreamReveal
     ]
   )
 
@@ -1001,6 +949,12 @@ export default function ChatScreen({
     if (!conversationId) return
     try {
       const result = await collieClient.stopConversation(conversationId)
+      if (activeIdRef.current !== conversationId) return
+      stopStreamReveal()
+      streamRef.current = ''
+      streamDisplayRef.current = ''
+      setStreaming(false)
+      setCardPreview(null)
       setRuntimeStatus((previous) => ({
         ...previous,
         active_agents: (previous.active_agents || []).filter(
@@ -1033,7 +987,7 @@ export default function ChatScreen({
     } catch {
       setErrorText('I could not stop that response cleanly.')
     }
-  }, [])
+  }, [stopStreamReveal])
 
   useEffect(() => {
     if (!isWorkActive) return
@@ -1122,7 +1076,7 @@ export default function ChatScreen({
         </header>
         <div className={`workspace-body flex min-h-0 flex-1 ${thingsOpen && things.length > 0 ? 'has-things' : ''}`}>
         <div className="conversation-panel">
-          <MessageList messages={messages} streamText={streamText} streaming={streaming} cardPreview={cardPreview} />
+          <MessageList key={activeId} messages={messages} streamText={streamText} streaming={streaming} cardPreview={cardPreview} activityLabel={streaming ? (activeThinking?.phrase || "Collie is thinking…") : undefined} />
         {errorText && (
           <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
             style={{ borderColor: 'var(--collie-snoot)' }}>

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -1893,21 +1893,28 @@ button {
   color: #fff;
 }
 
-/* Streaming answer frame: while the first tokens are on their way the
-   assistant card shows a quiet skeleton (placeholder lines). The frame
-   stays once text arrives — the stream fills the same card and the
-   placeholder lines fade out beneath it. */
-.message-row--assistant .message-bubble--writing {
-  position: relative;
-  min-width: 176px;
-  min-height: 104px;
-  overflow: hidden;
+.chat-transcript { position: relative; overscroll-behavior: contain; }
+.chat-activity { padding: 10px 4px; min-height: 38px; }
+.chat-jump-latest {
+  position: sticky;
+  z-index: 2;
+  bottom: 4px;
+  display: block;
+  margin: 12px auto 0;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--collie-bg);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+  font-size: 12px;
+  cursor: pointer;
+}
+.message-row--assistant .message-bubble {
+  width: 100%;
+  max-width: 100%;
 }
 
-/* Thinking cue: shown inside the answer bubble while Collie is still
-   forming the reply (before the first streamed token lands). It gives the
-   frame real content — without it the bubble collapsed to a 34px-wide
-   strip while the absolutely-positioned skeleton lines had no width. */
 .collie-thinking {
   position: relative;
   z-index: 1;
@@ -1966,57 +1973,9 @@ button {
   min-width: 0;
 }
 
-.collie-skeleton {
-  position: absolute;
-  z-index: 0;
-  top: 12px;
-  right: 16px;
-  left: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  opacity: 0;
-  transition: opacity var(--motion-smooth) ease-out;
-  pointer-events: none;
-}
 
-.collie-skeleton--active {
-  opacity: 1;
-}
 
-/* When the thinking cue is above, drop the placeholder lines below it
-   instead of drawing over the dots/label. */
-.collie-skeleton--below-thinking {
-  top: 42px;
-}
-
-.collie-skeleton-line {
-  height: 12px;
-  border-radius: 6px;
-  background: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--line) 62%, transparent) 25%,
-    color-mix(in srgb, var(--line) 34%, transparent) 50%,
-    color-mix(in srgb, var(--line) 62%, transparent) 75%
-  );
-  background-size: 200% 100%;
-  animation: collie-skeleton-shimmer 1.8s linear infinite;
-}
-
-.collie-skeleton-line:nth-child(1) { width: 92%; }
-.collie-skeleton-line:nth-child(2) { width: 100%; }
-.collie-skeleton-line:nth-child(3) { width: 58%; }
-
-@keyframes collie-skeleton-shimmer {
-  from { background-position: 200% 0; }
-  to { background-position: -200% 0; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .collie-skeleton-line { animation: none; }
-}
-
-.message-markdown { min-width: 0; overflow-wrap: anywhere; }
+.message-markdown { min-width: 0; overflow-wrap: anywhere; white-space: normal; }
 .message-markdown > :first-child { margin-top: 0; }
 .message-markdown > :last-child { margin-bottom: 0; }
 .message-markdown p { margin: 0 0 0.72em; }
@@ -2036,7 +1995,7 @@ button {
 .message-markdown blockquote { margin: 0.7em 0; border-left: 3px solid var(--grass); padding-left: 0.85em; color: var(--muted); }
 .message-markdown code { border-radius: 5px; background: var(--bone); padding: 0.12em 0.35em; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 0.9em; }
 .message-markdown pre { max-width: 100%; margin: 0.75em 0; overflow-x: auto; border-radius: 10px; background: #171819; padding: 12px; color: #f4f4f1; }
-.message-markdown pre code { background: transparent; padding: 0; color: inherit; }
+.message-markdown pre code { background: transparent; padding: 0; color: inherit; white-space: pre; }
 .message-markdown table { display: block; max-width: 100%; margin: 0.75em 0; overflow-x: auto; border-collapse: collapse; }
 .message-markdown th,
 .message-markdown td { border: 1px solid var(--line); padding: 6px 8px; text-align: left; }

--- a/docs/product/features/chat-experience.md
+++ b/docs/product/features/chat-experience.md
@@ -21,6 +21,12 @@ arrive, and the sidebar should prioritize starting and returning to chats.
   preview that can be dismissed without losing the user's place in the chat.
 - Assistant text streams at a smooth, readable pace without frame-like jumps,
   erratic reflow, or a blinking typing cursor.
+- Live text catches up after provider bursts; a delivered answer appears in
+  full immediately, without an artificial post-completion typing delay.
+- Before text arrives, a compact activity line shows the current work. It is
+  separate from the answer, with no overlapping skeleton placeholders.
+- Scrolling back pauses automatic following. **Jump to latest** resumes it;
+  switching conversations starts at the latest messages in that conversation.
 - Markdown is rendered continuously while a response streams. Users do not see
   raw formatting markers such as `**` or `__` before styled text appears.
 - The sidebar order is: **New Chat**, **Agents**, **Skills**, **Routines**,


### PR DESCRIPTION
Completed answers could keep typing for seconds because the renderer revealed only 18 characters every 32 ms, even after receiving the final message. Commit final messages immediately and let live text catch up after provider bursts. Streaming updates use a React transition so composer input takes priority.

Replace the large thinking skeleton with a compact activity line, keep answer width stable, and correct Markdown whitespace that inflated paragraph/list spacing. Pause auto-follow when the reader scrolls up, offer Jump to latest, and reset following when switching conversations. Stop and core restart cancel pending reveal timers.

Validation:
- Full UI suite: 454 passed, 1 skipped across 64 files.
- Typecheck and production build pass; repository snapshot check passes.
- Added a repeatable Electron renderer test: `npx electron scripts/verify-chat-stream.cjs` after `npm run build`.
- Electron checks cover completion, typing during streaming, scroll-back, Jump to latest, Stop, conversation isolation, and desktop dark/narrow light layouts. No renderer errors.
- Synthetic baseline: a roughly 9,200-character response had only 170 transcript characters visible at the post-completion check. The updated renderer shows the entire answer at that check.

The Electron test uses synthetic core events and an isolated temporary profile; it does not measure live provider latency or access user conversations. Screenshots remain outside source control. Updated the canonical chat experience acceptance criteria.
