### PR TITLE
test(core): make the MCP reconnect-shutdown repro deterministic

### DIFF
--- a/collie-core/tests/agent/test_mcp_reconnect_crash.py
+++ b/collie-core/tests/agent/test_mcp_reconnect_crash.py
@@ -62,6 +62,28 @@ def _run_mcp_server(port: int, ready_event: multiprocessing.Event) -> None:
         session_idle_timeout=_IDLE_TIMEOUT_SECONDS,
     )
 
+    from starlette.responses import JSONResponse
+
+    @mcp.custom_route("/control/expire", methods=["POST"])
+    async def _expire_sessions(request):  # noqa: ANN001, ARG001
+        """Terminate every live session, deterministically.
+
+        The idle sweep is timing-dependent on a loaded CI runner, and a session
+        that is still alive makes the reconnect tests wait for a reconnect that
+        never happens.  Terminating server-side keeps the production shape (the
+        client's next call sees a dead session) without the timing race.
+        """
+        manager = mcp._session_manager
+        terminated = 0
+        for session_id, transport in list(manager._server_instances.items()):
+            try:
+                await transport.terminate()
+            except Exception:  # pragma: no cover - best effort in a test server
+                pass
+            manager._server_instances.pop(session_id, None)
+            terminated += 1
+        return JSONResponse({"terminated": terminated})
+
     ready_event.set()
     mcp.run(transport="streamable-http")
 
@@ -80,6 +102,22 @@ async def _wait_for_server(url: str, timeout: float = 10.0) -> bool:
         except Exception:
             await asyncio.sleep(0.1)
     return False
+
+
+async def _terminate_server_sessions(url: str) -> int:
+    """Drop every live session on the repro server and return how many died.
+
+    Waiting for the server's idle sweep is timing-dependent on a loaded CI
+    runner: when the sweep has not fired yet the client's next call simply
+    succeeds, no reconnect is attempted, and the test waits for an event that
+    will never be set.  Terminating server-side removes that race while keeping
+    the production shape (the client's next call sees a dead session).
+    """
+    base = url.rsplit("/mcp", 1)[0]
+    async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
+        response = await client.post(f"{base}/control/expire")
+        response.raise_for_status()
+        return int(response.json().get("terminated", 0))
 
 
 @pytest.fixture(scope="module")
@@ -209,6 +247,11 @@ async def test_mcp_reconnect_during_shutdown_does_not_crash(
 
     await asyncio.create_task(tool.execute(name="first"))
     await asyncio.sleep(_IDLE_TIMEOUT_SECONDS + _IDLE_EXPIRY_GRACE_SECONDS)
+    # Guarantee the dead-session precondition.  The idle sweep is timing
+    # dependent on a loaded runner; if the session is still alive the second
+    # call simply succeeds and this test waits for a reconnect that never
+    # happens (the CI failure this replaced).
+    await _terminate_server_sessions(mcp_server_url)
 
     reconnect_started = asyncio.Event()
     finish_reconnect = asyncio.Event()
@@ -221,7 +264,10 @@ async def test_mcp_reconnect_during_shutdown_does_not_crash(
 
     monkeypatch.setattr(mcp_module, "connect_mcp_servers", gated_connect)
     call_task = asyncio.create_task(tool.execute(name="second"))
-    await asyncio.wait_for(reconnect_started.wait(), timeout=5)
+    # Hosted CI runners are far slower than a dev box: the dead-session
+    # detection that precedes the reconnect can take several seconds there.
+    # These budgets bound a hang; they are not the behaviour under test.
+    await asyncio.wait_for(reconnect_started.wait(), timeout=30)
     close_task = asyncio.create_task(loop.close_mcp())
     await asyncio.sleep(0)
     finish_reconnect.set()
@@ -236,7 +282,7 @@ async def test_mcp_reconnect_during_shutdown_does_not_crash(
     asyncio.get_running_loop().set_exception_handler(capture_unhandled)
 
     try:
-        await asyncio.wait_for(asyncio.gather(call_task, close_task), timeout=15)
+        await asyncio.wait_for(asyncio.gather(call_task, close_task), timeout=60)
     except asyncio.CancelledError:
         unhandled.append(asyncio.CancelledError("main task cancelled by leaked MCP cancel scope"))
     except Exception as exc:


### PR DESCRIPTION
## Problem

`tests/agent/test_mcp_reconnect_crash.py::test_mcp_reconnect_during_shutdown_does_not_crash` fails on hosted runners, red-lighting both core jobs — and `release.yml` runs the same suite, so a release cut from main fails at the test step.

The first attempt (raising the `asyncio.wait_for` budget) did **not** fix it: run 34238571778 failed again with `timeout = 30` still expired. The real cause is a race in the test's precondition, not a slow reconnect:

- the repro server kills sessions with a 0.25s idle sweep
- the test sleeps 0.5s and assumes the session is dead
- when the sweep has not fired yet (loaded runner), the second `tool.execute` simply **succeeds** — no reconnect is attempted, `reconnect_started` is never set, and the test fails on the timeout
- the sibling test (`test_mcp_reconnect_after_session_timeout`) passes either way because it only asserts the greeting, so the suite never surfaced the race

## Change

- the repro server gains `POST /control/expire`, which terminates every live session server-side
- the test calls it after the idle sleep, so the dead-session precondition is guaranteed instead of hoped for, while keeping the production shape (the client's next call sees a dead session)
- the `wait_for` budgets stay widened (5s → 30s, 15s → 60s) — they bound a genuine hang and make a real stall obvious

## Verification

- `pytest tests/agent/test_mcp_reconnect_crash.py -q` → `2 passed` in 1.47s / 1.48s / 1.48s **with the idle sleep removed**, proving the control route alone produces the dead session and the reconnect path fires
- `2 passed` in 2.00s / 1.98s / 1.98s in the final form (idle sleep + control route)
- also passes pinned to one CPU (`taskset -c 0`) and under a 6-way CPU load
