### PR TITLE
fix(ui): keep focus inside the feedback dialog after a failed submit

### DIFF
--- a/collie-ui/src/renderer/src/components/FeedbackDialog.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/FeedbackDialog.dom.test.tsx
@@ -91,3 +91,15 @@ it('preserves text when the bridge rejects', async () => {
   expect(document.querySelector('textarea')!.value).toBe('Still here')
   expect(document.querySelector('[role=alert]')).not.toBeNull()
 })
+
+it('keeps keyboard focus inside the dialog after a failed submit', async () => {
+  // The in-flight Send button is disabled, so Chromium drops focus to <body>
+  // unless the dialog reclaims it. Focus must land back on the textarea.
+  submitFeedback.mockResolvedValue({ ok: false, error: 'unavailable' })
+  input('Focus must stay here')
+  await send()
+  const dialog = document.querySelector('dialog')!
+  expect(document.querySelector('[role=alert]')).not.toBeNull()
+  expect(dialog.contains(document.activeElement)).toBe(true)
+  expect(document.activeElement?.tagName).toBe('TEXTAREA')
+})

--- a/collie-ui/src/renderer/src/components/FeedbackDialog.tsx
+++ b/collie-ui/src/renderer/src/components/FeedbackDialog.tsx
@@ -5,6 +5,7 @@ import { FEEDBACK_MAX_LENGTH } from '../../../shared/feedback'
 export default function FeedbackDialog({ onClose }: { onClose: () => void }): React.JSX.Element {
   const dialog = useRef<HTMLDialogElement>(null)
   const closeButton = useRef<HTMLButtonElement>(null)
+  const textarea = useRef<HTMLTextAreaElement>(null)
   const inFlight = useRef(false)
   const submissionId = useRef<string | null>(null)
   const [message, setMessage] = useState('')
@@ -21,6 +22,14 @@ export default function FeedbackDialog({ onClose }: { onClose: () => void }): Re
   useEffect(() => {
     if (sent) closeButton.current?.focus()
   }, [sent])
+
+  // A failed send can leave focus on <body>: the focused Send button is
+  // disabled while the request is in flight, and Chromium drops focus when the
+  // focused control becomes disabled. Put the user back in the dialog so
+  // Escape/Tab keep working and the preserved draft is ready to edit.
+  useEffect(() => {
+    if (error) textarea.current?.focus()
+  }, [error])
 
   async function send(): Promise<void> {
     if (inFlight.current || !message.trim()) return
@@ -62,7 +71,7 @@ export default function FeedbackDialog({ onClose }: { onClose: () => void }): Re
         </p>
         {sent ? <p role="status" className="mt-4">Thanks! Your feedback has been sent.</p> : <>
           <label className="form-field" htmlFor="feedback-message">Your feedback
-            <textarea id="feedback-message" rows={6} maxLength={FEEDBACK_MAX_LENGTH}
+            <textarea ref={textarea} id="feedback-message" rows={6} maxLength={FEEDBACK_MAX_LENGTH}
               value={message} disabled={sending} required
               onChange={(event) => {
                 setMessage(event.target.value)


### PR DESCRIPTION
## Problem

`FeedbackDialog` disables the Send button while the request is in flight, and Chromium drops focus to `<body>` when the focused control becomes disabled. A **failed** submit therefore left the dialog open with the error visible but focus outside the modal — Escape and Tab stopped working and the draft was unreachable for keyboard users.

Found by driving the live app with real mouse/keyboard events: active element was `BODY` after a failed submit.

## Fix

Refocus the textarea whenever the dialog surfaces an error. The draft is preserved, so the user can edit and retry immediately. The success path already moves focus to Done.

## Verification

- `npx vitest run src/renderer/src/components/FeedbackDialog.dom.test.tsx`
  - new test: `keeps keyboard focus inside the dialog after a failed submit`
  - **RED** on main: `1 failed | 5 passed` → **GREEN**: `6/6`
- Full UI suite: **70 files / 496 tests passed** (was 495), `npm run typecheck` exit 0
- Live app, real CDP input: `focus stays inside the dialog after the submit settles` → `{"active":"TEXTAREA","insideDialog":true,"alert":true,"draftLength":46}` (previously `BODY`)
