### PR TITLE
Add connection definitions and backward-compatible storage foundation (Steps 1–2)

### DIFF
--- a/collie-core/collie_core/connectors/manager.py
+++ b/collie-core/collie_core/connectors/manager.py
@@ -6,6 +6,7 @@ import json
 import threading
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 from loguru import logger
@@ -14,8 +15,12 @@ from collie_core.connectors.catalog import CONNECTOR_CATALOG, connector_def
 from collie_core.connectors.drivers.official_mcp import OfficialMcpDriver
 from collie_core.connectors.models import (
     ConnectionStatus,
+    ConnectorAuthStrategy,
     ConnectorDefinition,
     ConnectorDriverKind,
+    ConnectorProvenance,
+    ConnectorTransport,
+    InstalledConnectorDefinition,
     ProbeResult,
     RemoteRevocationStatus,
 )
@@ -60,6 +65,7 @@ class ConnectorManager:
         self._cancelled: set[str] = set()
         self._connecting: set[str] = set()
         self._migrate_legacy_credentials()
+        self._resolve_migrated_definitions()
 
     def _default_driver(self, definition: ConnectorDefinition) -> Any:
         if definition.driver == ConnectorDriverKind.OFFICIAL_MCP:
@@ -75,6 +81,60 @@ class ConnectorManager:
                 old = self.credentials.load(str(row["provider_id"]))
                 if old is not None:
                     self.credentials.save(target, old)
+
+    def _definition_for_row(self, row: dict[str, Any]) -> ConnectorDefinition | None:
+        """Resolve a connection against its installed snapshot when one is complete."""
+        recipe = connector_def(str(row["provider_id"]))
+        stored = self.db.get_connector_definition(str(row.get("definition_id") or ""))
+        if recipe is None or stored is None or stored.get("unresolved"):
+            return recipe
+        if stored.get("provenance") != ConnectorProvenance.CURATED.value:
+            return None
+        config = _json_value(stored.get("config_json"), {})
+        return replace(
+            recipe,
+            driver=ConnectorDriverKind(str(stored["driver"])),
+            auth_type=str(stored["auth_strategy"]),
+            endpoint=str(config.get("endpoint") or ""),
+            scopes=tuple(config.get("scopes") or ()),
+            trusted_hosts=tuple(config.get("trusted_hosts") or ()),
+            tool_overrides=dict(config.get("tool_overrides") or {}),
+        )
+
+    def _resolve_migrated_definitions(self) -> None:
+        """Pin the packaged recipe once for V15 accounts; unknown rows remain removable."""
+        for row in self.db.list_connector_connections():
+            stored = self.db.get_connector_definition(str(row.get("definition_id") or ""))
+            if not stored or not stored.get("unresolved"):
+                continue
+            recipe = connector_def(str(row["provider_id"]))
+            if recipe is not None and row["driver"] == recipe.driver.value:
+                self._save_definition_snapshot(recipe, str(row["id"]))
+
+    def _save_definition_snapshot(
+        self, definition: ConnectorDefinition, connection_id: str
+    ) -> None:
+        self.db.save_connector_definition(
+            InstalledConnectorDefinition(
+                id=f"def_{connection_id}",
+                provider_id=definition.id,
+                recipe_id=definition.id,
+                recipe_version="1",
+                driver=definition.driver,
+                transport=(
+                    ConnectorTransport.API
+                    if definition.driver == ConnectorDriverKind.OFFICIAL_API
+                    else ConnectorTransport.STREAMABLE_HTTP
+                ),
+                auth_strategy=ConnectorAuthStrategy(definition.auth_type),
+                provenance=ConnectorProvenance.CURATED,
+                endpoint=definition.endpoint or None,
+                oauth_registration="automatic" if definition.auth_type == "oauth" else None,
+                scopes=definition.scopes,
+                trusted_hosts=definition.trusted_hosts,
+                tool_overrides=definition.tool_overrides,
+            )
+        )
 
     # -- catalog and connection views ---------------------------------------
 
@@ -145,7 +205,7 @@ class ConnectorManager:
         return bool(tokens.get("access_token"))
 
     def _connection_view(self, row: dict[str, Any]) -> dict[str, Any]:
-        definition = connector_def(str(row["provider_id"]))
+        definition = self._definition_for_row(row)
         compatible = bool(
             definition and definition.available and row["driver"] == definition.driver.value
         )
@@ -256,6 +316,7 @@ class ConnectorManager:
                         last_error_message="The previous sign-in was interrupted.",
                     )
             connection_id = connection_id or f"con_{uuid.uuid4().hex}"
+            self._save_definition_snapshot(definition, connection_id)
             self.db.upsert_connector_connection(
                 connection_id,
                 provider_id=definition.id,
@@ -370,7 +431,7 @@ class ConnectorManager:
         row = self.db.get_connector_connection(connection_id)
         if row is None:
             raise ValueError("I couldn't find that connection.")
-        definition = connector_def(str(row["provider_id"]))
+        definition = self._definition_for_row(row)
         if definition is None:
             raise ValueError("That provider is no longer in this build.")
         if not definition.available:
@@ -452,7 +513,7 @@ class ConnectorManager:
                 "status": "disconnected",
                 "remote_revocation": RemoteRevocationStatus.NOT_APPLICABLE.value,
             }
-        definition = connector_def(str(row["provider_id"]))
+        definition = self._definition_for_row(row)
         with self._lock:
             # A concurrent connect() must not resurrect this connection.
             self._cancelled.add(connection_id)
@@ -504,7 +565,7 @@ class ConnectorManager:
         for row in self.db.list_connector_connections():
             if row["status"] != ConnectionStatus.CONNECTED.value:
                 continue
