### PR TITLE
fix(feedback): use manual redirects so the worker can reach Supabase and Resend

### DIFF
--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,6 +1,6 @@
 # In-app feedback
 
-**Status:** implemented; backend provisioning and live inbox verification required before release.
+**Status:** implemented; backend provisioned and verified end-to-end (Supabase table, Worker secrets, `feedback.heycollie.com` custom domain).
 
 The desktop sidebar has a **Submit Feedback** button, including when collapsed.
 The footer stacks Collapse navigation, Submit Feedback, and Settings in that
@@ -44,6 +44,15 @@ reviewed together in the main app repository, but deployed separately.
 5. From a preview/packaged app, submit a test message and confirm one database
    row and one email, then check offline failure/retry and collapsed navigation.
    Do not release the desktop feature until this live check passes.
+
+Steps 1–5 are complete: the table exists with RLS denying anonymous and
+authenticated access, the Worker holds its secrets, the custom domain is live,
+and a submission from the running app stored one row and reached Resend.
+
+Workers `fetch` accepts only `redirect: 'follow'` or `'manual'`; `'error'` throws
+at runtime before the request is sent. Keep the upstream calls on `'manual'` and
+let the response-status check fail closed, otherwise every submission returns 503
+even though the mocked unit tests pass.
 
 The endpoint fails closed when secrets or rate limiting are unavailable. IPs
 are used transiently by the Cloudflare limiter and are not stored in the feedback

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,6 +1,6 @@
 # In-app feedback
 
-**Status:** implemented; backend provisioned and verified end-to-end (Supabase table, Worker secrets, `feedback.heycollie.com` custom domain).
+**Status:** implemented; backend provisioning and app-to-Resend acceptance reported verified. Mailbox receipt and the remaining release checks below still require confirmation.
 
 The desktop sidebar has a **Submit Feedback** button, including when collapsed.
 The footer stacks Collapse navigation, Submit Feedback, and Settings in that
@@ -45,9 +45,11 @@ reviewed together in the main app repository, but deployed separately.
    row and one email, then check offline failure/retry and collapsed navigation.
    Do not release the desktop feature until this live check passes.
 
-Steps 1–5 are complete: the table exists with RLS denying anonymous and
-authenticated access, the Worker holds its secrets, the custom domain is live,
-and a submission from the running app stored one row and reached Resend.
+The provisioning report in PR #172 records the table, Worker secrets, custom
+domain, and a submission from the running app that stored one row and was
+accepted by Resend. This does not establish mailbox receipt or completion of
+every release check: confirm rate-limit namespace uniqueness, both client-role
+access checks, and the mailbox/offline-retry checks above before release.
 
 Workers `fetch` accepts only `redirect: 'follow'` or `'manual'`; `'error'` throws
 at runtime before the request is sent. Keep the upstream calls on `'manual'` and

