### PR TITLE
Arrange sidebar footer and subtly highlight Submit Feedback

### DIFF
--- a/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
@@ -134,6 +134,19 @@ it('opens feedback from the collapsed sidebar and returns focus on cancel', () =
   expect(document.activeElement).toBe(button)
 })
 
+it('stacks the footer as collapse, feedback, then settings', () => {
+  const container = renderSidebar()
+  const rows = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('.sidebar-footer > button')
+  )
+  // DOM order is the keyboard tab order; docs/product/feedback.md documents it.
+  expect(rows).toHaveLength(3)
+  expect(rows[0].classList.contains('sidebar-collapse-toggle')).toBe(true)
+  expect(rows[1].getAttribute('aria-label')).toBe('Submit Feedback')
+  expect(rows[1].classList.contains('sidebar-feedback')).toBe(true)
+  expect(rows[2].classList.contains('sidebar-settings')).toBe(true)
+})
+
 afterEach(() => {
   for (const root of roots.splice(0)) act(() => root.unmount())
   document.body.replaceChildren()

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -419,12 +419,6 @@ export default function Sidebar({
       </nav>
 
       <div className="sidebar-footer">
-        <button type="button" onClick={() => setFeedbackOpen(true)}
-          className="sidebar-footer-row mx-4 mb-2 flex items-center gap-2 px-3 py-2.5 text-sm transition"
-          title={ui("Submit Feedback")} aria-label={ui("Submit Feedback")} aria-haspopup="dialog">
-          <MessageCircle size={16} aria-hidden="true" />
-          <span>{ui("Submit Feedback")}</span>
-        </button>
         <button
           type="button"
           onClick={toggleCollapsed}
@@ -434,6 +428,12 @@ export default function Sidebar({
           aria-expanded={!collapsed}
         >
           {collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
+        </button>
+        <button type="button" onClick={() => setFeedbackOpen(true)}
+          className="sidebar-feedback sidebar-footer-row mx-4 mb-2 flex items-center gap-2 px-3 py-2.5 text-sm transition"
+          title={ui("Submit Feedback")} aria-label={ui("Submit Feedback")} aria-haspopup="dialog">
+          <MessageCircle size={16} aria-hidden="true" />
+          <span>{ui("Submit Feedback")}</span>
         </button>
         <button
           onClick={() => onNavigate('settings')}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -542,8 +542,38 @@ button {
 }
 
 .sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  padding-top: 8px;
   margin-top: auto;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+
+.sidebar-feedback {
+  border: 1px solid rgba(232, 145, 58, 0.18);
+  border-radius: 9px;
+  background: rgba(232, 145, 58, 0.05);
+  color: #cbbda9;
+}
+
+.sidebar-feedback:hover {
+  background: rgba(232, 145, 58, 0.10);
+  border-color: rgba(232, 145, 58, 0.30);
+}
+
+.sidebar-feedback:focus-visible {
+  outline: 2px solid var(--collie-amber);
+  outline-offset: 2px;
+}
+
+.sidebar.is-collapsed .sidebar-footer-row {
+  width: 40px;
+}
+
+.sidebar.is-collapsed .sidebar-feedback {
+  padding-left: 11px;
+  padding-right: 11px;
 }
 
 .sidebar-settings {

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -3,6 +3,9 @@
 **Status:** implemented; backend provisioning and live inbox verification required before release.
 
 The desktop sidebar has a **Submit Feedback** button, including when collapsed.
+The footer stacks Collapse navigation, Submit Feedback, and Settings in that
+order. Feedback uses a subtle warm tint and outline to distinguish it from
+ordinary navigation without competing with the main actions.
 It opens a keyboard-accessible dialog with one message field and Send. No account
 or email address is required. Only the typed text and a random submission ID leave
 the app; conversations, logs, device identifiers, and account details are excluded.


### PR DESCRIPTION
The sidebar footer could place Submit Feedback alongside Collapse navigation, and feedback looked like an ordinary navigation entry. Stack the footer explicitly in this order: Collapse navigation, Submit Feedback, Settings.

Give Submit Feedback a faint warm tint, thin outline, rounded corners, and keyboard focus indicator. Preserve accessible labels and the icon-only feedback action when collapsed; keep the collapsed footer buttons wide enough for full-size icons.

Validation: 10 sidebar DOM tests passed; TypeScript and production build passed. Verified the order and appearance in the running Electron app in expanded and collapsed views, and opened/cancelled the feedback dialog from the collapsed sidebar. No feedback message was sent. Updated the canonical feedback UI documentation; repository snapshot check passed.