-            definition = connector_def(str(row["provider_id"]))
+            definition = self._definition_for_row(row)
             if (
                 not definition
                 or not definition.available

--- a/collie-core/collie_core/connectors/models.py
+++ b/collie-core/collie_core/connectors/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
+from urllib.parse import urlsplit
 
 
 class ConnectionStatus(StrEnum):
@@ -23,6 +24,170 @@ class ConnectorDriverKind(StrEnum):
     OFFICIAL_API = "official_api"
     BUNDLED_MCP = "bundled_mcp"
     CUSTOM_MCP = "custom_mcp"
+
+
+class ConnectorTransport(StrEnum):
+    STREAMABLE_HTTP = "streamable_http"
+    SSE = "sse"
+    STDIO = "stdio"
+    API = "api"
+
+
+class ConnectorProvenance(StrEnum):
+    CURATED = "curated"
+    IMPORTED = "imported"
+    CUSTOM = "custom"
+
+
+class ConnectorAuthStrategy(StrEnum):
+    NONE = "none"
+    TOKEN = "token"
+    HEADERS = "headers"
+    OAUTH = "oauth"
+
+
+_SECRET_FIELD_FRAGMENTS = ("token", "secret", "password", "credential", "api_key", "apikey")
+
+
+@dataclass(frozen=True, slots=True)
+class InstalledConnectorDefinition:
+    """Validated, secret-free snapshot of an installed connector configuration."""
+
+    id: str
+    driver: ConnectorDriverKind
+    transport: ConnectorTransport
+    auth_strategy: ConnectorAuthStrategy
+    provenance: ConnectorProvenance
+    provider_id: str | None = None
+    recipe_id: str | None = None
+    recipe_version: str | None = None
+    endpoint: str | None = None
+    oauth_registration: str | None = None
+    client_id: str | None = None
+    scopes: tuple[str, ...] = ()
+    trusted_hosts: tuple[str, ...] = ()
+    tool_overrides: dict[str, str] = field(default_factory=dict)
+    unresolved: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id.strip():
+            raise ValueError("A definition id is required.")
+        for name in (
+            "provider_id",
+            "recipe_id",
+            "recipe_version",
+            "endpoint",
+            "oauth_registration",
+            "client_id",
+        ):
+            item = getattr(self, name)
+            if item is not None and not isinstance(item, str):
+                raise ValueError(f"{name} must be a string or null.")
+        if self.oauth_registration not in (None, "automatic", "preregistered"):
+            raise ValueError("Unsupported OAuth registration mode.")
+        if self.auth_strategy is ConnectorAuthStrategy.OAUTH:
+            if self.oauth_registration is None:
+                raise ValueError("OAuth definitions require a registration mode.")
+            if self.oauth_registration == "preregistered" and not self.client_id:
+                raise ValueError("Pre-registered OAuth definitions require a public client id.")
+        if (
+            self.transport in (ConnectorTransport.STREAMABLE_HTTP, ConnectorTransport.SSE)
+            and not self.endpoint
+            and not self.unresolved
+        ):
+            raise ValueError("Remote connector definitions require an endpoint.")
+        if self.endpoint:
+            parsed = urlsplit(self.endpoint)
+            if parsed.scheme not in ("http", "https") or not parsed.hostname:
+                raise ValueError("Connector endpoint must be an HTTP(S) URL.")
+            if parsed.username or parsed.password:
+                raise ValueError("Connector endpoint must not contain credentials.")
+            if parsed.query or parsed.fragment:
+                raise ValueError("Connector endpoint must not contain a query or fragment.")
+        if not isinstance(self.scopes, tuple) or not isinstance(self.trusted_hosts, tuple):
+            raise ValueError("Connector definition collections must be tuples.")
+        for value in (*self.scopes, *self.trusted_hosts):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError("Connector definition lists must contain non-empty strings.")
+        if not isinstance(self.unresolved, bool):
+            raise ValueError("unresolved must be a boolean.")
+        if not isinstance(self.tool_overrides, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in self.tool_overrides.items()
+        ):
+            raise ValueError("tool_overrides must map strings to strings.")
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> InstalledConnectorDefinition:
+        allowed = {
+            "id",
+            "driver",
+            "transport",
+            "auth_strategy",
+            "provenance",
+            "provider_id",
+            "recipe_id",
+            "recipe_version",
+            "endpoint",
+            "oauth_registration",
+            "client_id",
+            "scopes",
+            "trusted_hosts",
+            "tool_overrides",
+            "unresolved",
+        }
+        unknown = set(value) - allowed
+        if unknown:
+            raise ValueError(f"Unknown connector definition fields: {', '.join(sorted(unknown))}")
+        if not isinstance(value.get("id"), str):
+            raise ValueError("id must be a string.")
+        for key in ("scopes", "trusted_hosts"):
+            items = value.get(key, ())
+            if not isinstance(items, (list, tuple)) or not all(isinstance(x, str) for x in items):
+                raise ValueError(f"{key} must be a list of strings.")
+        if "unresolved" in value and not isinstance(value["unresolved"], bool):
+            raise ValueError("unresolved must be a boolean.")
+        overrides = value.get("tool_overrides", {})
+        if not isinstance(overrides, dict) or not all(
+            isinstance(key, str) and isinstance(item, str) for key, item in overrides.items()
+        ):
+            raise ValueError("tool_overrides must map strings to strings.")
+        return cls(
+            id=value["id"],
+            driver=ConnectorDriverKind(value["driver"]),
+            transport=ConnectorTransport(value["transport"]),
+            auth_strategy=ConnectorAuthStrategy(value["auth_strategy"]),
+            provenance=ConnectorProvenance(value["provenance"]),
+            provider_id=value.get("provider_id"),
+            recipe_id=value.get("recipe_id"),
+            recipe_version=value.get("recipe_version"),
+            endpoint=value.get("endpoint"),
+            oauth_registration=value.get("oauth_registration"),
+            client_id=value.get("client_id"),
+            scopes=tuple(value.get("scopes") or ()),
+            trusted_hosts=tuple(value.get("trusted_hosts") or ()),
+            tool_overrides=dict(overrides),
+            unresolved=value.get("unresolved", False),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "driver": self.driver.value,
+            "transport": self.transport.value,
+            "auth_strategy": self.auth_strategy.value,
+            "provenance": self.provenance.value,
+            "provider_id": self.provider_id,
+            "recipe_id": self.recipe_id,
+            "recipe_version": self.recipe_version,
+            "endpoint": self.endpoint,
+            "oauth_registration": self.oauth_registration,
+            "client_id": self.client_id,
+            "scopes": list(self.scopes),
+            "trusted_hosts": list(self.trusted_hosts),
+            "tool_overrides": dict(self.tool_overrides),
+            "unresolved": self.unresolved,
+        }
 
 
 class RemoteRevocationStatus(StrEnum):

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -572,6 +572,80 @@ CREATE TABLE product_metrics_daily (
 );
 """
 
+_SCHEMA_V16 = """
+CREATE TABLE connector_definitions (
+    id TEXT PRIMARY KEY,
+    provider_id TEXT,
+    recipe_id TEXT,
+    recipe_version TEXT,
+    driver TEXT NOT NULL,
+    transport TEXT NOT NULL,
+    auth_strategy TEXT NOT NULL,
+    provenance TEXT NOT NULL,
+    config_json TEXT NOT NULL,
+    unresolved INTEGER NOT NULL DEFAULT 0 CHECK(unresolved IN (0, 1)),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX connector_definitions_provider ON connector_definitions(provider_id);
+
+ALTER TABLE connector_connections ADD COLUMN definition_id TEXT;
+ALTER TABLE connector_connections ADD COLUMN credential_ref TEXT;
+ALTER TABLE connector_connections ADD COLUMN operation_revision INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE connector_tool_cache ADD COLUMN tool_identity TEXT;
+ALTER TABLE connector_tool_cache ADD COLUMN description TEXT;
+ALTER TABLE connector_tool_cache ADD COLUMN input_schema_json TEXT;
+ALTER TABLE connector_tool_cache ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
+
+INSERT INTO connector_definitions (
+    id, provider_id, recipe_id, driver, transport, auth_strategy, provenance,
+    config_json, unresolved, created_at, updated_at
+)
+SELECT
+    'def_' || id, provider_id, provider_id, driver,
+    CASE WHEN driver LIKE '%api' THEN 'api' ELSE 'streamable_http' END,
+    CASE WHEN auth_type = 'oauth' THEN 'oauth'
+         WHEN auth_type IN ('token', 'api_key') THEN 'token'
+         WHEN auth_type = 'none' THEN 'none' ELSE 'headers' END,
+    'curated', '{}', 1, COALESCE(connected_at, updated_at, CURRENT_TIMESTAMP),
+    COALESCE(updated_at, connected_at, CURRENT_TIMESTAMP)
+FROM connector_connections;
+
+UPDATE connector_connections
+SET definition_id = 'def_' || id,
+    credential_ref = 'connector:' || id;
+
+UPDATE connector_tool_cache
+SET tool_identity = length(connection_id) || ':' || connection_id || ':' ||
+                    length(remote_tool_name) || ':' || remote_tool_name,
+    enabled = CASE
+        WHEN (SELECT enabled_tools_json FROM connector_connections c
+              WHERE c.id = connector_tool_cache.connection_id) IS NULL THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM json_each((SELECT enabled_tools_json FROM connector_connections c
+                                     WHERE c.id = connector_tool_cache.connection_id))
+            WHERE value = connector_tool_cache.remote_tool_name OR value = '*'
+        ) THEN 1 ELSE 0 END;
+
+CREATE UNIQUE INDEX connector_tool_cache_identity ON connector_tool_cache(tool_identity);
+
+CREATE TRIGGER connector_connection_definition_insert
+BEFORE INSERT ON connector_connections
+WHEN NEW.definition_id IS NOT NULL
+ AND NOT EXISTS (SELECT 1 FROM connector_definitions WHERE id = NEW.definition_id)
+BEGIN SELECT RAISE(ABORT, 'unknown connector definition'); END;
+CREATE TRIGGER connector_connection_definition_update
+BEFORE UPDATE OF definition_id ON connector_connections
+WHEN NEW.definition_id IS NOT NULL
+ AND NOT EXISTS (SELECT 1 FROM connector_definitions WHERE id = NEW.definition_id)
+BEGIN SELECT RAISE(ABORT, 'unknown connector definition'); END;
+CREATE TRIGGER connector_definition_referenced_delete
+BEFORE DELETE ON connector_definitions
+WHEN EXISTS (SELECT 1 FROM connector_connections WHERE definition_id = OLD.id)
+BEGIN SELECT RAISE(ABORT, 'connector definition is in use'); END;
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -589,6 +663,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V13,
     _SCHEMA_V14,
     _SCHEMA_V15,
+    _SCHEMA_V16,
 ]
 
 
@@ -2868,9 +2943,57 @@ class CollieDB:
         last_verified_at: str | None = None,
         last_error_code: str | None = None,
         last_error_message: str | None = None,
+        definition_id: str | None = None,
     ) -> dict[str, Any]:
         now = utc_now()
         with self._write() as conn:
+            existing = conn.execute(
+                "SELECT definition_id, provider_id, driver FROM connector_connections WHERE id = ?",
+                (connection_id,),
+            ).fetchone()
+            if (
+                existing
+                and definition_id is not None
+                and existing["definition_id"] is not None
+                and definition_id != existing["definition_id"]
+            ):
+                raise ValueError("An installed connector definition cannot be replaced in place.")
+            definition_id = (
+                definition_id
+                or (
+                    str(existing["definition_id"])
+                    if existing and existing["definition_id"]
+                    else None
+                )
+                or f"def_{connection_id}"
+            )
+            associated = conn.execute(
+                "SELECT provider_id, driver FROM connector_definitions WHERE id = ?",
+                (definition_id,),
+            ).fetchone()
+            if associated and (
+                associated["provider_id"] not in (None, provider_id)
+                or associated["driver"] != driver
+            ):
+                raise ValueError("The connector definition does not match this account.")
+            conn.execute(
+                "INSERT OR IGNORE INTO connector_definitions "
+                "(id, provider_id, recipe_id, driver, transport, auth_strategy, provenance, "
+                "config_json, unresolved, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'curated', '{}', 1, ?, ?)",
+                (
+                    definition_id,
+                    provider_id,
+                    provider_id,
+                    driver,
+                    "api" if driver.endswith("api") else "streamable_http",
+                    "oauth"
+                    if auth_type == "oauth"
+                    else ("none" if auth_type == "none" else "token"),
+                    now,
+                    now,
+                ),
+            )
             conn.execute(
                 """
                 INSERT INTO connector_connections (
@@ -2878,8 +3001,8 @@ class CollieDB:
                     status, granted_scopes_json, enabled_capabilities_json,
                     enabled_tools_json, tool_policy_json, remote_account_id,
                     connected_at, updated_at, last_verified_at, last_error_code,
-                    last_error_message
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    last_error_message, definition_id, credential_ref
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     display_name = COALESCE(excluded.display_name, display_name),
                     account_label = COALESCE(excluded.account_label, account_label),
@@ -2933,8 +3056,17 @@ class CollieDB:
                     last_verified_at,
                     last_error_code,
                     last_error_message,
+                    definition_id,
+                    f"connector:{connection_id}",
                 ),
             )
+            if enabled_tools is not None:
+                conn.execute(
+                    "UPDATE connector_tool_cache SET enabled = CASE WHEN EXISTS "
+                    "(SELECT 1 FROM json_each(?) WHERE value = '*' "
+                    "OR value = remote_tool_name) THEN 1 ELSE 0 END WHERE connection_id = ?",
+                    (json.dumps(enabled_tools), connection_id),
+                )
         return self.get_connector_connection(connection_id)  # type: ignore[return-value]
 
     def get_connector_connection(self, connection_id: str) -> dict[str, Any] | None:
@@ -2951,10 +3083,122 @@ class CollieDB:
 
     def delete_connector_connection(self, connection_id: str) -> None:
         with self._write() as conn:
+            row = conn.execute(
+                "SELECT definition_id FROM connector_connections WHERE id = ?", (connection_id,)
+            ).fetchone()
             conn.execute("DELETE FROM connector_connections WHERE id = ?", (connection_id,))
+            if row and row["definition_id"]:
+                conn.execute(
+                    "DELETE FROM connector_definitions WHERE id = ? AND NOT EXISTS "
+                    "(SELECT 1 FROM connector_connections WHERE definition_id = ?)",
+                    (row["definition_id"], row["definition_id"]),
+                )
+
+    def save_connector_definition(self, definition: Any) -> dict[str, Any]:
+        """Persist a validated, secret-free installed definition snapshot."""
+        from collie_core.connectors.models import InstalledConnectorDefinition
+
+        if not isinstance(definition, InstalledConnectorDefinition):
+            definition = InstalledConnectorDefinition.from_dict(definition)
+        value = definition.to_dict()
+        config = {
+            key: value[key]
+            for key in (
+                "endpoint",
+                "oauth_registration",
+                "client_id",
+                "scopes",
+                "trusted_hosts",
+                "tool_overrides",
+            )
+            if value[key] not in (None, [], "")
+        }
+        now = utc_now()
+        with self._write() as conn:
+            current = conn.execute(
+                "SELECT * FROM connector_definitions WHERE id = ?", (definition.id,)
+            ).fetchone()
+            if current is not None and not current["unresolved"]:
+                current_config = json.loads(str(current["config_json"]))
+                immutable = (
+                    current["provider_id"],
+                    current["recipe_id"],
+                    current["recipe_version"],
+                    current["driver"],
+                    current["transport"],
+                    current["auth_strategy"],
+                    current["provenance"],
+                    current_config,
+                )
+                proposed = (
+                    definition.provider_id,
+                    definition.recipe_id,
+                    definition.recipe_version,
+                    definition.driver.value,
+                    definition.transport.value,
+                    definition.auth_strategy.value,
+                    definition.provenance.value,
+                    config,
+                )
+                if immutable != proposed:
+                    raise ValueError("Installed connector definitions are immutable.")
+                return dict(current)
+            conn.execute(
+                "INSERT INTO connector_definitions (id, provider_id, recipe_id, recipe_version, "
+                "driver, transport, auth_strategy, provenance, config_json, unresolved, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET provider_id=excluded.provider_id, "
+                "recipe_id=excluded.recipe_id, recipe_version=excluded.recipe_version, "
+                "driver=excluded.driver, transport=excluded.transport, "
+                "auth_strategy=excluded.auth_strategy, provenance=excluded.provenance, "
+                "config_json=excluded.config_json, unresolved=excluded.unresolved, "
+                "updated_at=excluded.updated_at",
+                (
+                    definition.id,
+                    definition.provider_id,
+                    definition.recipe_id,
+                    definition.recipe_version,
+                    definition.driver.value,
+                    definition.transport.value,
+                    definition.auth_strategy.value,
+                    definition.provenance.value,
+                    json.dumps(config, sort_keys=True),
+                    int(definition.unresolved),
+                    now,
+                    now,
+                ),
+            )
+        return self.get_connector_definition(definition.id)  # type: ignore[return-value]
+
+    def get_connector_definition(self, definition_id: str) -> dict[str, Any] | None:
+        return self._row("SELECT * FROM connector_definitions WHERE id = ?", (definition_id,))
+
+    def list_connector_definitions(self) -> list[dict[str, Any]]:
+        return self._rows("SELECT * FROM connector_definitions ORDER BY created_at, id")
+
+    def advance_connector_operation(self, connection_id: str, expected_revision: int) -> int:
+        """Claim the next lifecycle operation; reject absent or stale accounts."""
+        with self._write() as conn:
+            cursor = conn.execute(
+                "UPDATE connector_connections SET operation_revision = operation_revision + 1, "
+                "updated_at = ? WHERE id = ? AND operation_revision = ?",
+                (utc_now(), connection_id, expected_revision),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("The connection changed or no longer exists.")
+        return expected_revision + 1
 
     def replace_connector_tools(self, connection_id: str, tools: list[dict[str, Any]]) -> None:
         with self._write() as conn:
+            account = conn.execute(
+                "SELECT enabled_tools_json FROM connector_connections WHERE id = ?",
+                (connection_id,),
+            ).fetchone()
+            configured = (
+                json.loads(account["enabled_tools_json"])
+                if (account and account["enabled_tools_json"] is not None)
+                else None
+            )
             conn.execute(
                 "DELETE FROM connector_tool_cache WHERE connection_id = ?",
                 (connection_id,),
@@ -2962,7 +3206,8 @@ class CollieDB:
             conn.executemany(
                 "INSERT INTO connector_tool_cache "
                 "(connection_id, remote_tool_name, schema_hash, annotations_json, "
-                "risk, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+                "risk, discovered_at, tool_identity, description, input_schema_json, enabled) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 [
                     (
                         connection_id,
@@ -2971,6 +3216,24 @@ class CollieDB:
                         json.dumps(tool.get("annotations") or {}),
                         str(tool["risk"]),
                         utc_now(),
+                        f"{len(connection_id)}:{connection_id}:"
+                        f"{len(str(tool['name']))}:{tool['name']}",
+                        tool.get("description"),
+                        json.dumps(tool.get("input_schema"))
+                        if tool.get("input_schema") is not None
+                        else None,
+                        int(
+                            bool(
+                                tool.get(
+                                    "enabled",
+                                    (
+                                        configured is None
+                                        or "*" in configured
+                                        or str(tool["name"]) in configured
+                                    ),
+                                )
+                            )
+                        ),
                     )
                     for tool in tools
                 ],
@@ -3697,6 +3960,7 @@ class CollieDB:
             "budgets": self.list_budgets(),
             "health_logs": self._rows("SELECT * FROM health_logs ORDER BY logged_on"),
             "services": self.list_services(),
+            "connector_definitions": self.list_connector_definitions(),
             "connector_connections": self.list_connector_connections(),
             "connector_tools": self._rows(
                 "SELECT * FROM connector_tool_cache ORDER BY connection_id, remote_tool_name"
@@ -3753,6 +4017,7 @@ class CollieDB:
                 "services",
                 "connector_tool_cache",
                 "connector_connections",
+                "connector_definitions",
                 "subagents",
                 "usage",
                 "providers",

--- a/collie-core/tests/collie/test_connection_definition_validation.py
+++ b/collie-core/tests/collie/test_connection_definition_validation.py
@@ -1,0 +1,112 @@
+"""Validation and persistence boundaries for installed connector definitions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from collie_core.connectors.models import InstalledConnectorDefinition
+from collie_core.db import CollieDB
+
+
+def _base(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "id": "definition-1",
+        "driver": "custom_mcp",
+        "transport": "streamable_http",
+        "auth_strategy": "none",
+        "provenance": "custom",
+        "endpoint": "https://example.test/mcp",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_valid_no_auth_remote_definition_roundtrips_through_save(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    definition = InstalledConnectorDefinition.from_dict(
+        _base(trusted_hosts=["example.test"], scopes=["read"])
+    )
+
+    saved = db.save_connector_definition(definition)
+
+    assert saved["id"] == definition.id
+    assert json.loads(saved["config_json"]) == {
+        "endpoint": "https://example.test/mcp",
+        "scopes": ["read"],
+        "trusted_hosts": ["example.test"],
+        "tool_overrides": {},
+    }
+    db.close()
+
+
+def test_valid_oauth_definition_roundtrips_without_secret_fields(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    definition = InstalledConnectorDefinition.from_dict(
+        _base(
+            id="oauth-definition",
+            auth_strategy="oauth",
+            oauth_registration="preregistered",
+            client_id="public-client-id",
+            scopes=["read", "write"],
+            recipe_id="recipe-1",
+            recipe_version="1",
+        )
+    )
+
+    saved = db.save_connector_definition(definition)
+    config = json.loads(saved["config_json"])
+
+    assert config["oauth_registration"] == "preregistered"
+    assert config["client_id"] == "public-client-id"
+    assert config["scopes"] == ["read", "write"]
+    assert all(
+        fragment not in json.dumps(saved).lower()
+        for fragment in ("access_token", "refresh_token", "client_secret", "api_key")
+    )
+    db.close()
+
+
+@pytest.mark.parametrize(
+    "field", ["secret", "api_key", "access_token", "refresh_token", "client_secret", "credentials"]
+)
+def test_from_dict_rejects_unknown_or_credential_fields(field: str) -> None:
+    with pytest.raises(ValueError, match="Unknown connector definition fields"):
+        InstalledConnectorDefinition.from_dict(_base(**{field: "must-not-cross-boundary"}))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("scopes", "read"),
+        ("scopes", ["read", 1]),
+        ("trusted_hosts", "example.test"),
+        ("trusted_hosts", [""]),
+        ("tool_overrides", []),
+        ("tool_overrides", {"read": 1}),
+        ("unresolved", "false"),
+        ("id", 42),
+        ("driver", 42),
+        ("transport", None),
+        ("auth_strategy", []),
+        ("provenance", {}),
+    ],
+)
+def test_from_dict_rejects_malformed_collections_and_wrong_types(field: str, value: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        InstalledConnectorDefinition.from_dict(_base(**{field: value}))
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://user:password@example.test/mcp",
+        "https://example.test/mcp?token=secret",
+        "https://example.test/mcp#fragment",
+    ],
+)
+def test_from_dict_rejects_endpoint_userinfo_query_and_fragment(endpoint: str) -> None:
+    with pytest.raises(ValueError, match="credentials|query or fragment"):
+        InstalledConnectorDefinition.from_dict(_base(endpoint=endpoint))

--- a/collie-core/tests/collie/test_connector_foundation.py
+++ b/collie-core/tests/collie/test_connector_foundation.py
@@ -1,0 +1,194 @@
+"""Persistent connector-definition and V16 migration contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import collie_core.db as db_mod
+from collie_core.connectors.models import InstalledConnectorDefinition
+from collie_core.db import CollieDB
+
+
+def _v15(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.executescript(db_mod._SCHEMA_V1)
+    for migration in db_mod._MIGRATIONS[1:15]:
+        conn.executescript(migration)
+    conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    conn.execute("INSERT INTO schema_version VALUES (15)")
+    return conn
+
+
+def test_v15_upgrade_preserves_accounts_permissions_and_inventory(tmp_path: Path) -> None:
+    path = tmp_path / "upgrade.db"
+    conn = _v15(path)
+    conn.execute(
+        "INSERT INTO connector_connections "
+        "(id, provider_id, driver, auth_type, status, enabled_tools_json, tool_policy_json, "
+        "updated_at) VALUES ('account-a', 'unknown-provider', 'legacy_service', 'oauth', "
+        "'connected', '[]', '{\"read\":\"every_time\"}', '2026-01-01')"
+    )
+    conn.execute(
+        "INSERT INTO connector_tool_cache VALUES "
+        "('account-a', 'same_tool', 'hash', '{\"readOnlyHint\":true}', 'read', '2026-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    db = CollieDB(path)
+    row = db.get_connector_connection("account-a")
+    definition = db.get_connector_definition("def_account-a")
+    tools = db.list_connector_tools("account-a")
+    assert row is not None and row["credential_ref"] == "connector:account-a"
+    assert row["operation_revision"] == 0
+    assert row["enabled_tools_json"] == "[]"
+    assert json.loads(row["tool_policy_json"]) == {"read": "every_time"}
+    assert definition is not None and definition["unresolved"] == 1
+    assert definition["provider_id"] == "unknown-provider"
+    assert tools[0]["tool_identity"] == "9:account-a:9:same_tool"
+    assert tools[0]["enabled"] == 0
+    db.close()
+
+
+def test_definitions_are_validated_and_exported_without_credentials(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    with pytest.raises(ValueError, match="query or fragment"):
+        InstalledConnectorDefinition.from_dict(
+            {
+                "id": "unsafe",
+                "driver": "custom_mcp",
+                "transport": "streamable_http",
+                "auth_strategy": "token",
+                "provenance": "custom",
+                "endpoint": "https://example.test/mcp?key=secret",
+            }
+        )
+    with pytest.raises(ValueError, match="list of strings"):
+        InstalledConnectorDefinition.from_dict(
+            {
+                "id": "bad-list",
+                "driver": "custom_mcp",
+                "transport": "streamable_http",
+                "auth_strategy": "none",
+                "provenance": "custom",
+                "endpoint": "https://example.test/mcp",
+                "scopes": "read",
+            }
+        )
+    definition = InstalledConnectorDefinition.from_dict(
+        {
+            "id": "custom-1",
+            "driver": "custom_mcp",
+            "transport": "streamable_http",
+            "auth_strategy": "token",
+            "provenance": "custom",
+            "endpoint": "https://example.test/mcp",
+            "trusted_hosts": ["example.test"],
+        }
+    )
+    db.save_connector_definition(definition)
+    exported = db.export_all()
+    assert exported["connector_definitions"][0]["id"] == "custom-1"
+    assert "secret" not in json.dumps(exported["connector_definitions"]).lower()
+    db.clear_all()
+    assert db.list_connector_definitions() == []
+    db.close()
+
+
+def test_account_scoped_tool_identity_and_operation_revision_cas(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    for account in ("first", "second"):
+        db.upsert_connector_connection(
+            account,
+            provider_id="notion",
+            driver="official_mcp",
+            auth_type="oauth",
+            status="connected",
+            enabled_tools=[] if account == "first" else ["*"],
+        )
+        db.replace_connector_tools(
+            account,
+            [{"name": "search", "schema_hash": "h", "risk": "read"}],
+        )
+    identities = {
+        db.list_connector_tools("first")[0]["tool_identity"],
+        db.list_connector_tools("second")[0]["tool_identity"],
+    }
+    assert len(identities) == 2
+    assert db.list_connector_tools("first")[0]["enabled"] == 0
+    assert db.list_connector_tools("second")[0]["enabled"] == 1
+    assert db.advance_connector_operation("first", 0) == 1
+    with pytest.raises(ValueError, match="changed"):
+        db.advance_connector_operation("first", 0)
+    with pytest.raises(ValueError, match="no longer exists"):
+        db.advance_connector_operation("missing", 0)
+    db.delete_connector_connection("first")
+    assert db.get_connector_definition("def_first") is None
+    db.close()
+
+
+def test_explicit_definition_association_is_retained_and_checked(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    definition = InstalledConnectorDefinition.from_dict(
+        {
+            "id": "shared-definition",
+            "driver": "custom_mcp",
+            "transport": "streamable_http",
+            "auth_strategy": "none",
+            "provenance": "custom",
+            "provider_id": "custom",
+            "endpoint": "https://example.test/mcp",
+        }
+    )
+    db.save_connector_definition(definition)
+    db.upsert_connector_connection(
+        "account",
+        provider_id="custom",
+        driver="custom_mcp",
+        auth_type="none",
+        status="disconnected",
+        definition_id="shared-definition",
+    )
+    db.upsert_connector_connection(
+        "account",
+        provider_id="custom",
+        driver="custom_mcp",
+        auth_type="none",
+        status="failed",
+    )
+    assert db.get_connector_connection("account")["definition_id"] == "shared-definition"
+    with pytest.raises(ValueError, match="does not match"):
+        db.upsert_connector_connection(
+            "other",
+            provider_id="different",
+            driver="custom_mcp",
+            auth_type="none",
+            status="disconnected",
+            definition_id="shared-definition",
+        )
+    second = InstalledConnectorDefinition.from_dict(
+        {
+            "id": "second-definition",
+            "driver": "custom_mcp",
+            "transport": "streamable_http",
+            "auth_strategy": "none",
+            "provenance": "custom",
+            "provider_id": "custom",
+            "endpoint": "https://second.example.test/mcp",
+        }
+    )
+    db.save_connector_definition(second)
+    with pytest.raises(ValueError, match="cannot be replaced"):
+        db.upsert_connector_connection(
+            "account",
+            provider_id="custom",
+            driver="custom_mcp",
+            auth_type="none",
+            status="failed",
+            definition_id="second-definition",
+        )
+    db.close()

--- a/collie-core/tests/collie/test_connector_snapshot_runtime.py
+++ b/collie-core/tests/collie/test_connector_snapshot_runtime.py
@@ -1,0 +1,189 @@
+"""Runtime behavior for pinned installed connector recipe snapshots."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from collie_core.connectors import manager as manager_module
+from collie_core.connectors.catalog import connector_def
+from collie_core.connectors.manager import ConnectorManager
+from collie_core.connectors.models import ConnectorDefinition, ProbeResult
+from collie_core.db import CollieDB
+from collie_core.services.credentials import CredentialStore
+
+
+def _store(tmp_path: Path) -> CredentialStore:
+    return CredentialStore(
+        tmp_path / "credentials",
+        protect=lambda value: value[::-1],
+        unprotect=lambda value: value[::-1],
+    )
+
+
+def _connected(db: CollieDB, connection_id: str = "con_legacy_notion") -> None:
+    db.upsert_connector_connection(
+        connection_id,
+        provider_id="notion",
+        driver="official_mcp",
+        auth_type="oauth",
+        status="connected",
+    )
+
+
+class _RecordingDriver:
+    def __init__(self) -> None:
+        self.definitions: list[ConnectorDefinition] = []
+
+    def probe(self, definition: ConnectorDefinition, connection_id: str) -> ProbeResult:
+        del connection_id
+        self.definitions.append(definition)
+        return ProbeResult(tools=[{"name": "read_page", "schema_hash": "h", "risk": "read"}])
+
+
+def test_manager_initialization_backfills_known_legacy_recipe_snapshot(tmp_path: Path) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    credentials = _store(tmp_path)
+    _connected(db)
+    credentials.save("notion", {"tokens": {"access_token": "legacy-token"}})
+
+    ConnectorManager(db, credentials=credentials)
+
+    row = db.get_connector_definition("def_con_legacy_notion")
+    assert row is not None
+    assert row["provider_id"] == "notion"
+    assert row["unresolved"] == 0
+    assert json.loads(row["config_json"])["endpoint"] == connector_def("notion").endpoint
+    db.close()
+
+
+def test_runtime_uses_pinned_snapshot_after_catalog_recipe_mutation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    credentials = _store(tmp_path)
+    _connected(db, "con_snapshot")
+    credentials.save("connector:con_snapshot", {"tokens": {"access_token": "token"}})
+    driver = _RecordingDriver()
+    manager = ConnectorManager(db, credentials=credentials, driver_factory=lambda _: driver)
+
+    original = connector_def("notion")
+    assert original is not None
+    mutated = replace(
+        original,
+        available=True,
+        endpoint="https://changed.example/mcp",
+        scopes=("changed",),
+        tool_overrides={"read_page": "change"},
+    )
+    monkeypatch.setattr(
+        manager_module,
+        "connector_def",
+        lambda provider_id: mutated if provider_id == "notion" else None,
+    )
+
+    config = manager.mcp_servers_for_config()
+    server = next(iter(config.values()))
+    assert server["url"] == original.endpoint
+    assert server["connectorToolOverrides"] == original.tool_overrides
+
+    manager.test("con_snapshot")
+    assert driver.definitions[-1].endpoint == original.endpoint
+    assert driver.definitions[-1].scopes == original.scopes
+    assert driver.definitions[-1].tool_overrides == original.tool_overrides
+    db.close()
+
+
+def test_catalog_unavailability_disables_binding_even_with_pinned_snapshot(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    credentials = _store(tmp_path)
+    _connected(db, "con_unavailable")
+    credentials.save("connector:con_unavailable", {"tokens": {"access_token": "token"}})
+    manager = ConnectorManager(db, credentials=credentials)
+
+    original = connector_def("notion")
+    assert original is not None
+    unavailable = replace(original, available=False)
+    monkeypatch.setattr(
+        manager_module,
+        "connector_def",
+        lambda provider_id: unavailable if provider_id == "notion" else None,
+    )
+
+    assert manager.mcp_servers_for_config() == {}
+    db.close()
+
+
+def test_probe_keeps_cached_enabled_flags_in_sync(tmp_path: Path, monkeypatch) -> None:
+    recipe = replace(connector_def("notion"), available=True)
+    monkeypatch.setattr(manager_module, "connector_def", lambda _: recipe)
+    with CollieDB(tmp_path / "collie.db") as db:
+        credentials = _store(tmp_path)
+        db.upsert_connector_connection(
+            "account",
+            provider_id="notion",
+            driver="official_mcp",
+            auth_type="oauth",
+            status="connected",
+            enabled_tools=["old_tool"],
+        )
+        credentials.save("connector:account", {"tokens": {"access_token": "test-token"}})
+        manager = ConnectorManager(
+            db,
+            credentials=credentials,
+            driver_factory=lambda _: _RecordingDriver(),
+        )
+        manager.test("account")
+        assert db.list_connector_tools("account")[0]["enabled"] == 1
+        assert next(iter(manager.mcp_servers_for_config().values()))["enabledTools"] == [
+            "read_page"
+        ]
+        db.upsert_connector_connection(
+            "account",
+            provider_id="notion",
+            driver="official_mcp",
+            auth_type="oauth",
+            status="connected",
+            enabled_tools=[],
+        )
+        assert db.list_connector_tools("account")[0]["enabled"] == 0
+
+
+def test_manager_backfill_pins_recipe_endpoint_across_catalog_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from collie_core.connectors import catalog
+    from collie_core.connectors import manager as manager_module
+
+    recipe = catalog.connector_def("notion")
+    assert recipe is not None
+    initial = replace(recipe, available=True, endpoint="https://old.example.test/mcp")
+    monkeypatch.setitem(catalog._BY_ID, "notion", initial)
+    monkeypatch.setattr(manager_module, "connector_def", catalog.connector_def)
+    db = CollieDB(tmp_path / "collie.db")
+    db.upsert_connector_connection(
+        "old-account",
+        provider_id="notion",
+        driver="official_mcp",
+        auth_type="oauth",
+        status="connected",
+    )
+    store = CredentialStore(
+        tmp_path / "credentials",
+        protect=lambda value: value[::-1],
+        unprotect=lambda value: value[::-1],
+    )
+    store.save("connector:old-account", {"tokens": {"access_token": "kept-out-of-db"}})
+    manager = ConnectorManager(db, credentials=store)
+    changed = replace(initial, endpoint="https://new.example.test/mcp")
+    monkeypatch.setitem(catalog._BY_ID, "notion", changed)
+
+    servers = manager.mcp_servers_for_config()
+    assert next(iter(servers.values()))["url"] == "https://old.example.test/mcp"
+    assert "kept-out-of-db" not in repr(db.export_all())
+    db.close()

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 15
+    assert db.schema_version == 16
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,7 +25,7 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 15
+    assert d2.schema_version == 16
     d2.close()
 
 
@@ -416,7 +416,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.add_person("Sam")
     db.log_memory_journal("profile", "dietary", "add", "vegan")
     data = db.export_all()
-    assert data["schema_version"] == 15
+    assert data["schema_version"] == 16
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 15
+    assert db.schema_version == 16
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -85,7 +85,7 @@ def _build_db_at_version(path: Path, version: int) -> None:
 def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "collie.db")
     try:
-        assert db.schema_version == 15
+        assert db.schema_version == 16
         columns = {row["name"] for row in db._rows("PRAGMA table_info(turn_events)")}
         assert {"prompt_hash", "tool_schema_hash", "config_hash"} <= columns
     finally:
@@ -106,7 +106,7 @@ def test_old_rows_null_hashes(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 15
+        assert upgraded.schema_version == 16
         rows = upgraded.list_turn_events()
         assert len(rows) == 1
         assert rows[0]["prompt_hash"] is None

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -87,7 +87,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 15
+    assert db.schema_version == 16
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -109,7 +109,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 15
+        assert upgraded.schema_version == 16
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 15
+    assert db.schema_version == 16
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/collie-core/tests/collie/test_versions.py
+++ b/collie-core/tests/collie/test_versions.py
@@ -42,7 +42,7 @@ class _FakeConn:
 
 
 def test_v14_creates_artifact_versions_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 15
+    assert db.schema_version == 16
     rows = db._rows(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
     )
@@ -78,7 +78,7 @@ def test_v13_db_upgrades_to_v14_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 15
+        assert upgraded.schema_version == 16
         assert upgraded._rows(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
         )

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -95,6 +95,14 @@ React renderer
   -> streamed events back to the renderer
 ```
 
+Connection recipes remain in `collie_core/connectors/catalog.py`. Installed
+configuration snapshots and account/tool inventory live in SQLite through
+`collie_core/db.py`; `ConnectorManager` resolves existing accounts against those
+snapshots while retaining catalogue availability controls. Credential references
+point to the existing protected store. The connection specification in
+`docs/product/features/connectors.md` separates this foundation from later driver
+and desktop delivery.
+
 Electron owns OS integration and protected secret storage. Python owns agent
 behavior, durable product state, tool execution, and central permission
 evaluation. The renderer must not receive decrypted long-lived secrets.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,8 +11,8 @@
 
 ## Source inventory
 
-- Core Python files: **525**
-- Core Python test files: **240**
+- Core Python files: **528**
+- Core Python test files: **243**
 - Desktop TypeScript/TSX files: **190**
 - Desktop test files: **70**
 - Active Markdown docs: **36**

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -6,7 +6,7 @@ Active product truth is organized by purpose:
   first-run direction.
 - `features/agent-system.md` - chat-first configuration, Guide, Doctor, and
   evidence-driven Gardener direction.
-- `features/connectors.md` - target connector experience and initial provider
+- `features/connectors.md` - accepted connection architecture, staged delivery and provider
   stack.
 - `features/planning-ui-and-more/` - accepted checklist and reviewed-plan
   behavior.

--- a/docs/product/features/connectors.md
+++ b/docs/product/features/connectors.md
@@ -1,186 +1,315 @@
-# Collie Connectors Update
+# Collie connections
 
-**Status:** active product direction — 23 connections are live in the
-Connections directory as alpha (official hosted MCP with sign-in-your-account
-authorization): Notion, Linear, Todoist, Atlassian, Airtable, Asana, ClickUp,
-monday.com, Cal.com, Figma, Canva, Vimeo, Webflow, GitLab,
-Netlify, Supabase, Neon, Sentry, Cloudflare, PayPal, Square, Ramp, and
-Klaviyo. CircleCI is parked (coming soon) until its official MCP endpoint is
-verified. Google/Microsoft/Slack bundles await Collie-owned OAuth app
-registrations (see "Required from the owner").
-**Date:** 2026-08-01
+**Status: accepted implementation direction. Delivery is incremental; unimplemented steps are requirements, not availability claims.**
 
-## Objective
+Date: 2026-09-09. Product: Collie.
 
-Replace Collie's placeholder connector experience with real, working integrations:
+Baseline: live `FoxRick/Collie` main at [`b54311aaae24d12f92832fcfc68167c8fe2c81c6`](https://github.com/FoxRick/Collie/commit/b54311aaae24d12f92832fcfc68167c8fe2c81c6).
 
-- Official brand assets rather than invented logos
-- One-click browser authorization with the actual provider
-- Secure token storage
-- Live connection status and tool discovery
-- Clear disconnect, reconnect, and error recovery
-- Confirmation before consequential or destructive actions
+This is the canonical connection specification, adopted from the approved implementation plan against the baseline above. Steps 1–2 establish the storage foundation. Remote add/import, flexible authentication, provider adapters, and local execution remain later delivery steps. Existing catalogue availability is not evidence of real-account or packaged acceptance.
 
-The initial competitive stack is:
+## 1. Outcome and decisions
 
-1. Google Workspace
-2. Microsoft 365
-3. Direct hosted MCP providers
+Collie should let a user connect a compatible MCP server without a Collie code release, while providing tested, plain-language sign-in for popular services. The normal experience is: find the service, connect an account, see what Collie can do, and use it in chat.
 
-## Google Workspace
+Accepted decisions:
 
-Use Google's official hosted MCP servers for:
+- Build general MCP support and curated provider integrations on one connection lifecycle.
+- Support remote Streamable HTTP first, legacy SSE for compatibility, and managed local stdio servers in a subsequent delivery.
+- Support no-auth, protected API tokens/headers, and OAuth with both automatic and pre-registered client identities.
+- Deliver Slack through its official MCP and registered Collie application; deliver Microsoft Teams through delegated Microsoft Graph by default. Treat Microsoft-hosted Teams MCP as an additional eligible-tenant route.
+- Keep a searchable curated directory, but stop making membership in that directory a prerequisite for connecting.
+- Preserve local state, OS-protected credentials, central permission enforcement, and no mandatory Collie account for direct connections.
+- Keep a managed integration provider optional and independently evaluated. It must not block direct MCP or Slack/Microsoft delivery.
 
-- Gmail
-- Google Calendar
-- Google Drive
-- Google Docs
-- Google Sheets
-- Google Slides
-- Google Chat
-- Google Contacts / People
+Broad compatibility does not imply every service exposes an API/MCP, every account has access, or every server supports every operation. Product language must name supported transports and working capabilities, not promise universal authorization.
 
-The user should see one Google Workspace connector in Collie, with individual services and permissions selectable underneath it.
+## 2. Why this matches other harnesses
 
-### Required from the owner
+Cline accepts remote endpoints and local server configurations, including credentials. Claude Code accepts arbitrary HTTP/stdio servers, imports MCP configurations, and supports OAuth and pre-registered clients. Collie should offer comparable interoperability behind a graphical and conversational setup flow. [Cline](https://github.com/cline/cline/blob/main/docs/mcp/mcp-overview.mdx), [Claude Code](https://code.claude.com/docs/en/mcp)
 
-- A Google Cloud project owned by Collie
-- An OAuth application named **Collie**
-- `heycollie.com` configured as an authorized domain
-- A user-support email
-- A Google account added as an initial test user
-- OAuth credentials stored in secure local or backend configuration, never committed to the repository or pasted into chat
-- Public product, privacy-policy, terms-of-service, and support pages for production verification
+The live Collie connection manager currently implements only its official MCP driver. Custom MCP, bundled MCP, and API kinds exist as declarations, but are not complete driver paths. The underlying engine already supports multiple transports. Reuse that engine; complete the connection management layer rather than creating a second agent runtime. [Manager](https://github.com/FoxRick/Collie/blob/b54311aaae24d12f92832fcfc68167c8fe2c81c6/collie-core/collie_core/connectors/manager.py), [Engine transport support](https://github.com/FoxRick/Collie/blob/b54311aaae24d12f92832fcfc68167c8fe2c81c6/collie-core/nanobot/agent/tools/mcp.py)
 
-Google Workspace MCP is currently a Developer Preview. A test connection may be possible immediately once the Cloud project, APIs, OAuth consent screen, and test user are configured. Public access can require Google's sensitive/restricted-scope verification and is not guaranteed to be available on the same day.
+## 3. Architecture and ownership
 
-## Microsoft 365
+| Component | Planned responsibility |
+| --- | --- |
+| `collie_core/connectors/models.py` | Connection definition, transport/auth configuration, provenance, capabilities and lifecycle contracts |
+| `collie_core/db.py` | Persistent custom definitions, connection instances, discovered tool metadata, migrations |
+| `collie_core/connectors/manager.py` | Resolve definitions, dispatch drivers, coordinate connect/test/reconnect/remove and runtime attachment |
+| `collie_core/connectors/drivers/` | Shared remote MCP driver, local process driver, provider API adapters |
+| `collie_core/connectors/auth.py` | OAuth discovery, registration/profile selection, browser callbacks, refresh and reauthorization |
+| `collie_core/services/credentials.py` plus Electron main | OS-protected credential storage and narrowly scoped secret submission |
+| `collie_core/connectors/policy.py` and existing permissions | Tool classification, user authority and per-action approvals |
+| `collie_core/runtime.py`, `settings.py`, adapted MCP engine | Connection attachment, removal, tool routing and isolation |
+| `collie_core/ipc/server.py`, Electron/preload bridge, renderer `lib/ipc.ts` | Typed connection commands and authoritative status events |
+| `ConnectorsScreen.tsx` and connector components | Search, add/import, authentication, capability selection, status, repair and removal |
+| Existing chat connector tools | Equivalent approved setup actions from conversation |
 
-Use delegated Microsoft Graph authorization for the initial Microsoft bundle:
+Keep the existing connector manager as the authoritative entry point. Inventory the older `services/` catalogue/facade and migrate or retain explicit compatibility adapters; do not add a third catalogue or another token store. Changes to adapted `nanobot/` remain narrow.
 
-- Outlook Mail
-- Outlook Calendar
-- OneDrive
-- Microsoft Contacts
-- Microsoft To Do
-- Excel workbooks
+### Data contracts
 
-The app should support work/school accounts and personal Microsoft accounts where the corresponding Graph feature is available.
+Separate these concepts:
 
-### Required from the owner
+1. **Recipe:** versioned installation/auth instructions and service presentation; curated or imported.
+2. **Definition:** concrete server/API configuration selected by the user, including transport, endpoint or package, authentication profile and recipe version.
+3. **Connection:** one authenticated account/instance of a definition, with its own credential reference, granted capabilities, status and lifecycle revision.
+4. **Tool inventory:** namespaced tool identities, schemas/descriptions needed for execution, schema hashes, enabled state and policy classification.
 
-- A Microsoft Entra tenant, preferably owned through a Collie work/business account
-- A multi-tenant app registration named **Collie**
-- Collie's verified domain associated with the tenant
-- The application/client ID and tenant configuration stored securely
-- A Microsoft account with sample mail, calendar, file, and task data for testing
+Extend `connector_connections` and `connector_tool_cache` where appropriate; add a definition table rather than overloading `provider_id` with URLs or commands. Choose the next migration number at implementation time. No secrets belong in definition rows, exported configuration, logs, or cached tool metadata.
 
-The development connection can likely be tested immediately after registration. Public organizational adoption should include Microsoft publisher verification, because some tenants prevent users from consenting to new unverified multi-tenant applications.
+Existing provider IDs and connections must resolve unchanged after migration. A recipe update must not silently change an installed endpoint, executable package, requested scopes, or trust designation. Such changes require review/reconnection as applicable.
 
-## Direct hosted MCP connectors
+Keep provider availability separate from account status. Distinguish unsupported implementation, missing local requirements, account authentication, organization approval, and failed health checks. Existing statuses can remain on the wire with structured reason codes and additive fields.
 
-Prioritize everyday, high-value services:
+## 4. Step-by-step delivery
 
-- Notion
-- GitHub
-- Canva
-- Stripe
-- Linear
-- Airtable
+### Step 1 — Lock scope and establish regression evidence
 
-Todoist should not be a headline connector. It can remain a later catalog entry if it is inexpensive to support.
+Inventory the latest implementation, current dependencies, packaged runtime, and provider catalogue. Confirm the shared driver contract and the schema above. Capture regression cases for existing working connections before refactoring.
 
-Use official remote MCP endpoints where a provider operates one. Avoid maintaining custom API wrappers when a stable official MCP implementation already exists.
+First-release scope: remote MCP, flexible auth, add/import UI, Slack internal testing, and Microsoft Teams delegated Graph testing. Managed local servers follow. Continuous event subscriptions and chatting with Collie inside Slack/Teams are separate features; this plan initially concerns Collie acting on those services from its desktop chat.
 
-## Logo and brand-asset policy
+**Exit:** accepted architecture, capability matrix, and documented provider setup prerequisites; no enabled-only placeholder entries counted as working.
 
-- Obtain logos from each provider's official press kit, brand site, developer resources, or an explicitly licensed repository.
-- Bundle assets locally so the connector catalog is reliable offline.
-- Preserve the original aspect ratio, safe area, and provider-specified colors.
-- Maintain an asset manifest containing source URL, retrieval date, license or usage-policy URL, and any required attribution.
-- Never generate, approximate, redraw, or silently recolor another company's logo.
-- Do not treat a generic icon library as the authoritative brand source unless the provider explicitly recommends it.
+### Step 2 — Add persistent definitions and backward-compatible migration
 
-## Product behavior
+Implement custom definitions, credential references, namespaced tool inventory, and per-connection operation revisions. Migrate existing catalogue-backed connections without changing their permissions or losing credentials. Validate exports and user-data deletion for the new tables.
 
-Clicking **Connect** should:
+**Exit:** fresh-install and upgrade tests pass; existing accounts resolve to equivalent runtime configuration; interrupted migration recovery is documented. Ship migrations separately from broad feature changes where practical.
 
-1. Open the provider's real authorization page in the system browser.
-2. Display the exact permissions Collie is requesting.
-3. Return to Collie through a secure OAuth callback.
-4. Store tokens in the operating-system credential vault.
-5. Connect to the provider and discover its available MCP tools or API capabilities.
-6. Run a harmless verification request.
-7. Show a truthful status: `Connected`, `Needs authorization`, `Unavailable`, or `Error`.
+### Step 3 — Generalize the remote driver
 
-Static catalog flags must not be presented as proof that a connector works.
+Extract the common discovery/probing logic from `OfficialMcpDriver`. Accept validated definitions rather than requiring a hardcoded provider ID. Support Streamable HTTP and explicit legacy SSE. Reuse the adapted engine's transports, reconnect handling and schema normalization.
 
-## Initial permission posture
+Discover the complete tool inventory, including pagination. Handle protocol negotiation, timeouts, cancellation, malformed responses, duplicate names and partial availability. Use per-connection namespaces, not display names, to avoid collisions between accounts.
 
-Use least-privilege delegated access. For the alpha:
+Endpoint checks must cover initial URLs, redirects and discovered OAuth metadata. Permit localhost/private-network servers through an explicit local/private connection choice, without silently extending that access to unrelated destinations.
 
-- Email: read/search and create drafts; sending requires explicit confirmation
-- Calendar: read and manage events; destructive actions require confirmation
-- Files and documents: read and edit; deletion requires confirmation
-- Payments: read access first; payment-changing actions disabled until separately designed and approved
-- Never request tenant-wide application permissions when user-delegated permissions can satisfy the feature
+**Exit:** an unknown-to-Collie remote server can be added, queried and removed without modifying the catalogue.
 
-## Cost expectations
+### Step 4 — Complete authentication strategies
 
-The alpha should be mostly free to configure:
+Implement explicit strategies for:
 
-- Google and Microsoft app registration normally has no connector-registration fee.
-- Core Microsoft Graph mail, calendar, file, and task operations are not expected to require metered Graph billing.
-- Official hosted MCP servers do not require a connector-platform vendor such as Composio.
-- Users still need accounts and any applicable subscriptions for the connected products.
-- Collie needs a small secure OAuth callback or token-exchange service where a provider requires a confidential client secret.
+- Servers requiring no authentication.
+- API keys/bearer tokens/custom header credentials stored through the protected secret path.
+- OAuth discovery and PKCE, automatic client registration/client metadata where supported by the negotiated specification and SDK.
+- Pre-registered provider clients, fixed callbacks where required, and provider-specific scope/refresh behavior.
 
-**Google policy caveat (checked 2026-08-01):** Google's Workspace API quota
-rules changed from 2026-05-01 and Google describes billing for use above
-standard thresholds later in 2026. Alpha-scale use may still be inexpensive,
-but Collie must verify the current project quota, billing, and applicable API
-terms before describing a Google connection as free or enabling it broadly.
-This specification intentionally does not assume a price.
+Audit actual SDK support before selecting an upgrade; do not assume every mechanism is already implemented. Bind client registration and tokens to their issuer and intended resource. Prevent credentials following cross-origin redirects. Use one refresh coordinator per account and avoid unsolicited browser prompts during tasks.
 
-Potential later costs include hosting, provider-specific paid plans, and a third-party security assessment if Google classifies the production data access as requiring one.
+Secret fields may accept user input transiently, but must never be returned in account details, stored in renderer state beyond submission, or sent through model-visible chat. Explain expiry, cancelled consent and administrator blocks in ordinary language.
 
-## Delivery reality
+**Exit:** connect, refresh, restart, expired refresh token, denied consent and reauthorization work for representative auth strategies. [MCP authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 
-Can be implemented without provider approval:
+### Step 5 — Preserve permissions for dynamically discovered tools
 
-- Real logos and the brand-asset manifest
-- Connector catalog and grouped Google/Microsoft UX
-- OAuth callback infrastructure
-- Secure credential storage
-- Live health checks and tool discovery
-- Direct hosted MCP integrations
-- Microsoft Graph adapters
-- Confirmation and safety controls
+Route every new tool through existing central policy. Imported servers remain untrusted; read-only annotations alone do not grant authority. Distinguish granting access to a service from approving a send, publish, deletion or financial action.
 
-Requires owner participation:
+Do not promote a third-party server to trusted merely because it appears in a registry. Re-check newly discovered or materially changed tools before allowing prior approval preferences to apply. Account switching must not reuse another connection's grants. Server instructions are data, not authority to alter Collie's policy.
 
-- Approximately 30–60 minutes to create or authorize the Google and Microsoft application registrations
-- Acceptance of provider terms
-- Test-account authorization through the providers' browser flows
-- Approval and deployment of public identity and policy pages
-- Production verification submissions
+**Exit:** unknown tools cannot bypass approval; tool/schema changes and multiple-account cases have focused tests.
 
-An invited-user alpha can potentially work the same day once the registrations exist. A public Google/Microsoft launch cannot honestly be promised for the same day because provider review and customer tenant policies are external dependencies.
+### Step 6 — Add IPC and runtime lifecycle support
 
-## Recommended first release
+Add typed commands for validating/importing a definition, saving it, beginning/cancelling auth, inspecting tools/capabilities, reconnecting, and removal. Reuse existing commands where their semantics fit. Return sanitized errors and operation IDs/revisions so late auth/test results cannot resurrect a removed connection.
 
-- Google Workspace: Gmail, Calendar, Drive, Docs, Sheets, Slides
-- Microsoft 365: Outlook Mail, Calendar, OneDrive, Excel, To Do
-- Direct MCP: Notion, GitHub, Canva, Stripe
-- Read and draft/create workflows enabled
-- Send, delete, payment, and other consequential operations gated by explicit user confirmation
+Disconnect prevents new calls immediately and handles in-flight calls explicitly. Attach new connections at a safe boundary without disrupting unrelated chat. Preserve tool identity and connection scope in subagents and routines.
 
-## Official references
+For many connected services, search/select relevant tools rather than loading every schema into every prompt. Reuse an existing tool-discovery mechanism if available; otherwise introduce a bounded lookup that returns only enabled tools for the authorized connection.
 
-- [Google Workspace MCP configuration](https://developers.google.com/workspace/guides/configure-mcp-servers)
-- [Google Workspace tools and API usage](https://developers.google.com/workspace/tools-safety)
-- [Google OAuth verification requirements](https://developers.google.com/identity/protocols/oauth2/production-readiness/sensitive-scope-verification)
-- [Microsoft application registration](https://learn.microsoft.com/en-us/graph/auth-register-app-v2)
-- [Microsoft publisher verification](https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview)
-- [Microsoft Graph overview](https://learn.microsoft.com/en-us/graph/overview)
-- [Microsoft official MCP catalog](https://github.com/microsoft/mcp)
+**Exit:** add/remove/reconnect during active work behaves predictably; large tool inventories stay bounded; unrelated accounts and conversations remain unaffected.
+
+### Step 7 — Build the frontend add/import experience
+
+Keep **Connected** and **Explore**, adding **Add connection** with plain-language options:
+
+- Find a service.
+- Connect using a link.
+- Import a connection file.
+- Install a local connector, when Step 11 ships.
+
+Import common `mcpServers` configurations, map supported fields, and show unsupported options rather than silently dropping them. Import is a preview: it must not execute a command, install a package or contact a server automatically. Extract imported secrets into the protected submission path and exclude them from summaries/exports.
+
+Flow: identify connection → preview publisher/location/access → authenticate → discover capabilities → safe test → connected. Show the actual account/workspace, useful example tasks, and capabilities available to that account.
+
+An API-only adapter does not need to expose technical MCP terminology. Advanced fields stay available in expandable details. Chat-based setup calls the same backend flow.
+
+**Exit:** a user adds a new compatible remote connection without editing JSON or using a terminal; accessibility, cancellation, retry, refresh and duplicate-account behavior are covered.
+
+### Step 8 — Make connection failures actionable
+
+Replace generic coming-soon/failure messages with a truthful next step: sign in again, obtain workspace approval, install a runtime, correct an endpoint, or use an available alternative route. Keep service implementation status visible separately from user account health.
+
+Add per-account test, reconnect and disconnect controls. Explain local credential removal versus remote revocation. Diagnostics must show sanitized stage/error information without disclosing credentials or message contents.
+
+**Exit:** every supported failure class provides an accurate recovery action, and cancelled/removed connections cannot return as connected from stale events.
+
+### Step 9 — Finish Slack as a curated connection
+
+Register/configure a Collie Slack application, permitted callbacks and the minimum user scopes for search, read, and sending. Validate desktop PKCE with Slack's MCP-specific OAuth endpoints and refresh behavior. Fill the actual endpoint and profile into the recipe; keep send actions centrally gated.
+
+Test internal-workspace access first. Complete the Marketplace distribution path before claiming public out-of-box availability: Slack currently allows Marketplace-published and internal apps, not unlisted distributed apps, and does not support dynamic client registration. If public distribution is blocked, report that dependency instead of changing availability flags or claiming another API bypasses it.
+
+**Exit:** real search/read and approved-send tests, expiry/reconnect tests, workspace denial handling, and evidence for the intended distribution audience. App eligibility is an external dependency. [Slack MCP](https://docs.slack.dev/ai/slack-mcp-server/), [PKCE](https://docs.slack.dev/authentication/using-pkce/)
+
+### Step 10 — Finish Microsoft Teams and reusable Microsoft sign-in
+
+Implement an official API driver backed by Microsoft Graph and a Collie multitenant Entra application with public-client desktop authentication. Design sign-in once, then expose workload-specific capabilities without requesting every Microsoft permission up front.
+
+First capabilities: list/read the user's chats, read permitted channel content, and send chat/channel messages with approval. Resolve exact delegated scopes and account support against current endpoint documentation; distinguish user-consentable operations from admin-required access. Support partial capabilities when broader consent is unavailable.
+
+Use this foundation for Outlook email/calendar and OneDrive in subsequent provider slices, each with separate scopes and acceptance tests. Do not imply Teams work/school capabilities are available on personal Microsoft accounts. Add tenant-specific hosted Teams MCP only after verifying that customer's Work IQ licensing, admin grants and selected integration path.
+
+**Exit:** authenticated account/tenant is visible; permitted reads and approved sends work; admin-required features show precise restrictions; refresh and tenant/account switching pass. [Graph permissions](https://learn.microsoft.com/en-us/graph/permissions-reference), [Desktop auth](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-app-configuration), [Current Work IQ requirements](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/get-started)
+
+### Step 11 — Add managed local MCP servers
+
+Implement the stdio driver with a per-connection process lifecycle, scoped environment, bounded logs, stop/restart behavior and Windows packaging support. Audit which Node/Python/package runtimes the installer actually supplies; do not depend on a developer machine's PATH.
+
+Curated recipes specify pinned package versions and supported installation methods. Installation gets a separate review because it executes third-party software. Launch processes without shell-string concatenation and without visible terminal windows. Define enforceable filesystem/network/process containment for supported packages; tool-call permission prompts do not sandbox a server's own process. If a package requires broader host access, describe it explicitly instead of calling it contained.
+
+Arbitrary imported local commands may require advanced setup; universal dependency compatibility is not an acceptance claim. Provide the managed no-terminal experience for a documented supported package set first.
+
+**Exit:** clean Windows installation can install/start/use/update/remove supported local connectors, with failed installs, unavailable dependencies, crashes and permission boundaries tested.
+
+### Step 12 — Expand discovery without coupling it to releases
+
+Retain a bundled directory as an offline baseline. Add a versioned updateable recipe feed and optional external registry discovery. Show publisher/provenance and distinguish Collie-tested recipes from community results. Verify feed authenticity and schema, cache the last valid version, and tolerate feed outages.
+
+Registry listing is discovery evidence, not proof of compatibility or trust. A selected recipe goes through the same validation/auth/probe flow. An update must never silently install packages or expand access on existing connections.
+
+**Exit:** adding a recipe can make it discoverable without a binary release; existing connections work when discovery services are offline. [Official registry](https://registry.modelcontextprotocol.io/docs)
+
+### Step 13 — Evaluate optional managed-provider coverage
+
+Run a separate, bounded evaluation of a provider such as Pipedream for otherwise uncovered services. Verify exact actions, account types, OAuth distribution rights, consent requirements, production limits, cost, data handling, disconnect behavior and latency. Catalogue size alone is not an acceptance test.
+
+If adopted, keep server-side integration credentials out of the desktop binary, provide explicit user identity/account isolation, and mark which service handles the connection. Direct connections continue to work without this provider or a mandatory Collie account. A managed route cannot bypass workplace policy and must not be silently substituted for a direct route.
+
+**Exit:** documented product decision and demonstrated target workflows before any dependency is introduced. This step can be deferred without blocking Steps 1–12. [Pipedream MCP](https://pipedream.com/docs/connect/mcp), [OAuth production options](https://pipedream.com/docs/connect/managed-auth/oauth-clients)
+
+### Step 14 — Packaged acceptance, rollout and documentation
+
+Test on clean Windows machines, not just development environments. Exercise real account sign-in, useful read, approved write in a test destination, restart, refresh, reconnect, cancellation and removal. Mock servers cover deterministic transport/auth/protocol failures; real provider tests cover platform behavior that mocks cannot prove.
+
+Roll out remote MCP first, then independently validated Slack/Teams routes, followed by local packages and broader discovery. Keep independent route controls so one broken integration does not disable all connections. These controls are rollout/recovery tools, not permanent substitutes for missing implementations.
+
+Back up migration-sensitive state before rollout, define compatible rollback versions, and avoid dropping new user definitions during rollback. Endpoint/recipe rollback must not downgrade trust or broaden permissions. Publish the verified capability matrix and update the canonical product/architecture documentation only as implementation truth changes.
+
+**Exit:** all release criteria below pass for each advertised route; installer/version and provider-test evidence are recorded.
+
+## 5. Dependency order and reviewable work packages
+
+| Package | Steps | Depends on | Review result |
+| --- | --- | --- | --- |
+| A | 1–2 | Implementation authorization | Contracts, migration and compatibility evidence |
+| B | 3–5 | A | General remote transports, authentication and central policy |
+| C | 6–8 | B; frontend mocks can start after A | Complete desktop/chat add-connect-use-recover flow |
+| D | 9 | B–C; begin app-registration preparation after approval | Slack internal acceptance, then separately public eligibility |
+| E | 10 | A–C; Microsoft registration preparation after approval | Teams Graph acceptance and reusable Microsoft sign-in |
+| F | 11 | A–C | Managed local package support |
+| G | 12 | C; local recipes depend on F | Updateable discovery with provenance |
+| H | 13 | Independent evaluation; integration depends on C | Optional managed-provider decision |
+| Release | 14 | Each selected package's acceptance | Incremental verified rollout |
+
+Provider registration/review can proceed alongside software development after authorization. Do not make generic MCP wait for Slack Marketplace review. Do not estimate external review completion as engineering time. Re-estimate engineering effort after A establishes actual SDK/runtime gaps.
+
+## 6. Release acceptance matrix
+
+| Area | Required proof |
+| --- | --- |
+| Existing connections | Upgrade preserves IDs, credentials, capabilities and approval preferences |
+| Unknown remote server | Connect and call tools without adding a provider to source code |
+| Authentication | No-auth, token/header and OAuth cases; rejected consent, expiry, refresh and reauthorization |
+| Interoperability | Negotiation, paginated discovery, malformed tools, name collisions, HTTP/SSE and disconnects |
+| Permissions | Imported tool hints cannot bypass policy; changed tools require appropriate review |
+| Isolation | Separate accounts, issuer-bound tokens, scoped subagent/routine use and no cross-account grants |
+| Lifecycle | Cancel/remove wins against late completion; restart restores correct state; in-flight calls are handled |
+| Frontend | Add/import/search, keyboard use, accessible status, actionable failures and secret-safe diagnostics |
+| Slack | Real account search/read/approved send plus audience-appropriate app eligibility |
+| Teams | Actual delegated capabilities, approved send, partial consent and tenant restrictions |
+| Local packages | Clean Windows setup, managed dependencies, process cleanup and stated containment |
+| Scale | Bounded prompt/tool loading and no connection storms with a large installed inventory |
+| Privacy | No secrets in model context, SQLite definitions, exports, diagnostics or logs; truthful data routing |
+
+## 7. Owner-controlled dependencies and unresolved choices
+
+- Slack application ownership, internal test workspace, and public Marketplace eligibility/review.
+- Microsoft application ownership, test tenant, publisher/tenant consent requirements and delegated scope validation.
+- Test accounts and explicit authorization for real write tests; keep them in designated test conversations/resources.
+- Supported local package runtime set and enforcement mechanism, decided before advertising managed local execution.
+- Hosting/ownership of a recipe feed if dynamic discovery ships.
+- Optional managed provider's cost and data-processing decision; default proposal is to defer adoption until evaluated.
+
+Implementation is authorized. Provider account consent, designated real-write test destinations, application ownership, distribution approval, and clean-machine acceptance remain explicit external dependencies. No provider is newly advertised by the storage foundation.
+
+
+
+## 8. Presentation and brand assets
+
+Use official, locally bundled provider brand assets with a manifest recording source,
+retrieval date, and usage terms. Preserve their aspect ratio and required attribution.
+Do not generate or approximate another company's logo. Keep Connected and Explore
+as the main views, with advanced transport/authentication details behind disclosure.
+Google Workspace, Outlook, OneDrive, and other workload bundles remain separately
+scoped follow-on work; this plan does not imply their availability.
+
+## 9. Foundation capability baseline
+
+The Step 1 inventory against the baseline commit found 34 bundled recipes;
+23 were enabled as alpha on Windows with protected credential storage available.
+These flags describe implementation routing, not verified provider acceptance.
+
+| Boundary | Baseline implementation | Delivery still required |
+| --- | --- | --- |
+| Driver | `OfficialMcpDriver`, Streamable HTTP, OAuth, one-page discovery | Arbitrary definitions, SSE, pagination, no-auth/header and registered-client auth |
+| Manager | One authoritative lifecycle with legacy `services/` compatibility | Revision-aware IPC completion and generalized drivers |
+| Storage | Schema V15; connection/tool tables introduced in V7 | Definition snapshots, credential references, operation revisions, inventory identities |
+| Permissions | Central conservative classification and approval preferences | Material tool-change review and broader account isolation coverage |
+| Desktop | Connected/Explore, curated search, sign-in/test/remove | Add link/import preview and richer recovery |
+| Providers | Curated hosted MCP route | Slack registration/acceptance; Teams Graph driver and Entra registration/acceptance |
+| Packaging | CPython 3.12 staging and Node probe runtime (`24.18.0` package engine declaration) | Managed local package installation, containment and clean-machine acceptance |
+
+Dependencies remain unchanged: `mcp>=1.26.0,<2.0.0` and
+`httpx>=0.28.0,<1.0.0`. The local regression environment used CPython 3.12.14
+and MCP 1.29.0; this is development evidence, not a packaged SDK guarantee.
+The baseline passed 97 tests across `test_connectors.py`, `test_services.py`,
+`test_db.py`, `test_connect_validation.py`, `test_mcp_connection.py`, and
+`test_mcp_reconnect_crash.py`. The existing local environment lacked
+`pytest-timeout`, producing configuration warnings; no real-provider or installer
+acceptance was performed. These suites cover lifecycle, credential loss, removal,
+cancellation, policy, legacy compatibility, and engine reconnect behavior.
+
+The shared driver contract retains `connect_and_probe`, noninteractive `probe`,
+and best-effort `revoke`, returning `ProbeResult`. New installed-definition
+snapshots adapt to that contract for existing official routes. The manager remains
+authoritative; no second catalogue, token store, or runtime is introduced.
+
+### Upgrade and recovery contract
+
+Schema V16 is an additive migration. Back up the closed application's SQLite
+state and protected credential directory together before rollout; do not copy a
+live WAL database as if its main file were a complete backup. Credential blobs
+remain tied to their operating-system protection context.
+
+The migration runner commits each schema change and version bump in one
+`BEGIN IMMEDIATE` transaction. If V16 fails before commit, reopen with the fixed
+build to retry from V15; do not manually advance `schema_version` or drop tables.
+Installed snapshots unresolved after schema migration are completed by the manager
+when their legacy provider is known. Unknown provider rows remain stored and
+removable, with no guessed endpoint or newly granted authority.
+
+Definitions and connection metadata are included in user-data export, while
+credential references contain no credential payload. User-data deletion covers
+the definition table. Tool inventory identities are additive storage identities;
+existing runtime tool names remain stable in this slice. Operation revisions are
+storage primitives here; stale IPC completion protection is Step 6 acceptance.
+
+Downgrading to a pre-V16 build is not a supported rollback path: old writes can
+leave newly added metadata inconsistent. Use a V16-compatible corrective build,
+or restore the complete pre-upgrade backup with the app closed, accepting that
+post-backup user changes are lost. Export any new definitions before a deliberate
+restore. No automatic destructive downgrade is introduced.


### PR DESCRIPTION
This implements Steps 1–2 of the approved connections plan. Existing connections previously resolved against the mutable bundled catalogue; they now retain a validated installed configuration snapshot while live catalogue availability controls still apply.

- Add the V16 migration for persistent definitions, unchanged protected credential references, account operation revisions, and namespaced tool inventory. Preserve existing grants, wildcard/disabled tool selection, exports, and user-data deletion.
- Resolve existing official MCP connections through immutable snapshots of endpoint, scopes, and tool policy. Custom definitions are storage-only in this slice.
- Adopt the canonical staged specification with the capability baseline, provider prerequisites, and upgrade/recovery guidance. Migration, manager compatibility, and documentation are separate commits.

Validation: 260 affected backend tests passed on Windows / Python 3.12.14, including migration, definition validation, manager snapshots, IPC contracts, services, storage, and MCP reconnect coverage. Ruff lint/format, git diff whitespace checks, and generated repository snapshot checks pass. The local environment lacks pytest-timeout, yielding two existing configuration warnings. Astra reviewed the final implementation and all identified findings were resolved; Sol and Luna implemented and tested bounded portions.

This PR does not enable general remote add/import, new auth strategies, Slack/Teams, or local servers. Steps 3–14 remain staged follow-on work. Real provider and clean-installer acceptance have not been performed. Pre-V16 downgrade is unsupported; recovery guidance calls for a compatible corrective build or a complete pre-upgrade backup restore.