--- a/tools/feedback/worker.mjs
+++ b/tools/feedback/worker.mjs
@@ -69,14 +69,16 @@ export default {
         headers.Authorization = `Bearer ${env.SUPABASE_SECRET_KEY}`
       }
       const stored = await fetch(endpoint, {
+        // Workers fetch only accepts 'follow' or 'manual' — 'error' throws at
+        // runtime, so every submission failed with a 503 until this was fixed.
         method: 'POST', headers: { ...headers, Prefer: 'return=minimal' },
-        body: JSON.stringify({ id, message }), redirect: 'error', signal: AbortSignal.timeout(8000)
+        body: JSON.stringify({ id, message }), redirect: 'manual', signal: AbortSignal.timeout(8000)
       })
       if (stored.status === 409) {
         // A retry must use the original content. Never overwrite an accepted message.
         endpoint.search = new URLSearchParams({ id: `eq.${id}`, select: 'message' }).toString()
         const existing = await fetch(endpoint, {
-          headers, redirect: 'error', signal: AbortSignal.timeout(8000)
+          headers, redirect: 'manual', signal: AbortSignal.timeout(8000)
         })
         if (!existing.ok) return json({ ok: false }, 503)
         const rows = await existing.json()
@@ -87,7 +89,7 @@ export default {
         return json({ ok: false }, 503)
       }
       const emailed = await fetch('https://api.resend.com/emails', {
-        method: 'POST', redirect: 'error', signal: AbortSignal.timeout(8000),
+        method: 'POST', redirect: 'manual', signal: AbortSignal.timeout(8000),
         headers: {
           Authorization: `Bearer ${env.RESEND_API_KEY}`,
           'Content-Type': 'application/json',

--- a/tools/feedback/worker.test.mjs
+++ b/tools/feedback/worker.test.mjs
@@ -97,3 +97,22 @@ test('does not expose a read endpoint or accept browser form posts', async () =>
   const form = request(); form.headers.set('Content-Type', 'text/plain')
   assert.equal((await worker.fetch(form, env())).status, 415)
 })
+
+test('uses manual redirects on every upstream call, the only mode the Workers runtime accepts', async () => {
+  // `redirect: 'error'` throws in the Workers runtime ("Invalid redirect value"),
+  // which failed every submission with a 503 in production while these mocked
+  // tests stayed green. Pin the mode on all three call sites: store, dedupe
+  // read, and email.
+  const modes = []
+  const responses = [new Response('', { status: 409 }), Response.json([{ message: body.message }]), Response.json({ id: 'mail' })]
+  globalThis.fetch = async (url, options) => { modes.push(options.redirect); return responses.shift() }
+  assert.equal((await worker.fetch(request(), env())).status, 200)
+  assert.deepEqual(modes, ['manual', 'manual', 'manual'])
+})
+
+test('fails closed when an upstream answers with a redirect instead of storing', async () => {
+  let calls = 0
+  globalThis.fetch = async () => { calls++; return new Response('', { status: 302 }) }
+  assert.equal((await worker.fetch(request(), env())).status, 503)
+  assert.equal(calls, 1)
+})


### PR DESCRIPTION
## Problem

The feedback Worker could never succeed in production, even with the backend fully provisioned. Cloudflare's Workers runtime rejects `redirect: 'error'` on `fetch`:

```
FB_DEBUG failed_at store Invalid redirect value, must be one of "follow" or "manual"
("error" won't be implemented since it does not make sense at the edge; use "manual"
and check the response status code).
```

Every submission threw before the Supabase insert and returned `{"ok":false}` 503. The unit tests mock `globalThis.fetch`, so the runtime never validated the option — 9/9 green while production was broken.

Found while provisioning the backend for the UX tester's "real delivery unproven" gap: the Worker had never been deployed, no DNS record existed, and `public.app_feedback` was missing, so the shipped Submit Feedback button had always failed.

## Change

- `redirect: 'error'` → `redirect: 'manual'` on all three upstream calls (Supabase store, dedupe read, Resend), with a comment at the call site
- two tests: the mode is `manual` on every call site, and a 3xx from Supabase fails closed without emailing
- `docs/product/feedback.md`: status + deployment notes, including the runtime caveat

## Verification

- `node --test tools/feedback/worker.test.mjs` → **11/11 pass**
- Provisioned: `public.app_feedback` created with RLS (anon select and insert denied, service role allowed), Worker `collie-feedback` deployed with its five secrets, `feedback.heycollie.com` custom domain live and resolving
- Live against production:
  - first send → `{"ok":true}` 200
  - identical retry → `{"ok":true}` 200
  - same id, different content → `409`
  - `GET` 405, wrong path 404, `text/plain` 415
  - row present in Supabase, Resend accepted the notification
- App path: a real click in the running app created row `2dc4073e-206d-430c-ab99-b43e38f37c5c`, the dialog showed the success state and focus stayed inside the dialog

## Caveat

The rate-limit namespace `1001` is account-scoped: if another Worker in this account uses the same id the counters are shared. Worth confirming when the website Worker is next touched.
