### PR TITLE
feat: multiplayer shared sessions and verified local auto-archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  collaboration-backend:
+    name: Collaboration SQL and Edge functions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: 22
+      - name: Install isolated SQL test runtime
+        run: npm install --prefix .tmp/collaboration-validation --no-save --no-audit --no-fund @electric-sql/pglite@0.3.14
+      - name: SQL authority, quota, and archive regressions
+        run: node tools/test_collaboration_backend.mjs
+      - name: Edge signature, upload, and purge regressions
+        run: npm exec --yes --package=deno@2.5.6 -- deno test --allow-env supabase/functions/_shared/slack-security.test.ts supabase/functions/slack-events/index.test.ts supabase/functions/archive-worker/index.test.ts supabase/functions/collaboration-files/index.test.ts
+      - name: Check all Edge entry points
+        run: npm exec --yes --package=deno@2.5.6 -- deno check supabase/functions/slack-install/index.ts supabase/functions/slack-callback/index.ts supabase/functions/slack-events/index.ts supabase/functions/slack-interactions/index.ts supabase/functions/slack-worker/index.ts supabase/functions/archive-worker/index.ts supabase/functions/collaboration-files/index.ts
+
   collie-core:
     name: collie-core (Python 3.11)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ collie-ui/out/
 
 # Generated build and visual QA artifacts
 *.tsbuildinfo
+supabase/.temp/
 collie-ui/screenshots/
 
 # Private company material and reference repositories stay outside the public product repository

--- a/collie-core/collie_core/collaboration/__init__.py
+++ b/collie-core/collie_core/collaboration/__init__.py
@@ -2,12 +2,12 @@
 
 from .archive import ArchiveError, ArchiveManager
 from .models import SharedExecutionContext
-from .store import CollaborationStore, SyncConflict
+from .store import CollaborationStore, SyncConflictError
 
 __all__ = [
     "ArchiveError",
     "ArchiveManager",
     "CollaborationStore",
     "SharedExecutionContext",
-    "SyncConflict",
+    "SyncConflictError",
 ]

--- a/collie-core/collie_core/collaboration/__init__.py
+++ b/collie-core/collie_core/collaboration/__init__.py
@@ -1,0 +1,13 @@
+"""Local-first storage and requester-bound execution for shared sessions."""
+
+from .archive import ArchiveError, ArchiveManager
+from .models import SharedExecutionContext
+from .store import CollaborationStore, SyncConflict
+
+__all__ = [
+    "ArchiveError",
+    "ArchiveManager",
+    "CollaborationStore",
+    "SharedExecutionContext",
+    "SyncConflict",
+]

--- a/collie-core/collie_core/collaboration/archive.py
+++ b/collie-core/collie_core/collaboration/archive.py
@@ -32,7 +32,6 @@ def _durable_replace(source: Path, destination: Path) -> None:
         _fsync_directory(destination.parent)
         return
     import ctypes
-
     from ctypes import wintypes
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -40,7 +39,9 @@ def _durable_replace(source: Path, destination: Path) -> None:
     kernel32.MoveFileExW.restype = wintypes.BOOL
     # MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH
     if not kernel32.MoveFileExW(str(source), str(destination), 0x1 | 0x8):
-        raise OSError(ctypes.get_last_error(), f"Could not durably install archive at {destination}")
+        raise OSError(
+            ctypes.get_last_error(), f"Could not durably install archive at {destination}"
+        )
 
 
 class ArchiveManager:
@@ -53,7 +54,10 @@ class ArchiveManager:
 
     def bind_account(self, account_id: str) -> None:
         value = str(account_id).strip()
-        if value and any(ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_" for ch in value):
+        if value and any(
+            ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
+            for ch in value
+        ):
             raise ArchiveError("The archive account ID is invalid.")
         self._account_id = value
 
@@ -83,8 +87,12 @@ class ArchiveManager:
     @staticmethod
     def _validate_manifest(manifest: dict[str, Any]) -> None:
         required = (
-            "version", "session_id", "membership_revision",
-            "recipients", "events", "files",
+            "version",
+            "session_id",
+            "membership_revision",
+            "recipients",
+            "events",
+            "files",
         )
         if any(key not in manifest for key in required):
             raise ArchiveError("The archive manifest is incomplete.")
@@ -103,17 +111,27 @@ class ArchiveManager:
             raise ArchiveError("The archive event sequence is incomplete or unordered.")
         file_ids = [str(item.get("file_id") or "") for item in manifest["files"]]
         if len(file_ids) != len(set(file_ids)) or any(
-            not item or any(ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_" for ch in item)
+            not item
+            or any(
+                ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
+                for ch in item
+            )
             for item in file_ids
         ):
             raise ArchiveError("The archive contains invalid or duplicate file IDs.")
         sizes = [int(item.get("byte_length") or 0) for item in manifest["files"]]
-        if any(size < 0 or size > 5 * 1024 * 1024 for size in sizes) or sum(sizes) > 20 * 1024 * 1024:
+        if (
+            any(size < 0 or size > 5 * 1024 * 1024 for size in sizes)
+            or sum(sizes) > 20 * 1024 * 1024
+        ):
             raise ArchiveError("The archive files exceed the supported size limits.")
 
     def session_path(self, session_id: str) -> Path:
         safe = str(session_id).strip()
-        if not safe or any(ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_" for ch in safe):
+        if not safe or any(
+            ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
+            for ch in safe
+        ):
             raise ArchiveError("The archive session ID is invalid.")
         return self.root / safe
 
@@ -178,8 +196,10 @@ class ArchiveManager:
             self.verify(final)
             return {
                 "session_id": str(manifest["session_id"]),
-                "digest": expected_digest.lower(), "byte_length": len(raw),
-                "final_seq": self._final_seq(manifest), "path": str(final),
+                "digest": expected_digest.lower(),
+                "byte_length": len(raw),
+                "final_seq": self._final_seq(manifest),
+                "path": str(final),
             }
         except Exception:
             shutil.rmtree(temp_dir, ignore_errors=True)
@@ -195,7 +215,10 @@ class ArchiveManager:
         for descriptor in manifest["files"]:
             candidate = path / "files" / str(descriptor["file_id"])
             data = candidate.read_bytes()
-            if len(data) != int(descriptor["byte_length"]) or self.digest(data) != str(descriptor["sha256"]).lower():
+            if (
+                len(data) != int(descriptor["byte_length"])
+                or self.digest(data) != str(descriptor["sha256"]).lower()
+            ):
                 raise ArchiveError("A local archive file is corrupt or missing.")
         return manifest
 
@@ -210,7 +233,9 @@ class ArchiveManager:
                         manifest = self.verify(archive)
                     except (ArchiveError, OSError, ValueError):
                         continue
-                    result.append({"path": str(archive), "manifest": manifest, "digest": archive.name})
+                    result.append(
+                        {"path": str(archive), "manifest": manifest, "digest": archive.name}
+                    )
         return result
 
     def export(self, archive_dir: Path, destination: Path) -> Path:

--- a/collie-core/collie_core/collaboration/archive.py
+++ b/collie-core/collie_core/collaboration/archive.py
@@ -1,0 +1,264 @@
+"""Verified, durable shared-session archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+class ArchiveError(ValueError):
+    pass
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _durable_replace(source: Path, destination: Path) -> None:
+    if os.name != "nt":
+        os.replace(source, destination)
+        _fsync_directory(destination.parent)
+        return
+    import ctypes
+
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.MoveFileExW.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD)
+    kernel32.MoveFileExW.restype = wintypes.BOOL
+    # MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH
+    if not kernel32.MoveFileExW(str(source), str(destination), 0x1 | 0x8):
+        raise OSError(ctypes.get_last_error(), f"Could not durably install archive at {destination}")
+
+
+class ArchiveManager:
+    """Writes archives atomically and acknowledges only verified read-back bytes."""
+
+    def __init__(self, root: Path) -> None:
+        self._base_root = Path(root)
+        self._base_root.mkdir(parents=True, exist_ok=True)
+        self._account_id = ""
+
+    def bind_account(self, account_id: str) -> None:
+        value = str(account_id).strip()
+        if value and any(ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_" for ch in value):
+            raise ArchiveError("The archive account ID is invalid.")
+        self._account_id = value
+
+    @property
+    def root(self) -> Path:
+        if not self._account_id:
+            raise ArchiveError("Sign in before accessing shared archives.")
+        path = self._base_root / self._account_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    @staticmethod
+    def digest(raw: bytes) -> str:
+        return hashlib.sha256(raw).hexdigest()
+
+    @staticmethod
+    def _final_seq(manifest: dict[str, Any]) -> int:
+        """Read the backend's canonical field, accepting the draft-era alias."""
+        present = [key for key in ("final_seq", "final_sequence") if key in manifest]
+        if not present:
+            raise ArchiveError("The archive manifest is incomplete.")
+        values = {int(manifest[key]) for key in present}
+        if len(values) != 1:
+            raise ArchiveError("The archive manifest has conflicting final sequences.")
+        return values.pop()
+
+    @staticmethod
+    def _validate_manifest(manifest: dict[str, Any]) -> None:
+        required = (
+            "version", "session_id", "membership_revision",
+            "recipients", "events", "files",
+        )
+        if any(key not in manifest for key in required):
+            raise ArchiveError("The archive manifest is incomplete.")
+        if int(manifest["version"]) != 1:
+            raise ArchiveError("This archive version is not supported.")
+        final = ArchiveManager._final_seq(manifest)
+        if final < 0 or int(manifest["membership_revision"]) < 1:
+            raise ArchiveError("The archive manifest has invalid revisions.")
+        events = manifest["events"]
+        if not isinstance(events, list) or not isinstance(manifest["files"], list):
+            raise ArchiveError("The archive manifest has invalid content lists.")
+        if len(events) > 1_000 or len(manifest["files"]) > 100:
+            raise ArchiveError("The archive exceeds the supported pilot limits.")
+        sequences = [int(event.get("seq") or 0) for event in events]
+        if sequences != list(range(1, final + 1)):
+            raise ArchiveError("The archive event sequence is incomplete or unordered.")
+        file_ids = [str(item.get("file_id") or "") for item in manifest["files"]]
+        if len(file_ids) != len(set(file_ids)) or any(
+            not item or any(ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_" for ch in item)
+            for item in file_ids
+        ):
+            raise ArchiveError("The archive contains invalid or duplicate file IDs.")
+        sizes = [int(item.get("byte_length") or 0) for item in manifest["files"]]
+        if any(size < 0 or size > 5 * 1024 * 1024 for size in sizes) or sum(sizes) > 20 * 1024 * 1024:
+            raise ArchiveError("The archive files exceed the supported size limits.")
+
+    def session_path(self, session_id: str) -> Path:
+        safe = str(session_id).strip()
+        if not safe or any(ch not in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_" for ch in safe):
+            raise ArchiveError("The archive session ID is invalid.")
+        return self.root / safe
+
+    def write(
+        self,
+        manifest_json: str,
+        expected_digest: str,
+        *,
+        attachments: dict[str, Path] | None = None,
+    ) -> dict[str, Any]:
+        raw = manifest_json.encode("utf-8")
+        if len(raw) > 16 * 1024 * 1024:
+            raise ArchiveError("The archive manifest is too large.")
+        if self.digest(raw) != expected_digest.lower():
+            raise ArchiveError("The archive manifest did not match its digest.")
+        try:
+            manifest = json.loads(manifest_json)
+        except (TypeError, ValueError) as error:
+            raise ArchiveError("The archive manifest is not valid JSON.") from error
+        if not isinstance(manifest, dict):
+            raise ArchiveError("The archive manifest must be an object.")
+        self._validate_manifest(manifest)
+        session_dir = self.session_path(str(manifest["session_id"]))
+        session_dir.mkdir(parents=True, exist_ok=True)
+        expected_files = {str(item["file_id"]): item for item in manifest["files"]}
+        supplied = attachments or {}
+        if set(supplied) != set(expected_files):
+            raise ArchiveError("The archive is missing one or more shared files.")
+        temp_dir = Path(tempfile.mkdtemp(prefix=".incoming-", dir=session_dir))
+        try:
+            file_dir = temp_dir / "files"
+            file_dir.mkdir()
+            for file_id, descriptor in expected_files.items():
+                source = Path(supplied[file_id])
+                if not source.is_file():
+                    raise ArchiveError("A shared archive file is missing.")
+                data = source.read_bytes()
+                if len(data) != int(descriptor["byte_length"]):
+                    raise ArchiveError("A shared archive file has the wrong size.")
+                if self.digest(data) != str(descriptor["sha256"]).lower():
+                    raise ArchiveError("A shared archive file failed verification.")
+                target = file_dir / file_id
+                with target.open("wb") as stream:
+                    stream.write(data)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            _fsync_directory(file_dir)
+            manifest_path = temp_dir / "manifest.json"
+            with manifest_path.open("wb") as stream:
+                stream.write(raw)
+                stream.flush()
+                os.fsync(stream.fileno())
+            if manifest_path.read_bytes() != raw:
+                raise ArchiveError("The archive manifest could not be read back.")
+            _fsync_directory(temp_dir)
+            final = session_dir / expected_digest.lower()
+            if final.exists():
+                self.verify(final)
+                shutil.rmtree(temp_dir)
+            else:
+                _durable_replace(temp_dir, final)
+            self.verify(final)
+            return {
+                "session_id": str(manifest["session_id"]),
+                "digest": expected_digest.lower(), "byte_length": len(raw),
+                "final_seq": self._final_seq(manifest), "path": str(final),
+            }
+        except Exception:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            raise
+
+    def verify(self, archive_dir: Path) -> dict[str, Any]:
+        path = Path(archive_dir)
+        raw = (path / "manifest.json").read_bytes()
+        if self.digest(raw) != path.name.lower():
+            raise ArchiveError("The local archive manifest is corrupt.")
+        manifest = json.loads(raw.decode("utf-8"))
+        self._validate_manifest(manifest)
+        for descriptor in manifest["files"]:
+            candidate = path / "files" / str(descriptor["file_id"])
+            data = candidate.read_bytes()
+            if len(data) != int(descriptor["byte_length"]) or self.digest(data) != str(descriptor["sha256"]).lower():
+                raise ArchiveError("A local archive file is corrupt or missing.")
+        return manifest
+
+    def list(self) -> list[dict[str, Any]]:
+        result = []
+        for session in self.root.iterdir():
+            if not session.is_dir():
+                continue
+            for archive in session.iterdir():
+                if archive.is_dir() and not archive.name.startswith("."):
+                    try:
+                        manifest = self.verify(archive)
+                    except (ArchiveError, OSError, ValueError):
+                        continue
+                    result.append({"path": str(archive), "manifest": manifest, "digest": archive.name})
+        return result
+
+    def export(self, archive_dir: Path, destination: Path) -> Path:
+        source = Path(archive_dir)
+        self.verify(source)
+        destination = Path(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temp = destination.with_name(f".{destination.name}.tmp")
+        with zipfile.ZipFile(temp, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+            for file in sorted(source.rglob("*")):
+                if file.is_file():
+                    bundle.write(file, file.relative_to(source).as_posix())
+        with temp.open("r+b") as stream:
+            stream.flush()
+            os.fsync(stream.fileno())
+        _durable_replace(temp, destination)
+        return destination
+
+    def import_bundle(self, source: Path) -> dict[str, Any]:
+        source = Path(source)
+        temp_root = Path(tempfile.mkdtemp(prefix=".import-", dir=self.root))
+        try:
+            with zipfile.ZipFile(source) as bundle:
+                infos = bundle.infolist()
+                if len(infos) > 102 or sum(item.file_size for item in infos) > 36 * 1024 * 1024:
+                    raise ArchiveError("The archive bundle is too large.")
+                names = {item.filename for item in infos}
+                if "manifest.json" not in names:
+                    raise ArchiveError("The archive bundle has no manifest.")
+                for info in infos:
+                    relative = Path(info.filename)
+                    if relative.is_absolute() or ".." in relative.parts:
+                        raise ArchiveError("The archive bundle contains an unsafe path.")
+                    if info.external_attr >> 16 & 0o170000 == 0o120000:
+                        raise ArchiveError("The archive bundle contains a symbolic link.")
+                bundle.extractall(temp_root)
+            raw = (temp_root / "manifest.json").read_bytes()
+            manifest = json.loads(raw.decode("utf-8"))
+            self._validate_manifest(manifest)
+            expected_names = {"manifest.json"} | {
+                f"files/{item['file_id']}" for item in manifest.get("files", [])
+            }
+            if {name.rstrip("/") for name in names if not name.endswith("/")} != expected_names:
+                raise ArchiveError("The archive bundle contains unexpected files.")
+            attachments = {
+                str(item["file_id"]): temp_root / "files" / str(item["file_id"])
+                for item in manifest.get("files", [])
+            }
+            return self.write(raw.decode("utf-8"), self.digest(raw), attachments=attachments)
+        finally:
+            shutil.rmtree(temp_root, ignore_errors=True)

--- a/collie-core/collie_core/collaboration/models.py
+++ b/collie-core/collie_core/collaboration/models.py
@@ -1,0 +1,70 @@
+"""Versioned collaboration DTOs and fail-closed execution identity checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class SharedExecutionContext:
+    session_id: str
+    requester_id: str
+    credential_owner_id: str
+    executor_device_id: str
+    audience_revision: int
+    context_cutoff: int
+    run_id: str
+    lease_token: str
+    lease_expires_at: str
+    publication_authorized: bool = False
+
+    @classmethod
+    def from_claim(
+        cls,
+        claim: Mapping[str, Any],
+        *,
+        enrolled_account_id: str,
+        enrolled_device_id: str,
+    ) -> "SharedExecutionContext":
+        required = (
+            "session_id", "requester_id", "credential_owner_id", "executor_device_id",
+            "audience_revision", "context_cutoff", "run_id", "lease_token", "lease_expires_at",
+        )
+        if any(claim.get(key) in (None, "") for key in required):
+            raise ValueError("The shared run claim is incomplete.")
+        requester = str(claim["requester_id"])
+        credential_owner = str(claim["credential_owner_id"])
+        executor = str(claim["executor_device_id"])
+        if not enrolled_account_id or requester != enrolled_account_id:
+            raise ValueError("This shared request belongs to another account.")
+        if credential_owner != enrolled_account_id:
+            raise ValueError("Shared work cannot use another person's credentials.")
+        if not enrolled_device_id or executor != enrolled_device_id:
+            raise ValueError("This shared request belongs to another device.")
+        revision = int(claim["audience_revision"])
+        cutoff = int(claim["context_cutoff"])
+        if revision < 1 or cutoff < 0:
+            raise ValueError("The shared run claim has an invalid revision.")
+        return cls(
+            session_id=str(claim["session_id"]), requester_id=requester,
+            credential_owner_id=credential_owner, executor_device_id=executor,
+            audience_revision=revision, context_cutoff=cutoff, run_id=str(claim["run_id"]),
+            lease_token=str(claim["lease_token"]),
+            lease_expires_at=str(claim["lease_expires_at"]),
+            publication_authorized=bool(claim.get("publication_authorized", False)),
+        )
+
+    def permission_metadata(self) -> dict[str, Any]:
+        return {
+            "shared_session_id": self.session_id,
+            "requester_id": self.requester_id,
+            "credential_owner_id": self.credential_owner_id,
+            "executor_device_id": self.executor_device_id,
+            "audience_revision": self.audience_revision,
+            "context_cutoff": self.context_cutoff,
+            "shared_run_id": self.run_id,
+            "lease_token": self.lease_token,
+            "lease_expires_at": self.lease_expires_at,
+            "publication_authorized": self.publication_authorized,
+        }

--- a/collie-core/collie_core/collaboration/models.py
+++ b/collie-core/collie_core/collaboration/models.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,10 +27,17 @@ class SharedExecutionContext:
         *,
         enrolled_account_id: str,
         enrolled_device_id: str,
-    ) -> "SharedExecutionContext":
+    ) -> SharedExecutionContext:
         required = (
-            "session_id", "requester_id", "credential_owner_id", "executor_device_id",
-            "audience_revision", "context_cutoff", "run_id", "lease_token", "lease_expires_at",
+            "session_id",
+            "requester_id",
+            "credential_owner_id",
+            "executor_device_id",
+            "audience_revision",
+            "context_cutoff",
+            "run_id",
+            "lease_token",
+            "lease_expires_at",
         )
         if any(claim.get(key) in (None, "") for key in required):
             raise ValueError("The shared run claim is incomplete.")
@@ -47,9 +55,13 @@ class SharedExecutionContext:
         if revision < 1 or cutoff < 0:
             raise ValueError("The shared run claim has an invalid revision.")
         return cls(
-            session_id=str(claim["session_id"]), requester_id=requester,
-            credential_owner_id=credential_owner, executor_device_id=executor,
-            audience_revision=revision, context_cutoff=cutoff, run_id=str(claim["run_id"]),
+            session_id=str(claim["session_id"]),
+            requester_id=requester,
+            credential_owner_id=credential_owner,
+            executor_device_id=executor,
+            audience_revision=revision,
+            context_cutoff=cutoff,
+            run_id=str(claim["run_id"]),
             lease_token=str(claim["lease_token"]),
             lease_expires_at=str(claim["lease_expires_at"]),
             publication_authorized=bool(claim.get("publication_authorized", False)),

--- a/collie-core/collie_core/collaboration/store.py
+++ b/collie-core/collie_core/collaboration/store.py
@@ -1,0 +1,275 @@
+"""Durable local outbox, materialized shared history, and cursor storage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Iterable
+
+from collie_core.db import utc_now
+
+
+class SyncConflict(ValueError):
+    pass
+
+
+class CollaborationStore:
+    """A separate local database so personal chat schema and semantics stay intact."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._account_id = ""
+        self._conn: sqlite3.Connection | None = None
+
+    @property
+    def _connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(self.path, check_same_thread=False)
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA synchronous=FULL")
+            self._migrate()
+        return self._conn
+
+    def _migrate(self) -> None:
+        connection = self._conn
+        assert connection is not None
+        with connection:
+            connection.executescript("""
+            CREATE TABLE IF NOT EXISTS shared_events (
+              account_id TEXT NOT NULL, event_id TEXT NOT NULL, session_id TEXT NOT NULL, seq INTEGER NOT NULL,
+              kind TEXT NOT NULL CHECK(kind IN ('message','edit','delete')),
+              message_id TEXT NOT NULL, author_id TEXT NOT NULL, role TEXT NOT NULL,
+              content TEXT NOT NULL, revision INTEGER NOT NULL, created_at TEXT NOT NULL,
+              payload_json TEXT NOT NULL, PRIMARY KEY(account_id,event_id), UNIQUE(account_id,session_id,seq)
+            );
+            CREATE INDEX IF NOT EXISTS idx_shared_events_session_seq
+              ON shared_events(account_id,session_id, seq);
+            CREATE TABLE IF NOT EXISTS shared_outbox (
+              account_id TEXT NOT NULL, event_id TEXT NOT NULL, session_id TEXT NOT NULL, payload_json TEXT NOT NULL,
+              state TEXT NOT NULL DEFAULT 'pending', attempts INTEGER NOT NULL DEFAULT 0,
+              last_error TEXT, created_at TEXT NOT NULL, cloud_seq INTEGER,
+              PRIMARY KEY(account_id,event_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_shared_outbox_pending
+              ON shared_outbox(account_id,state, created_at);
+            CREATE TABLE IF NOT EXISTS shared_cursors (
+              account_id TEXT NOT NULL, session_id TEXT NOT NULL, high_water INTEGER NOT NULL DEFAULT 0,
+              updated_at TEXT NOT NULL, PRIMARY KEY(account_id,session_id)
+            );
+            CREATE TABLE IF NOT EXISTS shared_session_cache (
+              account_id TEXT NOT NULL, session_id TEXT NOT NULL, metadata_json TEXT NOT NULL,
+              membership_revision INTEGER NOT NULL, state TEXT NOT NULL,
+              updated_at TEXT NOT NULL, PRIMARY KEY(account_id,session_id)
+            );
+            """)
+
+    def bind_account(self, account_id: str) -> None:
+        self._account_id = str(account_id).strip()
+
+    @property
+    def is_bound(self) -> bool:
+        return bool(self._account_id)
+
+    @property
+    def account_id(self) -> str:
+        return self._account()
+
+    def _account(self) -> str:
+        if not self._account_id:
+            raise ValueError("Sign in before using shared-session storage.")
+        return self._account_id
+
+    @staticmethod
+    def _canonical(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    def queue_event(self, session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Persist an optimistic event and outbox row in the same transaction."""
+        return self.queue_event_for_account(self._account(), session_id, payload)
+
+    def queue_event_for_account(
+        self, account_id: str, session_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Persist an event for its previously verified creator account.
+
+        Scheduled routines may finish while another account (or no account) is
+        bound to the UI.  Their configured creator identity is stored when the
+        authenticated main process enables delivery, so enqueue directly into
+        that account partition and let its next reconciliation publish it.
+        """
+        account = str(account_id).strip()
+        if not account:
+            raise ValueError("Shared event requires a creator account.")
+        event = dict(payload)
+        event.setdefault("event_id", str(uuid.uuid4()))
+        event.setdefault("session_id", session_id)
+        event.setdefault("created_at", utc_now())
+        if event["session_id"] != session_id:
+            raise SyncConflict("The event session does not match its outbox session.")
+        for key in ("event_id", "message_id", "author_id", "role", "kind"):
+            if not str(event.get(key) or ""):
+                raise ValueError(f"Shared event requires {key}.")
+        if event["kind"] not in {"message", "edit", "delete"}:
+            raise ValueError("Unsupported shared event kind.")
+        event.setdefault("content", "")
+        event.setdefault("revision", 1)
+        raw = self._canonical(event)
+        with self._lock, self._connection:
+            prior = self._connection.execute(
+                "SELECT payload_json FROM shared_outbox WHERE account_id=? AND event_id=?", (account, event["event_id"])
+            ).fetchone()
+            if prior and prior[0] != raw:
+                raise SyncConflict("An event ID cannot be reused with a different payload.")
+            self._connection.execute(
+                "INSERT OR IGNORE INTO shared_outbox(account_id,event_id,session_id,payload_json,created_at) VALUES(?,?,?,?,?)",
+                (account, event["event_id"], session_id, raw, event["created_at"]),
+            )
+        return event
+
+    def pending(self, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._connection.execute(
+            "SELECT payload_json,attempts,last_error FROM shared_outbox WHERE account_id=? AND state='pending' ORDER BY created_at LIMIT ?",
+            (self._account(), max(1, min(int(limit), 500))),
+        ).fetchall()
+        return [json.loads(r[0]) | {"attempts": r[1], "last_error": r[2]} for r in rows]
+
+    def mark_attempt(self, event_id: str, error: str | None = None) -> None:
+        with self._lock, self._connection:
+            self._connection.execute(
+                "UPDATE shared_outbox SET attempts=attempts+1,last_error=? WHERE account_id=? AND event_id=? AND state='pending'",
+                (error, self._account(), event_id),
+            )
+
+    def settle_outbox(self, event_id: str, status: str, error: str | None = None) -> None:
+        if status not in {"acknowledged", "rejected"}:
+            raise ValueError("invalid outbox terminal status")
+        with self._lock, self._connection:
+            self._connection.execute(
+                """UPDATE shared_outbox SET state=?, attempts=attempts+1,last_error=?
+                WHERE account_id=? AND event_id=? AND state='pending'""",
+                (status, error, self._account(), event_id),
+            )
+
+    def apply_page(
+        self, session_id: str, events: Iterable[dict[str, Any]], *, next_cursor: int
+    ) -> int:
+        """Apply a complete ordered page and advance its cursor atomically."""
+        page = [dict(item) for item in events]
+        with self._lock, self._connection:
+            account = self._account()
+            current = self.cursor(session_id)
+            expected = current + 1
+            for event in page:
+                if str(event.get("session_id") or "") != session_id:
+                    raise SyncConflict("A remote page contained another session.")
+                seq = int(event.get("seq") or 0)
+                raw = self._canonical(event)
+                prior = self._connection.execute(
+                    "SELECT payload_json,seq FROM shared_events WHERE account_id=? AND event_id=?", (account, event.get("event_id"))
+                ).fetchone()
+                if prior:
+                    if prior[0] != raw:
+                        raise SyncConflict("A remote event changed after acceptance.")
+                    expected = max(expected, int(prior[1]) + 1)
+                    continue
+                if seq != expected:
+                    raise SyncConflict(f"Expected shared sequence {expected}, received {seq}.")
+                self._connection.execute(
+                    """INSERT INTO shared_events
+                    (account_id,event_id,session_id,seq,kind,message_id,author_id,role,content,revision,created_at,payload_json)
+                    VALUES(?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    (account, event["event_id"], session_id, seq, event["kind"], event["message_id"],
+                     event["author_id"], event["role"], str(event.get("content") or ""),
+                     int(event.get("revision") or 1), event["created_at"], raw),
+                )
+                self._connection.execute(
+                    "UPDATE shared_outbox SET state='acknowledged',cloud_seq=?,last_error=NULL WHERE account_id=? AND event_id=?",
+                    (seq, account, event["event_id"]),
+                )
+                expected += 1
+            if next_cursor < current or (page and next_cursor != int(page[-1]["seq"])):
+                raise SyncConflict("The remote page cursor does not match its last event.")
+            if not page and next_cursor != current:
+                raise SyncConflict("An empty remote page cannot advance the cursor.")
+            self._connection.execute(
+                """INSERT INTO shared_cursors(account_id,session_id,high_water,updated_at) VALUES(?,?,?,?)
+                ON CONFLICT(account_id,session_id) DO UPDATE SET high_water=excluded.high_water,updated_at=excluded.updated_at""",
+                (account, session_id, next_cursor, utc_now()),
+            )
+        return next_cursor
+
+    def cursor(self, session_id: str) -> int:
+        row = self._connection.execute(
+            "SELECT high_water FROM shared_cursors WHERE account_id=? AND session_id=?", (self._account(), session_id)
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def events(self, session_id: str, *, through: int | None = None) -> list[dict[str, Any]]:
+        sql = "SELECT payload_json FROM shared_events WHERE account_id=? AND session_id=?"
+        args: list[Any] = [self._account(), session_id]
+        if through is not None:
+            sql += " AND seq<=?"
+            args.append(int(through))
+        rows = self._connection.execute(sql + " ORDER BY seq", args).fetchall()
+        return [json.loads(row[0]) for row in rows]
+
+    def materialized_messages(self, session_id: str, *, through: int | None = None) -> list[dict[str, Any]]:
+        messages: dict[str, dict[str, Any]] = {}
+        order: list[str] = []
+        events = self.events(session_id, through=through)
+        if through is None:
+            pending_rows = self._connection.execute(
+                """SELECT payload_json FROM shared_outbox
+                WHERE account_id=? AND session_id=? AND state='pending' ORDER BY created_at""",
+                (self._account(), session_id),
+            ).fetchall()
+            events.extend(json.loads(row[0]) | {"sync_state": "local"} for row in pending_rows)
+        for event in events:
+            mid = str(event["message_id"])
+            if event["kind"] == "message":
+                if mid not in messages:
+                    order.append(mid)
+                messages[mid] = event | {"deleted": False}
+            elif mid in messages and int(event.get("revision", 0)) > int(messages[mid].get("revision", 0)):
+                messages[mid]["content"] = str(event.get("content") or "")
+                messages[mid]["revision"] = int(event.get("revision") or 0)
+                messages[mid]["last_event_seq"] = int(event.get("seq") or 0)
+                messages[mid]["deleted"] = event["kind"] == "delete"
+        return [messages[mid] for mid in order]
+
+    def cache_bootstrap(self, snapshot: dict[str, Any]) -> None:
+        raw = self._canonical(snapshot)
+        if len(raw.encode("utf-8")) > 2 * 1024 * 1024:
+            raise ValueError("The collaboration bootstrap cache is too large.")
+        revision = int(snapshot.get("revision") or 0)
+        with self._lock, self._connection:
+            self._connection.execute(
+                """INSERT INTO shared_session_cache
+                (account_id,session_id,metadata_json,membership_revision,state,updated_at)
+                VALUES(?,?,?,?,?,?)
+                ON CONFLICT(account_id,session_id) DO UPDATE SET
+                  metadata_json=excluded.metadata_json,
+                  membership_revision=excluded.membership_revision,
+                  state=excluded.state,
+                  updated_at=excluded.updated_at""",
+                (self._account(), "__bootstrap__", raw, revision, "cached", utc_now()),
+            )
+
+    def cached_bootstrap(self) -> dict[str, Any] | None:
+        row = self._connection.execute(
+            "SELECT metadata_json FROM shared_session_cache WHERE account_id=? AND session_id='__bootstrap__'",
+            (self._account(),),
+        ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None

--- a/collie-core/collie_core/collaboration/store.py
+++ b/collie-core/collie_core/collaboration/store.py
@@ -6,13 +6,14 @@ import json
 import sqlite3
 import threading
 import uuid
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from collie_core.db import utc_now
 
 
-class SyncConflict(ValueError):
+class SyncConflictError(ValueError):
     pass
 
 
@@ -111,7 +112,7 @@ class CollaborationStore:
         event.setdefault("session_id", session_id)
         event.setdefault("created_at", utc_now())
         if event["session_id"] != session_id:
-            raise SyncConflict("The event session does not match its outbox session.")
+            raise SyncConflictError("The event session does not match its outbox session.")
         for key in ("event_id", "message_id", "author_id", "role", "kind"):
             if not str(event.get(key) or ""):
                 raise ValueError(f"Shared event requires {key}.")
@@ -122,10 +123,11 @@ class CollaborationStore:
         raw = self._canonical(event)
         with self._lock, self._connection:
             prior = self._connection.execute(
-                "SELECT payload_json FROM shared_outbox WHERE account_id=? AND event_id=?", (account, event["event_id"])
+                "SELECT payload_json FROM shared_outbox WHERE account_id=? AND event_id=?",
+                (account, event["event_id"]),
             ).fetchone()
             if prior and prior[0] != raw:
-                raise SyncConflict("An event ID cannot be reused with a different payload.")
+                raise SyncConflictError("An event ID cannot be reused with a different payload.")
             self._connection.execute(
                 "INSERT OR IGNORE INTO shared_outbox(account_id,event_id,session_id,payload_json,created_at) VALUES(?,?,?,?,?)",
                 (account, event["event_id"], session_id, raw, event["created_at"]),
@@ -167,26 +169,38 @@ class CollaborationStore:
             expected = current + 1
             for event in page:
                 if str(event.get("session_id") or "") != session_id:
-                    raise SyncConflict("A remote page contained another session.")
+                    raise SyncConflictError("A remote page contained another session.")
                 seq = int(event.get("seq") or 0)
                 raw = self._canonical(event)
                 prior = self._connection.execute(
-                    "SELECT payload_json,seq FROM shared_events WHERE account_id=? AND event_id=?", (account, event.get("event_id"))
+                    "SELECT payload_json,seq FROM shared_events WHERE account_id=? AND event_id=?",
+                    (account, event.get("event_id")),
                 ).fetchone()
                 if prior:
                     if prior[0] != raw:
-                        raise SyncConflict("A remote event changed after acceptance.")
+                        raise SyncConflictError("A remote event changed after acceptance.")
                     expected = max(expected, int(prior[1]) + 1)
                     continue
                 if seq != expected:
-                    raise SyncConflict(f"Expected shared sequence {expected}, received {seq}.")
+                    raise SyncConflictError(f"Expected shared sequence {expected}, received {seq}.")
                 self._connection.execute(
                     """INSERT INTO shared_events
                     (account_id,event_id,session_id,seq,kind,message_id,author_id,role,content,revision,created_at,payload_json)
                     VALUES(?,?,?,?,?,?,?,?,?,?,?,?)""",
-                    (account, event["event_id"], session_id, seq, event["kind"], event["message_id"],
-                     event["author_id"], event["role"], str(event.get("content") or ""),
-                     int(event.get("revision") or 1), event["created_at"], raw),
+                    (
+                        account,
+                        event["event_id"],
+                        session_id,
+                        seq,
+                        event["kind"],
+                        event["message_id"],
+                        event["author_id"],
+                        event["role"],
+                        str(event.get("content") or ""),
+                        int(event.get("revision") or 1),
+                        event["created_at"],
+                        raw,
+                    ),
                 )
                 self._connection.execute(
                     "UPDATE shared_outbox SET state='acknowledged',cloud_seq=?,last_error=NULL WHERE account_id=? AND event_id=?",
@@ -194,9 +208,9 @@ class CollaborationStore:
                 )
                 expected += 1
             if next_cursor < current or (page and next_cursor != int(page[-1]["seq"])):
-                raise SyncConflict("The remote page cursor does not match its last event.")
+                raise SyncConflictError("The remote page cursor does not match its last event.")
             if not page and next_cursor != current:
-                raise SyncConflict("An empty remote page cannot advance the cursor.")
+                raise SyncConflictError("An empty remote page cannot advance the cursor.")
             self._connection.execute(
                 """INSERT INTO shared_cursors(account_id,session_id,high_water,updated_at) VALUES(?,?,?,?)
                 ON CONFLICT(account_id,session_id) DO UPDATE SET high_water=excluded.high_water,updated_at=excluded.updated_at""",
@@ -206,7 +220,8 @@ class CollaborationStore:
 
     def cursor(self, session_id: str) -> int:
         row = self._connection.execute(
-            "SELECT high_water FROM shared_cursors WHERE account_id=? AND session_id=?", (self._account(), session_id)
+            "SELECT high_water FROM shared_cursors WHERE account_id=? AND session_id=?",
+            (self._account(), session_id),
         ).fetchone()
         return int(row[0]) if row else 0
 
@@ -219,7 +234,9 @@ class CollaborationStore:
         rows = self._connection.execute(sql + " ORDER BY seq", args).fetchall()
         return [json.loads(row[0]) for row in rows]
 
-    def materialized_messages(self, session_id: str, *, through: int | None = None) -> list[dict[str, Any]]:
+    def materialized_messages(
+        self, session_id: str, *, through: int | None = None
+    ) -> list[dict[str, Any]]:
         messages: dict[str, dict[str, Any]] = {}
         order: list[str] = []
         events = self.events(session_id, through=through)
@@ -236,7 +253,9 @@ class CollaborationStore:
                 if mid not in messages:
                     order.append(mid)
                 messages[mid] = event | {"deleted": False}
-            elif mid in messages and int(event.get("revision", 0)) > int(messages[mid].get("revision", 0)):
+            elif mid in messages and int(event.get("revision", 0)) > int(
+                messages[mid].get("revision", 0)
+            ):
                 messages[mid]["content"] = str(event.get("content") or "")
                 messages[mid]["revision"] = int(event.get("revision") or 0)
                 messages[mid]["last_event_seq"] = int(event.get("seq") or 0)

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -572,6 +572,13 @@ CREATE TABLE product_metrics_daily (
 );
 """
 
+_SCHEMA_V16 = """
+ALTER TABLE automations ADD COLUMN shared_delivery TEXT;
+ALTER TABLE automations ADD COLUMN shared_delivery_status TEXT;
+ALTER TABLE automations ADD COLUMN shared_delivery_event_id TEXT;
+ALTER TABLE automations ADD COLUMN shared_delivery_error TEXT;
+"""
+
 # Ordered migrations: index 0 == schema version 1, etc.
 _MIGRATIONS: list[str] = [
     _SCHEMA_V1,
@@ -589,6 +596,7 @@ _MIGRATIONS: list[str] = [
     _SCHEMA_V13,
     _SCHEMA_V14,
     _SCHEMA_V15,
+    _SCHEMA_V16,
 ]
 
 
@@ -1449,6 +1457,35 @@ class CollieDB:
             if cursor.rowcount != 1:
                 raise ValueError("routine not found")
         return self.get_automation(automation_id)  # type: ignore[return-value]
+
+    def set_routine_shared_delivery(
+        self, automation_id: str, delivery: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        with self._write() as conn:
+            cursor = conn.execute(
+                """UPDATE automations SET shared_delivery=?, shared_delivery_status=?,
+                shared_delivery_event_id=NULL, shared_delivery_error=NULL, updated_at=? WHERE id=?""",
+                (
+                    json.dumps(delivery, sort_keys=True) if delivery else None,
+                    "ready" if delivery else None,
+                    utc_now(), automation_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("routine not found")
+        return self.get_automation(automation_id)  # type: ignore[return-value]
+
+    def record_routine_shared_delivery(
+        self, automation_id: str, *, status: str, event_id: str | None, error: str | None
+    ) -> None:
+        if status not in {"ready", "pending", "acknowledged", "rejected"}:
+            raise ValueError("invalid shared delivery status")
+        with self._write() as conn:
+            conn.execute(
+                """UPDATE automations SET shared_delivery_status=?,
+                shared_delivery_event_id=?, shared_delivery_error=?, updated_at=? WHERE id=?""",
+                (status, event_id, error, utc_now(), automation_id),
+            )
 
     def delete_automation(self, automation_id: str) -> None:
         with self._write() as conn:

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -1468,7 +1468,8 @@ class CollieDB:
                 (
                     json.dumps(delivery, sort_keys=True) if delivery else None,
                     "ready" if delivery else None,
-                    utc_now(), automation_id,
+                    utc_now(),
+                    automation_id,
                 ),
             )
             if cursor.rowcount != 1:

--- a/collie-core/collie_core/headless.py
+++ b/collie-core/collie_core/headless.py
@@ -405,6 +405,7 @@ async def _run_one_in_home(args: argparse.Namespace, home: Path) -> tuple[int, d
             recorder = RunRecorder.active_for(runtime.db)
             if recorder is not None:
                 recorder.shutdown()
+            runtime.collaboration.close()
         if db is not None:
             db.close()
 

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -247,6 +247,11 @@ class CollieIPCServer:
         dream_runner: Callable[[], Awaitable[dict[str, Any]]] | None = None,
         gardener_runner: Callable[[], Awaitable[dict[str, Any]]] | None = None,
         thing_store: Any = None,
+        collaboration_store: Any = None,
+        archive_manager: Any = None,
+        shared_chat_runner: Callable[..., Awaitable[Any]] | None = None,
+        collaboration_identity_binder: Callable[[str, str], None] | None = None,
+        collaboration_run_controller: Callable[..., Awaitable[dict[str, Any]]] | None = None,
     ) -> None:
         self.db = db
         self.host = host
@@ -282,6 +287,11 @@ class CollieIPCServer:
         self._dream_runner = dream_runner
         self._gardener_runner = gardener_runner
         self._thing_store = thing_store
+        self._collaboration_store = collaboration_store
+        self._archive_manager = archive_manager
+        self._shared_chat_runner = shared_chat_runner
+        self._collaboration_identity_binder = collaboration_identity_binder
+        self._collaboration_run_controller = collaboration_run_controller
         self._clients: set[ServerConnection] = set()
         self._server: Any = None
         self._chat_tasks: dict[str, asyncio.Task] = {}
@@ -478,6 +488,15 @@ class CollieIPCServer:
 
         kind = frame["type"]
         req_id = frame.get("id")
+        if kind.startswith("collaboration_"):
+            expected = str(os.environ.get("COLLIE_IDENTITY_BIND_TOKEN") or "")
+            supplied = str(frame.get("identity_token") or frame.get("bind_token") or "")
+            if not expected or not supplied or not __import__("hmac").compare_digest(expected, supplied):
+                await self._send(connection, {
+                    "type": "error", "id": req_id,
+                    "message": "Shared-session access was not authorized.",
+                })
+                return
         handler = getattr(self, f"_cmd_{kind}", None)
         if handler is None:
             await self._send(
@@ -540,6 +559,151 @@ class CollieIPCServer:
             "active_agents": status.get("active_agents") or [],
             "recent_agents": status.get("recent_agents") or [],
         }
+
+    # -- local shared-session transport -----------------------------------------------
+
+    async def _cmd_collaboration_status(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None:
+            return {"available": False}
+        session_id = str(frame.get("session_id") or "")
+        bound = bool(self._collaboration_store.is_bound)
+        return {
+            "available": True,
+            "signed_in": bound,
+            "cursor": self._collaboration_store.cursor(session_id) if bound and session_id else 0,
+            "pending": self._collaboration_store.pending(
+                _bounded_list_limit(frame.get("limit"), default=100) or 100
+            ) if bound else [],
+            "archives": self._archive_manager.list() if self._archive_manager and bound else [],
+        }
+
+    async def _cmd_collaboration_bind_identity(self, connection: ServerConnection, frame: dict) -> dict:
+        expected = str(os.environ.get("COLLIE_IDENTITY_BIND_TOKEN") or "")
+        supplied = str(frame.get("bind_token") or "")
+        if not expected or not supplied or not __import__("hmac").compare_digest(expected, supplied):
+            raise ValueError("Shared-session identity binding was not authorized.")
+        if self._collaboration_identity_binder is None:
+            raise ValueError("Shared sessions are unavailable.")
+        account_id = str(frame.get("account_id") or "")
+        device_id = str(frame.get("device_id") or "")
+        if bool(account_id) != bool(device_id):
+            raise ValueError("Account and device identity must be bound together.")
+        self._collaboration_identity_binder(account_id, device_id)
+        return {"bound": bool(account_id)}
+
+    async def _cmd_collaboration_queue_event(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None:
+            raise ValueError("Shared sessions are unavailable.")
+        return self._collaboration_store.queue_event(
+            str(frame.get("session_id") or ""), dict(frame.get("event") or {})
+        )
+
+    async def _cmd_collaboration_cache_bootstrap(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None:
+            raise ValueError("Shared sessions are unavailable.")
+        snapshot = frame.get("snapshot")
+        if not isinstance(snapshot, dict):
+            raise ValueError("A collaboration bootstrap snapshot is required.")
+        self._collaboration_store.cache_bootstrap(snapshot)
+        return {"cached": True}
+
+    async def _cmd_collaboration_get_cached_bootstrap(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None:
+            raise ValueError("Shared sessions are unavailable.")
+        return {"snapshot": self._collaboration_store.cached_bootstrap()}
+
+    async def _cmd_collaboration_set_routine_delivery(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None or not self._collaboration_store.is_bound:
+            raise ValueError("Sign in before sharing a routine result.")
+        routine_id = str(frame.get("routine_id") or "")
+        delivery = frame.get("shared_delivery")
+        if delivery is None:
+            return {"routine": self.db.set_routine_shared_delivery(routine_id, None)}
+        if not isinstance(delivery, dict):
+            raise ValueError("Shared routine delivery must be an object.")
+        session_id = str(delivery.get("session_id") or "")
+        revision = int(delivery.get("audience_revision") or 0)
+        creator = str(delivery.get("creator_account_id") or "")
+        if not session_id or revision < 1 or creator != self._collaboration_store.account_id:
+            raise ValueError("Shared routine delivery identity or audience is invalid.")
+        normalized = {
+            "session_id": session_id, "audience_revision": revision,
+            "creator_account_id": creator,
+        }
+        return {"routine": self.db.set_routine_shared_delivery(routine_id, normalized)}
+
+    async def _cmd_collaboration_mark_routine_delivery(self, connection: ServerConnection, frame: dict) -> dict:
+        routine_id = str(frame.get("routine_id") or "")
+        event_id = str(frame.get("event_id") or "")
+        status = str(frame.get("status") or "")
+        if status not in {"acknowledged", "rejected", "pending"}:
+            raise ValueError("Invalid routine delivery status.")
+        error = str(frame.get("error") or "")[:300] or None
+        self.db.record_routine_shared_delivery(
+            routine_id, status=status, event_id=event_id or None, error=error
+        )
+        if event_id and self._collaboration_store is not None and status != "pending":
+            self._collaboration_store.settle_outbox(event_id, status, error)
+        return {"recorded": True}
+
+    async def _cmd_collaboration_apply_page(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None:
+            raise ValueError("Shared sessions are unavailable.")
+        session_id = str(frame.get("session_id") or "")
+        cursor = self._collaboration_store.apply_page(
+            session_id, list(frame.get("events") or []), next_cursor=int(frame.get("next_cursor") or 0)
+        )
+        return {"cursor": cursor}
+
+    async def _cmd_collaboration_list_messages(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_store is None:
+            raise ValueError("Shared sessions are unavailable.")
+        session_id = str(frame.get("session_id") or "")
+        through = frame.get("through")
+        return {"messages": self._collaboration_store.materialized_messages(
+            session_id, through=int(through) if through is not None else None
+        )}
+
+    async def _cmd_collaboration_write_archive(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._archive_manager is None:
+            raise ValueError("Local archives are unavailable.")
+        attachments = {
+            str(item["file_id"]): Path(str(item["path"]))
+            for item in list(frame.get("attachments") or [])
+        }
+        return self._archive_manager.write(
+            str(frame.get("manifest_json") or ""), str(frame.get("digest") or ""),
+            attachments=attachments,
+        )
+
+    async def _cmd_collaboration_export_archive(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._archive_manager is None:
+            raise ValueError("Local archives are unavailable.")
+        output = self._archive_manager.export(Path(str(frame.get("archive_path") or "")), Path(str(frame.get("destination") or "")))
+        return {"path": str(output)}
+
+    async def _cmd_collaboration_import_archive(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._archive_manager is None:
+            raise ValueError("Local archives are unavailable.")
+        return self._archive_manager.import_bundle(Path(str(frame.get("source") or "")))
+
+    async def _cmd_collaboration_run_shared(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._shared_chat_runner is None:
+            raise ValueError("Shared execution is unavailable.")
+        return await self._shared_chat_runner(
+            content=str(frame.get("content") or ""), claim=dict(frame.get("claim") or {}),
+            published_history=list(frame.get("published_history") or []),
+            mode=str(frame.get("mode") or "shared"),
+        )
+
+    async def _cmd_collaboration_control_run(self, connection: ServerConnection, frame: dict) -> dict:
+        if self._collaboration_run_controller is None:
+            raise ValueError("Shared execution is unavailable.")
+        return await self._collaboration_run_controller(
+            run_id=str(frame.get("run_id") or ""), action=str(frame.get("action") or ""),
+            lease_token=str(frame.get("lease_token") or ""),
+            lease_expires_at=str(frame.get("lease_expires_at") or ""),
+        )
 
     async def _cmd_list_commands(self, connection: ServerConnection, frame: dict) -> dict:
         if self._command_catalog is None:

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -491,11 +491,19 @@ class CollieIPCServer:
         if kind.startswith("collaboration_"):
             expected = str(os.environ.get("COLLIE_IDENTITY_BIND_TOKEN") or "")
             supplied = str(frame.get("identity_token") or frame.get("bind_token") or "")
-            if not expected or not supplied or not __import__("hmac").compare_digest(expected, supplied):
-                await self._send(connection, {
-                    "type": "error", "id": req_id,
-                    "message": "Shared-session access was not authorized.",
-                })
+            if (
+                not expected
+                or not supplied
+                or not __import__("hmac").compare_digest(expected, supplied)
+            ):
+                await self._send(
+                    connection,
+                    {
+                        "type": "error",
+                        "id": req_id,
+                        "message": "Shared-session access was not authorized.",
+                    },
+                )
                 return
         handler = getattr(self, f"_cmd_{kind}", None)
         if handler is None:
@@ -573,14 +581,22 @@ class CollieIPCServer:
             "cursor": self._collaboration_store.cursor(session_id) if bound and session_id else 0,
             "pending": self._collaboration_store.pending(
                 _bounded_list_limit(frame.get("limit"), default=100) or 100
-            ) if bound else [],
+            )
+            if bound
+            else [],
             "archives": self._archive_manager.list() if self._archive_manager and bound else [],
         }
 
-    async def _cmd_collaboration_bind_identity(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_bind_identity(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         expected = str(os.environ.get("COLLIE_IDENTITY_BIND_TOKEN") or "")
         supplied = str(frame.get("bind_token") or "")
-        if not expected or not supplied or not __import__("hmac").compare_digest(expected, supplied):
+        if (
+            not expected
+            or not supplied
+            or not __import__("hmac").compare_digest(expected, supplied)
+        ):
             raise ValueError("Shared-session identity binding was not authorized.")
         if self._collaboration_identity_binder is None:
             raise ValueError("Shared sessions are unavailable.")
@@ -591,14 +607,18 @@ class CollieIPCServer:
         self._collaboration_identity_binder(account_id, device_id)
         return {"bound": bool(account_id)}
 
-    async def _cmd_collaboration_queue_event(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_queue_event(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_store is None:
             raise ValueError("Shared sessions are unavailable.")
         return self._collaboration_store.queue_event(
             str(frame.get("session_id") or ""), dict(frame.get("event") or {})
         )
 
-    async def _cmd_collaboration_cache_bootstrap(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_cache_bootstrap(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_store is None:
             raise ValueError("Shared sessions are unavailable.")
         snapshot = frame.get("snapshot")
@@ -607,12 +627,16 @@ class CollieIPCServer:
         self._collaboration_store.cache_bootstrap(snapshot)
         return {"cached": True}
 
-    async def _cmd_collaboration_get_cached_bootstrap(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_get_cached_bootstrap(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_store is None:
             raise ValueError("Shared sessions are unavailable.")
         return {"snapshot": self._collaboration_store.cached_bootstrap()}
 
-    async def _cmd_collaboration_set_routine_delivery(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_set_routine_delivery(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_store is None or not self._collaboration_store.is_bound:
             raise ValueError("Sign in before sharing a routine result.")
         routine_id = str(frame.get("routine_id") or "")
@@ -627,12 +651,15 @@ class CollieIPCServer:
         if not session_id or revision < 1 or creator != self._collaboration_store.account_id:
             raise ValueError("Shared routine delivery identity or audience is invalid.")
         normalized = {
-            "session_id": session_id, "audience_revision": revision,
+            "session_id": session_id,
+            "audience_revision": revision,
             "creator_account_id": creator,
         }
         return {"routine": self.db.set_routine_shared_delivery(routine_id, normalized)}
 
-    async def _cmd_collaboration_mark_routine_delivery(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_mark_routine_delivery(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         routine_id = str(frame.get("routine_id") or "")
         event_id = str(frame.get("event_id") or "")
         status = str(frame.get("status") or "")
@@ -646,25 +673,35 @@ class CollieIPCServer:
             self._collaboration_store.settle_outbox(event_id, status, error)
         return {"recorded": True}
 
-    async def _cmd_collaboration_apply_page(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_apply_page(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_store is None:
             raise ValueError("Shared sessions are unavailable.")
         session_id = str(frame.get("session_id") or "")
         cursor = self._collaboration_store.apply_page(
-            session_id, list(frame.get("events") or []), next_cursor=int(frame.get("next_cursor") or 0)
+            session_id,
+            list(frame.get("events") or []),
+            next_cursor=int(frame.get("next_cursor") or 0),
         )
         return {"cursor": cursor}
 
-    async def _cmd_collaboration_list_messages(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_list_messages(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_store is None:
             raise ValueError("Shared sessions are unavailable.")
         session_id = str(frame.get("session_id") or "")
         through = frame.get("through")
-        return {"messages": self._collaboration_store.materialized_messages(
-            session_id, through=int(through) if through is not None else None
-        )}
+        return {
+            "messages": self._collaboration_store.materialized_messages(
+                session_id, through=int(through) if through is not None else None
+            )
+        }
 
-    async def _cmd_collaboration_write_archive(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_write_archive(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._archive_manager is None:
             raise ValueError("Local archives are unavailable.")
         attachments = {
@@ -672,35 +709,48 @@ class CollieIPCServer:
             for item in list(frame.get("attachments") or [])
         }
         return self._archive_manager.write(
-            str(frame.get("manifest_json") or ""), str(frame.get("digest") or ""),
+            str(frame.get("manifest_json") or ""),
+            str(frame.get("digest") or ""),
             attachments=attachments,
         )
 
-    async def _cmd_collaboration_export_archive(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_export_archive(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._archive_manager is None:
             raise ValueError("Local archives are unavailable.")
-        output = self._archive_manager.export(Path(str(frame.get("archive_path") or "")), Path(str(frame.get("destination") or "")))
+        output = self._archive_manager.export(
+            Path(str(frame.get("archive_path") or "")), Path(str(frame.get("destination") or ""))
+        )
         return {"path": str(output)}
 
-    async def _cmd_collaboration_import_archive(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_import_archive(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._archive_manager is None:
             raise ValueError("Local archives are unavailable.")
         return self._archive_manager.import_bundle(Path(str(frame.get("source") or "")))
 
-    async def _cmd_collaboration_run_shared(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_run_shared(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._shared_chat_runner is None:
             raise ValueError("Shared execution is unavailable.")
         return await self._shared_chat_runner(
-            content=str(frame.get("content") or ""), claim=dict(frame.get("claim") or {}),
+            content=str(frame.get("content") or ""),
+            claim=dict(frame.get("claim") or {}),
             published_history=list(frame.get("published_history") or []),
             mode=str(frame.get("mode") or "shared"),
         )
 
-    async def _cmd_collaboration_control_run(self, connection: ServerConnection, frame: dict) -> dict:
+    async def _cmd_collaboration_control_run(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
         if self._collaboration_run_controller is None:
             raise ValueError("Shared execution is unavailable.")
         return await self._collaboration_run_controller(
-            run_id=str(frame.get("run_id") or ""), action=str(frame.get("action") or ""),
+            run_id=str(frame.get("run_id") or ""),
+            action=str(frame.get("action") or ""),
             lease_token=str(frame.get("lease_token") or ""),
             lease_expires_at=str(frame.get("lease_expires_at") or ""),
         )

--- a/collie-core/collie_core/permissions/broker.py
+++ b/collie-core/collie_core/permissions/broker.py
@@ -24,11 +24,13 @@ class ApprovalBroker:
         broadcaster: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         *,
         timeout_seconds: float = 300,
+        context_validator: Callable[[ExecutionContext], bool] | None = None,
     ) -> None:
         self.db = db
         self.evaluator = evaluator
         self.broadcaster = broadcaster
         self.timeout_seconds = timeout_seconds
+        self.context_validator = context_validator
         self._pending: dict[str, asyncio.Future[str]] = {}
 
     async def _enforce_plan_change(self, context: ExecutionContext, request: Any) -> None:
@@ -75,6 +77,8 @@ class ApprovalBroker:
         tool: Any,
         params: dict[str, Any],
     ) -> None:
+        if self.context_validator is not None and not self.context_validator(context):
+            raise PermissionDeniedError("This shared run is no longer authorized on this device.")
         request = classify_tool(tool, str(tool_call.name), params)
         await self._enforce_plan_change(context, request)
         decision = self.evaluator.evaluate(context, request)
@@ -96,6 +100,10 @@ class ApprovalBroker:
                 "suggested_scope": request.suggested_scope,
                 "approve_for_me_eligible": self.evaluator._approve_for_me_eligible(request),
                 "reason": decision.reason,
+                "requester_id": context.requester_id,
+                "shared_session_id": context.shared_session_id,
+                "audience_revision": context.audience_revision,
+                "private_to_requester": bool(context.shared_session_id),
             },
             run_id=context.run_id,
             conversation_id=context.conversation_id,
@@ -116,6 +124,8 @@ class ApprovalBroker:
             self._pending.pop(request_id, None)
         if resolution not in {"allow_once", "allow_run"}:
             raise PermissionDeniedError("You rejected this action.")
+        if self.context_validator is not None and not self.context_validator(context):
+            raise PermissionDeniedError("This shared run is no longer authorized on this device.")
         await self._enforce_plan_change(context, request)
 
     async def resolve(
@@ -176,6 +186,23 @@ class ApprovalBroker:
                         "approval": resolved,
                     }
                 )
+        return len(rows)
+
+    async def cancel_shared_requester(self, requester_id: str) -> int:
+        """Resolve requester-private approvals before an account switch can expose them."""
+        rows = []
+        for row in self.db.list_pending_approvals():
+            display = row.get("display") if isinstance(row.get("display"), dict) else {}
+            if display.get("private_to_requester") and str(display.get("requester_id") or "") == requester_id:
+                rows.append(row)
+        for row in rows:
+            request_id = str(row["id"])
+            resolved = self.db.resolve_approval_request(request_id, "cancelled")
+            future = self._pending.get(request_id)
+            if future and not future.done():
+                future.set_result("cancelled")
+            if self.broadcaster:
+                await self.broadcaster({"type": "approval_resolved", "approval": resolved})
         return len(rows)
 
     def cancel_all(self) -> None:

--- a/collie-core/collie_core/permissions/broker.py
+++ b/collie-core/collie_core/permissions/broker.py
@@ -193,7 +193,10 @@ class ApprovalBroker:
         rows = []
         for row in self.db.list_pending_approvals():
             display = row.get("display") if isinstance(row.get("display"), dict) else {}
-            if display.get("private_to_requester") and str(display.get("requester_id") or "") == requester_id:
+            if (
+                display.get("private_to_requester")
+                and str(display.get("requester_id") or "") == requester_id
+            ):
                 rows.append(row)
         for row in rows:
             request_id = str(row["id"])

--- a/collie-core/collie_core/permissions/evaluator.py
+++ b/collie-core/collie_core/permissions/evaluator.py
@@ -86,10 +86,7 @@ class PermissionEvaluator:
             return PermissionDecision(
                 Effect.DENY, "Shared execution identity is incomplete, so this action is blocked."
             )
-        if (
-            context.shared_session_id
-            and context.requester_id != context.credential_owner_id
-        ):
+        if context.shared_session_id and context.requester_id != context.credential_owner_id:
             return PermissionDecision(
                 Effect.DENY, "Shared work cannot use another person's credentials."
             )

--- a/collie-core/collie_core/permissions/evaluator.py
+++ b/collie-core/collie_core/permissions/evaluator.py
@@ -74,6 +74,31 @@ class PermissionEvaluator:
         self.local_write_preset = preset
 
     def evaluate(self, context: ExecutionContext, request: PermissionRequest) -> PermissionDecision:
+        if context.shared_session_id and not all(
+            (
+                context.requester_id,
+                context.credential_owner_id,
+                context.executor_device_id,
+                context.audience_revision,
+                context.lease_token,
+            )
+        ):
+            return PermissionDecision(
+                Effect.DENY, "Shared execution identity is incomplete, so this action is blocked."
+            )
+        if (
+            context.shared_session_id
+            and context.requester_id != context.credential_owner_id
+        ):
+            return PermissionDecision(
+                Effect.DENY, "Shared work cannot use another person's credentials."
+            )
+
+        if context.shared_session_id and request.action.startswith("memory."):
+            return PermissionDecision(
+                Effect.ASK,
+                "Remembering from shared work requires the requester to approve it explicitly.",
+            )
         if context.parent_effect == Effect.DENY:
             return PermissionDecision(Effect.DENY, "The parent run denied this capability.")
 

--- a/collie-core/collie_core/permissions/models.py
+++ b/collie-core/collie_core/permissions/models.py
@@ -43,6 +43,14 @@ class ExecutionContext:
     parent_effect: Effect | None = None
     approve_all_for_run: bool = False
     project_path: str | None = None
+    requester_id: str | None = None
+    credential_owner_id: str | None = None
+    executor_device_id: str | None = None
+    shared_session_id: str | None = None
+    audience_revision: int | None = None
+    context_cutoff: int | None = None
+    lease_token: str | None = None
+    publication_authorized: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -26,8 +26,8 @@ from loguru import logger
 
 from collie_core import settings as collie_settings
 from collie_core.automations.scheduler import AutomationScheduler
-from collie_core.commands import CommandController
 from collie_core.collaboration import ArchiveManager, CollaborationStore, SharedExecutionContext
+from collie_core.commands import CommandController
 from collie_core.connectors.manager import ConnectorManager
 from collie_core.db import CollieDB, collie_home, utc_now
 from collie_core.ipc.server import CollieIPCServer
@@ -190,7 +190,9 @@ class CollieRuntime:
             collaboration_run_controller=self._control_shared_run,
         )
         self.approvals = ApprovalBroker(
-            self.db, self.permission_evaluator, self.ipc.broadcast,
+            self.db,
+            self.permission_evaluator,
+            self.ipc.broadcast,
             context_validator=self._validate_execution_context,
         )
         self.ipc.approval_broker = self.approvals
@@ -1126,26 +1128,44 @@ class CollieRuntime:
         routine_id = str(auto.get("id") or "")
         creator = str(raw.get("creator_account_id") or "")
         session_id = str(raw.get("session_id") or "")
-        event_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"collie:routine:{routine_id}:{assistant.get('id')}"))
+        event_id = str(
+            uuid.uuid5(uuid.NAMESPACE_URL, f"collie:routine:{routine_id}:{assistant.get('id')}")
+        )
         try:
             revision = int(raw.get("audience_revision") or 0)
             if not creator or not session_id or revision < 1:
                 raise ValueError("The routine shared-delivery configuration is invalid.")
-            self.collaboration.queue_event_for_account(creator, session_id, {
-                "event_id": event_id, "session_id": session_id,
-                "kind": "message", "publication_kind": "routine_result",
-                "message_id": str(uuid.uuid5(uuid.NAMESPACE_URL, f"{event_id}:message")),
-                "author_id": creator, "role": "assistant", "content": content,
-                "revision": 1, "audience_revision": revision,
-                "routine_id": routine_id, "created_at": utc_now(),
-            })
+            self.collaboration.queue_event_for_account(
+                creator,
+                session_id,
+                {
+                    "event_id": event_id,
+                    "session_id": session_id,
+                    "kind": "message",
+                    "publication_kind": "routine_result",
+                    "message_id": str(uuid.uuid5(uuid.NAMESPACE_URL, f"{event_id}:message")),
+                    "author_id": creator,
+                    "role": "assistant",
+                    "content": content,
+                    "revision": 1,
+                    "audience_revision": revision,
+                    "routine_id": routine_id,
+                    "created_at": utc_now(),
+                },
+            )
             self.db.record_routine_shared_delivery(
                 routine_id, status="pending", event_id=event_id, error=None
             )
-            asyncio.create_task(self.ipc.broadcast({
-                "type": "collaboration_outbox_pending", "routine_id": routine_id,
-                "session_id": session_id, "event_id": event_id,
-            }))
+            asyncio.create_task(
+                self.ipc.broadcast(
+                    {
+                        "type": "collaboration_outbox_pending",
+                        "routine_id": routine_id,
+                        "session_id": session_id,
+                        "event_id": event_id,
+                    }
+                )
+            )
         except Exception as error:
             self.db.record_routine_shared_delivery(
                 routine_id, status="pending", event_id=event_id, error=str(error)[:300]
@@ -1537,12 +1557,22 @@ class CollieRuntime:
                 raise ValueError("Shared history contains another session.")
             previous_seq = seq
         supplied_projection = [
-            (str(item.get("message_id") or ""), str(item.get("role") or ""), str(item.get("content") or ""))
-            for item in published_history if not bool(item.get("deleted"))
+            (
+                str(item.get("message_id") or ""),
+                str(item.get("role") or ""),
+                str(item.get("content") or ""),
+            )
+            for item in published_history
+            if not bool(item.get("deleted"))
         ]
         canonical_projection = [
-            (str(item.get("message_id") or ""), str(item.get("role") or ""), str(item.get("content") or ""))
-            for item in canonical_history if not bool(item.get("deleted"))
+            (
+                str(item.get("message_id") or ""),
+                str(item.get("role") or ""),
+                str(item.get("content") or ""),
+            )
+            for item in canonical_history
+            if not bool(item.get("deleted"))
         ]
         if supplied_projection and supplied_projection != canonical_projection:
             raise ValueError("Shared history does not match the synchronized canonical copy.")
@@ -1557,25 +1587,35 @@ class CollieRuntime:
         # These capabilities consume private profile/specialist context or can
         # continue after the fenced parent run. They stay fail-closed until an
         # explicit requester-only flow supplies scoped input and publication review.
-        private_context_tools = {"remember", "suggest_profile", "call_subagent"} if mode == "shared" else set()
+        private_context_tools = (
+            {"remember", "suggest_profile", "call_subagent"} if mode == "shared" else set()
+        )
         for name in self.loop.tools.tool_names:
             tool = self.loop.tools.get(name)
             if tool is not None and name not in private_context_tools:
                 shared_tools.register(tool)
 
         async def private_stream(delta: str = "", **_kwargs: Any) -> None:
-            await self.ipc.broadcast({
-                "type": "collaboration_private_delta", "run_id": context.run_id,
-                "requester_id": context.requester_id, "delta": str(delta),
-            })
+            await self.ipc.broadcast(
+                {
+                    "type": "collaboration_private_delta",
+                    "run_id": context.run_id,
+                    "requester_id": context.requester_id,
+                    "delta": str(delta),
+                }
+            )
 
         async def private_progress(text: str = "", **kwargs: Any) -> None:
             # Private local frame: Electron must never forward this to the shared publisher.
-            await self.ipc.broadcast({
-                "type": "collaboration_private_progress", "run_id": context.run_id,
-                "requester_id": context.requester_id, "text": str(text),
-                "state": str(kwargs.get("state") or "working"),
-            })
+            await self.ipc.broadcast(
+                {
+                    "type": "collaboration_private_progress",
+                    "run_id": context.run_id,
+                    "requester_id": context.requester_id,
+                    "text": str(text),
+                    "state": str(kwargs.get("state") or "working"),
+                }
+            )
 
         prompt_content = content
         if published_history:
@@ -1587,7 +1627,8 @@ class CollieRuntime:
         if context.run_id in self._active_shared_runs:
             raise ValueError("This shared run is already active on this device.")
         self._active_shared_runs[context.run_id] = {
-            "lease_token": context.lease_token, "session_key": session_key,
+            "lease_token": context.lease_token,
+            "session_key": session_key,
             "lease_expires_at": context.lease_expires_at,
         }
         try:
@@ -1632,9 +1673,12 @@ class CollieRuntime:
 
     def _bind_collaboration_identity(self, account_id: str, device_id: str) -> None:
         previous_account = self._collaboration_account_id
-        if (account_id, device_id) != (
-            self._collaboration_account_id, self._collaboration_device_id
-        ) and self._active_shared_runs and self.loop is not None:
+        if (
+            (account_id, device_id)
+            != (self._collaboration_account_id, self._collaboration_device_id)
+            and self._active_shared_runs
+            and self.loop is not None
+        ):
             for active in list(self._active_shared_runs.values()):
                 asyncio.create_task(self.loop.cancel_session(active["session_key"]))
         if previous_account and previous_account != str(account_id).strip():

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -27,8 +27,9 @@ from loguru import logger
 from collie_core import settings as collie_settings
 from collie_core.automations.scheduler import AutomationScheduler
 from collie_core.commands import CommandController
+from collie_core.collaboration import ArchiveManager, CollaborationStore, SharedExecutionContext
 from collie_core.connectors.manager import ConnectorManager
-from collie_core.db import CollieDB, collie_home
+from collie_core.db import CollieDB, collie_home, utc_now
 from collie_core.ipc.server import CollieIPCServer
 from collie_core.memory.profile import ProfileStore
 from collie_core.messengers import CollieBus, MessengerManager
@@ -78,6 +79,14 @@ class CollieRuntime:
         self, *, port: int = 3818, db: CollieDB | None = None, ipc_token: str | None = None
     ) -> None:
         self.db = db or CollieDB()
+        data_root = self.db.path.parent
+        self.collaboration = CollaborationStore(data_root / "collaboration.db")
+        self.archives = ArchiveManager(data_root / "archives" / "shared")
+        self._collaboration_account_id = str(os.environ.get("COLLIE_ACCOUNT_ID") or "")
+        self._collaboration_device_id = str(os.environ.get("COLLIE_DEVICE_ID") or "")
+        self._active_shared_runs: dict[str, dict[str, str]] = {}
+        self.collaboration.bind_account(self._collaboration_account_id)
+        self.archives.bind_account(self._collaboration_account_id)
         # Anchor the engine's runtime data dir (media downloads, pairing
         # store, cron jobs) under ~/.collie instead of ~/.nanobot. No JSON
         # config file is ever written — the path only derives directories.
@@ -174,8 +183,16 @@ class CollieRuntime:
             dream_runner=self._run_dream_manual,
             gardener_runner=self._run_gardener_manual,
             thing_store=self.things,
+            collaboration_store=self.collaboration,
+            archive_manager=self.archives,
+            shared_chat_runner=self._run_shared_chat,
+            collaboration_identity_binder=self._bind_collaboration_identity,
+            collaboration_run_controller=self._control_shared_run,
         )
-        self.approvals = ApprovalBroker(self.db, self.permission_evaluator, self.ipc.broadcast)
+        self.approvals = ApprovalBroker(
+            self.db, self.permission_evaluator, self.ipc.broadcast,
+            context_validator=self._validate_execution_context,
+        )
         self.ipc.approval_broker = self.approvals
         self.messengers.broadcaster = self.ipc.broadcast
         self._scheduler = AutomationScheduler(
@@ -1004,6 +1021,7 @@ class CollieRuntime:
             return
 
         assistant = self.db.add_message(conv_id, "assistant", content)
+        self._queue_routine_shared_delivery(auto, assistant, content)
         await self.ipc.broadcast(
             {
                 "type": "message",
@@ -1066,6 +1084,7 @@ class CollieRuntime:
         if not content:
             return
         assistant = self.db.add_message(conv_id, "assistant", content)
+        self._queue_routine_shared_delivery(auto, assistant, content)
         await self.ipc.broadcast(
             {
                 "type": "message",
@@ -1092,6 +1111,45 @@ class CollieRuntime:
         targets.update(self.messengers.automation_targets())
         for target in sorted(targets):
             await self.messengers.deliver(target, f"🔔 {name}\n\n{content}")
+
+    def _queue_routine_shared_delivery(
+        self, auto: dict[str, Any], assistant: dict[str, Any], content: str
+    ) -> None:
+        raw = auto.get("shared_delivery")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except (TypeError, ValueError):
+                raw = None
+        if not isinstance(raw, dict):
+            return
+        routine_id = str(auto.get("id") or "")
+        creator = str(raw.get("creator_account_id") or "")
+        session_id = str(raw.get("session_id") or "")
+        event_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"collie:routine:{routine_id}:{assistant.get('id')}"))
+        try:
+            revision = int(raw.get("audience_revision") or 0)
+            if not creator or not session_id or revision < 1:
+                raise ValueError("The routine shared-delivery configuration is invalid.")
+            self.collaboration.queue_event_for_account(creator, session_id, {
+                "event_id": event_id, "session_id": session_id,
+                "kind": "message", "publication_kind": "routine_result",
+                "message_id": str(uuid.uuid5(uuid.NAMESPACE_URL, f"{event_id}:message")),
+                "author_id": creator, "role": "assistant", "content": content,
+                "revision": 1, "audience_revision": revision,
+                "routine_id": routine_id, "created_at": utc_now(),
+            })
+            self.db.record_routine_shared_delivery(
+                routine_id, status="pending", event_id=event_id, error=None
+            )
+            asyncio.create_task(self.ipc.broadcast({
+                "type": "collaboration_outbox_pending", "routine_id": routine_id,
+                "session_id": session_id, "event_id": event_id,
+            }))
+        except Exception as error:
+            self.db.record_routine_shared_delivery(
+                routine_id, status="pending", event_id=event_id, error=str(error)[:300]
+            )
 
     async def _run_dream_manual(self) -> dict[str, Any]:
         """Manual 'Review now' trigger (Settings -> Memory)."""
@@ -1442,6 +1500,191 @@ class CollieRuntime:
                 logger.exception("Failed to record usage for {}", default_provider.get("id"))
         return outbound
 
+    async def _run_shared_chat(
+        self,
+        *,
+        content: str,
+        claim: dict[str, Any],
+        published_history: list[dict[str, Any]],
+        mode: str = "shared",
+    ) -> dict[str, Any]:
+        """Execute a backend-claimed run privately on the requester's enrolled device.
+
+        Electron supplies a claim returned by the authenticated backend. The account and
+        device bindings are injected into this process at launch, not accepted in this
+        command. The result is returned only to Electron for an explicit complete_run RPC.
+        """
+        context = SharedExecutionContext.from_claim(
+            claim,
+            enrolled_account_id=self._collaboration_account_id,
+            enrolled_device_id=self._collaboration_device_id,
+        )
+        if not content.strip():
+            raise ValueError("A shared request cannot be empty.")
+        if mode not in {"shared", "private_result"}:
+            raise ValueError("Unsupported shared execution mode.")
+        if self.collaboration.cursor(context.session_id) < context.context_cutoff:
+            raise ValueError("Shared history is not synchronized through the claimed cutoff.")
+        canonical_history = self.collaboration.materialized_messages(
+            context.session_id, through=context.context_cutoff
+        )
+        previous_seq = 0
+        for item in canonical_history:
+            seq = int(item.get("seq") or 0)
+            if seq <= previous_seq or seq > context.context_cutoff:
+                raise ValueError("Shared history is unordered or exceeds the claimed cutoff.")
+            if str(item.get("session_id") or context.session_id) != context.session_id:
+                raise ValueError("Shared history contains another session.")
+            previous_seq = seq
+        supplied_projection = [
+            (str(item.get("message_id") or ""), str(item.get("role") or ""), str(item.get("content") or ""))
+            for item in published_history if not bool(item.get("deleted"))
+        ]
+        canonical_projection = [
+            (str(item.get("message_id") or ""), str(item.get("role") or ""), str(item.get("content") or ""))
+            for item in canonical_history if not bool(item.get("deleted"))
+        ]
+        if supplied_projection and supplied_projection != canonical_projection:
+            raise ValueError("Shared history does not match the synchronized canonical copy.")
+        published_history = [item for item in canonical_history if not bool(item.get("deleted"))]
+        if self.loop is None:
+            configured = await self._configure()
+            if not configured.get("configured"):
+                raise RuntimeError(configured.get("error") or "no provider configured")
+        from nanobot.agent.tools.registry import ToolRegistry
+
+        shared_tools = ToolRegistry()
+        # These capabilities consume private profile/specialist context or can
+        # continue after the fenced parent run. They stay fail-closed until an
+        # explicit requester-only flow supplies scoped input and publication review.
+        private_context_tools = {"remember", "suggest_profile", "call_subagent"} if mode == "shared" else set()
+        for name in self.loop.tools.tool_names:
+            tool = self.loop.tools.get(name)
+            if tool is not None and name not in private_context_tools:
+                shared_tools.register(tool)
+
+        async def private_stream(delta: str = "", **_kwargs: Any) -> None:
+            await self.ipc.broadcast({
+                "type": "collaboration_private_delta", "run_id": context.run_id,
+                "requester_id": context.requester_id, "delta": str(delta),
+            })
+
+        async def private_progress(text: str = "", **kwargs: Any) -> None:
+            # Private local frame: Electron must never forward this to the shared publisher.
+            await self.ipc.broadcast({
+                "type": "collaboration_private_progress", "run_id": context.run_id,
+                "requester_id": context.requester_id, "text": str(text),
+                "state": str(kwargs.get("state") or "working"),
+            })
+
+        prompt_content = content
+        if published_history:
+            last = published_history[-1]
+            if str(last.get("role") or "") == "user" and str(last.get("content") or "") == content:
+                prompt_content = ""
+
+        session_key = f"shared-private:{context.run_id}"
+        if context.run_id in self._active_shared_runs:
+            raise ValueError("This shared run is already active on this device.")
+        self._active_shared_runs[context.run_id] = {
+            "lease_token": context.lease_token, "session_key": session_key,
+            "lease_expires_at": context.lease_expires_at,
+        }
+        try:
+            outbound = await self.loop.process_direct(
+                prompt_content,
+                session_key=session_key,
+                channel="shared-private",
+                chat_id=context.session_id,
+                on_stream=private_stream,
+                on_progress=private_progress,
+                ephemeral=True,
+                persist_user_message=False,
+                tools=shared_tools,
+                message_metadata={
+                    "audience_mode": mode,
+                    "published_history": published_history,
+                    "shared_execution": context.permission_metadata(),
+                },
+                permission_context={
+                    "execution_mode": "execute",
+                    "run_id": context.run_id,
+                    "origin": "shared",
+                    "audience_mode": mode,
+                    **context.permission_metadata(),
+                },
+            )
+        finally:
+            # A requester-bound specialist may not outlive its fenced parent and
+            # re-enter as an ordinary system turn with private context.
+            await self.loop.subagents.cancel_by_session(session_key)
+            self._active_shared_runs.pop(context.run_id, None)
+        return {
+            "run_id": context.run_id,
+            "session_id": context.session_id,
+            "audience_revision": context.audience_revision,
+            "context_cutoff": context.context_cutoff,
+            "content": str(getattr(outbound, "content", "") or ""),
+            "publication_authorized": context.publication_authorized,
+            "mode": mode,
+            "requires_publication_review": True,
+        }
+
+    def _bind_collaboration_identity(self, account_id: str, device_id: str) -> None:
+        previous_account = self._collaboration_account_id
+        if (account_id, device_id) != (
+            self._collaboration_account_id, self._collaboration_device_id
+        ) and self._active_shared_runs and self.loop is not None:
+            for active in list(self._active_shared_runs.values()):
+                asyncio.create_task(self.loop.cancel_session(active["session_key"]))
+        if previous_account and previous_account != str(account_id).strip():
+            asyncio.create_task(self.approvals.cancel_shared_requester(previous_account))
+        self._collaboration_account_id = str(account_id).strip()
+        self._collaboration_device_id = str(device_id).strip()
+        self.collaboration.bind_account(self._collaboration_account_id)
+        self.archives.bind_account(self._collaboration_account_id)
+
+    async def _control_shared_run(
+        self, *, run_id: str, action: str, lease_token: str, lease_expires_at: str
+    ) -> dict[str, Any]:
+        active = self._active_shared_runs.get(run_id)
+        if active is None:
+            return {"active": False, "cancelled": 0}
+        if action == "renew":
+            if not lease_token or not lease_expires_at:
+                raise ValueError("A renewed lease token and expiry are required.")
+            active["lease_token"] = lease_token
+            active["lease_expires_at"] = lease_expires_at
+            return {"active": True, "renewed": True}
+        if action in {"cancel", "fenced"}:
+            self._active_shared_runs.pop(run_id, None)
+            cancelled = 0
+            if self.loop is not None:
+                cancelled = await self.loop.cancel_session(active["session_key"])
+            return {"active": False, "cancelled": cancelled}
+        raise ValueError("Unsupported shared-run control action.")
+
+    def _validate_execution_context(self, context: ExecutionContext) -> bool:
+        if not context.shared_session_id:
+            return True
+        active = self._active_shared_runs.get(str(context.run_id or ""))
+        try:
+            from datetime import UTC, datetime
+
+            expiry = datetime.fromisoformat(str((active or {}).get("lease_expires_at") or ""))
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=UTC)
+            lease_live = expiry > datetime.now(UTC)
+        except (TypeError, ValueError):
+            lease_live = False
+        return bool(
+            active
+            and lease_live
+            and context.requester_id == self._collaboration_account_id
+            and context.credential_owner_id == self._collaboration_account_id
+            and context.executor_device_id == self._collaboration_device_id
+        )
+
     # -- process lifecycle ----------------------------------------------------
 
     def _gc_media_uploads(self) -> None:
@@ -1576,6 +1819,7 @@ class CollieRuntime:
             if recorder is not None:
                 recorder.shutdown()
             self.db.close()
+            self.collaboration.close()
 
 
 def _env_port(default: int = 3818) -> int:

--- a/collie-core/collie_core/tools/subagent.py
+++ b/collie-core/collie_core/tools/subagent.py
@@ -142,7 +142,10 @@ class CallSubagentTool(Tool):
             if isinstance(request_ctx.metadata, dict)
             else {}
         )
-        for inherited_key in ("run_id", "approve_all_for_run", "plan_id", "plan_version"):
+        inherited_keys = ["approve_all_for_run", "plan_id", "plan_version"]
+        if not permission_context.get("shared_session_id"):
+            inherited_keys.append("run_id")
+        for inherited_key in inherited_keys:
             permission_context.pop(inherited_key, None)
         return await self._manager.spawn(
             task=composite,

--- a/collie-core/nanobot/agent/context.py
+++ b/collie-core/nanobot/agent/context.py
@@ -72,8 +72,17 @@ class ContextBuilder:
         include_memory_recent_history: bool = True,
         session_key: str | None = None,
         unified_session: bool = False,
+        audience_mode: str = "private",
     ) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
+        if audience_mode == "shared":
+            return (
+                "You are Collie, helping in a shared conversation. Use only the published "
+                "conversation content provided in this prompt. Do not infer or reveal personal "
+                "memory, private workspace instructions, credentials, local paths, tool details, "
+                "or private drafts. Private-resource work may happen locally, but publish only a "
+                "result the requester explicitly authorized for this audience."
+            )
         root = workspace or self.workspace
         parts = [self._get_identity(channel=channel, workspace=root)]
 
@@ -207,6 +216,26 @@ class ContextBuilder:
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         root = workspace or self.workspace
+        audience_mode = str((session_metadata or {}).get("audience_mode") or "private")
+        if audience_mode in {"shared", "private_result"}:
+            canonical = (session_metadata or {}).get("published_history")
+            if not isinstance(canonical, list):
+                raise ValueError("Shared turns require canonical published history.")
+            history = [
+                {
+                    "role": str(item.get("role") or ""),
+                    "content": (
+                        f"[Author: {str(item.get('author_id') or 'unknown')}]\n"
+                        f"{str(item.get('content') or '')}"
+                    ),
+                }
+                for item in canonical
+                if isinstance(item, Mapping) and item.get("role") in {"user", "assistant"}
+            ]
+            if audience_mode == "shared":
+                include_memory_recent_history = False
+                session_summary = None
+                skill_names = None
         user_content = self._build_user_content(current_message, media)
         blocks = list(runtime_context_blocks or ()) if current_role == "user" else []
         merged, runtime_context_meta = append_runtime_context(user_content, blocks)
@@ -221,6 +250,7 @@ class ContextBuilder:
                     include_memory_recent_history=include_memory_recent_history,
                     session_key=session_key,
                     unified_session=unified_session,
+                    audience_mode=audience_mode,
                 ),
             },
             *history,

--- a/collie-core/nanobot/agent/loop.py
+++ b/collie-core/nanobot/agent/loop.py
@@ -766,6 +766,18 @@ class AgentLoop:
     ) -> list[dict[str, Any]]:
         """Build the initial message list for the LLM turn."""
         scope = self.workspace_scopes.for_message(msg, session.metadata)
+        audience_mode = str(msg.metadata.get("audience_mode") or "")
+        shared = audience_mode in {"shared", "private_result"}
+        metadata = session.metadata if not shared else dict(session.metadata)
+        if shared:
+            metadata.update(
+                audience_mode=audience_mode,
+                published_history=msg.metadata.get("published_history"),
+            )
+            # Runtime context providers may describe private local state. Shared
+            # prompts receive only canonical published history and public policy.
+            if audience_mode == "shared":
+                runtime_context_blocks = []
         return self.context.build_messages(
             history=history,
             current_message=msg.content,
@@ -774,10 +786,12 @@ class AgentLoop:
             chat_id=self._runtime_chat_id(msg),
             sender_id=msg.sender_id,
             session_summary=pending_summary,
-            session_metadata=session.metadata,
-            workspace=scope.project_path,
+            session_metadata=metadata,
+            workspace=None if audience_mode == "shared" else scope.project_path,
             runtime_context_blocks=runtime_context_blocks,
-            include_memory_recent_history=include_memory_recent_history,
+            include_memory_recent_history=(
+                include_memory_recent_history and audience_mode != "shared"
+            ),
             session_key=session.key,
             unified_session=self._unified_session,
         )
@@ -1101,6 +1115,14 @@ class AgentLoop:
                 conversation_id=permission_context.get("conversation_id") or chat_id,
                 routine_id=permission_context.get("routine_id"),
                 origin=str(permission_context.get("origin") or channel),
+                requester_id=permission_context.get("requester_id"),
+                credential_owner_id=permission_context.get("credential_owner_id"),
+                executor_device_id=permission_context.get("executor_device_id"),
+                shared_session_id=permission_context.get("shared_session_id"),
+                audience_revision=permission_context.get("audience_revision"),
+                context_cutoff=permission_context.get("context_cutoff"),
+                lease_token=permission_context.get("lease_token"),
+                publication_authorized=bool(permission_context.get("publication_authorized", False)),
                 approve_all_for_run=bool(
                     permission_context.get("approve_all_for_run", False)
                 ),

--- a/collie-core/nanobot/agent/runner.py
+++ b/collie-core/nanobot/agent/runner.py
@@ -92,6 +92,14 @@ class AgentRunSpec:
     conversation_id: str | None = None
     routine_id: str | None = None
     origin: str = "chat"
+    requester_id: str | None = None
+    credential_owner_id: str | None = None
+    executor_device_id: str | None = None
+    shared_session_id: str | None = None
+    audience_revision: int | None = None
+    context_cutoff: int | None = None
+    lease_token: str | None = None
+    publication_authorized: bool = False
     execution_posture: str = "inherit"
     approve_all_for_run: bool = False
 
@@ -1243,6 +1251,14 @@ class AgentRunner:
                 execution_posture=spec.execution_posture,
                 approve_all_for_run=spec.approve_all_for_run,
                 project_path=str(spec.workspace) if spec.workspace is not None else None,
+                requester_id=spec.requester_id,
+                credential_owner_id=spec.credential_owner_id,
+                executor_device_id=spec.executor_device_id,
+                shared_session_id=spec.shared_session_id,
+                audience_revision=spec.audience_revision,
+                context_cutoff=spec.context_cutoff,
+                lease_token=spec.lease_token,
+                publication_authorized=spec.publication_authorized,
             )
             try:
                 await spec.authorizer.authorize(

--- a/collie-core/nanobot/agent/subagent.py
+++ b/collie-core/nanobot/agent/subagent.py
@@ -423,6 +423,7 @@ class SubagentManager:
                 message_id=origin_message_id,
                 session_key=sess_key,
                 runtime=runtime,
+                metadata={"permission_context": dict(origin)},
             ))
             token = bind_workspace_scope(workspace_scope) if workspace_scope is not None else None
             try:
@@ -449,6 +450,14 @@ class SubagentManager:
                     conversation_id=origin.get("chat_id"),
                     routine_id=origin.get("routine_id"),
                     origin="subagent",
+                    requester_id=origin.get("requester_id"),
+                    credential_owner_id=origin.get("credential_owner_id"),
+                    executor_device_id=origin.get("executor_device_id"),
+                    shared_session_id=origin.get("shared_session_id"),
+                    audience_revision=origin.get("audience_revision"),
+                    context_cutoff=origin.get("context_cutoff"),
+                    lease_token=origin.get("lease_token"),
+                    publication_authorized=bool(origin.get("publication_authorized", False)),
                     execution_posture=execution_posture,
                 ))
             finally:

--- a/collie-core/tests/agent/test_shared_context_isolation.py
+++ b/collie-core/tests/agent/test_shared_context_isolation.py
@@ -1,0 +1,41 @@
+from nanobot.agent.context import ContextBuilder
+
+
+def test_shared_context_excludes_private_bootstrap_memory_and_skills(tmp_path):
+    (tmp_path / "VISION.md").write_text("PRIVATE_BOOTSTRAP_SENTINEL", encoding="utf-8")
+    memory = tmp_path / "memory"
+    memory.mkdir()
+    (memory / "MEMORY.md").write_text("PRIVATE_MEMORY_SENTINEL", encoding="utf-8")
+    builder = ContextBuilder(tmp_path)
+    messages = builder.build_messages(
+        history=[{"role": "user", "content": "PRIVATE_SESSION_SENTINEL"}],
+        current_message="published request",
+        session_metadata={
+            "audience_mode": "shared",
+            "published_history": [{"role": "user", "content": "published history"}],
+        },
+    )
+    serialized = repr(messages)
+    assert "published history" in serialized
+    assert "published request" in serialized
+    assert "PRIVATE_BOOTSTRAP_SENTINEL" not in serialized
+    assert "PRIVATE_MEMORY_SENTINEL" not in serialized
+    assert "PRIVATE_SESSION_SENTINEL" not in serialized
+
+
+def test_private_result_uses_requesters_private_context_for_review(tmp_path):
+    (tmp_path / "VISION.md").write_text("PRIVATE_BOOTSTRAP_SENTINEL", encoding="utf-8")
+    builder = ContextBuilder(tmp_path)
+    messages = builder.build_messages(
+        history=[], current_message="private task",
+        session_metadata={
+            "audience_mode": "private_result",
+            "published_history": [
+                {"role": "user", "author_id": "alice", "content": "shared input"}
+            ],
+        },
+    )
+    serialized = repr(messages)
+    assert "PRIVATE_BOOTSTRAP_SENTINEL" in serialized
+    assert "shared input" in serialized
+    assert "Author: alice" in serialized

--- a/collie-core/tests/collie/test_collaboration_storage.py
+++ b/collie-core/tests/collie/test_collaboration_storage.py
@@ -10,18 +10,24 @@ from collie_core.collaboration import (
     ArchiveManager,
     CollaborationStore,
     SharedExecutionContext,
-    SyncConflict,
+    SyncConflictError,
 )
+from collie_core.db import CollieDB
 from collie_core.permissions.evaluator import PermissionEvaluator
 from collie_core.permissions.models import Effect, ExecutionContext, PermissionRequest, Risk
-from collie_core.db import CollieDB
 
 
 def _event(seq: int, *, event_id: str | None = None, content: str = "hello") -> dict:
     return {
-        "event_id": event_id or f"event-{seq}", "session_id": "session-1", "seq": seq,
-        "kind": "message", "message_id": f"message-{seq}", "author_id": "alice",
-        "role": "user", "content": content, "revision": 1,
+        "event_id": event_id or f"event-{seq}",
+        "session_id": "session-1",
+        "seq": seq,
+        "kind": "message",
+        "message_id": f"message-{seq}",
+        "author_id": "alice",
+        "role": "user",
+        "content": content,
+        "revision": 1,
         "created_at": "2026-09-09T00:00:00+00:00",
     }
 
@@ -31,8 +37,10 @@ def test_page_and_cursor_commit_atomically_and_deduplicate(tmp_path):
     store.bind_account("alice")
     assert store.apply_page("session-1", [_event(1)], next_cursor=1) == 1
     assert store.apply_page("session-1", [_event(1)], next_cursor=1) == 1
-    with pytest.raises(SyncConflict):
-        store.apply_page("session-1", [_event(2, event_id="event-1", content="changed")], next_cursor=2)
+    with pytest.raises(SyncConflictError):
+        store.apply_page(
+            "session-1", [_event(2, event_id="event-1", content="changed")], next_cursor=2
+        )
     assert store.cursor("session-1") == 1
     assert [item["content"] for item in store.materialized_messages("session-1")] == ["hello"]
 
@@ -42,7 +50,7 @@ def test_outbox_rejects_event_id_reuse(tmp_path):
     store.bind_account("alice")
     draft = _event(0)
     store.queue_event("session-1", draft)
-    with pytest.raises(SyncConflict):
+    with pytest.raises(SyncConflictError):
         store.queue_event("session-1", draft | {"content": "different"})
     assert store.materialized_messages("session-1")[0]["sync_state"] == "local"
 
@@ -82,8 +90,13 @@ def test_archive_ack_data_requires_durable_verified_readback(tmp_path):
     manager = ArchiveManager(tmp_path / "archives")
     manager.bind_account("alice")
     manifest = {
-        "version": 1, "session_id": "session-1", "membership_revision": 2,
-        "final_seq": 1, "recipients": ["alice"], "events": [_event(1)], "files": [],
+        "version": 1,
+        "session_id": "session-1",
+        "membership_revision": 2,
+        "final_seq": 1,
+        "recipients": ["alice"],
+        "events": [_event(1)],
+        "files": [],
     }
     raw = json.dumps(manifest, separators=(",", ":"))
     digest = hashlib.sha256(raw.encode()).hexdigest()
@@ -98,8 +111,13 @@ def test_archive_accepts_draft_final_sequence_alias_without_changing_digest(tmp_
     manager = ArchiveManager(tmp_path / "archives")
     manager.bind_account("alice")
     manifest = {
-        "version": 1, "session_id": "session-legacy", "membership_revision": 1,
-        "final_sequence": 1, "recipients": ["alice"], "events": [_event(1)], "files": [],
+        "version": 1,
+        "session_id": "session-legacy",
+        "membership_revision": 1,
+        "final_sequence": 1,
+        "recipients": ["alice"],
+        "events": [_event(1)],
+        "files": [],
     }
     raw = json.dumps(manifest, separators=(",", ":"))
     receipt = manager.write(raw, hashlib.sha256(raw.encode()).hexdigest())
@@ -108,9 +126,14 @@ def test_archive_accepts_draft_final_sequence_alias_without_changing_digest(tmp_
 
 def test_shared_claim_must_match_enrolled_requester_and_device():
     claim = {
-        "session_id": "s", "requester_id": "alice", "credential_owner_id": "alice",
-        "executor_device_id": "device-a", "audience_revision": 1, "context_cutoff": 4,
-        "run_id": "run", "lease_token": "fence",
+        "session_id": "s",
+        "requester_id": "alice",
+        "credential_owner_id": "alice",
+        "executor_device_id": "device-a",
+        "audience_revision": 1,
+        "context_cutoff": 4,
+        "run_id": "run",
+        "lease_token": "fence",
         "lease_expires_at": "2099-01-01T00:00:00+00:00",
     }
     SharedExecutionContext.from_claim(
@@ -124,13 +147,22 @@ def test_shared_claim_must_match_enrolled_requester_and_device():
 
 def test_shared_memory_write_always_requires_requester_approval():
     context = ExecutionContext(
-        run_id="run", requester_id="alice", credential_owner_id="alice",
-        executor_device_id="device", shared_session_id="session",
-        audience_revision=1, context_cutoff=2, lease_token="lease",
+        run_id="run",
+        requester_id="alice",
+        credential_owner_id="alice",
+        executor_device_id="device",
+        shared_session_id="session",
+        audience_revision=1,
+        context_cutoff=2,
+        lease_token="lease",
     )
     request = PermissionRequest(
-        action="memory.write", resource="profile", risk=Risk.LOCAL_WRITE,
-        summary="Remember", reversible=True, approval_free=True,
+        action="memory.write",
+        resource="profile",
+        risk=Risk.LOCAL_WRITE,
+        summary="Remember",
+        reversible=True,
+        approval_free=True,
     )
     assert PermissionEvaluator().evaluate(context, request).effect == Effect.ASK
 
@@ -138,10 +170,14 @@ def test_shared_memory_write_always_requires_requester_approval():
 def test_routine_shared_delivery_config_and_status_are_separate_from_run(tmp_path):
     db = CollieDB(tmp_path / "collie.db")
     routine = db.add_automation("Daily note", automation_id="routine-1")
-    configured = db.set_routine_shared_delivery(routine["id"], {
-        "session_id": "session-1", "audience_revision": 3,
-        "creator_account_id": "alice",
-    })
+    configured = db.set_routine_shared_delivery(
+        routine["id"],
+        {
+            "session_id": "session-1",
+            "audience_revision": 3,
+            "creator_account_id": "alice",
+        },
+    )
     assert json.loads(configured["shared_delivery"])["audience_revision"] == 3
     db.mark_routine_result(routine["id"], success=True)
     db.record_routine_shared_delivery(

--- a/collie-core/tests/collie/test_collaboration_storage.py
+++ b/collie-core/tests/collie/test_collaboration_storage.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from collie_core.collaboration import (
+    ArchiveError,
+    ArchiveManager,
+    CollaborationStore,
+    SharedExecutionContext,
+    SyncConflict,
+)
+from collie_core.permissions.evaluator import PermissionEvaluator
+from collie_core.permissions.models import Effect, ExecutionContext, PermissionRequest, Risk
+from collie_core.db import CollieDB
+
+
+def _event(seq: int, *, event_id: str | None = None, content: str = "hello") -> dict:
+    return {
+        "event_id": event_id or f"event-{seq}", "session_id": "session-1", "seq": seq,
+        "kind": "message", "message_id": f"message-{seq}", "author_id": "alice",
+        "role": "user", "content": content, "revision": 1,
+        "created_at": "2026-09-09T00:00:00+00:00",
+    }
+
+
+def test_page_and_cursor_commit_atomically_and_deduplicate(tmp_path):
+    store = CollaborationStore(tmp_path / "collaboration.db")
+    store.bind_account("alice")
+    assert store.apply_page("session-1", [_event(1)], next_cursor=1) == 1
+    assert store.apply_page("session-1", [_event(1)], next_cursor=1) == 1
+    with pytest.raises(SyncConflict):
+        store.apply_page("session-1", [_event(2, event_id="event-1", content="changed")], next_cursor=2)
+    assert store.cursor("session-1") == 1
+    assert [item["content"] for item in store.materialized_messages("session-1")] == ["hello"]
+
+
+def test_outbox_rejects_event_id_reuse(tmp_path):
+    store = CollaborationStore(tmp_path / "collaboration.db")
+    store.bind_account("alice")
+    draft = _event(0)
+    store.queue_event("session-1", draft)
+    with pytest.raises(SyncConflict):
+        store.queue_event("session-1", draft | {"content": "different"})
+    assert store.materialized_messages("session-1")[0]["sync_state"] == "local"
+
+
+def test_local_cache_is_partitioned_by_signed_in_account(tmp_path):
+    store = CollaborationStore(tmp_path / "collaboration.db")
+    store.bind_account("alice")
+    store.queue_event("session-1", _event(0))
+    store.bind_account("bob")
+    assert store.pending() == []
+    assert store.materialized_messages("session-1") == []
+
+
+def test_routine_result_can_be_queued_for_creator_while_another_account_is_bound(tmp_path):
+    store = CollaborationStore(tmp_path / "collaboration.db")
+    store.bind_account("bob")
+    store.queue_event_for_account("alice", "session-1", _event(0))
+    assert store.pending() == []
+    store.bind_account("alice")
+    assert [item["event_id"] for item in store.pending()] == ["event-0"]
+
+
+def test_bootstrap_cache_is_durable_and_account_partitioned(tmp_path):
+    path = tmp_path / "collaboration.db"
+    store = CollaborationStore(path)
+    store.bind_account("alice")
+    store.cache_bootstrap({"revision": 4, "organizations": [{"id": "org"}]})
+    store.close()
+    reopened = CollaborationStore(path)
+    reopened.bind_account("alice")
+    assert reopened.cached_bootstrap()["revision"] == 4
+    reopened.bind_account("bob")
+    assert reopened.cached_bootstrap() is None
+
+
+def test_archive_ack_data_requires_durable_verified_readback(tmp_path):
+    manager = ArchiveManager(tmp_path / "archives")
+    manager.bind_account("alice")
+    manifest = {
+        "version": 1, "session_id": "session-1", "membership_revision": 2,
+        "final_seq": 1, "recipients": ["alice"], "events": [_event(1)], "files": [],
+    }
+    raw = json.dumps(manifest, separators=(",", ":"))
+    digest = hashlib.sha256(raw.encode()).hexdigest()
+    receipt = manager.write(raw, digest)
+    assert receipt["final_seq"] == 1
+    assert manager.verify(receipt["path"])["recipients"] == ["alice"]
+    with pytest.raises(ArchiveError):
+        manager.write(raw, "0" * 64)
+
+
+def test_archive_accepts_draft_final_sequence_alias_without_changing_digest(tmp_path):
+    manager = ArchiveManager(tmp_path / "archives")
+    manager.bind_account("alice")
+    manifest = {
+        "version": 1, "session_id": "session-legacy", "membership_revision": 1,
+        "final_sequence": 1, "recipients": ["alice"], "events": [_event(1)], "files": [],
+    }
+    raw = json.dumps(manifest, separators=(",", ":"))
+    receipt = manager.write(raw, hashlib.sha256(raw.encode()).hexdigest())
+    assert receipt["final_seq"] == 1
+
+
+def test_shared_claim_must_match_enrolled_requester_and_device():
+    claim = {
+        "session_id": "s", "requester_id": "alice", "credential_owner_id": "alice",
+        "executor_device_id": "device-a", "audience_revision": 1, "context_cutoff": 4,
+        "run_id": "run", "lease_token": "fence",
+        "lease_expires_at": "2099-01-01T00:00:00+00:00",
+    }
+    SharedExecutionContext.from_claim(
+        claim, enrolled_account_id="alice", enrolled_device_id="device-a"
+    )
+    with pytest.raises(ValueError):
+        SharedExecutionContext.from_claim(
+            claim, enrolled_account_id="bob", enrolled_device_id="device-a"
+        )
+
+
+def test_shared_memory_write_always_requires_requester_approval():
+    context = ExecutionContext(
+        run_id="run", requester_id="alice", credential_owner_id="alice",
+        executor_device_id="device", shared_session_id="session",
+        audience_revision=1, context_cutoff=2, lease_token="lease",
+    )
+    request = PermissionRequest(
+        action="memory.write", resource="profile", risk=Risk.LOCAL_WRITE,
+        summary="Remember", reversible=True, approval_free=True,
+    )
+    assert PermissionEvaluator().evaluate(context, request).effect == Effect.ASK
+
+
+def test_routine_shared_delivery_config_and_status_are_separate_from_run(tmp_path):
+    db = CollieDB(tmp_path / "collie.db")
+    routine = db.add_automation("Daily note", automation_id="routine-1")
+    configured = db.set_routine_shared_delivery(routine["id"], {
+        "session_id": "session-1", "audience_revision": 3,
+        "creator_account_id": "alice",
+    })
+    assert json.loads(configured["shared_delivery"])["audience_revision"] == 3
+    db.mark_routine_result(routine["id"], success=True)
+    db.record_routine_shared_delivery(
+        routine["id"], status="pending", event_id="event-1", error="offline"
+    )
+    saved = db.get_automation(routine["id"])
+    assert saved["last_success_at"]
+    assert saved["shared_delivery_status"] == "pending"
+    assert saved["shared_delivery_event_id"] == "event-1"

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 15
+    assert db.schema_version == 16
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,7 +25,7 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 15
+    assert d2.schema_version == 16
     d2.close()
 
 
@@ -416,7 +416,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.add_person("Sam")
     db.log_memory_journal("profile", "dietary", "add", "vegan")
     data = db.export_all()
-    assert data["schema_version"] == 15
+    assert data["schema_version"] == 16
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_db.py
+++ b/collie-core/tests/collie/test_db.py
@@ -15,7 +15,7 @@ def db(tmp_path: Path) -> CollieDB:
 
 
 def test_schema_created(db: CollieDB) -> None:
-    assert db.schema_version == 16
+    assert db.schema_version == 17
 
 
 def test_migration_idempotent(tmp_path: Path) -> None:
@@ -25,7 +25,7 @@ def test_migration_idempotent(tmp_path: Path) -> None:
     d1.close()
     d2 = CollieDB(path)
     assert d2.get_setting("provider.name") == "openai"
-    assert d2.schema_version == 16
+    assert d2.schema_version == 17
     d2.close()
 
 
@@ -416,7 +416,7 @@ def test_export_and_clear(db: CollieDB) -> None:
     db.add_person("Sam")
     db.log_memory_journal("profile", "dietary", "add", "vegan")
     data = db.export_all()
-    assert data["schema_version"] == 16
+    assert data["schema_version"] == 17
     assert len(data["conversations"]) == 1
     assert data["profile"] == {"dietary": "vegan"}
 

--- a/collie-core/tests/collie/test_ipc_contract.py
+++ b/collie-core/tests/collie/test_ipc_contract.py
@@ -44,13 +44,19 @@ _SERVER_ONLY_ALLOWLIST: dict[str, str] = {
     **{
         command: "main-only authenticated collaboration coordinator"
         for command in (
-            "collaboration_apply_page", "collaboration_bind_identity",
-            "collaboration_cache_bootstrap", "collaboration_control_run",
-            "collaboration_export_archive", "collaboration_get_cached_bootstrap",
-            "collaboration_import_archive", "collaboration_list_messages",
+            "collaboration_apply_page",
+            "collaboration_bind_identity",
+            "collaboration_cache_bootstrap",
+            "collaboration_control_run",
+            "collaboration_export_archive",
+            "collaboration_get_cached_bootstrap",
+            "collaboration_import_archive",
+            "collaboration_list_messages",
             "collaboration_mark_routine_delivery",
-            "collaboration_queue_event", "collaboration_run_shared",
-            "collaboration_status", "collaboration_write_archive",
+            "collaboration_queue_event",
+            "collaboration_run_shared",
+            "collaboration_status",
+            "collaboration_write_archive",
             "collaboration_set_routine_delivery",
         )
     },

--- a/collie-core/tests/collie/test_ipc_contract.py
+++ b/collie-core/tests/collie/test_ipc_contract.py
@@ -38,6 +38,22 @@ _UI_SRC = _REPO_ROOT / "collie-ui" / "src"
 #   - Dead: no caller at all; candidates for removal, listed so the
 #     decision to remove (or wire up) is explicit.
 _SERVER_ONLY_ALLOWLIST: dict[str, str] = {
+    # Authenticated collaboration transport is called only by Electron main's
+    # collaboration coordinator. It intentionally bypasses the renderer bridge
+    # and carries a per-process main-only identity token.
+    **{
+        command: "main-only authenticated collaboration coordinator"
+        for command in (
+            "collaboration_apply_page", "collaboration_bind_identity",
+            "collaboration_cache_bootstrap", "collaboration_control_run",
+            "collaboration_export_archive", "collaboration_get_cached_bootstrap",
+            "collaboration_import_archive", "collaboration_list_messages",
+            "collaboration_mark_routine_delivery",
+            "collaboration_queue_event", "collaboration_run_shared",
+            "collaboration_status", "collaboration_write_archive",
+            "collaboration_set_routine_delivery",
+        )
+    },
     # Health check used by backend tests (tests/collie/test_ipc.py).
     "ping": "test-only heartbeat; renderer relies on the WS itself",
     # Plan engine commands driven by backend tests; the UI plans flow

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 15
+    assert db.schema_version == 16
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_message_attachments.py
+++ b/collie-core/tests/collie/test_message_attachments.py
@@ -25,7 +25,7 @@ def test_message_attachments_roundtrip(tmp_path: Path) -> None:
 
     assert created["attachments"] == attachments
     assert stored["attachments"] == attachments
-    assert db.schema_version == 16
+    assert db.schema_version == 17
 
 
 @pytest.mark.asyncio

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -85,7 +85,7 @@ def _build_db_at_version(path: Path, version: int) -> None:
 def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "collie.db")
     try:
-        assert db.schema_version == 15
+        assert db.schema_version == 16
         columns = {row["name"] for row in db._rows("PRAGMA table_info(turn_events)")}
         assert {"prompt_hash", "tool_schema_hash", "config_hash"} <= columns
     finally:
@@ -106,7 +106,7 @@ def test_old_rows_null_hashes(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 15
+        assert upgraded.schema_version == 16
         rows = upgraded.list_turn_events()
         assert len(rows) == 1
         assert rows[0]["prompt_hash"] is None

--- a/collie-core/tests/collie/test_prompt_hashes.py
+++ b/collie-core/tests/collie/test_prompt_hashes.py
@@ -85,7 +85,7 @@ def _build_db_at_version(path: Path, version: int) -> None:
 def test_v12_adds_hash_columns_on_fresh_db(tmp_path: Path) -> None:
     db = CollieDB(tmp_path / "collie.db")
     try:
-        assert db.schema_version == 16
+        assert db.schema_version == 17
         columns = {row["name"] for row in db._rows("PRAGMA table_info(turn_events)")}
         assert {"prompt_hash", "tool_schema_hash", "config_hash"} <= columns
     finally:
@@ -106,7 +106,7 @@ def test_old_rows_null_hashes(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 16
+        assert upgraded.schema_version == 17
         rows = upgraded.list_turn_events()
         assert len(rows) == 1
         assert rows[0]["prompt_hash"] is None

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -87,7 +87,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 15
+    assert db.schema_version == 16
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -109,7 +109,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 15
+        assert upgraded.schema_version == 16
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_run_records.py
+++ b/collie-core/tests/collie/test_run_records.py
@@ -87,7 +87,7 @@ def _table_names(path: Path) -> set[str]:
 
 
 def test_schema_v11_tables_created_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 16
+    assert db.schema_version == 17
     tables = _table_names(db.path)
     assert {"turn_events", "tool_events"} <= tables
 
@@ -109,7 +109,7 @@ def test_v10_db_upgrades_to_v11_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 16
+        assert upgraded.schema_version == 17
         assert upgraded.get_conversation("c1")["title"] == "Keep me"
     finally:
         upgraded.close()

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 15
+    assert db.schema_version == 16
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/collie-core/tests/collie/test_task_checklists.py
+++ b/collie-core/tests/collie/test_task_checklists.py
@@ -58,7 +58,7 @@ def test_v9_persists_a_full_initial_task_snapshot(db: CollieDB) -> None:
 
     task = _create_checklist(db, str(conversation["id"]))
 
-    assert db.schema_version == 16
+    assert db.schema_version == 17
     assert task["source"] == "checklist"
     assert task["conversation_id"] == conversation["id"]
     assert task["status"] == "active"

--- a/collie-core/tests/collie/test_versions.py
+++ b/collie-core/tests/collie/test_versions.py
@@ -42,7 +42,7 @@ class _FakeConn:
 
 
 def test_v14_creates_artifact_versions_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 15
+    assert db.schema_version == 16
     rows = db._rows(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
     )
@@ -78,7 +78,7 @@ def test_v13_db_upgrades_to_v14_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 15
+        assert upgraded.schema_version == 16
         assert upgraded._rows(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
         )

--- a/collie-core/tests/collie/test_versions.py
+++ b/collie-core/tests/collie/test_versions.py
@@ -42,7 +42,7 @@ class _FakeConn:
 
 
 def test_v14_creates_artifact_versions_on_fresh_db(db: CollieDB) -> None:
-    assert db.schema_version == 16
+    assert db.schema_version == 17
     rows = db._rows(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
     )
@@ -78,7 +78,7 @@ def test_v13_db_upgrades_to_v14_preserving_data(tmp_path: Path) -> None:
 
     upgraded = CollieDB(path)
     try:
-        assert upgraded.schema_version == 16
+        assert upgraded.schema_version == 17
         assert upgraded._rows(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='artifact_versions'"
         )

--- a/collie-ui/src/main/account-auth.ts
+++ b/collie-ui/src/main/account-auth.ts
@@ -52,12 +52,18 @@ export interface AccountState {
   access: 'granted' | 'waiting' | 'unknown'
 }
 
-interface StoredSession {
+export interface StoredSession {
   access_token: string
   refresh_token: string
   /** Epoch milliseconds. */
   expires_at: number
   email: string
+}
+
+export interface VerifiedAccount {
+  id: string
+  email: string | null
+  accessToken: string
 }
 
 /** All fields stored as safeStorage-encrypted base64 blobs (secrets.ts style). */
@@ -315,6 +321,24 @@ export async function getAccountState(): Promise<AccountState> {
     return state
   }
   return { ...state, access: await fetchAccessStatus(session.access_token) }
+}
+
+/** Refresh if needed, then ask Supabase Auth to verify the bearer and return its subject. */
+export async function getVerifiedAccount(): Promise<VerifiedAccount> {
+  const state = await getAccountState()
+  const session = getStoredSession()
+  if (!state.signedIn || !session?.access_token) throw new Error('Sign in to use shared conversations.')
+  const baseUrl = SUPABASE_URL.replace(/\/+$/, '')
+  if (!baseUrl || !SUPABASE_ANON_KEY) throw new Error('Shared conversations are not enabled in this build yet.')
+  const response = await fetch(`${baseUrl}/auth/v1/user`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${session.access_token}` },
+    signal: AbortSignal.timeout(10_000)
+  })
+  const user = await response.json().catch(() => null) as { id?: unknown; email?: unknown } | null
+  if (!response.ok || typeof user?.id !== 'string' || !user.id) {
+    throw new Error('Your sign-in could not be verified. Sign in again and retry.')
+  }
+  return { id: user.id, email: typeof user.email === 'string' ? user.email : null, accessToken: session.access_token }
 }
 
 /* ------------------------------------------------------------------ *

--- a/collie-ui/src/main/collaboration.test.ts
+++ b/collie-ui/src/main/collaboration.test.ts
@@ -1,0 +1,330 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  account: 'user-a',
+  userData: '',
+  calls: [] as Array<{ type: string; payload: Record<string, unknown> }>,
+  replies: [] as Array<Response>,
+  archives: [] as Array<Record<string, unknown>>
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => state.userData },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf8')
+  },
+  dialog: {},
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: class {}
+}))
+vi.mock('../shared/account-config', () => ({
+  SUPABASE_URL: 'https://test.supabase.co',
+  SUPABASE_ANON_KEY: 'anon'
+}))
+vi.mock('./python', () => ({
+  collaborationIdentityBindToken: 'main-only-capability'
+}))
+vi.mock('./account-auth', () => ({
+  getVerifiedAccount: () =>
+    Promise.resolve({
+      id: state.account,
+      email: null,
+      accessToken: `token-${state.account}`
+    })
+}))
+vi.mock('./core-client', () => ({
+  commandWithCore: (type: string, payload: Record<string, unknown>) => {
+    state.calls.push({ type, payload })
+    if (type === 'collaboration_status')
+      return Promise.resolve({
+        available: true,
+        cursor: 0,
+        pending: [],
+        archives: state.archives
+      })
+    if (type === 'collaboration_list_messages')
+      return Promise.resolve({
+        messages: [{ message_id: 'm1', content: 'hello' }]
+      })
+    if (type === 'collaboration_run_shared')
+      return Promise.resolve({
+        run_id: 'run-1',
+        content: 'private',
+        state: 'complete'
+      })
+    return Promise.resolve({})
+  }
+}))
+
+const originalFetch = global.fetch
+
+beforeEach(() => {
+  state.account = 'user-a'
+  state.calls = []
+  state.replies = []
+  state.archives = []
+  state.userData = mkdtempSync(join(tmpdir(), 'collie-collaboration-'))
+  global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    if (String(url).endsWith('/auth/v1/user'))
+      return new Response(JSON.stringify({ id: state.account }), {
+        status: 200
+      })
+    const request = init?.body
+      ? (JSON.parse(String(init.body)) as { p_command?: string })
+      : {}
+    if (request.p_command === 'enroll_device')
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    return (
+      state.replies.shift() ??
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    )
+  }) as typeof fetch
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  rmSync(state.userData, { recursive: true, force: true })
+})
+
+describe('protected collaboration orchestration', () => {
+  it('normalizes bootstrap IDs and puts the main-only capability on every core call', async () => {
+    state.replies.push(
+      new Response(
+        JSON.stringify({
+          organizations: [{ org_id: 'o1' }],
+          sessions: [{ session_id: 's1', org_id: 'o1' }],
+          invites: [{ invite_id: 'i1', session_id: 's1' }]
+        }),
+        { status: 200 }
+      )
+    )
+    const { bootstrapCollaboration } = await import('./collaboration')
+    const result = (await bootstrapCollaboration()) as {
+      organizations: Array<{ id: string }>
+      sessions: Array<{ id: string; organization_id: string }>
+      invites: Array<{ id: string }>
+    }
+    expect(result.organizations[0].id).toBe('o1')
+    expect(result.sessions[0]).toMatchObject({
+      id: 's1',
+      organization_id: 'o1'
+    })
+    expect(result.invites[0].id).toBe('i1')
+    expect(
+      state.calls.every(
+        (call) => call.payload.identity_token === 'main-only-capability'
+      )
+    ).toBe(true)
+  })
+
+  it('reuses the same protected device key across enrollment cycles', async () => {
+    state.replies.push(
+      new Response(
+        JSON.stringify({ organizations: [], sessions: [], invites: [] }),
+        { status: 200 }
+      )
+    )
+    state.replies.push(
+      new Response(
+        JSON.stringify({ organizations: [], sessions: [], invites: [] }),
+        { status: 200 }
+      )
+    )
+    const { bootstrapCollaboration, clearCollaborationIdentity } = await import(
+      './collaboration'
+    )
+    await bootstrapCollaboration()
+    const firstEnroll = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) =>
+        call[1]?.body
+          ? (JSON.parse(String(call[1].body)) as Record<string, unknown>)
+          : {}
+      )
+      .find((body) => body.p_command === 'enroll_device') as {
+      p_payload: { device_id: string; public_key: string }
+    }
+    await clearCollaborationIdentity()
+    await bootstrapCollaboration()
+    const enrollments = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) =>
+        call[1]?.body
+          ? (JSON.parse(String(call[1].body)) as Record<string, unknown>)
+          : {}
+      )
+      .filter((body) => body.p_command === 'enroll_device') as Array<{
+      p_payload: { device_id: string; public_key: string }
+    }>
+    expect(enrollments).toHaveLength(2)
+    expect(enrollments[1].p_payload).toMatchObject(firstEnroll.p_payload)
+    expect(firstEnroll.p_payload.public_key).toMatch(/^[A-Za-z0-9_-]{43}$/)
+  })
+
+  it('applies the backend next_cursor and returns materialized local events', async () => {
+    state.replies.push(
+      new Response(
+        JSON.stringify({
+          events: [{ event_id: 'e1' }],
+          next_cursor: 1,
+          high_water: 9
+        }),
+        { status: 200 }
+      )
+    )
+    state.replies.push(
+      new Response(
+        JSON.stringify({ events: [], next_cursor: 1, high_water: 9 }),
+        { status: 200 }
+      )
+    )
+    const { openSharedSession } = await import('./collaboration')
+    const result = await openSharedSession('s1')
+    const apply = state.calls.find(
+      (call) => call.type === 'collaboration_apply_page'
+    )
+    expect(apply?.payload).toMatchObject({ next_cursor: 1 })
+    expect(apply?.payload).not.toHaveProperty('high_water')
+    expect(result.events).toEqual([{ message_id: 'm1', content: 'hello' }])
+  })
+
+  it('queues before the network and reports a durable pending event on failure', async () => {
+    state.replies.push(new Response('offline', { status: 503 }))
+    const { sendSharedMessage } = await import('./collaboration')
+    const mentioned = '11111111-1111-4111-8111-111111111111'
+    const result = await sendSharedMessage('s1', 'keep me', undefined, false, [
+      mentioned
+    ])
+    const queued = state.calls.find(
+      (call) => call.type === 'collaboration_queue_event'
+    )
+    expect(queued).toBeDefined()
+    expect(result).toMatchObject({ pending: true })
+    expect((result.event as Record<string, unknown>).content).toBe('keep me')
+    expect(
+      (result.event as Record<string, unknown>).mentioned_user_ids
+    ).toEqual([mentioned])
+  })
+
+  it('reuses a verified archive digest before sending its authenticated receipt', async () => {
+    state.archives = [{ digest: 'abc', path: 'verified/local/archive' }]
+    state.replies.push(
+      new Response(
+        JSON.stringify({
+          manifest_json: '{}',
+          digest: 'abc',
+          archive_revision: 2,
+          final_seq: 7,
+          byte_length: 123
+        }),
+        { status: 200 }
+      )
+    )
+    state.replies.push(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    )
+    const { saveVerifiedArchive } = await import('./collaboration')
+    const result = await saveVerifiedArchive('s1')
+    expect(result).toMatchObject({
+      state: 'saved_locally',
+      local_path: 'verified/local/archive',
+      digest: 'abc'
+    })
+    expect(
+      state.calls.some((call) => call.type === 'collaboration_write_archive')
+    ).toBe(false)
+    const receipt = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) =>
+        call[1]?.body
+          ? (JSON.parse(String(call[1].body)) as Record<string, unknown>)
+          : {}
+      )
+      .find((body) => body.p_command === 'ack_archive') as {
+      p_payload: Record<string, unknown>
+    }
+    expect(receipt.p_payload).toMatchObject({
+      session_id: 's1',
+      archive_revision: 2,
+      digest: 'abc',
+      final_seq: 7,
+      byte_length: 123
+    })
+  })
+
+  it('materializes an edited claim through its cutoff before private execution', async () => {
+    const claimEvents = [
+      {
+        event_id: 'e1',
+        session_id: 's1',
+        seq: 1,
+        kind: 'message',
+        message_id: 'm1',
+        author_id: 'user-a',
+        role: 'user',
+        content: 'old',
+        revision: 1,
+        created_at: '2026-09-09T00:00:00Z'
+      },
+      {
+        event_id: 'e2',
+        session_id: 's1',
+        seq: 2,
+        kind: 'edit',
+        message_id: 'm1',
+        author_id: 'user-a',
+        role: 'user',
+        content: 'new',
+        revision: 2,
+        created_at: '2026-09-09T00:01:00Z'
+      }
+    ]
+    state.replies.push(
+      new Response(JSON.stringify({ run_id: 'run-1' }), { status: 200 })
+    )
+    state.replies.push(
+      new Response(
+        JSON.stringify({ events: [], next_cursor: 0, high_water: 0 }),
+        { status: 200 }
+      )
+    )
+    state.replies.push(
+      new Response(JSON.stringify({ files: [] }), { status: 200 })
+    )
+    state.replies.push(
+      new Response(
+        JSON.stringify({
+          run_id: 'run-1',
+          session_id: 's1',
+          requester_id: 'user-a',
+          credential_owner_id: 'user-a',
+          executor_device_id: 'device',
+          audience_revision: 1,
+          context_cutoff: 2,
+          lease_token: 'lease',
+          lease_expires_at: '2099-01-01T00:00:00Z',
+          events: claimEvents
+        }),
+        { status: 200 }
+      )
+    )
+    const { clearCollaborationIdentity, runSharedPrivately } = await import(
+      './collaboration'
+    )
+    await runSharedPrivately('s1', 'new')
+    const appliedIndex = state.calls.findIndex(
+      (call) =>
+        call.type === 'collaboration_apply_page' &&
+        call.payload.next_cursor === 2
+    )
+    const runIndex = state.calls.findIndex(
+      (call) => call.type === 'collaboration_run_shared'
+    )
+    expect(appliedIndex).toBeGreaterThanOrEqual(0)
+    expect(appliedIndex).toBeLessThan(runIndex)
+    expect(state.calls[runIndex].payload.published_history).toEqual([])
+    await clearCollaborationIdentity()
+  })
+})

--- a/collie-ui/src/main/collaboration.ts
+++ b/collie-ui/src/main/collaboration.ts
@@ -1,0 +1,1401 @@
+import { app, BrowserWindow, dialog, safeStorage, shell } from 'electron'
+import { createHash, randomBytes, randomUUID } from 'crypto'
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'fs'
+import { basename, dirname, join } from 'path'
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../shared/account-config'
+import type {
+  SharedDraft,
+  SharedSessionEvent,
+  SharedSessionStatus
+} from '../shared/collaboration'
+import { getVerifiedAccount } from './account-auth'
+import { commandWithCore } from './core-client'
+import { collaborationIdentityBindToken } from './python'
+
+const RPC_COMMANDS = new Set([
+  'bootstrap',
+  'create_organization',
+  'invite_organization',
+  'accept_organization_invite',
+  'directory',
+  'create_session',
+  'invite',
+  'accept_invite',
+  'read_events',
+  'append_message',
+  'edit_message',
+  'delete_message',
+  'enroll_device',
+  'list_pending_runs',
+  'claim_run',
+  'renew_run',
+  'cancel_run',
+  'stop_session_run',
+  'resolve_reconciliation',
+  'complete_run',
+  'request_archive',
+  'archive_manifest',
+  'ack_archive',
+  'archive_status',
+  'continue_session',
+  'revoke_member',
+  'slack_settings',
+  'begin_slack_link',
+  'select_slack_channel',
+  'notifications',
+  'ack_notifications',
+  'publish_routine'
+])
+type StoredDraft = {
+  accountId: string
+  runId: string
+  fence: unknown
+  sessionId: string
+  content: string
+  eventId: string
+  messageId: string
+}
+const drafts = new Map<string, StoredDraft>()
+const activeRuns = new Map<string, { runId: string; leaseToken: unknown }>()
+const draftRenewals = new Map<string, ReturnType<typeof setInterval>>()
+let boundIdentity = ''
+let reconcilePromise: Promise<void> | null = null
+let periodicReconcile: ReturnType<typeof setInterval> | null = null
+type LocalIdentity = {
+  id: string
+  accessToken: string
+  deviceId: string
+  email?: string | null
+}
+
+function collaborationCore(
+  type: string,
+  payload: Record<string, unknown>
+): Promise<unknown> {
+  if (!type.startsWith('collaboration_'))
+    throw new Error('Invalid collaboration core command.')
+  return commandWithCore(type, {
+    ...payload,
+    identity_token: collaborationIdentityBindToken
+  })
+}
+
+function serviceUrl(): string {
+  const value = SUPABASE_URL.replace(/\/+$/, '')
+  if (!value || !SUPABASE_ANON_KEY)
+    throw new Error('Shared conversations are not enabled in this build yet.')
+  return value
+}
+
+function deviceIdentity(): { id: string; publicKey: string } {
+  const path = join(app.getPath('userData'), 'collaboration-device.json')
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as {
+      id?: unknown
+      public_key?: unknown
+    }
+    if (
+      typeof value.id === 'string' &&
+      /^[0-9a-f-]{36}$/i.test(value.id) &&
+      typeof value.public_key === 'string'
+    ) {
+      const publicKey = safeStorage.decryptString(
+        Buffer.from(value.public_key, 'base64')
+      )
+      if (/^[A-Za-z0-9_-]{43}$/.test(publicKey))
+        return { id: value.id, publicKey }
+    }
+  } catch {
+    /* create it below */
+  }
+  if (!safeStorage.isEncryptionAvailable())
+    throw new Error('Secure device enrollment is unavailable on this computer.')
+  const id = randomUUID()
+  const publicKey = randomBytes(32).toString('base64url')
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(
+    path,
+    JSON.stringify({
+      id,
+      public_key: safeStorage.encryptString(publicKey).toString('base64')
+    }),
+    { encoding: 'utf8', mode: 0o600 }
+  )
+  try {
+    chmodSync(path, 0o600)
+  } catch {
+    /* best effort on non-POSIX filesystems */
+  }
+  return { id, publicKey }
+}
+
+function bindingPath(): string {
+  return join(app.getPath('userData'), 'collaboration-binding.bin')
+}
+function draftsPath(): string {
+  return join(app.getPath('userData'), 'collaboration-drafts.bin')
+}
+function saveBinding(
+  accountId: string,
+  localDeviceId: string,
+  email?: string | null
+): void {
+  if (!safeStorage.isEncryptionAvailable()) return
+  writeFileSync(
+    bindingPath(),
+    safeStorage.encryptString(
+      JSON.stringify({ accountId, deviceId: localDeviceId, email })
+    ),
+    { mode: 0o600 }
+  )
+}
+function readBinding(): LocalIdentity | null {
+  try {
+    if (!safeStorage.isEncryptionAvailable()) return null
+    const value = JSON.parse(
+      safeStorage.decryptString(readFileSync(bindingPath()))
+    ) as { accountId?: unknown; deviceId?: unknown; email?: unknown }
+    if (
+      typeof value.accountId !== 'string' ||
+      typeof value.deviceId !== 'string'
+    )
+      return null
+    return {
+      id: value.accountId,
+      deviceId: value.deviceId,
+      accessToken: '',
+      email: typeof value.email === 'string' ? value.email : null
+    }
+  } catch {
+    return null
+  }
+}
+function loadDrafts(): void {
+  if (drafts.size || !safeStorage.isEncryptionAvailable()) return
+  try {
+    const values = JSON.parse(
+      safeStorage.decryptString(readFileSync(draftsPath()))
+    ) as Record<string, StoredDraft>
+    for (const [id, draft] of Object.entries(values)) drafts.set(id, draft)
+  } catch {
+    /* no readable drafts */
+  }
+}
+function persistDrafts(): void {
+  if (!safeStorage.isEncryptionAvailable()) return
+  writeFileSync(
+    draftsPath(),
+    safeStorage.encryptString(JSON.stringify(Object.fromEntries(drafts))),
+    { mode: 0o600 }
+  )
+}
+
+function unwrap(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object') return {}
+  const object = value as Record<string, unknown>
+  return object.data && typeof object.data === 'object'
+    ? (object.data as Record<string, unknown>)
+    : object
+}
+
+function normalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalize)
+  if (!value || typeof value !== 'object') return value
+  const source = value as Record<string, unknown>
+  const result: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(source))
+    result[key] = normalize(item)
+  if (typeof source.org_id === 'string') result.organization_id = source.org_id
+  if (typeof source.invite_id === 'string') result.id = source.invite_id
+  else if (typeof source.session_id === 'string') result.id = source.session_id
+  else if (typeof source.user_id === 'string') result.id = source.user_id
+  else if (typeof source.org_id === 'string') result.id = source.org_id
+  return result
+}
+
+export async function collaborationBackend(
+  command: string,
+  payload: Record<string, unknown>,
+  token?: string
+): Promise<Record<string, unknown>> {
+  if (!RPC_COMMANDS.has(command))
+    throw new Error('That collaboration action is not available.')
+  const accessToken = token ?? (await getVerifiedAccount()).accessToken
+  const response = await fetch(
+    `${serviceUrl()}/rest/v1/rpc/collaboration_command`,
+    {
+      method: 'POST',
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ p_command: command, p_payload: payload }),
+      signal: AbortSignal.timeout(20_000)
+    }
+  )
+  const body = await response.json().catch(() => null)
+  if (!response.ok) {
+    const detail =
+      body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
+    throw new Error(
+      typeof detail.message === 'string'
+        ? detail.message
+        : typeof detail.error === 'string'
+          ? detail.error
+          : 'Shared service is unavailable.'
+    )
+  }
+  return unwrap(body)
+}
+
+async function identity(cloudRequired = true): Promise<LocalIdentity> {
+  let account: { id: string; accessToken: string; email?: string | null }
+  try {
+    account = await getVerifiedAccount()
+  } catch (error) {
+    const cached = readBinding()
+    if (cloudRequired || !cached) throw error
+    account = cached
+  }
+  const device = account.accessToken
+    ? deviceIdentity()
+    : { id: (account as LocalIdentity).deviceId, publicKey: '' }
+  const localDeviceId = device.id
+  const key = `${account.id}:${localDeviceId}`
+  if (boundIdentity !== key) {
+    await collaborationCore('collaboration_bind_identity', {
+      bind_token: collaborationIdentityBindToken,
+      account_id: account.id,
+      device_id: localDeviceId
+    })
+    if (account.accessToken) {
+      await collaborationBackend(
+        'enroll_device',
+        {
+          device_id: localDeviceId,
+          label: process.env.COMPUTERNAME || 'Collie desktop',
+          public_key: device.publicKey
+        },
+        account.accessToken
+      )
+      saveBinding(account.id, localDeviceId, account.email)
+    }
+    boundIdentity = key
+  }
+  return {
+    id: account.id,
+    accessToken: account.accessToken,
+    deviceId: localDeviceId,
+    email: account.email
+  }
+}
+
+export async function bootstrapCollaboration(): Promise<
+  Record<string, unknown>
+> {
+  const account = await identity(false)
+  try {
+    const result = normalize(
+      await collaborationBackend('bootstrap', {})
+    ) as Record<string, unknown>
+    const organizations = Array.isArray(result.organizations)
+      ? (result.organizations as Array<Record<string, unknown>>)
+      : []
+    for (const organization of organizations) {
+      if (typeof organization.id !== 'string') continue
+      try {
+        const directory = normalize(
+          await collaborationBackend('directory', { org_id: organization.id })
+        ) as { members?: unknown[] }
+        organization.members = directory.members || []
+      } catch {
+        organization.members = []
+      }
+    }
+    result.account = {
+      id: account.id,
+      display_name: account.email || 'You',
+      email: account.email || null
+    }
+    await collaborationCore('collaboration_cache_bootstrap', {
+      snapshot: result
+    })
+    return result
+  } catch (error) {
+    const cached = (await collaborationCore(
+      'collaboration_get_cached_bootstrap',
+      {}
+    )) as { snapshot?: Record<string, unknown> }
+    if (cached.snapshot)
+      return {
+        ...cached.snapshot,
+        sync_error: error instanceof Error ? error.message : 'Waiting to sync.'
+      }
+    throw error
+  }
+}
+
+async function localStatus(sessionId = ''): Promise<SharedSessionStatus> {
+  return (await collaborationCore('collaboration_status', {
+    session_id: sessionId,
+    limit: 200
+  })) as SharedSessionStatus
+}
+
+async function applyPage(
+  sessionId: string,
+  page: Record<string, unknown>
+): Promise<void> {
+  const events = Array.isArray(page.events)
+    ? page.events
+    : page.event && typeof page.event === 'object'
+      ? [page.event]
+      : []
+  const eventSeq =
+    events.length &&
+    typeof (events[events.length - 1] as Record<string, unknown>).seq ===
+      'number'
+      ? Number((events[events.length - 1] as Record<string, unknown>).seq)
+      : 0
+  const highWater = Number(
+    page.next_cursor ?? page.high_water ?? page.highWater ?? eventSeq
+  )
+  if (events.length || highWater)
+    await collaborationCore('collaboration_apply_page', {
+      session_id: sessionId,
+      events,
+      next_cursor: highWater
+    })
+}
+
+export async function openSharedSession(
+  sessionId: string
+): Promise<Record<string, unknown>> {
+  if (!sessionId) throw new Error('Choose a shared conversation.')
+  const account = await identity(false)
+  let cursor = Number((await localStatus(sessionId)).cursor || 0)
+  let cloud: Record<string, unknown> = {}
+  let syncError: string | undefined
+  try {
+    for (let pages = 0; pages < 50; pages += 1) {
+      cloud = await collaborationBackend(
+        'read_events',
+        { session_id: sessionId, cursor, limit: 100 },
+        account.accessToken || undefined
+      )
+      await applyPage(sessionId, cloud)
+      const events = Array.isArray(cloud.events) ? cloud.events : []
+      cursor = Number(cloud.next_cursor ?? cloud.high_water ?? cursor)
+      if (cursor >= Number(cloud.high_water ?? cursor) || events.length === 0)
+        break
+    }
+  } catch (error) {
+    syncError = error instanceof Error ? error.message : 'Waiting to sync.'
+  }
+  const local = (await collaborationCore('collaboration_list_messages', {
+    session_id: sessionId
+  })) as Record<string, unknown>
+  let files: unknown[] = []
+  if (!syncError) {
+    try {
+      files = ((await listSharedFiles(sessionId)).files as unknown[]) || []
+    } catch {
+      /* message history remains usable */
+    }
+  }
+  return {
+    ...cloud,
+    ...local,
+    events: Array.isArray(local.messages) ? local.messages : [],
+    files,
+    next_cursor: cursor,
+    ...(syncError ? { sync_error: syncError } : {})
+  }
+}
+
+function stableUserIds(value: unknown): string[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value) || value.length > 20)
+    throw new Error('The mentioned people list is invalid.')
+  const ids = [
+    ...new Set(value.map((item) => (typeof item === 'string' ? item : '')))
+  ]
+  if (ids.some((id) => !/^[0-9a-f-]{36}$/i.test(id)))
+    throw new Error('The mentioned people list is invalid.')
+  return ids
+}
+
+export async function sendSharedMessage(
+  sessionId: string,
+  content: string,
+  expectedRevision?: number,
+  requestRun = false,
+  mentionedUserIds?: string[]
+): Promise<Record<string, unknown>> {
+  const text = content.trim()
+  if (!sessionId || !text || Buffer.byteLength(text, 'utf8') > 2 * 1024 * 1024)
+    throw new Error('Write a message within the shared-session limit.')
+  const account = await identity(false)
+  const mentions = stableUserIds(mentionedUserIds)
+  const event: SharedSessionEvent = {
+    event_id: randomUUID(),
+    session_id: sessionId,
+    kind: 'message',
+    message_id: randomUUID(),
+    author_id: account.id,
+    role: 'user',
+    content: text,
+    revision: 1,
+    request_run: requestRun,
+    mentioned_user_ids: mentions,
+    created_at: new Date().toISOString()
+  }
+  await collaborationCore('collaboration_queue_event', {
+    session_id: sessionId,
+    event
+  })
+  try {
+    const accepted = await collaborationBackend(
+      'append_message',
+      {
+        session_id: sessionId,
+        event_id: event.event_id,
+        message_id: event.message_id,
+        content: text,
+        request_run: requestRun,
+        mentioned_user_ids: mentions
+      },
+      account.accessToken || undefined
+    )
+    await openSharedSession(sessionId)
+    return accepted
+  } catch (error) {
+    if (requestRun) throw error
+    return {
+      pending: true,
+      event,
+      error: error instanceof Error ? error.message : 'Waiting to sync.'
+    }
+  }
+}
+
+export async function changeSharedMessage(
+  kind: 'edit_message' | 'delete_message',
+  sessionId: string,
+  messageId: string,
+  content: string,
+  expectedRevision: number
+): Promise<Record<string, unknown>> {
+  const account = await identity()
+  if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 1)
+    throw new Error('The message revision is invalid.')
+  const event: SharedSessionEvent = {
+    event_id: randomUUID(),
+    session_id: sessionId,
+    kind: kind === 'edit_message' ? 'edit' : 'delete',
+    message_id: messageId,
+    author_id: account.id,
+    role: 'user',
+    content: kind === 'edit_message' ? content : '',
+    expected_revision: expectedRevision,
+    revision: expectedRevision + 1,
+    created_at: new Date().toISOString()
+  }
+  await collaborationCore('collaboration_queue_event', {
+    session_id: sessionId,
+    event
+  })
+  try {
+    const result = await collaborationBackend(
+      kind,
+      {
+        session_id: sessionId,
+        event_id: event.event_id,
+        message_id: messageId,
+        expected_revision: expectedRevision,
+        ...(kind === 'edit_message' ? { content } : {})
+      },
+      account.accessToken
+    )
+    await openSharedSession(sessionId)
+    return result
+  } catch (error) {
+    return {
+      pending: true,
+      event,
+      error: error instanceof Error ? error.message : 'Waiting to sync.'
+    }
+  }
+}
+
+export async function reconcileCollaboration(): Promise<void> {
+  if (reconcilePromise) return reconcilePromise
+  reconcilePromise = (async () => {
+    const account = await identity()
+    const status = await localStatus()
+    for (const event of status.pending || []) {
+      try {
+        const command =
+          event.publication_kind === 'routine_result'
+            ? 'publish_routine'
+            : event.kind === 'edit'
+              ? 'edit_message'
+              : event.kind === 'delete'
+                ? 'delete_message'
+                : 'append_message'
+        const accepted = await collaborationBackend(
+          command,
+          {
+            session_id: event.session_id,
+            event_id: event.event_id,
+            message_id: event.message_id,
+            ...(event.kind !== 'delete' ? { content: event.content } : {}),
+            ...(event.publication_kind === 'routine_result'
+              ? {
+                  routine_id: event.routine_id,
+                  audience_revision: event.audience_revision
+                }
+              : event.kind === 'message'
+                ? {
+                    request_run: Boolean(event.request_run),
+                    mentioned_user_ids: event.mentioned_user_ids || []
+                  }
+                : { expected_revision: event.expected_revision })
+          },
+          account.accessToken
+        )
+        if (event.publication_kind === 'routine_result') {
+          await openSharedSession(event.session_id)
+          await collaborationCore('collaboration_mark_routine_delivery', {
+            routine_id: event.routine_id,
+            event_id: event.event_id,
+            status: 'acknowledged'
+          })
+        } else await applyPage(event.session_id, accepted)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (
+          event.publication_kind === 'routine_result' &&
+          /(FORBIDDEN|NOT_FOUND|SESSION_CLOSED|REVISION_CONFLICT|STALE|REVOKED)/i.test(
+            message
+          )
+        ) {
+          await collaborationCore('collaboration_mark_routine_delivery', {
+            routine_id: event.routine_id,
+            event_id: event.event_id,
+            status: 'rejected',
+            error: message
+          }).catch(() => undefined)
+        }
+        // Offline and transient failures remain in the durable outbox.
+      }
+    }
+    const boot = await collaborationBackend(
+      'bootstrap',
+      {},
+      account.accessToken
+    )
+    for (const session of Array.isArray(boot.sessions)
+      ? (boot.sessions as Array<Record<string, unknown>>)
+      : []) {
+      const sessionId =
+        typeof session.session_id === 'string'
+          ? session.session_id
+          : typeof session.id === 'string'
+            ? session.id
+            : ''
+      if (sessionId) {
+        await openSharedSession(sessionId)
+        if (session.status === 'archive_pending') {
+          try {
+            const archive = await collaborationBackend(
+              'archive_status',
+              { session_id: sessionId },
+              account.accessToken
+            )
+            const ownReceipt = (
+              Array.isArray(archive.recipients) ? archive.recipients : []
+            ).find(
+              (item) =>
+                item &&
+                typeof item === 'object' &&
+                (item as Record<string, unknown>).user_id === account.id
+            ) as Record<string, unknown> | undefined
+            if (ownReceipt && ownReceipt.received !== true)
+              await saveVerifiedArchive(sessionId)
+          } catch {
+            /* archive remains pending and retries on the next bounded pass */
+          }
+        }
+      }
+    }
+    const pending = await collaborationBackend(
+      'list_pending_runs',
+      {},
+      account.accessToken
+    )
+    for (const run of Array.isArray(pending.runs)
+      ? (pending.runs as Array<Record<string, unknown>>)
+      : []) {
+      if (
+        typeof run.run_id === 'string' &&
+        typeof run.session_id === 'string' &&
+        !activeRuns.has(run.session_id)
+      ) {
+        void executePendingRun(run.run_id, run.session_id).catch(
+          () => undefined
+        )
+      }
+    }
+  })().finally(() => {
+    reconcilePromise = null
+  })
+  return reconcilePromise
+}
+
+async function executePendingRun(
+  runId: string,
+  sessionId: string
+): Promise<void> {
+  const account = await identity()
+  const claim = await collaborationBackend('claim_run', {
+    run_id: runId,
+    device_id: account.deviceId
+  })
+  const content =
+    typeof claim.request_content === 'string' ? claim.request_content : ''
+  if (!content) {
+    await collaborationBackend('cancel_run', {
+      run_id: runId,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    return
+  }
+  activeRuns.set(sessionId, { runId, leaseToken: claim.lease_token })
+  try {
+    await applyPage(sessionId, {
+      events: Array.isArray(claim.events) ? claim.events : [],
+      next_cursor: claim.context_cutoff
+    })
+  } catch (error) {
+    activeRuns.delete(sessionId)
+    await collaborationBackend('cancel_run', {
+      run_id: runId,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    throw error
+  }
+  let fenced = false
+  const timer = setInterval(() => {
+    void collaborationBackend('renew_run', {
+      run_id: runId,
+      device_id: account.deviceId,
+      lease_token: claim.lease_token
+    })
+      .then((renewed) =>
+        collaborationCore('collaboration_control_run', {
+          run_id: runId,
+          action: 'renew',
+          lease_token: claim.lease_token,
+          lease_expires_at: renewed.lease_expires_at
+        })
+      )
+      .catch(() => {
+        fenced = true
+        void collaborationCore('collaboration_control_run', {
+          run_id: runId,
+          action: 'fenced',
+          lease_token: claim.lease_token
+        }).catch(() => undefined)
+      })
+  }, 15_000)
+  try {
+    const result = (await collaborationCore('collaboration_run_shared', {
+      mode: 'private_result',
+      content,
+      claim,
+      published_history: []
+    })) as Record<string, unknown>
+    if (fenced || typeof result.content !== 'string')
+      throw new Error('Run lease lost.')
+    const draftId = randomUUID()
+    drafts.set(draftId, {
+      accountId: account.id,
+      runId,
+      fence: claim.lease_token,
+      sessionId,
+      content: result.content,
+      eventId: randomUUID(),
+      messageId: randomUUID()
+    })
+    draftRenewals.set(draftId, timer)
+    persistDrafts()
+  } catch (error) {
+    clearInterval(timer)
+    await collaborationBackend('cancel_run', {
+      run_id: runId,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    throw error
+  } finally {
+    activeRuns.delete(sessionId)
+  }
+}
+
+export async function runSharedPrivately(
+  sessionId: string,
+  content: string
+): Promise<SharedDraft> {
+  const text = content.trim()
+  if (!text) throw new Error('Write a request first.')
+  const account = await identity()
+  const admitted = await sendSharedMessage(sessionId, text, undefined, true)
+  const runIdToClaim = String(admitted.run_id || '')
+  if (!runIdToClaim)
+    throw new Error(
+      'The shared request was saved, but no execution was admitted.'
+    )
+  const claim = await collaborationBackend(
+    'claim_run',
+    { run_id: runIdToClaim, device_id: account.deviceId },
+    account.accessToken
+  )
+  activeRuns.set(sessionId, {
+    runId: String(claim.run_id),
+    leaseToken: claim.lease_token
+  })
+  try {
+    await applyPage(sessionId, {
+      events: Array.isArray(claim.events) ? claim.events : [],
+      next_cursor: claim.context_cutoff
+    })
+  } catch (error) {
+    activeRuns.delete(sessionId)
+    await collaborationBackend('cancel_run', {
+      run_id: claim.run_id,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    throw error
+  }
+  let leaseFailed = false
+  const renew = setInterval(() => {
+    void collaborationBackend('renew_run', {
+      run_id: claim.run_id,
+      device_id: account.deviceId,
+      lease_token: claim.lease_token
+    })
+      .then((renewed) =>
+        collaborationCore('collaboration_control_run', {
+          run_id: claim.run_id,
+          action: 'renew',
+          lease_token: claim.lease_token,
+          lease_expires_at: renewed.lease_expires_at
+        })
+      )
+      .catch(() => {
+        leaseFailed = true
+        void collaborationCore('collaboration_control_run', {
+          run_id: claim.run_id,
+          action: 'fenced',
+          lease_token: claim.lease_token
+        }).catch(() => undefined)
+      })
+  }, 15_000)
+  let result: Record<string, unknown>
+  try {
+    result = (await collaborationCore('collaboration_run_shared', {
+      mode: 'private_result',
+      content: text,
+      claim,
+      published_history: []
+    })) as Record<string, unknown>
+  } catch (error) {
+    clearInterval(renew)
+    activeRuns.delete(sessionId)
+    await collaborationBackend('cancel_run', {
+      run_id: claim.run_id,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    throw error
+  }
+  activeRuns.delete(sessionId)
+  if (leaseFailed) {
+    clearInterval(renew)
+    await collaborationBackend('cancel_run', {
+      run_id: claim.run_id,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    throw new Error(
+      'The execution lease was lost. This run needs reconciliation before it can be retried.'
+    )
+  }
+  const runId = String(result.run_id || claim.run_id || '')
+  if (!runId || typeof result.content !== 'string') {
+    clearInterval(renew)
+    await collaborationBackend('cancel_run', {
+      run_id: claim.run_id,
+      lease_token: claim.lease_token
+    }).catch(() => undefined)
+    throw new Error(
+      'The private shared run did not return a reviewable result.'
+    )
+  }
+  const draftId = randomUUID()
+  drafts.set(draftId, {
+    accountId: account.id,
+    runId,
+    fence: claim.lease_token,
+    sessionId,
+    content: result.content,
+    eventId: randomUUID(),
+    messageId: randomUUID()
+  })
+  draftRenewals.set(draftId, renew)
+  persistDrafts()
+  return {
+    draftId,
+    runId,
+    content: result.content,
+    state: String(result.state || 'ready_for_review')
+  }
+}
+
+export async function listPrivateDrafts(): Promise<
+  Array<
+    SharedDraft & {
+      sessionId: string
+      state: 'ready_for_review' | 'lease_lost'
+    }
+  >
+> {
+  const account = await identity(false)
+  loadDrafts()
+  const result: Array<
+    SharedDraft & {
+      sessionId: string
+      state: 'ready_for_review' | 'lease_lost'
+    }
+  > = []
+  for (const [draftId, draft] of drafts) {
+    if (draft.accountId !== account.id) continue
+    let state: 'ready_for_review' | 'lease_lost' = 'ready_for_review'
+    try {
+      await collaborationBackend('renew_run', {
+        run_id: draft.runId,
+        device_id: account.deviceId,
+        lease_token: draft.fence
+      })
+      if (!draftRenewals.has(draftId)) {
+        const timer = setInterval(() => {
+          void collaborationBackend('renew_run', {
+            run_id: draft.runId,
+            device_id: account.deviceId,
+            lease_token: draft.fence
+          }).catch(() => {
+            clearInterval(timer)
+            draftRenewals.delete(draftId)
+          })
+        }, 15_000)
+        draftRenewals.set(draftId, timer)
+      }
+    } catch {
+      state = 'lease_lost'
+    }
+    result.push({
+      draftId,
+      runId: draft.runId,
+      sessionId: draft.sessionId,
+      content: draft.content,
+      state
+    })
+  }
+  return result
+}
+
+export async function stopSessionRun(
+  sessionId: string
+): Promise<Record<string, unknown>> {
+  const active = activeRuns.get(sessionId)
+  if (active)
+    await collaborationCore('collaboration_control_run', {
+      run_id: active.runId,
+      action: 'cancel',
+      lease_token: active.leaseToken
+    }).catch(() => undefined)
+  return collaborationBackend('stop_session_run', { session_id: sessionId })
+}
+
+export async function publishSharedDraft(
+  draftId: string,
+  content: string
+): Promise<Record<string, unknown>> {
+  const account = await identity()
+  loadDrafts()
+  const draft = drafts.get(draftId)
+  if (!draft || draft.accountId !== account.id)
+    throw new Error('That private draft is no longer available.')
+  const selected = content.trim()
+  if (!selected || Buffer.byteLength(selected, 'utf8') > 2 * 1024 * 1024)
+    throw new Error('Choose a result within the publication limit.')
+  const result = await collaborationBackend(
+    'complete_run',
+    {
+      run_id: draft.runId,
+      lease_token: draft.fence,
+      event_id: draft.eventId,
+      message_id: draft.messageId,
+      content: selected
+    },
+    account.accessToken
+  )
+  const renewal = draftRenewals.get(draftId)
+  if (renewal) clearInterval(renewal)
+  draftRenewals.delete(draftId)
+  drafts.delete(draftId)
+  persistDrafts()
+  await openSharedSession(draft.sessionId)
+  return result
+}
+
+export async function saveVerifiedArchive(
+  sessionId: string
+): Promise<Record<string, unknown>> {
+  const account = await identity()
+  const descriptor = await collaborationBackend(
+    'archive_manifest',
+    { session_id: sessionId },
+    account.accessToken
+  )
+  if (
+    typeof descriptor.manifest_json !== 'string' ||
+    typeof descriptor.digest !== 'string'
+  )
+    throw new Error('The archive manifest is unavailable.')
+  const existing = (await localStatus()).archives.find(
+    (item) =>
+      item &&
+      typeof item === 'object' &&
+      (item as Record<string, unknown>).digest === descriptor.digest
+  ) as Record<string, unknown> | undefined
+  if (existing) {
+    await collaborationBackend(
+      'ack_archive',
+      {
+        session_id: sessionId,
+        archive_revision: descriptor.archive_revision,
+        device_id: account.deviceId,
+        digest: descriptor.digest,
+        final_seq: descriptor.final_seq,
+        byte_length: descriptor.byte_length
+      },
+      account.accessToken
+    )
+    return {
+      state: 'saved_locally',
+      local_path: existing.path,
+      digest: descriptor.digest,
+      final_seq: descriptor.final_seq,
+      byte_length: descriptor.byte_length
+    }
+  }
+  const attachments: Array<{ file_id: string; path: string }> = []
+  const tempRoot = join(app.getPath('temp'), `collie-archive-${randomUUID()}`)
+  try {
+    const parsedManifest = JSON.parse(descriptor.manifest_json) as {
+      files?: Array<Record<string, unknown>>
+    }
+    const files = Array.isArray(descriptor.files)
+      ? (descriptor.files as Array<Record<string, unknown>>)
+      : parsedManifest.files || []
+    if (files.length) mkdirSync(tempRoot, { recursive: true })
+    for (const file of files) {
+      if (
+        typeof file.file_id !== 'string' ||
+        !/^[0-9a-f-]{36}$/i.test(file.file_id)
+      )
+        throw new Error('The archive file list is incomplete.')
+      const objectPath =
+        typeof file.object_path === 'string' ? file.object_path : ''
+      const rawUrl =
+        typeof file.download_url === 'string'
+          ? file.download_url
+          : `${serviceUrl()}/storage/v1/object/authenticated/collaboration-files/${objectPath.split('/').map(encodeURIComponent).join('/')}`
+      const url = new URL(rawUrl)
+      const expected = new URL(serviceUrl())
+      if (
+        url.protocol !== 'https:' ||
+        url.origin !== expected.origin ||
+        !url.pathname.startsWith('/storage/v1/object/')
+      )
+        throw new Error('An archive file had an unsafe download address.')
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${account.accessToken}` },
+        signal: AbortSignal.timeout(60_000)
+      })
+      if (!response.ok)
+        throw new Error('A shared archive file could not be downloaded.')
+      const declaredLength = Number(response.headers.get('content-length') || 0)
+      if (declaredLength > 5 * 1024 * 1024)
+        throw new Error('A shared archive file exceeded its limit.')
+      const bytes = Buffer.from(await response.arrayBuffer())
+      if (bytes.byteLength > 5 * 1024 * 1024)
+        throw new Error('A shared archive file exceeded its limit.')
+      const path = join(tempRoot, file.file_id)
+      writeFileSync(path, bytes, { mode: 0o600 })
+      attachments.push({ file_id: file.file_id, path })
+    }
+    const receipt = (await collaborationCore('collaboration_write_archive', {
+      manifest_json: descriptor.manifest_json,
+      digest: descriptor.digest,
+      attachments
+    })) as Record<string, unknown>
+    await collaborationBackend(
+      'ack_archive',
+      {
+        session_id: sessionId,
+        archive_revision: descriptor.archive_revision,
+        device_id: account.deviceId,
+        digest: receipt.digest,
+        final_seq: receipt.final_seq,
+        byte_length: receipt.byte_length
+      },
+      account.accessToken
+    )
+    return { state: 'saved_locally', local_path: receipt.path, ...receipt }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+export async function uploadSharedFile(
+  mainWindow: BrowserWindow | null,
+  sessionId: string,
+  expectedSessionRevision: number,
+  membershipRevision: number
+): Promise<Record<string, unknown>> {
+  if (
+    !Number.isSafeInteger(expectedSessionRevision) ||
+    !Number.isSafeInteger(membershipRevision)
+  )
+    throw new Error('Refresh the conversation before attaching a file.')
+  const options = {
+    title: 'Share a file with this conversation',
+    properties: ['openFile'] as Array<'openFile'>
+  }
+  const picked = mainWindow
+    ? await dialog.showOpenDialog(mainWindow, options)
+    : await dialog.showOpenDialog(options)
+  if (picked.canceled || !picked.filePaths[0]) return { canceled: true }
+  const account = await identity()
+  const path = picked.filePaths[0]
+  const name = basename(path)
+  if (!name || name.length > 255 || /[\x00-\x1f\x7f]/.test(name))
+    throw new Error('That filename cannot be shared.')
+  const bytes = readFileSync(path)
+  if (bytes.byteLength < 1 || bytes.byteLength > 5 * 1024 * 1024)
+    throw new Error('Choose a file up to 5 MiB.')
+  const fileId = randomUUID()
+  const sha256 = createHash('sha256').update(bytes).digest('hex')
+  const endpoint = `${serviceUrl()}/functions/v1/collaboration-files`
+  const headers = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${account.accessToken}`
+  }
+  const reserve = await fetch(endpoint, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      action: 'reserve',
+      session_id: sessionId,
+      file_id: fileId,
+      name,
+      content_type: 'application/octet-stream',
+      byte_length: bytes.byteLength,
+      sha256,
+      expected_session_revision: expectedSessionRevision,
+      membership_revision: membershipRevision
+    }),
+    signal: AbortSignal.timeout(20_000)
+  })
+  if (!reserve.ok) throw new Error('The shared file could not be reserved.')
+  const upload = await fetch(
+    `${endpoint}?file_id=${encodeURIComponent(fileId)}`,
+    {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/octet-stream' },
+      body: new Uint8Array(bytes),
+      signal: AbortSignal.timeout(60_000)
+    }
+  )
+  const result = (await upload.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null
+  if (!upload.ok || !result) {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'cancel', file_id: fileId })
+    }).catch(() => undefined)
+    throw new Error('The shared file could not be uploaded.')
+  }
+  return { canceled: false, ...result }
+}
+
+async function sharedFileRequest(
+  action: string,
+  sessionId: string
+): Promise<{
+  account: LocalIdentity
+  endpoint: string
+  headers: Record<string, string>
+  result: Record<string, unknown>
+}> {
+  const account = await identity()
+  const endpoint = `${serviceUrl()}/functions/v1/collaboration-files`
+  const headers = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${account.accessToken}`
+  }
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, session_id: sessionId }),
+    signal: AbortSignal.timeout(20_000)
+  })
+  const result = (await response.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null
+  if (!response.ok || !result) throw new Error('Shared files are unavailable.')
+  return { account, endpoint, headers, result }
+}
+
+export async function listSharedFiles(
+  sessionId: string
+): Promise<Record<string, unknown>> {
+  return (await sharedFileRequest('list', sessionId)).result
+}
+
+export async function downloadSharedFile(
+  mainWindow: BrowserWindow | null,
+  sessionId: string,
+  fileId: string
+): Promise<Record<string, unknown>> {
+  if (!/^[0-9a-f-]{36}$/i.test(fileId))
+    throw new Error('That shared file is invalid.')
+  const { endpoint, headers, result } = await sharedFileRequest(
+    'list',
+    sessionId
+  )
+  const descriptor = (Array.isArray(result.files) ? result.files : []).find(
+    (item) =>
+      item &&
+      typeof item === 'object' &&
+      (item as Record<string, unknown>).file_id === fileId
+  ) as Record<string, unknown> | undefined
+  if (
+    !descriptor ||
+    typeof descriptor.name !== 'string' ||
+    typeof descriptor.sha256 !== 'string'
+  )
+    throw new Error('That shared file is unavailable.')
+  const response = await fetch(
+    `${endpoint}?file_id=${encodeURIComponent(fileId)}`,
+    { headers, signal: AbortSignal.timeout(60_000) }
+  )
+  if (!response.ok) throw new Error('The shared file could not be downloaded.')
+  const bytes = Buffer.from(await response.arrayBuffer())
+  if (
+    bytes.byteLength !== Number(descriptor.byte_length) ||
+    bytes.byteLength > 5 * 1024 * 1024 ||
+    createHash('sha256').update(bytes).digest('hex') !== descriptor.sha256
+  )
+    throw new Error('The downloaded shared file failed verification.')
+  const options = {
+    title: 'Save shared file',
+    defaultPath: basename(descriptor.name),
+    buttonLabel: 'Save copy'
+  }
+  const picked = mainWindow
+    ? await dialog.showSaveDialog(mainWindow, options)
+    : await dialog.showSaveDialog(options)
+  if (picked.canceled || !picked.filePath) return { canceled: true }
+  const temp = `${picked.filePath}.collie-tmp-${randomUUID()}`
+  try {
+    writeFileSync(temp, bytes, { mode: 0o600 })
+    renameSync(temp, picked.filePath)
+  } finally {
+    rmSync(temp, { force: true })
+  }
+  return { canceled: false, path: picked.filePath, file_id: fileId }
+}
+
+export async function exportSharedArchive(
+  mainWindow: BrowserWindow | null,
+  archivePath: string
+): Promise<{ canceled: boolean; path?: string }> {
+  const known = (await localStatus()).archives.some(
+    (item) =>
+      item &&
+      typeof item === 'object' &&
+      (item as Record<string, unknown>).path === archivePath
+  )
+  if (!known) throw new Error('Choose a verified local archive.')
+  const options = {
+    title: 'Export shared conversation archive',
+    defaultPath: `${basename(archivePath)}.zip`,
+    filters: [{ name: 'Collie archive', extensions: ['zip'] }]
+  }
+  const result = mainWindow
+    ? await dialog.showSaveDialog(mainWindow, options)
+    : await dialog.showSaveDialog(options)
+  if (result.canceled || !result.filePath) return { canceled: true }
+  const saved = (await collaborationCore('collaboration_export_archive', {
+    archive_path: archivePath,
+    destination: result.filePath
+  })) as { path: string }
+  return { canceled: false, path: saved.path }
+}
+
+export async function importSharedArchive(
+  mainWindow: BrowserWindow | null
+): Promise<{ canceled: boolean; archive?: unknown }> {
+  const options = {
+    title: 'Import shared conversation archive',
+    properties: ['openFile'] as Array<'openFile'>,
+    filters: [{ name: 'Collie archive', extensions: ['zip'] }]
+  }
+  const result = mainWindow
+    ? await dialog.showOpenDialog(mainWindow, options)
+    : await dialog.showOpenDialog(options)
+  if (result.canceled || !result.filePaths[0]) return { canceled: true }
+  return {
+    canceled: false,
+    archive: await collaborationCore('collaboration_import_archive', {
+      source: result.filePaths[0]
+    })
+  }
+}
+
+export async function installSlack(
+  organizationId: string
+): Promise<{ opened: boolean }> {
+  const account = await identity()
+  const response = await fetch(`${serviceUrl()}/functions/v1/slack-install`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${account.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ org_id: organizationId }),
+    signal: AbortSignal.timeout(20_000)
+  })
+  const body = (await response.json().catch(() => null)) as {
+    url?: unknown
+    error?: unknown
+  } | null
+  if (!response.ok || typeof body?.url !== 'string')
+    throw new Error(
+      typeof body?.error === 'string'
+        ? body.error
+        : 'Slack installation is unavailable.'
+    )
+  const url = new URL(body.url)
+  if (
+    url.protocol !== 'https:' ||
+    url.hostname !== 'slack.com' ||
+    url.pathname !== '/oauth/v2/authorize'
+  )
+    throw new Error('Slack returned an unsafe authorization address.')
+  await shell.openExternal(url.toString())
+  return { opened: true }
+}
+
+export async function clearCollaborationIdentity(): Promise<void> {
+  for (const timer of draftRenewals.values()) clearInterval(timer)
+  draftRenewals.clear()
+  drafts.clear()
+  boundIdentity = ''
+  rmSync(bindingPath(), { force: true })
+  try {
+    await collaborationCore('collaboration_bind_identity', {
+      bind_token: collaborationIdentityBindToken,
+      account_id: '',
+      device_id: ''
+    })
+  } catch {
+    /* core may be stopping */
+  }
+}
+
+export function startCollaborationReconciliation(): void {
+  if (periodicReconcile) return
+  void reconcileCollaboration().catch(() => undefined)
+  periodicReconcile = setInterval(() => {
+    void reconcileCollaboration().catch(() => undefined)
+  }, 30_000)
+}
+
+export function stopCollaborationReconciliation(): void {
+  if (periodicReconcile) clearInterval(periodicReconcile)
+  periodicReconcile = null
+}
+
+export async function beginSlackSenderLink(
+  installationId: string
+): Promise<Record<string, unknown>> {
+  return collaborationBackend('begin_slack_link', {
+    installation_id: installationId
+  })
+}
+
+export async function selectSlackChannel(
+  organizationId: string,
+  installationId: string,
+  channelId: string
+): Promise<Record<string, unknown>> {
+  return collaborationBackend('select_slack_channel', {
+    org_id: organizationId,
+    installation_id: installationId,
+    channel_id: channelId
+  })
+}
+
+export async function setRoutineDelivery(
+  routineId: string,
+  sessionId: string | null,
+  audienceRevision?: number
+): Promise<unknown> {
+  const account = await identity()
+  if (sessionId === null)
+    return collaborationCore('collaboration_set_routine_delivery', {
+      routine_id: routineId,
+      shared_delivery: null
+    })
+  if (!Number.isSafeInteger(audienceRevision) || Number(audienceRevision) < 1)
+    throw new Error(
+      'Refresh the shared conversation before choosing it for routine delivery.'
+    )
+  return collaborationCore('collaboration_set_routine_delivery', {
+    routine_id: routineId,
+    shared_delivery: {
+      session_id: sessionId,
+      audience_revision: Number(audienceRevision),
+      creator_account_id: account.id
+    }
+  })
+}
+
+export async function listLocalArchives(): Promise<unknown[]> {
+  return ((await localStatus()).archives || []) as unknown[]
+}

--- a/collie-ui/src/main/core-client.ts
+++ b/collie-ui/src/main/core-client.ts
@@ -349,6 +349,12 @@ export function coreSend(frame: CoreCommandFrame): Promise<unknown> {
   if (typeof type !== 'string' || typeof id !== 'string') {
     return Promise.reject(new Error('Malformed core command frame'))
   }
+  // Shared-session storage, archives, identity binding and execution cross a
+  // trust boundary. Only collaboration.ts may invoke those commands after it
+  // verifies the protected account and obtains canonical backend claims.
+  if (type.startsWith('collaboration_')) {
+    return Promise.reject(new Error('Use the protected collaboration bridge.'))
+  }
   return coreBroker.send(type, id, payload)
 }
 

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Menu, Tray, dialog, ipcMain, shell, nativeImage, session } from 'electron'
+import { randomUUID } from 'crypto'
 import { basename, extname, isAbsolute, join } from 'path'
 import { homedir } from 'os'
 import { pathToFileURL } from 'url'
@@ -33,6 +34,12 @@ import {
 } from './core-client'
 import { startKeychainServer, stopKeychainServer } from './keychain-server'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
+import {
+  beginSlackSenderLink, bootstrapCollaboration, changeSharedMessage, clearCollaborationIdentity, collaborationBackend, exportSharedArchive, importSharedArchive,
+  downloadSharedFile, installSlack, listLocalArchives, listPrivateDrafts, listSharedFiles, openSharedSession, publishSharedDraft, reconcileCollaboration,
+  runSharedPrivately, saveVerifiedArchive, selectSlackChannel, sendSharedMessage, setRoutineDelivery,
+  startCollaborationReconciliation, stopCollaborationReconciliation, stopSessionRun, uploadSharedFile
+} from './collaboration'
 import { submitFeedback } from './feedback'
 import {
   enableSync,
@@ -284,6 +291,7 @@ function createWindow(): void {
     // Returning to the app is an acknowledgement that the user reviewed
     // the latest completion announcement.
     sendPetCommand('status:dismiss')
+    void reconcileCollaboration().catch(() => undefined)
   })
 
   mainWindow.on('close', (e) => {
@@ -360,6 +368,10 @@ function registerIpc(): void {
   ): void => {
     ipcMain.handle(channel, guardIpcHandler(validSender, handler))
   }
+  const textArg = (value: unknown, label: string, max = 500): string => {
+    if (typeof value !== 'string' || !value.trim() || value.length > max) throw new Error(`Invalid ${label}.`)
+    return value.trim()
+  }
 
   handle('collie:core-state', () => coreState())
   // #122: the renderer no longer holds the per-boot token or opens its own
@@ -391,7 +403,10 @@ function registerIpc(): void {
   handle('account:start-sign-in', () => startAccountSignIn())
   handle('collie:submit-feedback', (submission: unknown) => submitFeedback(submission))
   handle('account:get-state', () => getAccountState())
-  handle('account:sign-out', () => signOut())
+  handle('account:sign-out', async () => {
+    await clearCollaborationIdentity()
+    return signOut()
+  })
   // Account cloud sync (account-cloud-sync.md): per-device snapshots,
   // opt-in. Payloads never include secrets; RLS scopes every REST call.
   handle('account:sync-status', () => getSyncStatus())
@@ -399,6 +414,53 @@ function registerIpc(): void {
   handle('account:sync-upload', () => uploadSnapshot())
   handle('account:sync-list', () => listSnapshots())
   handle('account:sync-restore', (deviceId: string) => restoreFromDevice(String(deviceId)))
+  handle('collaboration:bootstrap', () => bootstrapCollaboration())
+  handle('collaboration:create-organization', (name: unknown) => collaborationBackend('create_organization', { name: textArg(name, 'organization name', 120) }))
+  handle('collaboration:invite-organization', (organizationId: unknown, userId: unknown, displayName: unknown) => collaborationBackend('invite_organization', { org_id: textArg(organizationId, 'organization'), user_id: textArg(userId, 'account'), display_name: textArg(displayName, 'display name', 120), invite_id: randomUUID() }))
+  handle('collaboration:accept-organization-invite', (inviteId: unknown) => collaborationBackend('accept_organization_invite', { invite_id: textArg(inviteId, 'invitation') }))
+  handle('collaboration:directory', (organizationId: unknown, query: unknown) => collaborationBackend('directory', { org_id: textArg(organizationId, 'organization'), query: typeof query === 'string' ? query.slice(0, 200) : '' }))
+  handle('collaboration:create-session', (organizationId: unknown, title: unknown) => collaborationBackend('create_session', { org_id: textArg(organizationId, 'organization'), title: textArg(title, 'title', 200) }))
+  handle('collaboration:invite', (sessionId: unknown, memberId: unknown, policy: unknown) => {
+    if (!policy || typeof policy !== 'object') throw new Error('Describe the invitation audience.')
+    const value = policy as Record<string, unknown>
+    if (typeof value.includes_existing_history !== 'boolean') throw new Error('The invitation audience is invalid.')
+    return collaborationBackend('invite', { session_id: textArg(sessionId, 'session'), user_id: textArg(memberId, 'member'), invite_id: randomUUID(), audience_policy: { summary: textArg(value.summary, 'audience summary', 500), includes_existing_history: value.includes_existing_history }, audience_policy_version: 1 })
+  })
+  handle('collaboration:accept-invite', (inviteId: unknown, audienceConsent: unknown, policyVersion: unknown) => {
+    if (typeof audienceConsent !== 'boolean' || !Number.isSafeInteger(policyVersion) || Number(policyVersion) < 1) throw new Error('Review the invitation audience before accepting.')
+    return collaborationBackend('accept_invite', { invite_id: textArg(inviteId, 'invitation'), audience_consent: audienceConsent, audience_policy_version: Number(policyVersion) })
+  })
+  handle('collaboration:open-session', (sessionId: unknown) => openSharedSession(textArg(sessionId, 'session')))
+  handle('collaboration:send-message', (sessionId: unknown, content: unknown, expectedRevision: unknown, mentionedUserIds: unknown) => sendSharedMessage(textArg(sessionId, 'session'), textArg(content, 'message', 2 * 1024 * 1024), typeof expectedRevision === 'number' ? expectedRevision : undefined, false, mentionedUserIds as string[] | undefined))
+  handle('collaboration:edit-message', (sessionId: unknown, messageId: unknown, content: unknown, expectedRevision: unknown) => changeSharedMessage('edit_message', textArg(sessionId, 'session'), textArg(messageId, 'message'), textArg(content, 'message', 2 * 1024 * 1024), Number(expectedRevision)))
+  handle('collaboration:delete-message', (sessionId: unknown, messageId: unknown, expectedRevision: unknown) => changeSharedMessage('delete_message', textArg(sessionId, 'session'), textArg(messageId, 'message'), '', Number(expectedRevision)))
+  handle('collaboration:upload-file', (sessionId: unknown, expectedRevision: unknown, membershipRevision: unknown) => uploadSharedFile(mainWindow, textArg(sessionId, 'session'), Number(expectedRevision), Number(membershipRevision)))
+  handle('collaboration:list-files', (sessionId: unknown) => listSharedFiles(textArg(sessionId, 'session')))
+  handle('collaboration:download-file', (sessionId: unknown, fileId: unknown) => downloadSharedFile(mainWindow, textArg(sessionId, 'session'), textArg(fileId, 'file')))
+  handle('collaboration:run-private', (sessionId: unknown, content: unknown) => runSharedPrivately(textArg(sessionId, 'session'), textArg(content, 'request', 2 * 1024 * 1024)))
+  handle('collaboration:publish-draft', (draftId: unknown, content: unknown) => publishSharedDraft(textArg(draftId, 'draft'), textArg(content, 'publication', 2 * 1024 * 1024)))
+  handle('collaboration:list-private-drafts', () => listPrivateDrafts())
+  handle('collaboration:stop-session-run', (sessionId: unknown) => stopSessionRun(textArg(sessionId, 'session')))
+  handle('collaboration:resolve-reconciliation', (runId: unknown) => collaborationBackend('resolve_reconciliation', { run_id: textArg(runId, 'request') }))
+  handle('collaboration:request-archive', (sessionId: unknown) => collaborationBackend('request_archive', { session_id: textArg(sessionId, 'session') }))
+  handle('collaboration:archive-status', (sessionId: unknown) => collaborationBackend('archive_status', { session_id: textArg(sessionId, 'session') }))
+  handle('collaboration:save-archive', (sessionId: unknown) => saveVerifiedArchive(textArg(sessionId, 'session')))
+  handle('collaboration:export-archive', (archivePath: unknown) => exportSharedArchive(mainWindow, textArg(archivePath, 'archive path', 4096)))
+  handle('collaboration:import-archive', () => importSharedArchive(mainWindow))
+  handle('collaboration:list-local-archives', () => listLocalArchives())
+  handle('collaboration:continue-session', (sessionId: unknown, title: unknown) => collaborationBackend('continue_session', { session_id: textArg(sessionId, 'session'), ...(typeof title === 'string' && title.trim() ? { title: title.trim().slice(0, 200) } : {}) }))
+  handle('collaboration:revoke-member', (sessionId: unknown, memberId: unknown) => collaborationBackend('revoke_member', { session_id: textArg(sessionId, 'session'), user_id: textArg(memberId, 'member') }))
+  handle('collaboration:install-slack', (organizationId: unknown) => installSlack(textArg(organizationId, 'organization')))
+  handle('collaboration:link-slack-sender', (installationId: unknown) => beginSlackSenderLink(textArg(installationId, 'Slack installation')))
+  handle('collaboration:select-slack-channel', (organizationId: unknown, installationId: unknown, channelId: unknown) => selectSlackChannel(textArg(organizationId, 'organization'), textArg(installationId, 'Slack installation'), textArg(channelId, 'Slack channel')))
+  handle('collaboration:notifications', (cursor: unknown) => collaborationBackend('notifications', { cursor: typeof cursor === 'number' && Number.isSafeInteger(cursor) && cursor >= 0 ? cursor : 0, limit: 100 }))
+  handle('collaboration:ack-notifications', (through: unknown) => {
+    if (typeof through !== 'number' || !Number.isSafeInteger(through) || through < 0) throw new Error('The notification cursor is invalid.')
+    return collaborationBackend('ack_notifications', { through })
+  })
+  handle('collaboration:set-routine-delivery', (routineId: unknown, sessionId: unknown, audienceRevision: unknown) => setRoutineDelivery(textArg(routineId, 'routine'), sessionId === null ? null : textArg(sessionId, 'session'), typeof audienceRevision === 'number' ? audienceRevision : undefined))
+  handle('collaboration:slack-settings', (organizationId: unknown) => collaborationBackend('slack_settings', { org_id: textArg(organizationId, 'organization') }))
+  handle('collaboration:link-slack-channel', (organizationId: unknown, installationId: unknown, channelId: unknown) => collaborationBackend('select_slack_channel', { org_id: textArg(organizationId, 'organization'), installation_id: textArg(installationId, 'Slack installation'), channel_id: textArg(channelId, 'Slack channel') }))
   handle('collie:pick-attachments', async (): Promise<SelectedAttachment[]> => {
     const options = {
       title: 'Attach files to your message',
@@ -631,6 +693,7 @@ app.whenReady().then(async () => {
     // Retry persisted counters after startup, including short previous launches.
     flushMetrics(readProductMetrics)
     void pushStoredSecretsToCore()
+    startCollaborationReconciliation()
   })
   await spawnCore(isDev)
   // If this boot was an update, verify the new version came up healthy
@@ -668,6 +731,7 @@ app.on('before-quit', () => {
 })
 
 app.on('will-quit', () => {
+  stopCollaborationReconciliation()
   stopHeartbeat()
   stopCore()
   stopCoreBroker()

--- a/collie-ui/src/main/python.ts
+++ b/collie-ui/src/main/python.ts
@@ -19,6 +19,8 @@ const IPC_PORT = Number(process.env.COLLIE_IPC_PORT || 3818)
 // main-process broker's WebSocket (core-client.ts). It is NEVER sent to the
 // renderer, so no renderer compromise can open a socket that drives the core.
 export const ipcToken = randomBytes(32).toString('hex')
+/** Separate capability for account/device binding; never exposed to the renderer. */
+export const collaborationIdentityBindToken = randomBytes(32).toString('hex')
 
 let child: ChildProcess | null = null
 let state: 'stopped' | 'starting' | 'running' | 'failed' = 'stopped'
@@ -133,6 +135,7 @@ export async function spawnCore(isDev: boolean): Promise<void> {
       COLLIE_IPC_PORT: String(IPC_PORT),
       COLLIE_TIMEZONE: Intl.DateTimeFormat().resolvedOptions().timeZone,
       COLLIE_IPC_TOKEN: ipcToken,
+      COLLIE_IDENTITY_BIND_TOKEN: collaborationIdentityBindToken,
       COLLIE_PRODUCT_METRICS: isDev ? '0' : '1',
       COLLIE_MCP_RUNTIME_ROOT: bundledMcpRuntime(isDev),
       ...(keychain

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { FeedbackResult, FeedbackSubmission } from '../shared/feedback'
+import type { CollaborationBridge } from '../shared/collaboration'
 
 export type UpdatePhase =
   | 'idle'
@@ -160,7 +161,45 @@ const accountApi = {
     ipcRenderer.invoke('account:sync-upload'),
   syncList: (): Promise<SyncSnapshotSummary[]> => ipcRenderer.invoke('account:sync-list'),
   syncRestore: (deviceId: string): Promise<void> =>
-    ipcRenderer.invoke('account:sync-restore', deviceId)
+    ipcRenderer.invoke('account:sync-restore', deviceId),
+  collaboration: {
+    bootstrap: () => ipcRenderer.invoke('collaboration:bootstrap'),
+    createOrganization: (name: string) => ipcRenderer.invoke('collaboration:create-organization', name),
+    inviteOrganization: (organizationId: string, userId: string, displayName: string) => ipcRenderer.invoke('collaboration:invite-organization', organizationId, userId, displayName),
+    acceptOrganizationInvite: (inviteId: string) => ipcRenderer.invoke('collaboration:accept-organization-invite', inviteId),
+    directory: (organizationId: string, query: string) => ipcRenderer.invoke('collaboration:directory', organizationId, query),
+    createSession: (organizationId: string, title: string) => ipcRenderer.invoke('collaboration:create-session', organizationId, title),
+    invite: (sessionId: string, memberId: string, audiencePolicy: import('../shared/collaboration').SharedAudiencePolicy) => ipcRenderer.invoke('collaboration:invite', sessionId, memberId, audiencePolicy),
+    acceptInvite: (inviteId: string, audienceConsent: boolean, policyVersion: number) => ipcRenderer.invoke('collaboration:accept-invite', inviteId, audienceConsent, policyVersion),
+    openSession: (sessionId: string) => ipcRenderer.invoke('collaboration:open-session', sessionId),
+    sendMessage: (sessionId: string, content: string, expectedRevision?: number, mentionedUserIds?: string[]) => ipcRenderer.invoke('collaboration:send-message', sessionId, content, expectedRevision, mentionedUserIds),
+    editMessage: (sessionId: string, messageId: string, content: string, expectedRevision: number) => ipcRenderer.invoke('collaboration:edit-message', sessionId, messageId, content, expectedRevision),
+    deleteMessage: (sessionId: string, messageId: string, expectedRevision: number) => ipcRenderer.invoke('collaboration:delete-message', sessionId, messageId, expectedRevision),
+    uploadFile: (sessionId: string, expectedSessionRevision: number, membershipRevision: number) => ipcRenderer.invoke('collaboration:upload-file', sessionId, expectedSessionRevision, membershipRevision),
+    listFiles: (sessionId: string) => ipcRenderer.invoke('collaboration:list-files', sessionId),
+    downloadFile: (sessionId: string, fileId: string) => ipcRenderer.invoke('collaboration:download-file', sessionId, fileId),
+    runPrivate: (sessionId: string, content: string) => ipcRenderer.invoke('collaboration:run-private', sessionId, content),
+    publishDraft: (draftId: string, content: string) => ipcRenderer.invoke('collaboration:publish-draft', draftId, content),
+    listPrivateDrafts: () => ipcRenderer.invoke('collaboration:list-private-drafts'),
+    stopSessionRun: (sessionId: string) => ipcRenderer.invoke('collaboration:stop-session-run', sessionId),
+    resolveReconciliation: (runId: string) => ipcRenderer.invoke('collaboration:resolve-reconciliation', runId),
+    requestArchive: (sessionId: string) => ipcRenderer.invoke('collaboration:request-archive', sessionId),
+    archiveStatus: (sessionId: string) => ipcRenderer.invoke('collaboration:archive-status', sessionId),
+    saveArchive: (sessionId: string) => ipcRenderer.invoke('collaboration:save-archive', sessionId),
+    exportArchive: (archivePath: string) => ipcRenderer.invoke('collaboration:export-archive', archivePath),
+    importArchive: () => ipcRenderer.invoke('collaboration:import-archive'),
+    listLocalArchives: () => ipcRenderer.invoke('collaboration:list-local-archives'),
+    continueSession: (sessionId: string, title?: string) => ipcRenderer.invoke('collaboration:continue-session', sessionId, title),
+    revokeMember: (sessionId: string, memberId: string) => ipcRenderer.invoke('collaboration:revoke-member', sessionId, memberId),
+    installSlack: (organizationId: string) => ipcRenderer.invoke('collaboration:install-slack', organizationId),
+    linkSlackSender: (installationId: string) => ipcRenderer.invoke('collaboration:link-slack-sender', installationId),
+    selectSlackChannel: (organizationId: string, installationId: string, channelId: string) => ipcRenderer.invoke('collaboration:select-slack-channel', organizationId, installationId, channelId),
+    notifications: (cursor?: number) => ipcRenderer.invoke('collaboration:notifications', cursor),
+    ackNotifications: (through: number) => ipcRenderer.invoke('collaboration:ack-notifications', through),
+    setRoutineDelivery: (routineId: string, sessionId: string | null, audienceRevision?: number) => ipcRenderer.invoke('collaboration:set-routine-delivery', routineId, sessionId, audienceRevision),
+    slackSettings: (organizationId: string) => ipcRenderer.invoke('collaboration:slack-settings', organizationId),
+    linkSlackChannel: (sessionId: string, installationId: string, channelId: string) => ipcRenderer.invoke('collaboration:link-slack-channel', sessionId, installationId, channelId)
+  } satisfies CollaborationBridge
 }
 
 contextBridge.exposeInMainWorld('collie', api)

--- a/collie-ui/src/renderer/src/components/MessageBubble.tsx
+++ b/collie-ui/src/renderer/src/components/MessageBubble.tsx
@@ -20,6 +20,8 @@ interface Props {
   cardData?: Record<string, unknown> | null
   attachments?: MessageAttachment[] | null
   taskState?: TaskState | null
+  authorName?: string
+  syncStatus?: 'local' | 'pending' | 'synced' | 'error'
 }
 
 const PREVIEWABLE_IMAGE_TYPES = new Set([
@@ -35,7 +37,7 @@ function attachmentPreviewSource(attachment: MessageAttachment): string | null {
   return /^data:image\/(?:png|jpeg|webp|gif);base64,/i.test(source) ? source : null
 }
 
-function MessageBubble({ role, content, streaming, settled = true, cardType, cardData, attachments, taskState }: Props): React.JSX.Element {
+function MessageBubble({ role, content, streaming, settled = true, cardType, cardData, attachments, taskState, authorName, syncStatus }: Props): React.JSX.Element {
   const t = useT()
   const [preview, setPreview] = useState<{ name: string; source: string } | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
@@ -72,6 +74,7 @@ function MessageBubble({ role, content, streaming, settled = true, cardType, car
     <div
       className={`message-row ${streaming ? 'message-row--streaming' : 'collie-reveal'} ${isUser ? 'message-row--user' : 'message-row--assistant'}`}
     >
+      {authorName || syncStatus ? <div className={`message-attribution ${isUser ? 'is-user' : ''}`}><span>{authorName || (isUser ? 'You' : 'Collie')}</span>{syncStatus ? <span className={`message-sync-status is-${syncStatus}`}>{syncStatus === 'synced' ? 'Saved to shared chat' : syncStatus === 'pending' ? 'Saving…' : syncStatus === 'error' ? 'Needs sync' : 'Saved locally'}</span> : null}</div> : null}
       <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
         <div
           className={`message-bubble max-w-[80%] whitespace-pre-wrap px-4 py-3 text-[15px] leading-relaxed ${writing ? 'message-bubble--writing' : ''}`}

--- a/collie-ui/src/renderer/src/components/SharedMessageList.tsx
+++ b/collie-ui/src/renderer/src/components/SharedMessageList.tsx
@@ -1,0 +1,62 @@
+import { memo, useEffect, useRef } from 'react'
+import MessageBubble from './MessageBubble'
+import type { CollaborationEvent } from '../lib/collaboration'
+
+interface Props {
+  events: CollaborationEvent[]
+  readOnly?: boolean
+  viewerId?: string
+  onEdit?: (event: CollaborationEvent) => void
+}
+
+function SharedMessageList({
+  events,
+  readOnly,
+  viewerId,
+  onEdit
+}: Props): React.JSX.Element {
+  const endRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ block: 'end' })
+  }, [events.length])
+  return (
+    <div
+      className="shared-events shared-events-reusable"
+      role="log"
+      aria-label="Shared conversation"
+    >
+      {events.length === 0 ? (
+        <p className="settings-empty">No published messages yet.</p>
+      ) : (
+        events.map((event) => (
+          <div key={event.id}>
+            <MessageBubble
+              role={event.role === 'system' ? 'assistant' : event.role}
+              content={event.content}
+              authorName={
+                event.author_name ||
+                (event.role === 'assistant' ? 'Collie' : 'Member')
+              }
+              syncStatus={event.sync_status}
+            />
+            {!readOnly &&
+              event.author_id === viewerId &&
+              event.role === 'user' &&
+              event.sync_status === 'synced' &&
+              onEdit && (
+                <button
+                  className="settings-button"
+                  onClick={() => onEdit(event)}
+                >
+                  Edit or remove my message
+                </button>
+              )}
+          </div>
+        ))
+      )}
+      <div ref={endRef} />
+    </div>
+  )
+}
+
+export default memo(SharedMessageList)

--- a/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.dom.test.tsx
@@ -26,6 +26,7 @@ vi.mock('lucide-react', () => ({
   Search: () => null,
   Settings: () => null,
   Shapes: () => null,
+  Users: () => null,
   Trash2: () => null
 }))
 vi.mock('../lib/i18n', () => ({

--- a/collie-ui/src/renderer/src/components/Sidebar.tsx
+++ b/collie-ui/src/renderer/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Plug,
   Repeat2,
   Search,
+  Users,
   Settings,
   Shapes,
   Trash2
@@ -314,6 +315,9 @@ export default function Sidebar({
       </div>
 
       <nav className="sidebar-primary px-3" aria-label="Primary navigation">
+        <button type="button" className={`sidebar-nav-item ${activeView === 'shared' ? 'is-active' : ''}`} onClick={() => onNavigate('shared')}>
+          <Users size={16} /> <span>Shared conversations</span>
+        </button>
         {primaryItems.map(({ key, label, icon: Icon }) => (
           <button
             key={key}

--- a/collie-ui/src/renderer/src/lib/collaboration.test.ts
+++ b/collie-ui/src/renderer/src/lib/collaboration.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { canComposeSharedSession, canInviteToSession, formatBytes, sharedMessages } from './collaboration'
+
+describe('collaboration display helpers', () => {
+  it('formats quota bytes with stable binary units', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(1024)).toBe('1.0 KiB')
+    expect(formatBytes(2 * 1024 * 1024)).toBe('2.0 MiB')
+  })
+
+  it('materializes edits and deletions while retaining unsynced local content', () => {
+    const rows = sharedMessages([
+      { event_id: 'e1', message_id: 'm1', kind: 'message', seq: 1, content: 'first' },
+      { event_id: 'e2', message_id: 'm2', kind: 'message', seq: 2, content: 'remove me' },
+      { event_id: 'e3', message_id: 'm1', kind: 'edit', seq: 3, content: 'edited' },
+      { event_id: 'e4', message_id: 'm2', kind: 'delete', seq: 4 },
+      { event_id: 'pending', message_id: 'm3', kind: 'message', content: 'offline' }
+    ])
+    expect(rows.map(row => [row.id, row.content, row.sequence, row.sync_status])).toEqual([
+      ['m1', 'edited', 1, 'synced'], ['m3', 'offline', 0, 'pending']
+    ])
+  })
+
+  it('closes composition for archive and purge states', () => {
+    expect(canComposeSharedSession('active')).toBe(true)
+    for (const status of ['closing', 'archive_pending', 'purging', 'archived_local', 'unknown', undefined]) {
+      expect(canComposeSharedSession(status)).toBe(false)
+    }
+  })
+
+  it('does not treat directory membership as access and rejects duplicate invites', () => {
+    expect(canInviteToSession(undefined, 'member-2', [{ id: 'member-1' }])).toBe(false)
+    expect(canInviteToSession('session-1', 'member-1', [{ id: 'member-1' }])).toBe(false)
+    expect(canInviteToSession('session-1', 'member-2', [{ id: 'member-1' }])).toBe(true)
+  })
+})

--- a/collie-ui/src/renderer/src/lib/collaboration.ts
+++ b/collie-ui/src/renderer/src/lib/collaboration.ts
@@ -1,0 +1,307 @@
+import type { LocalCollaborationEvent } from './ipc'
+
+export interface CollaborationMember {
+  id: string
+  display_name: string
+  email?: string | null
+  role?: string
+  status?: string
+}
+export interface CollaborationOrganization {
+  id: string
+  name: string
+  member_count?: number
+  members?: CollaborationMember[]
+}
+export interface CollaborationInvite {
+  id: string
+  kind?: 'session' | 'organization'
+  session_id?: string
+  organization_id?: string
+  inviter_name?: string
+  email?: string
+  status: string
+  created_at?: string
+  audience_policy?: { summary: string; includes_existing_history: boolean }
+  audience_policy_version?: number
+}
+export interface SharedNotification {
+  notification_id: number
+  session_id: string
+  kind: string
+  read_at?: string | null
+}
+export interface SharedRunState {
+  run_id: string
+  status: string
+  requested_by: string
+  created_at?: string
+}
+export interface CollaborationSession {
+  id: string
+  title: string
+  organization_id: string
+  status: string
+  revision?: number
+  membership_revision?: number
+  members?: CollaborationMember[]
+  unread?: number
+  archive_status?: string
+  quota?: CollaborationQuota
+  run_state?: SharedRunState
+}
+export interface CollaborationQuota {
+  used_bytes?: number
+  limit_bytes?: number
+  used_messages?: number
+  limit_messages?: number
+  reserved_bytes?: number
+  warning?: string | null
+}
+export interface CollaborationEvent {
+  id: string
+  event_id?: string
+  session_id?: string
+  sequence: number
+  seq?: number
+  kind?: string
+  message_id?: string
+  author_id?: string
+  author_name?: string
+  role: 'user' | 'assistant' | 'system'
+  content: string
+  created_at: string
+  revision?: number
+  sync_status?: 'local' | 'pending' | 'synced' | 'error'
+}
+export interface ArchiveStatus {
+  state: string
+  pending_participants?: CollaborationMember[]
+  progress?: number
+  local_path?: string | null
+  reclaimed?: boolean
+  final_sequence?: number
+}
+export interface CollaborationBootstrap {
+  organizations?: CollaborationOrganization[]
+  sessions?: CollaborationSession[]
+  invites?: CollaborationInvite[]
+  account?: CollaborationMember
+  feature_enabled?: boolean
+  message?: string
+  sync_error?: string
+}
+export interface SharedFile {
+  file_id: string
+  name: string
+  byte_length: number
+  version?: number
+}
+
+export function formatBytes(value?: number): string {
+  if (!Number.isFinite(value) || !value || value < 1024)
+    return `${Math.max(0, value || 0)} B`
+  const units = ['KiB', 'MiB', 'GiB']
+  let amount = value
+  let unit = -1
+  while (amount >= 1024 && unit < units.length - 1) {
+    amount /= 1024
+    unit += 1
+  }
+  return `${amount.toFixed(amount >= 10 ? 0 : 1)} ${units[unit]}`
+}
+
+export function canComposeSharedSession(status?: string): boolean {
+  return status === 'active'
+}
+
+export function canInviteToSession(
+  sessionId: string | undefined,
+  memberId: string,
+  members: Array<{ id: string }>
+): boolean {
+  return Boolean(
+    sessionId && memberId && !members.some((member) => member.id === memberId)
+  )
+}
+
+export function retainOptimisticEvent<T extends { sync_status?: string }>(
+  events: T[],
+  event: T
+): T[] {
+  return [...events, { ...event, sync_status: event.sync_status || 'pending' }]
+}
+
+export interface CollaborationFacade {
+  bootstrap: () => Promise<CollaborationBootstrap>
+  createOrganization: (name: string) => Promise<unknown>
+  createSession: (
+    orgId: string,
+    title: string
+  ) => Promise<{ session?: CollaborationSession }>
+  invite: (
+    sessionId: string,
+    memberId: string,
+    policy: { summary: string; includes_existing_history: boolean }
+  ) => Promise<unknown>
+  acceptInvite: (
+    inviteId: string,
+    audienceConsent: boolean,
+    policyVersion: number
+  ) => Promise<unknown>
+  openSession: (
+    sessionId: string
+  ) => Promise<{
+    events?: LocalCollaborationEvent[]
+    high_water?: number
+    archive?: ArchiveStatus
+    files?: SharedFile[]
+    sync_error?: string
+    run_state?: SharedRunState
+  }>
+  sendMessage: (
+    sessionId: string,
+    content: string,
+    expectedRevision?: number,
+    mentionedUserIds?: string[]
+  ) => Promise<{
+    event?: LocalCollaborationEvent
+    events?: LocalCollaborationEvent[]
+    high_water?: number
+  }>
+  runPrivate: (
+    sessionId: string,
+    content: string
+  ) => Promise<{
+    draftId: string
+    runId?: string
+    content?: string
+    state?: string
+  }>
+  publishDraft: (draftId: string, content: string) => Promise<unknown>
+  listPrivateDrafts: () => Promise<
+    Array<{
+      draftId: string
+      runId: string
+      sessionId: string
+      content: string
+      state: string
+    }>
+  >
+  requestArchive: (sessionId: string) => Promise<{ archive?: ArchiveStatus }>
+  archiveStatus: (sessionId: string) => Promise<ArchiveStatus>
+  saveArchive: (sessionId: string) => Promise<ArchiveStatus>
+  exportArchive: (archivePath: string) => Promise<{ path: string }>
+  importArchive: () => Promise<unknown>
+  listLocalArchives: () => Promise<Array<Record<string, unknown>>>
+  continueSession: (
+    sessionId: string
+  ) => Promise<{ session?: CollaborationSession }>
+  installSlack: (orgId: string) => Promise<unknown>
+  linkSlackSender: (
+    installationId: string
+  ) => Promise<{ code?: string; message?: string }>
+  slackSettings: (
+    orgId: string
+  ) => Promise<{
+    installations?: Array<{
+      installation_id: string
+      team_id: string
+      status: string
+    }>
+  }>
+  selectSlackChannel: (
+    orgId: string,
+    installationId: string,
+    channelId: string
+  ) => Promise<unknown>
+  editMessage: (
+    sessionId: string,
+    messageId: string,
+    content: string,
+    expectedRevision: number
+  ) => Promise<unknown>
+  deleteMessage: (
+    sessionId: string,
+    messageId: string,
+    expectedRevision: number
+  ) => Promise<unknown>
+  inviteOrganization: (
+    orgId: string,
+    userId: string,
+    displayName: string
+  ) => Promise<unknown>
+  uploadFile: (
+    sessionId: string,
+    expectedRevision: number,
+    membershipRevision: number
+  ) => Promise<unknown>
+  listFiles: (sessionId: string) => Promise<{ files?: SharedFile[] }>
+  downloadFile: (sessionId: string, fileId: string) => Promise<unknown>
+  stopSessionRun: (sessionId: string) => Promise<unknown>
+  resolveReconciliation: (runId: string) => Promise<unknown>
+  revokeMember: (sessionId: string, memberId: string) => Promise<unknown>
+  acceptOrganizationInvite: (inviteId: string) => Promise<unknown>
+  notifications: () => Promise<{
+    notifications?: SharedNotification[]
+    next_cursor: number
+  }>
+  ackNotifications: (through: number) => Promise<unknown>
+  setRoutineDelivery: (
+    routineId: string,
+    sessionId: string | null,
+    audienceRevision?: number
+  ) => Promise<unknown>
+}
+
+/** Apply canonical edits/tombstones, retaining pending local rows returned by main. */
+export function sharedMessages(
+  rows: Array<
+    Partial<LocalCollaborationEvent> & { seq?: number; sync_status?: string }
+  >,
+  members: CollaborationMember[] = []
+): CollaborationEvent[] {
+  const authors = new Map(
+    members.map((member) => [member.id, member.display_name])
+  )
+  const messages = new Map<string, CollaborationEvent>()
+  for (const row of rows) {
+    const id = row.message_id || row.event_id
+    if (!id) continue
+    if (row.kind === 'delete' || (row as { deleted?: boolean }).deleted) {
+      messages.delete(id)
+      continue
+    }
+    const prior = messages.get(id)
+    messages.set(id, {
+      id,
+      event_id: row.event_id,
+      author_id: row.author_id,
+      sequence: prior?.sequence ?? Number(row.seq || 0),
+      role: row.role || prior?.role || 'user',
+      content: row.content || '',
+      author_name:
+        row.role === 'assistant'
+          ? `Collie · requested by ${authors.get(row.author_id || '') || 'member'}`
+          : authors.get(row.author_id || '') || row.author_id || 'Member',
+      created_at: prior?.created_at || row.created_at || '',
+      revision: row.revision,
+      sync_status: (row.sync_status ||
+        (row.seq ? 'synced' : 'pending')) as CollaborationEvent['sync_status']
+    })
+  }
+  return [...messages.values()]
+}
+
+export function sharedCollaboration(): CollaborationFacade {
+  const value: {
+    [K in keyof CollaborationFacade]: (
+      ...args: Parameters<CollaborationFacade[K]>
+    ) => Promise<unknown>
+  } = window.account.collaboration
+  if (!value)
+    throw new Error(
+      'Shared conversations are not available in this desktop build.'
+    )
+  return value as unknown as CollaborationFacade
+}

--- a/collie-ui/src/renderer/src/lib/ipc.ts
+++ b/collie-ui/src/renderer/src/lib/ipc.ts
@@ -50,6 +50,18 @@ export interface Conversation {
   project_path?: string | null
 }
 
+export interface LocalCollaborationEvent {
+  event_id: string
+  session_id: string
+  kind: 'message' | 'edit' | 'delete'
+  message_id: string
+  author_id: string
+  role: 'user' | 'assistant' | 'system'
+  content: string
+  revision?: number
+  created_at?: string
+}
+
 export type ExecutionMode = 'plan' | 'execute'
 export type ApprovalPreset = 'ask' | 'allow'
 export type FileAccessMode = 'selected_folder' | 'chosen_folders' | 'full_file_access'
@@ -764,6 +776,7 @@ export class CollieClient {
   getMessages(conversationId: string): Promise<{ messages: CollieMessage[] }> {
     return this.command('get_messages', { conversation_id: conversationId })
   }
+
 
   getActiveTask(conversationId: string): Promise<{ task: TaskState | null }> {
     return this.command('get_active_task', { conversation_id: conversationId })

--- a/collie-ui/src/renderer/src/lib/navigation.ts
+++ b/collie-ui/src/renderer/src/lib/navigation.ts
@@ -4,6 +4,7 @@ export type AppView =
   | 'skills'
   | 'loops'
   | 'connectors'
+  | 'shared'
   | 'settings'
 
 export const PINNED_CONVERSATIONS_STORAGE_KEY = 'collie.pinnedConversations'

--- a/collie-ui/src/renderer/src/screens/ChatScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/ChatScreen.tsx
@@ -28,6 +28,7 @@ import AgentsScreen from './AgentsScreen'
 import SkillsScreen from './SkillsScreen'
 import RoutinesScreen from './RoutinesScreen'
 import ConnectorsScreen from './ConnectorsScreen'
+import SharedWorkspace from './SharedWorkspace'
 import type { AppView } from '../lib/navigation'
 import { mergeStreamDelta, nextStreamReveal, visibleStreamText } from '../lib/stream'
 import ApprovalSheet from '../components/approvals/ApprovalSheet'
@@ -1056,6 +1057,8 @@ export default function ChatScreen({
         <RoutinesScreen />
       ) : activeView === 'connectors' ? (
         <ConnectorsScreen />
+      ) : activeView === 'shared' ? (
+        <SharedWorkspace onBack={() => onNavigate('chat')} personalMessages={messages.filter(message => !message.card_type)} />
       ) : (
       <main className="workspace flex min-w-0 flex-1 flex-col">
         <header className="workspace-header">

--- a/collie-ui/src/renderer/src/screens/SharedWorkspace.dom.test.tsx
+++ b/collie-ui/src/renderer/src/screens/SharedWorkspace.dom.test.tsx
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import SharedWorkspace from './SharedWorkspace'
+import type {
+  CollaborationBootstrap,
+  CollaborationFacade
+} from '../lib/collaboration'
+
+const roots: Root[] = []
+const session = {
+  id: 'session-1',
+  title: 'Project room',
+  organization_id: 'org-1',
+  status: 'active',
+  revision: 2,
+  members: [{ id: 'member-1', display_name: 'Owner' }]
+}
+const organization = {
+  id: 'org-1',
+  name: 'Acme',
+  members: [
+    { id: 'member-1', display_name: 'Owner' },
+    { id: 'member-2', display_name: 'Riley' }
+  ]
+}
+
+function bootstrap(
+  overrides: Partial<CollaborationBootstrap> = {}
+): CollaborationBootstrap {
+  return {
+    account: { id: 'member-1', display_name: 'Owner' },
+    organizations: [organization],
+    sessions: [session],
+    invites: [],
+    ...overrides
+  }
+}
+
+function facade(
+  initial: CollaborationBootstrap = bootstrap()
+): CollaborationFacade {
+  return {
+    bootstrap: vi.fn().mockResolvedValue(initial),
+    createOrganization: vi.fn().mockResolvedValue({}),
+    createSession: vi.fn().mockResolvedValue({ session }),
+    invite: vi.fn().mockResolvedValue({}),
+    acceptInvite: vi.fn().mockResolvedValue({}),
+    acceptOrganizationInvite: vi.fn().mockResolvedValue({}),
+    openSession: vi.fn().mockResolvedValue({ events: [] }),
+    sendMessage: vi.fn().mockResolvedValue({ events: [] }),
+    runPrivate: vi
+      .fn()
+      .mockResolvedValue({
+        draftId: 'draft-1',
+        sessionId: session.id,
+        content: 'Private answer',
+        state: 'ready'
+      }),
+    publishDraft: vi.fn().mockResolvedValue({}),
+    listPrivateDrafts: vi.fn().mockResolvedValue([]),
+    requestArchive: vi
+      .fn()
+      .mockResolvedValue({
+        archive: {
+          state: 'archive_pending',
+          pending_participants: [{ id: 'member-2', display_name: 'Riley' }]
+        }
+      }),
+    archiveStatus: vi.fn().mockResolvedValue({ state: 'archive_pending' }),
+    saveArchive: vi
+      .fn()
+      .mockResolvedValue({
+        state: 'archived_local',
+        local_path: 'C:\\archives\\room'
+      }),
+    exportArchive: vi.fn().mockResolvedValue({ path: 'room.zip' }),
+    importArchive: vi.fn().mockResolvedValue({}),
+    listLocalArchives: vi.fn().mockResolvedValue([]),
+    continueSession: vi
+      .fn()
+      .mockResolvedValue({
+        session: { ...session, id: 'session-2', status: 'active' }
+      }),
+    installSlack: vi.fn().mockResolvedValue({}),
+    linkSlackSender: vi.fn().mockResolvedValue({}),
+    slackSettings: vi.fn().mockResolvedValue({ installations: [] }),
+    selectSlackChannel: vi.fn().mockResolvedValue({}),
+    editMessage: vi.fn().mockResolvedValue({}),
+    deleteMessage: vi.fn().mockResolvedValue({}),
+    inviteOrganization: vi.fn().mockResolvedValue({}),
+    uploadFile: vi.fn().mockResolvedValue({}),
+    listFiles: vi.fn().mockResolvedValue({ files: [] }),
+    downloadFile: vi.fn().mockResolvedValue({}),
+    stopSessionRun: vi.fn().mockResolvedValue({}),
+    notifications: vi
+      .fn()
+      .mockResolvedValue({ notifications: [], next_cursor: 0 }),
+    ackNotifications: vi.fn().mockResolvedValue({}),
+    setRoutineDelivery: vi.fn().mockResolvedValue({}),
+    resolveReconciliation: vi.fn().mockResolvedValue({}),
+    revokeMember: vi.fn().mockResolvedValue({})
+  }
+}
+
+function render(api: CollaborationFacade): HTMLElement {
+  Object.defineProperty(window, 'account', {
+    configurable: true,
+    value: { collaboration: api }
+  })
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => root.render(<SharedWorkspace onBack={() => undefined} />))
+  return container
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+beforeAll(() => {
+  ;(
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+  Element.prototype.scrollIntoView = vi.fn()
+})
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  document.body.replaceChildren()
+})
+
+describe('SharedWorkspace collaboration states', () => {
+  it('keeps a policy requiring consent from granting access', async () => {
+    const api = facade(
+      bootstrap({
+        invites: [
+          {
+            id: 'invite-1',
+            kind: 'session',
+            status: 'pending',
+            inviter_name: 'Owner',
+            audience_policy: {
+              summary: 'Read existing history',
+              includes_existing_history: true
+            },
+            audience_policy_version: 3
+          }
+        ]
+      })
+    )
+    const container = render(api)
+    await settle()
+    const accept = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Accept')
+    ) as HTMLButtonElement
+    expect(accept.disabled).toBe(true)
+    const checkbox = container.querySelector(
+      'input[type="checkbox"]'
+    ) as HTMLInputElement
+    act(() => {
+      checkbox.click()
+    })
+    expect(accept.disabled).toBe(false)
+    act(() => {
+      accept.click()
+    })
+    await settle()
+    expect(api.acceptInvite).toHaveBeenCalledWith('invite-1', true, 3)
+  })
+
+  it('shows archive waiting participants and disables the composer', async () => {
+    const archived = { ...session, status: 'archive_pending' }
+    const api = facade(bootstrap({ sessions: [archived] }))
+    vi.mocked(api.openSession).mockResolvedValue({
+      events: [],
+      archive: {
+        state: 'archive_pending',
+        pending_participants: [{ id: 'member-2', display_name: 'Riley' }]
+      }
+    })
+    const container = render(api)
+    await settle()
+    const room = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Project room')
+    ) as HTMLButtonElement
+    act(() => {
+      room.click()
+    })
+    await settle()
+    expect(container.textContent).toContain('Waiting for Riley')
+    expect(
+      (
+        container.querySelector(
+          'textarea[aria-label="Shared message"]'
+        ) as HTMLTextAreaElement
+      ).disabled
+    ).toBe(true)
+  })
+
+  it.each(['active', 'closing'])(
+    'publishes an accepted private draft through publishDraft while %s',
+    async (status) => {
+      const api = facade(bootstrap({ sessions: [{ ...session, status }] }))
+      vi.mocked(api.listPrivateDrafts).mockResolvedValue([
+        {
+          draftId: 'draft-1',
+          runId: 'run-1',
+          sessionId: session.id,
+          content: 'Private answer',
+          state: 'ready'
+        }
+      ])
+      const container = render(api)
+      await settle()
+      const room = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.includes('Project room')
+      ) as HTMLButtonElement
+      act(() => {
+        room.click()
+      })
+      await settle()
+      const review = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.includes('Review saved result')
+      ) as HTMLButtonElement
+      act(() => {
+        review.click()
+      })
+      await settle()
+      const publish = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.includes('Publish reviewed result')
+      ) as HTMLButtonElement
+      act(() => {
+        publish.click()
+      })
+      await settle()
+      expect(api.publishDraft).toHaveBeenCalledWith('draft-1', 'Private answer')
+      expect(api.sendMessage).not.toHaveBeenCalled()
+    }
+  )
+
+  it('keeps the composer draft when local save fails', async () => {
+    const api = facade()
+    vi.mocked(api.sendMessage).mockRejectedValue(new Error('offline'))
+    const container = render(api)
+    await settle()
+    const room = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Project room')
+    ) as HTMLButtonElement
+    act(() => {
+      room.click()
+    })
+    await settle()
+    const composer = container.querySelector(
+      'textarea[aria-label="Shared message"]'
+    ) as HTMLTextAreaElement
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value'
+      )?.set
+      setter?.call(composer, 'Keep this draft')
+      composer.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const send = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Send')
+    ) as HTMLButtonElement
+    act(() => {
+      send.click()
+    })
+    await settle()
+    expect(api.sendMessage).toHaveBeenCalled()
+    expect(container.textContent).toContain('offline')
+    expect(composer.value).toBe('Keep this draft')
+  })
+})

--- a/collie-ui/src/renderer/src/screens/SharedWorkspace.tsx
+++ b/collie-ui/src/renderer/src/screens/SharedWorkspace.tsx
@@ -1,0 +1,1285 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Archive, Download, RefreshCw, Send, Users, X } from 'lucide-react'
+import {
+  canComposeSharedSession,
+  formatBytes,
+  sharedCollaboration,
+  sharedMessages,
+  type ArchiveStatus,
+  type CollaborationBootstrap,
+  type CollaborationEvent,
+  type CollaborationSession,
+  type SharedFile,
+  type SharedNotification
+} from '../lib/collaboration'
+import {
+  collieClient,
+  type LocalCollaborationEvent,
+  type CollieAutomation
+} from '../lib/ipc'
+import SharedMessageList from '../components/SharedMessageList'
+
+interface Props {
+  onBack: () => void
+  personalMessages?: Array<{ id: string; role: string; content: string }>
+}
+interface SavedArchive {
+  path: string
+  digest: string
+  manifest: {
+    session_id: string
+    events: LocalCollaborationEvent[]
+    recipients?: string[]
+  }
+}
+interface DraftResult {
+  draftId: string
+  sessionId: string
+  content: string
+  state: string
+}
+const lifecycle: Record<string, string> = {
+  active: 'Shared conversation',
+  closing: 'Closing · waiting for accepted work',
+  archive_pending: 'Waiting for verified local copies',
+  purging: 'Removing cloud content',
+  archived_local: 'Cloud copy removed · recover from a local archive'
+}
+const audiencePolicy = {
+  summary:
+    'Owners may invite additional participants who can read all published history.',
+  includes_existing_history: true
+}
+
+export default function SharedWorkspace({
+  onBack,
+  personalMessages = []
+}: Props): React.JSX.Element {
+  const [api] = useState(sharedCollaboration)
+  const [data, setData] = useState<CollaborationBootstrap>({})
+  const [orgId, setOrgId] = useState('')
+  const [orgName, setOrgName] = useState('')
+  const [active, setActive] = useState<CollaborationSession | null>(null)
+  const activeId = useRef<string | null>(null)
+  const [events, setEvents] = useState<CollaborationEvent[]>([])
+  const [files, setFiles] = useState<SharedFile[]>([])
+  const [syncError, setSyncError] = useState('')
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const [mentions, setMentions] = useState<Record<string, string[]>>({})
+  const [consents, setConsents] = useState<Record<string, boolean>>({})
+  const [notifications, setNotifications] = useState<SharedNotification[]>([])
+  const [notificationCursor, setNotificationCursor] = useState(0)
+  const [notice, setNotice] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [sending, setSending] = useState(false)
+  const [archive, setArchive] = useState<ArchiveStatus | null>(null)
+  const [archives, setArchives] = useState<SavedArchive[]>([])
+  const [offlineArchive, setOfflineArchive] = useState<SavedArchive | null>(
+    null
+  )
+  const [privateResult, setPrivateResult] = useState<DraftResult | null>(null)
+  const [savedDrafts, setSavedDrafts] = useState<DraftResult[]>([])
+  const [copyOpen, setCopyOpen] = useState(false)
+  const [copyIds, setCopyIds] = useState<string[]>([])
+  const [copyText, setCopyText] = useState('')
+  const [routines, setRoutines] = useState<CollieAutomation[] | null>(null)
+  const [routineId, setRoutineId] = useState('')
+  const [privateBusy, setPrivateBusy] = useState(false)
+  const [query, setQuery] = useState('')
+  const [slackOpen, setSlackOpen] = useState(false)
+  const [channelId, setChannelId] = useState('')
+  const [installations, setInstallations] = useState<
+    Array<{ installation_id: string; team_id: string; status: string }>
+  >([])
+  const [installationId, setInstallationId] = useState('')
+  const [editing, setEditing] = useState<CollaborationEvent | null>(null)
+  const [inviteAccount, setInviteAccount] = useState('')
+  const [inviteName, setInviteName] = useState('')
+  const [runningSession, setRunningSession] = useState<string | null>(null)
+  const mounted = useRef(true)
+  const refreshing = useRef(false)
+  const readableError = (error: unknown): string =>
+    error instanceof Error
+      ? error.message
+      : 'That did not work. Please try again.'
+
+  const refreshArchives = useCallback(async () => {
+    const local = await api.listLocalArchives()
+    if (mounted.current) setArchives(local as unknown as SavedArchive[])
+  }, [api])
+  const refresh = useCallback(async () => {
+    if (refreshing.current) return
+    refreshing.current = true
+    try {
+      const next = await api.bootstrap()
+      if (!mounted.current) return
+      setData(next)
+      setSyncError(next.sync_error || '')
+      setOrgId((current) => current || next.organizations?.[0]?.id || '')
+      setActive((current) =>
+        current
+          ? next.sessions?.find((session) => session.id === current.id) ||
+            current
+          : null
+      )
+      const recovered = await api.listPrivateDrafts()
+      if (mounted.current) setSavedDrafts(recovered)
+      const inbox = await api.notifications()
+      if (mounted.current) {
+        setNotifications(inbox.notifications || [])
+        setNotificationCursor(inbox.next_cursor)
+      }
+    } catch (error) {
+      if (mounted.current) setNotice(readableError(error))
+    } finally {
+      refreshing.current = false
+    }
+  }, [api])
+  useEffect(() => {
+    mounted.current = true
+    void refresh()
+    void refreshArchives().catch(() => undefined)
+    const visible = (): void => {
+      if (document.visibilityState === 'visible') void refresh()
+    }
+    const timer = window.setInterval(visible, 20000)
+    document.addEventListener('visibilitychange', visible)
+    return () => {
+      mounted.current = false
+      clearInterval(timer)
+      document.removeEventListener('visibilitychange', visible)
+    }
+  }, [refresh, refreshArchives])
+
+  const reconcile = useCallback(
+    async (session: CollaborationSession) => {
+      // Main reconciles paginated cloud events into its durable local materializer.
+      const result = await api.openSession(session.id)
+      if (!mounted.current || activeId.current !== session.id) return
+      setEvents(sharedMessages(result.events || [], session.members))
+      setFiles(result.files || [])
+      setSyncError(result.sync_error || '')
+      setActive((current) =>
+        current?.id === session.id &&
+        JSON.stringify(current.run_state) !== JSON.stringify(result.run_state)
+          ? { ...current, run_state: result.run_state }
+          : current
+      )
+      if (result.archive) setArchive(result.archive)
+    },
+    [api]
+  )
+  useEffect(() => {
+    if (!active || offlineArchive) return
+    let inFlight = false
+    const update = async (): Promise<void> => {
+      if (inFlight || document.visibilityState !== 'visible') return
+      inFlight = true
+      try {
+        await reconcile(active)
+      } catch (error) {
+        if (activeId.current === active.id) setNotice(readableError(error))
+      } finally {
+        inFlight = false
+      }
+    }
+    void update()
+    const timer = window.setInterval(() => void update(), 8000)
+    return () => clearInterval(timer)
+  }, [active, offlineArchive, reconcile])
+
+  const perform = async (
+    operation: () => Promise<unknown>,
+    success = ''
+  ): Promise<void> => {
+    setBusy(true)
+    setNotice('')
+    try {
+      await operation()
+      if (success) setNotice(success)
+    } catch (error) {
+      setNotice(readableError(error))
+    } finally {
+      setBusy(false)
+    }
+  }
+  const choose = (session: CollaborationSession): void => {
+    activeId.current = session.id
+    setActive(session)
+    setEvents([])
+    setFiles([])
+    setArchive(null)
+    setOfflineArchive(null)
+    setEditing(null)
+    setNotice('')
+  }
+  const openArchive = (saved: SavedArchive): void => {
+    activeId.current = null
+    setActive(null)
+    setOfflineArchive(saved)
+    setArchive(null)
+    setFiles([])
+    setSyncError('')
+    setEvents(sharedMessages(saved.manifest.events || []))
+    setNotice(
+      'This verified copy is available on this computer. Supabase cannot restore it after cloud deletion.'
+    )
+  }
+  const draft = active ? drafts[active.id] || '' : ''
+  const setDraft = (value: string): void => {
+    if (active) setDrafts((current) => ({ ...current, [active.id]: value }))
+  }
+  const writable = Boolean(
+    active && !offlineArchive && canComposeSharedSession(active.status)
+  )
+  const canPublishAccepted = Boolean(
+    active && !offlineArchive && ['active', 'closing'].includes(active.status)
+  )
+  const send = async (): Promise<void> => {
+    if (!active || !writable || !draft.trim() || sending) return
+    const session = active
+    const content = draft.trim()
+    setSending(true)
+    setNotice('')
+    try {
+      // Main persists first; only a successful local save permits clearing the composer.
+      const mentioned = (mentions[session.id] || []).filter((id) =>
+        session.members?.some(
+          (member) =>
+            member.id === id && content.includes(`@${member.display_name}`)
+        )
+      )
+      await api.sendMessage(session.id, content, session.revision, mentioned)
+      setMentions((current) => ({ ...current, [session.id]: [] }))
+      setDrafts((current) => ({
+        ...current,
+        [session.id]:
+          current[session.id]?.trim() === content ? '' : current[session.id]
+      }))
+      await reconcile(session)
+    } catch (error) {
+      setNotice(readableError(error))
+    } finally {
+      setSending(false)
+    }
+  }
+  const runPrivate = async (): Promise<void> => {
+    if (!active || !writable || !draft.trim() || privateBusy) return
+    const session = active
+    const content = draft.trim()
+    setPrivateBusy(true)
+    setRunningSession(session.id)
+    setNotice('')
+    try {
+      const result = await api.runPrivate(session.id, content)
+      setPrivateResult({
+        draftId: result.draftId,
+        sessionId: session.id,
+        content: result.content || '',
+        state: result.state || 'Review this private result before publishing.'
+      })
+      setDrafts((current) => ({ ...current, [session.id]: '' }))
+    } catch (error) {
+      setNotice(readableError(error))
+    } finally {
+      setPrivateBusy(false)
+      setRunningSession(null)
+    }
+  }
+  const publish = async (): Promise<void> => {
+    if (
+      !privateResult?.content ||
+      active?.id !== privateResult.sessionId ||
+      !canPublishAccepted
+    )
+      return
+    await perform(async () => {
+      await api.publishDraft(privateResult.draftId, privateResult.content)
+      setSavedDrafts((current) =>
+        current.filter((item) => item.draftId !== privateResult.draftId)
+      )
+      setPrivateResult(null)
+      await reconcile(active)
+    })
+  }
+  const saveArchive = async (): Promise<void> => {
+    if (!active) return
+    await perform(async () => {
+      setArchive(await api.saveArchive(active.id))
+      await refreshArchives()
+    }, 'Verified and saved on this computer. Other participants must verify their copies before cloud deletion.')
+  }
+  const selectedOrg = data.organizations?.find((org) => org.id === orgId)
+  const members = selectedOrg?.members || []
+  const matches = members.filter((member) =>
+    member.display_name.toLowerCase().includes(query.toLowerCase())
+  )
+  const currentPrivate =
+    privateResult?.sessionId === active?.id ? privateResult : null
+  const title = offlineArchive
+    ? 'Local archive'
+    : active?.title || 'Choose a shared conversation'
+  useEffect(() => {
+    if (!slackOpen || !active?.organization_id) return
+    let cancelled = false
+    void api
+      .slackSettings(active.organization_id)
+      .then((result) => {
+        if (cancelled) return
+        setInstallations(result.installations || [])
+        setInstallationId(
+          (current) =>
+            current || result.installations?.[0]?.installation_id || ''
+        )
+      })
+      .catch((error) => {
+        if (!cancelled) setNotice(readableError(error))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [api, slackOpen, active?.organization_id])
+
+  return (
+    <main className="shared-workspace">
+      <header className="shared-header">
+        <div>
+          <button className="settings-back" onClick={onBack}>
+            ← Back to local chat
+          </button>
+          <h1>
+            <Users size={22} /> Shared conversations
+          </h1>
+          <p>
+            Published content is visible to participants. Personal tools,
+            memory, and approvals stay private.
+          </p>
+        </div>
+        <button
+          className="settings-icon-button"
+          onClick={() => void refresh()}
+          aria-label="Refresh shared conversations"
+        >
+          <RefreshCw size={17} />
+        </button>
+      </header>
+      {notice && (
+        <div className="shared-notice" role="status">
+          {notice}
+        </div>
+      )}
+      {syncError && (
+        <div className="shared-notice" role="status">
+          Waiting to sync. Your saved local messages remain available.{' '}
+          {syncError}
+        </div>
+      )}
+      <div className="shared-grid">
+        <aside className="shared-list">
+          {!!data.invites?.length && (
+            <section className="shared-card">
+              <h2>Invitations</h2>
+              {data.invites.map((invite) => (
+                <div className="shared-invite" key={invite.id}>
+                  <span>{invite.inviter_name || 'Invitation'}</span>
+                  {invite.kind !== 'organization' && (
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={consents[invite.id] || false}
+                        onChange={(event) =>
+                          setConsents((current) => ({
+                            ...current,
+                            [invite.id]: event.target.checked
+                          }))
+                        }
+                      />
+                      {invite.audience_policy?.summary ||
+                        'Owners may invite additional participants who can read all published history.'}
+                    </label>
+                  )}
+                  <button
+                    disabled={
+                      busy ||
+                      (invite.kind !== 'organization' && !consents[invite.id])
+                    }
+                    className="settings-button"
+                    onClick={() =>
+                      void perform(async () => {
+                        if (invite.kind === 'organization')
+                          await api.acceptOrganizationInvite(invite.id)
+                        else
+                          await api.acceptInvite(
+                            invite.id,
+                            consents[invite.id] === true,
+                            invite.audience_policy_version || 1
+                          )
+                        await refresh()
+                      })
+                    }
+                  >
+                    Accept
+                  </button>
+                </div>
+              ))}
+            </section>
+          )}
+          {notifications.some((item) => !item.read_at) && (
+            <section className="shared-card">
+              <h2>Notifications</h2>
+              {notifications
+                .filter((item) => !item.read_at)
+                .map((item) => (
+                  <button
+                    className="shared-session"
+                    key={item.notification_id}
+                    onClick={() => {
+                      const session = data.sessions?.find(
+                        (row) => row.id === item.session_id
+                      )
+                      if (session) choose(session)
+                    }}
+                  >
+                    {item.kind === 'mention'
+                      ? 'You were mentioned'
+                      : 'Conversation invitation'}{' '}
+                    ·{' '}
+                    {data.sessions?.find((row) => row.id === item.session_id)
+                      ?.title || 'Shared conversation'}
+                  </button>
+                ))}
+              <button
+                className="settings-button"
+                onClick={() =>
+                  void perform(async () => {
+                    await api.ackNotifications(notificationCursor)
+                    await refresh()
+                  })
+                }
+              >
+                Mark as read
+              </button>
+            </section>
+          )}
+          <section className="shared-card">
+            <h2>Your organization</h2>
+            <select
+              value={orgId}
+              onChange={(event) => setOrgId(event.target.value)}
+              aria-label="Organization"
+            >
+              <option value="">Choose an organization</option>
+              {data.organizations?.map((org) => (
+                <option value={org.id} key={org.id}>
+                  {org.name}
+                </option>
+              ))}
+            </select>
+            <div className="shared-create-row">
+              <input
+                value={orgName}
+                onChange={(event) => setOrgName(event.target.value)}
+                placeholder="New organization name"
+                aria-label="New organization name"
+              />
+              <button
+                className="settings-button"
+                disabled={!orgName.trim() || busy}
+                onClick={() =>
+                  void perform(async () => {
+                    await api.createOrganization(orgName.trim())
+                    setOrgName('')
+                    await refresh()
+                  })
+                }
+              >
+                Create
+              </button>
+            </div>
+          </section>
+          <section className="shared-card">
+            <div className="shared-card-heading">
+              <h2>Conversations</h2>
+              <button
+                className="settings-button"
+                disabled={!orgId || busy}
+                onClick={() =>
+                  void perform(async () => {
+                    const result = await api.createSession(
+                      orgId,
+                      'New shared conversation'
+                    )
+                    await refresh()
+                    if (result.session) choose(result.session)
+                  })
+                }
+              >
+                New
+              </button>
+            </div>
+            {data.sessions
+              ?.filter((session) => session.organization_id === orgId)
+              .map((session) => (
+                <button
+                  className={`shared-session ${session.id === active?.id ? 'is-active' : ''}`}
+                  key={session.id}
+                  onClick={() => choose(session)}
+                >
+                  <span>{session.title || 'Archived conversation'}</span>
+                  <small>
+                    {lifecycle[session.status] || session.status}
+                    {session.unread ? ` · ${session.unread} unread` : ''}
+                  </small>
+                </button>
+              ))}
+          </section>
+          <section className="shared-card">
+            <h2>Invite to organization</h2>
+            <p>
+              Ask the person for the account ID shown in their shared workspace.
+            </p>
+            {data.account?.id && (
+              <small>Your account ID: {data.account.id}</small>
+            )}
+            <input
+              aria-label="Invitee account ID"
+              placeholder="Account ID"
+              value={inviteAccount}
+              onChange={(event) => setInviteAccount(event.target.value)}
+            />
+            <input
+              aria-label="Invitee display name"
+              placeholder="Their name"
+              value={inviteName}
+              onChange={(event) => setInviteName(event.target.value)}
+            />
+            <button
+              className="settings-button"
+              disabled={
+                !orgId || !inviteAccount.trim() || !inviteName.trim() || busy
+              }
+              onClick={() =>
+                void perform(async () => {
+                  await api.inviteOrganization(
+                    orgId,
+                    inviteAccount.trim(),
+                    inviteName.trim()
+                  )
+                  setInviteAccount('')
+                  setInviteName('')
+                }, 'Organization invitation sent. Conversation access requires a separate invitation.')
+              }
+            >
+              Invite person
+            </button>
+          </section>
+          <section className="shared-card">
+            <h2>Local archives</h2>
+            <button
+              className="settings-button"
+              disabled={busy}
+              onClick={() =>
+                void perform(async () => {
+                  await api.importArchive()
+                  await refreshArchives()
+                })
+              }
+            >
+              Import archive bundle
+            </button>
+            {archives.length ? (
+              archives.map((saved) => (
+                <button
+                  className="shared-session"
+                  key={saved.path}
+                  onClick={() => openArchive(saved)}
+                >
+                  <span>{saved.manifest.session_id}</span>
+                  <small>Verified local copy</small>
+                </button>
+              ))
+            ) : (
+              <p>No local archives on this computer.</p>
+            )}
+          </section>
+          <section className="shared-card">
+            <h2>Find people</h2>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search this organization"
+              aria-label="Search this organization"
+            />
+            {query &&
+              matches.map((member) => (
+                <div className="directory-row" key={member.id}>
+                  <span>{member.display_name}</span>
+                  <button
+                    className="settings-button"
+                    disabled={
+                      !writable ||
+                      busy ||
+                      active?.members?.some((item) => item.id === member.id)
+                    }
+                    onClick={() =>
+                      void perform(async () => {
+                        if (active)
+                          await api.invite(active.id, member.id, audiencePolicy)
+                      }, 'Invitation sent. History is available only after acceptance.')
+                    }
+                  >
+                    Invite
+                  </button>
+                </div>
+              ))}
+          </section>
+        </aside>
+        <section className="shared-card shared-chat">
+          <div className="shared-chat-heading">
+            <div>
+              <h2>{title}</h2>
+              {active && (
+                <>
+                  <p>{lifecycle[active.status] || active.status}</p>
+                    <div className="shared-participants" aria-label="Participants">
+                      {active.members?.map((member) => (
+                        <span className="shared-participant" key={member.id}>
+                          <span className="shared-avatar" aria-hidden="true">
+                            {member.display_name.slice(0, 1).toUpperCase()}
+                          </span>
+                          {member.display_name}
+                        </span>
+                      ))}
+                    </div>
+                    {active.members?.some(member => member.id === data.account?.id && member.role === 'owner') && active.status !== 'purging' && active.status !== 'archived_local' && (
+                      <details>
+                        <summary>Manage participants</summary>
+                        <p>Removing someone revokes cloud access and removes their archive-copy requirement. Existing local copies remain with them.</p>
+                        {active.members.filter(member => member.id !== data.account?.id).map(member => (
+                          <button key={member.id} className="settings-button" disabled={busy} onClick={() => void perform(async () => { await api.revokeMember(active.id, member.id); await refresh(); await reconcile(active) })}>
+                            Remove {member.display_name}'s access
+                          </button>
+                        ))}
+                      </details>
+                    )}
+                    {active.quota && (
+                    <small>
+                      Storage {formatBytes(active.quota.used_bytes)} /{' '}
+                      {formatBytes(active.quota.limit_bytes)} ·{' '}
+                      {active.quota.used_messages || 0} /{' '}
+                      {active.quota.limit_messages || 200} messages
+                    </small>
+                  )}
+                </>
+              )}
+            </div>
+            <div className="shared-actions">
+              {active && (
+                <>
+                  <button
+                    className="settings-button"
+                    onClick={() => setSlackOpen((value) => !value)}
+                  >
+                    Slack
+                  </button>
+                  <button
+                    className="settings-button"
+                    disabled={busy || active.status !== 'active'}
+                    onClick={() =>
+                      void perform(async () => {
+                        const result = await api.requestArchive(active.id)
+                        setArchive(result.archive || null)
+                        await refresh()
+                      })
+                    }
+                  >
+                    <Archive size={14} /> Archive
+                  </button>
+                  <button
+                    className="settings-button"
+                    disabled={
+                      busy ||
+                      !['archive_pending', 'purging'].includes(active.status)
+                    }
+                    onClick={() => void saveArchive()}
+                  >
+                    Save verified copy
+                  </button>
+                  {active.status !== 'active' && (
+                    <button
+                      className="settings-button"
+                      disabled={busy}
+                      onClick={() =>
+                        void perform(async () => {
+                          const result = await api.continueSession(active.id)
+                          await refresh()
+                          if (result.session) choose(result.session)
+                        })
+                      }
+                    >
+                      Start next conversation
+                    </button>
+                  )}
+                </>
+              )}
+              {(offlineArchive || archive?.local_path) && (
+                <button
+                  className="settings-button"
+                  disabled={busy}
+                  onClick={() =>
+                    void perform(() =>
+                      api.exportArchive(
+                        offlineArchive?.path || archive?.local_path || ''
+                      )
+                    )
+                  }
+                >
+                  <Download size={14} /> Export bundle
+                </button>
+              )}
+            </div>
+          </div>
+          {slackOpen && active && (
+            <section className="slack-settings">
+              <h3>Slack channel audience</h3>
+              <select
+                aria-label="Slack workspace"
+                value={installationId}
+                onChange={(event) => setInstallationId(event.target.value)}
+              >
+                <option value="">Choose a connected workspace</option>
+                {installations.map((item) => (
+                  <option
+                    key={item.installation_id}
+                    value={item.installation_id}
+                  >
+                    {item.team_id} · {item.status}
+                  </option>
+                ))}
+              </select>
+              <p>
+                Messages published here can be seen by the selected Slack
+                channel. Slack keeps its own history after Collie archives.
+                Every pilot participant must link their own desktop.
+              </p>
+              <button
+                className="settings-button"
+                disabled={busy}
+                onClick={() =>
+                  void perform(() => api.installSlack(active.organization_id))
+                }
+              >
+                Add to Slack
+              </button>
+              <button
+                className="settings-button"
+                disabled={busy}
+                onClick={() =>
+                  void perform(async () => {
+                    const result = await api.linkSlackSender(installationId)
+                    setNotice(
+                      result.message ||
+                        `Send @Collie link ${result.code} in Slack to verify your account.`
+                    )
+                  })
+                }
+              >
+                Link my Slack account
+              </button>
+              <label>
+                Selected channel ID
+                <input
+                  value={channelId}
+                  onChange={(event) => setChannelId(event.target.value)}
+                  placeholder="C…"
+                />
+              </label>
+              <button
+                className="settings-button"
+                disabled={!channelId || busy}
+                onClick={() =>
+                  void perform(
+                    () =>
+                      api.selectSlackChannel(
+                        active.organization_id,
+                        installationId,
+                        channelId
+                      ),
+                    'Selected channel updated.'
+                  )
+                }
+              >
+                Select channel
+              </button>
+            </section>
+          )}
+          {archive && (
+            <div className="archive-status" role="status">
+              <span>
+                {lifecycle[archive.state] || archive.state}
+                {archive.pending_participants?.length
+                  ? ` · Waiting for ${archive.pending_participants.map((member) => member.display_name).join(', ')}`
+                  : ''}
+              </span>
+              {archive.local_path && (
+                <small>Saved at {archive.local_path}</small>
+              )}
+            </div>
+          )}
+          {active?.run_state && (
+            <div className="shared-notice" role="status">
+              {active.run_state.status === 'queued'
+                ? 'Request queued · waiting for the requester’s computer'
+                : active.run_state.status === 'needs_reconciliation'
+                  ? 'Request paused · external actions need review before retry'
+                  : 'Request in progress · private work stays with the requester'}
+              {(active.run_state.requested_by === data.account?.id ||
+                active.members?.some(
+                  (member) =>
+                    member.id === data.account?.id && member.role === 'owner'
+                )) && (
+                <button
+                  className="settings-button"
+                  disabled={busy}
+                  onClick={() =>
+                    void perform(
+                      () => api.stopSessionRun(active.id),
+                      'Request stopped.'
+                    )
+                  }
+                >
+                  Stop request
+                </button>
+              )}
+            </div>
+          )}
+          {active?.run_state?.status === 'needs_reconciliation' &&
+            active.run_state.requested_by === data.account?.id && (
+              <section className="shared-card">
+                <p>
+                  Check your local tool activity and any external changes before
+                  trying again. This does not undo actions already performed.
+                </p>
+                <button
+                  className="settings-button"
+                  disabled={busy}
+                  onClick={() =>
+                    void perform(async () => {
+                      await api.resolveReconciliation(active.run_state!.run_id)
+                      await reconcile(active)
+                    }, 'Previous request closed. You can submit a new request.')
+                  }
+                >
+                  I reviewed the actions; close this request
+                </button>
+              </section>
+            )}
+          {active && writable && (
+            <button
+              className="settings-button"
+              disabled={busy}
+              onClick={() =>
+                void perform(async () => {
+                  await api.uploadFile(
+                    active.id,
+                    active.revision || 1,
+                    active.membership_revision || 1
+                  )
+                  await reconcile(active)
+                })
+              }
+            >
+              Share a file from this computer
+            </button>
+          )}
+          {active && files.length > 0 && (
+            <section className="shared-files" aria-label="Shared files">
+              {files.map((file) => (
+                <div className="directory-row" key={file.file_id}>
+                  <span>
+                    {file.name} · {formatBytes(file.byte_length)}
+                  </span>
+                  <button
+                    className="settings-button"
+                    disabled={busy}
+                    onClick={() =>
+                      void perform(() =>
+                        api.downloadFile(active.id, file.file_id)
+                      )
+                    }
+                  >
+                    <Download size={14} /> Save copy
+                  </button>
+                </div>
+              ))}
+            </section>
+          )}
+          {runningSession && (
+            <button
+              className="settings-button is-danger"
+              onClick={() =>
+                void perform(
+                  () => api.stopSessionRun(runningSession),
+                  'Stopped. Review any external actions before retrying.'
+                )
+              }
+            >
+              Stop my running request
+            </button>
+          )}
+          <SharedMessageList
+            events={events}
+            readOnly={!writable}
+            viewerId={data.account?.id}
+            onEdit={setEditing}
+          />
+          {editing && active && writable && (
+            <section className="shared-card">
+              <label>
+                Edit your published message
+                <textarea
+                  value={editing.content}
+                  onChange={(event) =>
+                    setEditing({ ...editing, content: event.target.value })
+                  }
+                />
+              </label>
+              <button
+                className="settings-button"
+                disabled={busy || !editing.content.trim()}
+                onClick={() =>
+                  void perform(async () => {
+                    await api.editMessage(
+                      active.id,
+                      editing.id,
+                      editing.content,
+                      editing.revision || 1
+                    )
+                    setEditing(null)
+                    await reconcile(active)
+                  })
+                }
+              >
+                Save edit
+              </button>
+              <button
+                className="settings-button is-danger"
+                disabled={busy}
+                onClick={() =>
+                  void perform(async () => {
+                    await api.deleteMessage(
+                      active.id,
+                      editing.id,
+                      editing.revision || 1
+                    )
+                    setEditing(null)
+                    await reconcile(active)
+                  })
+                }
+              >
+                Remove this message for participants
+              </button>
+              <button
+                className="settings-button"
+                onClick={() => setEditing(null)}
+              >
+                Cancel
+              </button>
+            </section>
+          )}
+          {active &&
+            savedDrafts
+              .filter(
+                (item) =>
+                  item.sessionId === active.id &&
+                  item.draftId !== currentPrivate?.draftId
+              )
+              .map((item) => (
+                <div className="shared-notice" key={item.draftId}>
+                  <span>
+                    Private result saved on this computer ·{' '}
+                    {item.state === 'lease_lost'
+                      ? 'Previous request expired; review before starting again.'
+                      : 'Ready to review'}
+                  </span>
+                  <button
+                    className="settings-button"
+                    onClick={() => setPrivateResult(item)}
+                  >
+                    Review saved result
+                  </button>
+                </div>
+              ))}
+          {writable && (
+            <button
+              className="settings-button"
+              onClick={() =>
+                void perform(async () => {
+                  setRoutines((await collieClient.listRoutines()).routines)
+                })
+              }
+            >
+              Routine delivery…
+            </button>
+          )}
+          {routines && active && (
+            <section className="shared-card">
+              <h3>Publish future routine results</h3>
+              <p>
+                The routine uses your model and tools. Its future result text
+                will be published automatically to{' '}
+                {active.members
+                  ?.map((member) => member.display_name)
+                  .join(', ')}
+                . Tool logs remain private. Audience changes pause delivery
+                until you authorize it again.
+              </p>
+              <select
+                aria-label="Your routine"
+                value={routineId}
+                onChange={(event) => setRoutineId(event.target.value)}
+              >
+                <option value="">Choose your routine</option>
+                {routines.map((routine) => (
+                  <option key={routine.id} value={routine.id}>
+                    {routine.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                className="settings-button"
+                disabled={!routineId || busy || !writable}
+                onClick={() =>
+                  void perform(
+                    () =>
+                      api.setRoutineDelivery(
+                        routineId,
+                        active.id,
+                        active.membership_revision
+                      ),
+                    'Future routine results will be published to this audience.'
+                  )
+                }
+              >
+                Authorize future result publication
+              </button>
+              <button
+                className="settings-button"
+                disabled={!routineId || busy}
+                onClick={() =>
+                  void perform(
+                    () => api.setRoutineDelivery(routineId, null),
+                    'Shared routine delivery disabled.'
+                  )
+                }
+              >
+                Disable shared delivery
+              </button>
+              <button
+                className="settings-button"
+                onClick={() => setRoutines(null)}
+              >
+                Close
+              </button>
+            </section>
+          )}
+          {writable && personalMessages.length > 0 && (
+            <button
+              className="settings-button"
+              onClick={() => {
+                setCopyOpen(true)
+                setCopyIds([])
+                setCopyText('')
+              }}
+            >
+              Share selected local messages…
+            </button>
+          )}
+          {copyOpen && active && writable && (
+            <section className="shared-card">
+              <h3>Review a copy for this audience</h3>
+              <p>
+                {active.members
+                  ?.map((member) => member.display_name)
+                  .join(', ')}{' '}
+                can read the published copy. Select message text, then review it
+                below. Attachments and tool logs are excluded.
+              </p>
+              {personalMessages.map((message) => (
+                <label className="shared-copy-choice" key={message.id}>
+                  <input
+                    type="checkbox"
+                    checked={copyIds.includes(message.id)}
+                    onChange={(event) => {
+                      const ids = event.target.checked
+                        ? [...copyIds, message.id]
+                        : copyIds.filter((id) => id !== message.id)
+                      setCopyIds(ids)
+                      setCopyText(
+                        personalMessages
+                          .filter((item) => ids.includes(item.id))
+                          .map(
+                            (item) =>
+                              `${item.role === 'user' ? 'Me' : 'Collie'}: ${item.content}`
+                          )
+                          .join('\n\n')
+                      )
+                    }}
+                  />
+                  <span>
+                    {message.role === 'user' ? 'Me' : 'Collie'}:{' '}
+                    {message.content.slice(0, 160)}
+                  </span>
+                </label>
+              ))}
+              <label>
+                Approved copy
+                <textarea
+                  value={copyText}
+                  onChange={(event) => setCopyText(event.target.value)}
+                />
+              </label>
+              <button
+                className="settings-button"
+                disabled={busy || !copyText.trim()}
+                onClick={() =>
+                  void perform(async () => {
+                    await api.sendMessage(active.id, copyText, active.revision)
+                    setCopyOpen(false)
+                    await reconcile(active)
+                  })
+                }
+              >
+                Publish this reviewed copy
+              </button>
+              <button
+                className="settings-button"
+                onClick={() => setCopyOpen(false)}
+              >
+                Cancel
+              </button>
+            </section>
+          )}
+          {currentPrivate && (
+            <aside className="private-result-drawer">
+              <div>
+                <strong>Private result · visible only to you</strong>
+                <button
+                  className="settings-icon-button"
+                  aria-label="Close private result"
+                  onClick={() => setPrivateResult(null)}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+              <p>{currentPrivate.state}</p>
+              <label>
+                Review what to publish
+                <textarea
+                  value={currentPrivate.content}
+                  onChange={(event) =>
+                    setPrivateResult({
+                      ...currentPrivate,
+                      content: event.target.value
+                    })
+                  }
+                />
+              </label>
+              <button
+                className="settings-button"
+                disabled={
+                  !currentPrivate.content ||
+                  busy ||
+                  !canPublishAccepted ||
+                  currentPrivate.state === 'lease_lost'
+                }
+                onClick={() => void publish()}
+              >
+                Publish reviewed result to these participants
+              </button>
+            </aside>
+          )}
+          {active && (
+            <div className="shared-composer">
+              <div className="shared-input-wrap">
+                <textarea
+                  value={draft}
+                  disabled={!writable}
+                  onChange={(event) => setDraft(event.target.value)}
+                  placeholder={
+                    writable
+                      ? 'Write for this audience…'
+                      : 'This conversation is read-only.'
+                  }
+                  aria-label="Shared message"
+                />
+                {writable && /@[^\s]*$/.test(draft) && (
+                  <div className="mention-picker">
+                    {members
+                      .filter((member) =>
+                        member.display_name
+                          .toLowerCase()
+                          .includes(draft.split('@').pop()!.toLowerCase())
+                      )
+                      .map((member) => (
+                        <button
+                          key={member.id}
+                          onClick={() => {
+                            if (
+                              active.members?.some(
+                                (item) => item.id === member.id
+                              )
+                            ) {
+                              setDraft(
+                                draft.replace(
+                                  /@[^\s]*$/,
+                                  `@${member.display_name} `
+                                )
+                              )
+                              setMentions((current) => ({
+                                ...current,
+                                [active.id]: [
+                                  ...new Set([
+                                    ...(current[active.id] || []),
+                                    member.id
+                                  ])
+                                ]
+                              }))
+                            } else {
+                              setQuery(member.display_name)
+                              setNotice(
+                                'This person is not a participant. Use Invite to share history with them.'
+                              )
+                            }
+                          }}
+                        >
+                          @{member.display_name}
+                          {active.members?.some((item) => item.id === member.id)
+                            ? ''
+                            : ' · invite first'}
+                        </button>
+                      ))}
+                  </div>
+                )}
+              </div>
+              <button
+                className="settings-button"
+                disabled={!writable || !draft.trim() || privateBusy}
+                onClick={() => void runPrivate()}
+              >
+                {privateBusy ? 'Running privately…' : 'Ask my Collie privately'}
+              </button>
+              <button
+                className="settings-button is-primary"
+                disabled={!writable || !draft.trim() || sending}
+                onClick={() => void send()}
+              >
+                <Send size={14} /> {sending ? 'Saving…' : 'Send'}
+              </button>
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/collie-ui/src/renderer/src/styles/globals.css
+++ b/collie-ui/src/renderer/src/styles/globals.css
@@ -167,6 +167,67 @@ body {
   overflow: hidden;
 }
 
+/* Shared conversations remain visually separate from private local chat so
+   audience and sync state are always obvious. */
+.shared-workspace { display: flex; min-width: 0; flex: 1; flex-direction: column; overflow: auto; background: var(--collie-bg); }
+.shared-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 24px 30px 18px; border-bottom: 1px solid var(--collie-border); background: var(--collie-surface); }
+.shared-header h1 { display: flex; align-items: center; gap: 9px; margin: 12px 0 4px; font-size: 1.35rem; letter-spacing: -0.03em; }
+.shared-header p { max-width: 650px; margin: 0; color: var(--collie-text-muted); font-size: .82rem; }
+.shared-grid { display: grid; grid-template-columns: minmax(250px, 340px) minmax(0, 1fr); gap: 18px; width: min(1180px, 100%); margin: 0 auto; padding: 20px 24px 34px; }
+.shared-list { display: grid; align-content: start; gap: 14px; }
+.shared-card { border: 1px solid var(--collie-border); border-radius: 14px; background: var(--collie-surface); box-shadow: var(--shadow-sm); padding: 15px; }
+.shared-card h2 { margin: 0; font-size: .88rem; }
+.shared-card-heading, .shared-chat-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.shared-session { display: grid; width: 100%; gap: 4px; margin-top: 8px; padding: 10px; border: 1px solid transparent; border-radius: 10px; text-align: left; }
+.shared-session:hover, .shared-session.is-active { border-color: var(--collie-border); background: color-mix(in srgb, var(--collie-amber) 10%, var(--collie-surface)); }
+.shared-session-title { overflow: hidden; font-size: .82rem; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+.shared-org-select, .shared-create-row input { width: 100%; margin-top: 9px; border: 1px solid var(--collie-border); border-radius: 8px; padding: 8px; background: var(--collie-bg); color: var(--collie-text); font-size: .77rem; }
+.shared-create-row { display: flex; align-items: center; gap: 7px; }
+.shared-create-row input { min-width: 0; margin-top: 8px; }
+.shared-continue-fab { position: sticky; right: 20px; bottom: 20px; align-self: flex-end; margin: 0 20px 20px; }
+.shared-session small, .directory-row small, .shared-event-meta span, .shared-event small { color: var(--collie-text-muted); font-size: .7rem; }
+.sync-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--collie-amber); }
+.sync-dot[data-status='synced'] { background: #5e9c6a; }
+.shared-search { display: flex; align-items: center; gap: 7px; margin-top: 10px; padding: 8px 9px; border: 1px solid var(--collie-border); border-radius: 9px; color: var(--collie-text-muted); }
+.shared-search input { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; color: var(--collie-text); font-size: .78rem; }
+.directory-row, .shared-invite { display: flex; align-items: center; gap: 8px; margin-top: 8px; font-size: .76rem; }
+.directory-row span, .shared-invite span { min-width: 0; flex: 1; }
+.directory-row small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shared-chat { display: flex; min-height: 560px; flex-direction: column; }
+.shared-chat-heading h2 { margin: 0; font-size: 1.05rem; }
+.shared-chat-heading p { display: flex; align-items: center; gap: 5px; margin: 5px 0 0; color: var(--collie-text-muted); font-size: .75rem; }
+.shared-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 7px; }
+.shared-events { min-height: 0; flex: 1; overflow: auto; margin: 15px -2px; padding: 4px 2px; }
+.shared-events:not(.shared-events-reusable) { display: none; }
+.message-attribution { display: flex; justify-content: flex-start; gap: 8px; margin: 0 auto 3px; max-width: 760px; color: var(--collie-text-muted); font-size: .68rem; }
+.message-attribution.is-user { justify-content: flex-end; }
+.message-sync-status.is-synced { color: #5e9c6a; }
+.message-sync-status.is-error { color: var(--collie-snoot); }
+.shared-event { max-width: 760px; margin: 0 auto 14px; padding: 11px 13px; border: 1px solid var(--collie-border); border-radius: 11px; background: color-mix(in srgb, var(--collie-bg) 62%, var(--collie-surface)); }
+.shared-event-meta { display: flex; justify-content: space-between; gap: 10px; font-size: .77rem; }
+.shared-event p { margin: 7px 0; white-space: pre-wrap; font-size: .87rem; line-height: 1.5; }
+.shared-composer { display: flex; gap: 8px; padding-top: 12px; border-top: 1px solid var(--collie-border); }
+.shared-input-wrap { position: relative; min-width: 0; flex: 1; }
+.shared-composer input { min-width: 0; flex: 1; border: 1px solid var(--collie-border); border-radius: 9px; padding: 10px 11px; background: var(--collie-bg); color: var(--collie-text); outline: 0; }
+.shared-input-wrap input { width: 100%; }
+.mention-picker { position: absolute; right: 0; bottom: calc(100% + 6px); left: 0; display: grid; gap: 2px; max-height: 170px; overflow: auto; padding: 5px; border: 1px solid var(--collie-border); border-radius: 9px; background: var(--collie-surface); box-shadow: var(--shadow-md); }
+.mention-picker button { padding: 7px 9px; border-radius: 6px; color: var(--collie-text); text-align: left; font-size: .76rem; }
+.mention-picker button:hover { background: color-mix(in srgb, var(--collie-amber) 12%, var(--collie-surface)); }
+.quota-line { display: block; margin-top: 4px; color: var(--collie-text-muted); font-size: .69rem; }
+.shared-empty { display: grid; flex: 1; align-content: center; justify-items: center; gap: 8px; color: var(--collie-text-muted); text-align: center; }
+.shared-empty h2 { margin: 0; color: var(--collie-text); font-size: 1rem; }
+.shared-empty p { max-width: 370px; margin: 0; font-size: .82rem; }
+.shared-notice, .archive-status, .slack-settings { display: flex; align-items: center; gap: 8px; margin: 14px auto 0; width: min(1120px, calc(100% - 48px)); padding: 10px 12px; border: 1px solid var(--collie-border); border-radius: 10px; color: var(--collie-text-muted); font-size: .78rem; }
+.archive-status { margin: 12px 0 0; justify-content: space-between; }
+.slack-settings { display: block; margin: 14px 0 0; background: color-mix(in srgb, var(--collie-amber) 7%, var(--collie-surface)); }
+.slack-settings h3 { display: flex; align-items: center; gap: 6px; margin: 0 0 5px; font-size: .82rem; }
+.slack-settings p { margin: 0 0 9px; font-size: .75rem; }
+.private-result-drawer { margin: 12px 0 0; padding: 12px; border: 1px solid color-mix(in srgb, var(--collie-amber) 45%, var(--collie-border)); border-radius: 10px; background: color-mix(in srgb, var(--collie-amber) 7%, var(--collie-surface)); }
+.private-result-drawer > div { display: flex; align-items: center; justify-content: space-between; }
+.private-result-drawer p { margin: 6px 0; color: var(--collie-text-muted); font-size: .75rem; }
+.private-result-drawer pre { max-height: 220px; overflow: auto; margin: 8px 0 10px; padding: 9px; border-radius: 7px; background: var(--collie-bg); white-space: pre-wrap; font: .8rem/1.45 var(--font-sans); }
+@media (max-width: 900px) { .shared-grid { grid-template-columns: 1fr; } .shared-chat { min-height: 520px; } }
+
 .onboarding-shell {
   background:
     radial-gradient(circle at 50% 0%, rgba(232, 145, 58, 0.13), transparent 34%),
@@ -3692,3 +3753,10 @@ button {
 
 .routine-timezone { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin: 8px 0; color: var(--muted); font-size: .75rem; }
 .routine-timezone select, .form-field select { max-width: 100%; border: 1px solid var(--line); border-radius: 8px; padding: 5px 8px; background: var(--collie-surface); color: var(--ink); font: inherit; }
+.shared-workspace textarea { width: 100%; min-height: 72px; resize: vertical; border: 1px solid var(--border-color, #d9d9d9); border-radius: 10px; padding: 10px; background: var(--surface-color, transparent); color: inherit; }
+.shared-workspace select, .shared-card > input { width: 100%; margin-block: 6px; padding: 8px; border-radius: 8px; color: inherit; background: transparent; border: 1px solid var(--border-color, #d9d9d9); }
+.shared-card > small { display: block; overflow-wrap: anywhere; }
+.private-result-drawer textarea { min-height: 140px; }
+.shared-workspace button:disabled { opacity: .5; cursor: not-allowed; }
+.shared-copy-choice { display: flex; align-items: start; gap: 8px; margin: 8px 0; overflow-wrap: anywhere; } .shared-copy-choice input { flex: 0 0 auto; }
+.shared-participants { display: flex; flex-wrap: wrap; gap: 10px; margin: 8px 0; } .shared-participant { display: inline-flex; align-items: center; gap: 5px; color: var(--muted); font-size: .75rem; } .shared-avatar { display: inline-grid; place-items: center; width: 22px; height: 22px; border-radius: 50%; background: var(--paper-deep); color: var(--ink); }

--- a/collie-ui/src/shared/collaboration.ts
+++ b/collie-ui/src/shared/collaboration.ts
@@ -1,0 +1,125 @@
+export interface SharedSessionEvent {
+  event_id: string
+  session_id: string
+  kind: 'message' | 'edit' | 'delete'
+  message_id: string
+  role: 'user' | 'assistant' | 'system'
+  content: string
+  revision?: number
+  seq?: number
+  created_at?: string
+  author_id?: string
+  request_run?: boolean
+  expected_revision?: number
+  mentioned_user_ids?: string[]
+  publication_kind?: 'routine_result'
+  routine_id?: string
+  audience_revision?: number
+}
+
+export interface SharedAudiencePolicy {
+  summary: string
+  includes_existing_history: boolean
+}
+
+export interface SharedSessionStatus {
+  available: boolean
+  cursor: number
+  pending: SharedSessionEvent[]
+  archives: Array<Record<string, unknown>>
+}
+
+export interface SharedDraft {
+  draftId: string
+  runId: string
+  content: string
+  state: string
+}
+
+export interface StoredSharedDraft extends SharedDraft {
+  sessionId: string
+  state: 'ready_for_review' | 'lease_lost'
+}
+
+export interface CollaborationBridge {
+  bootstrap(): Promise<unknown>
+  createOrganization(name: string): Promise<unknown>
+  inviteOrganization(
+    organizationId: string,
+    userId: string,
+    displayName: string
+  ): Promise<unknown>
+  acceptOrganizationInvite(inviteId: string): Promise<unknown>
+  directory(organizationId: string, query: string): Promise<unknown>
+  createSession(organizationId: string, title: string): Promise<unknown>
+  invite(
+    sessionId: string,
+    memberId: string,
+    audiencePolicy: SharedAudiencePolicy
+  ): Promise<unknown>
+  acceptInvite(
+    inviteId: string,
+    audienceConsent: boolean,
+    policyVersion: number
+  ): Promise<unknown>
+  openSession(sessionId: string): Promise<unknown>
+  sendMessage(
+    sessionId: string,
+    content: string,
+    expectedRevision?: number,
+    mentionedUserIds?: string[]
+  ): Promise<unknown>
+  editMessage(
+    sessionId: string,
+    messageId: string,
+    content: string,
+    expectedRevision: number
+  ): Promise<unknown>
+  deleteMessage(
+    sessionId: string,
+    messageId: string,
+    expectedRevision: number
+  ): Promise<unknown>
+  uploadFile(
+    sessionId: string,
+    expectedSessionRevision: number,
+    membershipRevision: number
+  ): Promise<unknown>
+  listFiles(sessionId: string): Promise<unknown>
+  downloadFile(sessionId: string, fileId: string): Promise<unknown>
+  runPrivate(sessionId: string, content: string): Promise<SharedDraft>
+  publishDraft(draftId: string, content: string): Promise<unknown>
+  listPrivateDrafts(): Promise<StoredSharedDraft[]>
+  stopSessionRun(sessionId: string): Promise<unknown>
+  resolveReconciliation(runId: string): Promise<unknown>
+  requestArchive(sessionId: string): Promise<unknown>
+  archiveStatus(sessionId: string): Promise<unknown>
+  saveArchive(sessionId: string): Promise<unknown>
+  exportArchive(
+    archivePath: string
+  ): Promise<{ canceled: boolean; path?: string }>
+  importArchive(): Promise<{ canceled: boolean; archive?: unknown }>
+  listLocalArchives(): Promise<Array<Record<string, unknown>>>
+  continueSession(sessionId: string, title?: string): Promise<unknown>
+  revokeMember(sessionId: string, memberId: string): Promise<unknown>
+  installSlack(organizationId: string): Promise<{ opened: boolean }>
+  linkSlackSender(installationId: string): Promise<unknown>
+  selectSlackChannel(
+    organizationId: string,
+    installationId: string,
+    channelId: string
+  ): Promise<unknown>
+  notifications(cursor?: number): Promise<unknown>
+  ackNotifications(through: number): Promise<unknown>
+  setRoutineDelivery(
+    routineId: string,
+    sessionId: string | null,
+    audienceRevision?: number
+  ): Promise<unknown>
+  slackSettings(organizationId: string): Promise<unknown>
+  linkSlackChannel(
+    sessionId: string,
+    installationId: string,
+    channelId: string
+  ): Promise<unknown>
+}

--- a/collie-ui/tsconfig.web.json
+++ b/collie-ui/tsconfig.web.json
@@ -15,5 +15,5 @@
       "@/*": ["./src/renderer/src/*"]
     }
   },
-  "include": ["src/renderer/src/**/*", "src/preload/index.d.ts", "src/shared/feedback.ts"]
+  "include": ["src/renderer/src/**/*", "src/preload/index.d.ts", "src/shared/feedback.ts", "src/shared/collaboration.ts"]
 }

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -82,6 +82,18 @@ the existing Supabase project and notifies the team through Resend; server
 credentials remain in Worker secrets. See [in-app feedback](product/feedback.md)
 for deployment ownership and the live verification gate.
 
+### Shared conversations
+
+`collie-core/collie_core/collaboration/` owns durable local shared-event storage
+and verified local archives. Electron main owns authenticated collaboration
+transport; the renderer receives product data without account tokens.
+`supabase/migrations/` owns membership, canonical event order, requester device
+leases, quota reservations, and archive receipts. `supabase/functions/` owns
+Slack OAuth, signed event intake, and bounded workers. See
+[shared session authority and recovery](engineering/architecture/shared-sessions.md)
+for privacy boundaries and release gates. An offline participant blocks cloud
+purge until their durable archive is verified.
+
 ## Primary data flow
 
 ```text

--- a/docs/engineering/architecture/account-cloud-sync.md
+++ b/docs/engineering/architecture/account-cloud-sync.md
@@ -9,6 +9,11 @@
 
 ## 1. Product rules (the promises we make users)
 
+Opt-in [shared sessions](shared-sessions.md) use a separate coordination service
+for explicitly published conversation content. This snapshot feature continues
+to exclude conversations, plans, and approvals; enabling one feature does not
+enable the other.
+
 1. **Opt-in only.** Sync is OFF by default. The toggle lives in
    Settings → Account, next to the sign-in state, in plain language.
 2. **Per-device snapshots.** Each computer uploads its own snapshot under its

--- a/docs/engineering/architecture/account-system-spec.md
+++ b/docs/engineering/architecture/account-system-spec.md
@@ -5,6 +5,9 @@
 > Amendment (2026-08-22): opt-in per-device backup of memory/personality is
 > now specified in `account-cloud-sync.md` — narrowing the "no sync" non-goal
 > below to conversations/plans/approvals only.
+> Amendment (2026-09-09): opt-in shared sessions are a separate, gated exception
+> for explicitly published conversation content. They do not synchronize private
+> conversations or approvals. See [shared session authority](shared-sessions.md).
 
 ## 1. Goals / Non-goals
 

--- a/docs/engineering/architecture/shared-sessions.md
+++ b/docs/engineering/architecture/shared-sessions.md
@@ -1,0 +1,152 @@
+# Shared session authority and recovery
+
+**Status:** implemented behind disabled release flags; two-computer and Slack pilot gates remain open.
+
+The [implementation plan](../../product/features/shared-sessions-implementation-plan.md)
+defines the acceptance contract. The desktop remains usable without an account.
+Opting into a shared session publishes selected content to a managed coordination
+service; this is separate from personal cloud snapshot backup.
+
+## Ownership
+
+- `supabase/migrations/` owns collaboration authority, membership, ordered events,
+  quota reservations, device leases, archive receipts, and Slack coordination.
+- `supabase/functions/` owns signed Slack intake, encrypted installation credentials,
+  OAuth callbacks, bounded delivery workers, and object purge orchestration.
+- `collie-core/collie_core/collaboration/` owns local outbox and materialization,
+  stable archives, manifest verification, and requester execution isolation.
+- Electron main owns authenticated transport and protected account credentials.
+  Preload exposes specific product operations. Renderer input is never evidence
+  of authenticated account identity, run ownership, or a verified local archive.
+
+## Authority and publication
+
+Organization membership permits directory discovery. Only accepted session
+membership permits transcript access. Author identity comes from authentication;
+membership, expected revision, quota, and lifecycle checks run on every command.
+An immutable event ID can be retried with the same payload. Reusing an ID with a
+different payload fails. Polling/realtime wakeups initiate durable cursor reads;
+they never replace ordered history.
+
+A request belongs to its author. Session ownership grants no use of another
+person's model, tools, approvals, or credentials. A device claim carries a fence,
+audience revision, and published context cutoff. Private computation and permission
+prompts remain local. Reading private data and publishing its result are separate
+decisions. Offline execution is shown as waiting, never delegated to a participant
+whose credentials happen to be available.
+
+## Feature coverage and validation boundaries
+
+Shared execution uses the requester's installed model, credentials, permissions,
+and tools. The desktop starts private-result work and requires separate review
+before publishing its result. Shared-safe context is also available in core; it
+uses canonical history and excludes personal context sources.
+
+| Capability | Implemented path | Validation boundary |
+|---|---|---|
+| Models and payer | Requester-owned execution, credential-owner context, server-derived requester identity. | Hosted provider/device acceptance remains required. |
+| Tools, connectors, files and skills | Private-result execution retains the requester's registry and permission broker; tool traces are not published. | Individual provider/connector credentials are not exercised by synthetic tests. |
+| Memory and context | Shared-safe prompts omit private bootstrap/history/memory; private-result prompts may use requester context. Automatic shared-history ingestion is excluded. | Local sentinel tests cover context separation; two-device acceptance remains required. |
+| Subagents and continuations | Requester/audience metadata propagates to child execution. Children are cancelled and drained when the parent is fenced. | Local context and regression tests; hosted interruption acceptance remains required. |
+| Plans and approvals | Existing local approval UI remains requester-private; core validates identity, action and local lease deadline. | Actual device permission and approval flows remain pilot gates. |
+| Routines | Optional creator-bound delivery stores the approved audience revision, queues immutable result events, and publishes through authenticated quota checks. The UI separately authorizes future result publication. | Offline/revocation delivery behavior is covered locally; real scheduled delivery remains a pilot gate. |
+| Versioned shared files | Native explicit upload, reserved byte limits, server-verified hashes, private member downloads, and manifest inclusion. | Local SQL/Edge tests; hosted Storage acceptance remains required. |
+| Stop, retry and result review | Leased requester pickup, cancellation, durable outbox retries, encrypted recoverable drafts, and explicit publication. | Local tests and static review; two-computer lease/reconnect acceptance remains required. |
+| Archives | Atomic durable save, read-back/hash verification, import/export, receipt-gated purge, and retryable object cleanup. | Local corruption/SQL/worker checks; hosted purge acceptance remains required. |
+
+A routine remains owned by its creator. Shared delivery does not grant other
+participants access to its tools or credentials. Audience changes reject delivery
+until reauthorized; delivery status is separate from private routine execution.
+
+## Archive invariants
+
+Archival progresses through `active`, `closing`, `archive_pending`, `purging`, and
+`archived_local`. Closing rejects new submissions and waits for accepted work.
+The final manifest freezes event order, membership revision, eligible recipients,
+and file hashes. A durable atomic write followed by reopening and verification
+precedes an account/device receipt. An evictable cache, browser download click, or
+JSON parse is not sufficient evidence.
+
+Every remaining eligible participant must have a verified copy. Offline people
+block purge. Membership changes use audited revocation and invalidate the old
+manifest revision; quota pressure never removes people automatically. Purge checks
+the manifest and receipts again under a lease, checkpoints object deletion, and
+retains a minimal tombstone. Old clients cannot resurrect a purged session.
+
+Local archives survive sign-out and cache eviction. Losing all copies after purge
+cannot be repaired from Supabase. Recovery uses a validated export or a copy from
+an authorized participant. Continuing starts a new session and publishes only a
+reviewed selection; it never silently uploads the archive. Slack retains its own
+messages independently of Collie's archive and purge lifecycle.
+
+## Release gates and evidence
+
+Enable shared text, shared execution, archive purge, and Slack independently per
+organization/user. Rollback pauses new work while retaining read, export, archive,
+and recovery. It does not drop tables or relax authorization.
+
+Before enabling a gate, record:
+
+1. Actual project database, object, egress, and connection use; isolated synthetic
+   40/200/1,000-message measurements including indexes, edits, and UTF-8 payloads.
+2. Isolated hosted RLS/function tests across organizations, revoked participants,
+   idempotent retry, atomic quota exhaustion, and run fencing.
+3. Two-computer offline/reconnect, requester permissions, and private-context
+   sentinel acceptance, including a sleeping participant during archive purge.
+4. Corrupt/missing archive objects, interrupted durable save, stale manifests,
+   object-deletion retry, and purge-worker crash recovery.
+5. Real Slack test-workspace acceptance: two linked authors, selected channel
+   audience, duplicate events, bot echo, uninstall, rate limits, uncertain outbound
+   delivery, and an explicit continuation after archive.
+
+Local test execution does not establish two-computer acceptance. Hosted schema
+validation uses the existing Collie project inside a transaction that rolls back
+all schema and fixture changes. No deployment is implied.
+
+### Implementation evidence snapshot
+
+The isolated SQL harness, desktop build, and typecheck pass. The full Python
+suite passed 3,707 tests with six skipped; the full desktop suite passed 510
+tests with one skipped. Eight Edge tests pass. Hosted rollback validation passed
+real authorization/RLS, quota, consent, notifications, requester leases, closing
+completion, and receipt-gated archive checks. A real hosted manifest containing
+the accepted closing completion also passed Windows durable save, readback,
+export, and import. The rollback-only
+capacity fixture measured approximately 104 KiB, 312 KiB, and 1.58 MiB of added
+physical event-table/index storage for 40, 200, and 1,000 messages with retained
+revisions and UTF-8 content. This is a synthetic event-table calibration, not a
+full production load model. Two-computer and real Slack workspace acceptance
+remain open; these results do not open any release gate.
+
+Reproduce the rollback-only hosted check with
+`node tools/build_hosted_collaboration_validation.mjs`, then run the generated
+`.tmp/hosted-collaboration-validation.sql` with the linked Supabase CLI's
+`db query --file` command. Save its JSON output and pass the file to
+`python tools/verify_hosted_archive.py` to validate the desktop round trip.
+The hosted script must retain its final `ROLLBACK`; it is not a deployment script.
+
+## Edge function configuration
+
+Deploy the SQL migration separately from desktop/function code. Configure
+`SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` only in the
+appropriate server environment. Slack functions additionally require
+`SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`,
+`SLACK_REDIRECT_URI`, and `SLACK_TOKEN_ENCRYPTION_KEY` (base64-encoded 32 random
+bytes). Worker invocation requires `COLLABORATION_WORKER_SECRET`. Never include
+these secrets in renderer configuration, logs, screenshots, or source control.
+
+Slack signature verification uses the exact raw request body and a five-minute
+timestamp window. OAuth state is random, hashed at rest, short-lived, and consumed
+once. Bot tokens use AES-GCM with the Slack team ID as authenticated associated
+data. Scheduled workers acknowledge only persisted work and use bounded batches.
+Unknown outbound outcomes require read-only reconciliation rather than a blind
+repeat of the external write.
+
+After deploying the functions, configure the two named Vault entries and run
+[`install_collaboration_workers.sql`](../../../tools/install_collaboration_workers.sql)
+as the project administrator. It schedules bounded archive/Slack workers and
+six-hour physical capacity snapshots without embedding credentials in job text.
+The desktop reconciles periodically while running, including in the tray, and
+automatically verifies and acknowledges eligible pending archives. This deployment
+setup has not been executed against the hosted project. The scheduler follows
+[Supabase's scheduled Edge function pattern](https://supabase.com/docs/guides/functions/schedule-functions).

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -15,7 +15,7 @@
 - Core Python test files: **240**
 - Desktop TypeScript/TSX files: **190**
 - Desktop test files: **70**
-- Active Markdown docs: **36**
+- Active Markdown docs: **37**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,16 +11,16 @@
 
 ## Source inventory
 
-- Core Python files: **525**
-- Core Python test files: **240**
-- Desktop TypeScript/TSX files: **190**
-- Desktop test files: **70**
-- Active Markdown docs: **37**
+- Core Python files: **531**
+- Core Python test files: **242**
+- Desktop TypeScript/TSX files: **198**
+- Desktop test files: **73**
+- Active Markdown docs: **38**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups
 
-`automations`, `catalog`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `things`, `tools`, `undo`
+`automations`, `catalog`, `collaboration`, `connectors`, `gardener`, `ipc`, `memory`, `messengers`, `permissions`, `pet`, `plans`, `providers`, `routines`, `services`, `subagents`, `telemetry`, `things`, `tools`, `undo`
 
 ## Required orientation files
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -10,9 +10,10 @@ Active product truth is organized by purpose:
   stack.
 - `features/planning-ui-and-more/` - accepted checklist and reviewed-plan
   behavior.
-- `features/shared-sessions-implementation-plan.md` - proposed account-based shared
+- `features/shared-sessions-implementation-plan.md` - account-based shared
   sessions, personal execution, bounded cloud sync, and verified local auto-archive;
-  step-by-step backend/core/frontend plan, not implemented.
+  backend/core/frontend acceptance contract, with implementation and release gates
+  tracked in `../engineering/architecture/shared-sessions.md`.
 - `features/share-collie.md` - parked earlier Telegram multiplayer proposal;
   its identity and execution defaults are superseded by the shared-session plan.
 - `design/assets/` - product and character design references used by the app.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -10,8 +10,11 @@ Active product truth is organized by purpose:
   stack.
 - `features/planning-ui-and-more/` - accepted checklist and reviewed-plan
   behavior.
-- `features/share-collie.md` - simple Telegram multiplayer, local identity,
-  shared-resource boundaries, and optional local-AI direction.
+- `features/shared-sessions-implementation-plan.md` - proposed account-based shared
+  sessions, personal execution, bounded cloud sync, and verified local auto-archive;
+  step-by-step backend/core/frontend plan, not implemented.
+- `features/share-collie.md` - parked earlier Telegram multiplayer proposal;
+  its identity and execution defaults are superseded by the shared-session plan.
 - `design/assets/` - product and character design references used by the app.
 
 When implementation changes a product decision, update the single relevant

--- a/docs/product/features/share-collie.md
+++ b/docs/product/features/share-collie.md
@@ -5,6 +5,10 @@
 **Parked:** 2026-08-03
 **Applies to:** Post-alpha multiplayer and shared-chat work
 
+The [shared-session implementation plan](shared-sessions-implementation-plan.md)
+supersedes this proposal's no-account and owner-execution defaults. This file
+remains historical reference; neither proposal is a claim of shipped multiplayer.
+
 ## Outcome
 
 Collie will support simple multiplayer use without becoming an organization

--- a/docs/product/features/shared-sessions-implementation-plan.md
+++ b/docs/product/features/shared-sessions-implementation-plan.md
@@ -1,0 +1,387 @@
+# Shared sessions: implementation plan
+
+**Status:** proposed implementation plan; no feature implementation in this PR.
+**Date:** 2026-09-09
+**Scope:** Python core, Electron/React desktop, managed Supabase coordination, then Slack.
+**Source baseline:** `b54311aaae24d12f92832fcfc68167c8fe2c81c6`.
+
+## Outcome and decisions
+
+People in an organization can find each other with `@`, invite one another into a
+conversation, and continue the same conversation from different computers. Only
+published session content is shared. Accounts, credentials, personal memory,
+permissions, and private execution remain individual. Personal use stays local
+and account-optional; shared sessions require sign-in.
+
+Use the existing Supabase account system as a managed mailbox, membership store,
+and ordering authority. Do not deploy a dedicated AI server or expose localhost
+IPC. Each request runs on its author's enrolled desktop using that person's
+configured provider and permissions. A sleeping executor means waiting, never
+execution on the creator's or another participant's account.
+
+Start with in-app shared conversations; add Slack over the same records later.
+Use cloud limits and automatic local archiving to bound storage. Archived content
+is removed from Supabase only after verified local copies exist for all remaining
+participants. This means storage cannot be reclaimed immediately if a participant
+is offline; new admissions may need to pause. There is no silent expiry of unread
+history to make a free tier appear unlimited.
+
+This direction supersedes the no-account, Telegram-owner-execution defaults in
+[the parked Share Collie proposal](share-collie.md). It does not activate that
+proposal or change existing Telegram behavior. The present PR adds a plan only:
+no migrations, runtime changes, credentials, deployments, or feature flags enabled.
+
+## Existing code to preserve and extend
+
+| Area | Current source | Planned responsibility |
+|---|---|---|
+| Runtime | `collie-core/collie_core/runtime.py` | Reuse composition and tools; introduce a requester-bound shared entry. |
+| Local data | `collie-core/collie_core/db.py` | Keep personal tables; add sync outbox/cache and local archive records separately. |
+| Model context | `collie-core/nanobot/agent/context.py` | Separate published-session inputs from personal bootstrap, memory, skills, and history. |
+| Agent execution | `collie-core/nanobot/agent/loop.py`, `collie-core/collie_core/session_identity.py` | Preserve local locks; carry shared request and context identity through continuations. |
+| Permissions | `collie-core/collie_core/permissions/` | Authorize actor, resource owner, action, and publication audience. |
+| Memory | `collie-core/collie_core/memory/`, `tools/memory.py`, Gardener hooks | Prevent automatic ingestion of shared history into private memory. |
+| Accounts | `collie-ui/src/main/account-auth.ts` | Reuse protected Supabase identity; add narrow authenticated collaboration commands. |
+| Desktop transport | `collie-ui/src/renderer/src/lib/ipc.ts`, `src/preload/`, `src/main/` | Separate local/private frames from published shared frames. |
+| Chat | `ChatScreen.tsx`, `Sidebar.tsx`, `MessageList.tsx`, `MessageBubble.tsx` under renderer | Add membership, authorship, sync state, storage, archive and requester status. |
+| Messenger | `collie-core/collie_core/messengers/manager.py`, `nanobot/channels/slack.py` | New exact Slack-thread mapping; keep Telegram mirror compatibility. |
+
+Current messages have no human author/workspace membership; the local IPC
+broadcast is not a multi-user authorization mechanism. The current context builder
+loads personal bootstrap files, memory and skills. Tools/profile stores include
+process-level bindings: do not put several people's runtimes in one process.
+Cloud snapshot backup excludes conversations and must remain a separate feature.
+
+## Initial limits and retention contract
+
+These are proposed pilot defaults, configurable and enforced by the backend.
+Step 1 calibrates them against actual database usage before rollout. MiB values
+below are binary application limits; provider quotas are measured independently.
+
+| Limit | Pilot default | Behavior |
+|---|---|---|
+| Participants | 5 accepted or reserved invitations per session | Reject additional invitations with a clear explanation. |
+| Concurrent cloud sessions | 5 per organization, including archive-pending sessions | Offer archive or continuation when capacity is available. |
+| Conversation length | 200 published human/assistant messages | Reserve a response slot before accepting a request; then close new submissions and archive. |
+| Shared text/event payload | 2 MiB per session | Warn/stop new requests at 1.5 MiB; remaining budget covers reserved bounded responses and finalization. |
+| Organization payload | 10 MiB | Count messages, retained revisions/events, reservations and pending archives, not only visible text. |
+| Project collaboration payload | Initially at most 100 MiB | Also enforce measured physical collaboration budget of at most 250 MB, reduced for existing use. |
+| Total database thresholds | Warn at 350 MB; stop new sessions before 400 MB | Reserve space for accepted runs, archive receipts, accounts and other writes; use a lower threshold when growth requires it. |
+| Inactivity archive | 14 days without new published content | Begin archive if no active run, pending approval or accepted outbound job. Warn participants in advance. |
+| Shared files | Initially 5 MiB/file, 20 MiB/session, 100 MiB project-wide | Separate object-storage quota; reserve before upload; include files in archive verification. |
+
+Quota reservations must be atomic across simultaneous submissions. Bound generated
+public answers to their reserved allowance; an oversized draft stays private and
+offers selected publication or a continuation. Never accept a run and then drop
+its result due to a predictable quota failure. Count each cloud session once,
+not once per member. Connection/egress limits need separate monitoring.
+
+Every message is stored once in canonical shared history; do not persist full
+transcript snapshots after each turn or every streamed token. Save only meaningful
+public progress. Diagnostic/tool logs and private drafts remain local. An
+organization allowance is a byte limit, not a guarantee that all five sessions
+can be filled regardless of indexes or other project usage.
+
+## Auto-archive state machine
+
+`active -> closing -> archive_pending -> purging -> archived_local`
+
+1. Trigger on inactivity, a session limit, or explicit Archive. In a transaction,
+   stop new submissions, settle or safely cancel in-flight work, and freeze a
+   final sequence, membership revision, and recipient set. Never purge a running
+   turn or an unresolved publication. A continuation is a new linked session.
+2. Produce a versioned archive manifest of published messages, authors, edits,
+   deletion state, public run results and shared files. Include canonical digest,
+   file hashes, byte lengths, final sequence and session ID. Personal memory,
+   secrets, approvals' private payloads and private tool state are excluded.
+3. Every remaining participant downloads to a stable app-managed local archive,
+   distinct from an evictable cache. Verify hashes and final sequence, write
+   durably, reopen successfully, then send an authenticated device/account receipt.
+   An existing incomplete cache or an unverified UI acknowledgement is insufficient.
+4. Require at least one verified local archive for each frozen eligible participant,
+   including the owner. Offline participants leave the session archive-pending.
+   Show who is still pending. Retries are idempotent. Revocation during archiving
+   invalidates the manifest revision and recomputes eligibility through the normal
+   audited membership flow; never auto-remove people to free storage.
+5. Recheck receipts, manifest, no active jobs, membership and lease before claiming
+   purge. Delete cloud content and session-exclusive file objects with an idempotent
+   job. Do not delete referenced objects used by other sessions. Database and object
+   deletion are not one transaction: record progress and retry either independently.
+6. Retain a small access-controlled tombstone and minimal sync/archive metadata
+   (session ID, final sequence/digest, archive revision/status, eligible identities,
+   receipt evidence, operation timestamps) so stale clients cannot resurrect old
+   content. Remove content-bearing titles, excerpts and file names. Account these
+   records in the quota and define eventual cleanup separately.
+7. Mark archived only after cloud content removal succeeds. Postgres deletion may
+   not immediately shrink physical usage; normal vacuum can make space reusable.
+   Do not trigger blocking `VACUUM FULL` from user requests or promise immediate
+   provider-metric reductions. Backend admission waits for measured safe capacity.
+
+Archived sessions remain readable locally but are not live shared chats. Starting
+again creates a new session; optionally publish a reviewed summary or selected
+messages under the new audience and quota. Never silently reupload the full archive.
+On a new computer, recover from the user's archive export or an available authorized
+participant; do not claim cloud recovery after purge. Warn before deleting a local
+archive that may be the last copy. Verified receipt proves a successful save at that
+time, not protection against future disk loss or a malicious client.
+
+Slack's own history is outside Supabase: local archive/cloud purge does not delete
+Slack messages. Require linked desktop participants for the first Slack pilot so
+archive receipt requirements are satisfiable. Explain this in Slack-facing help.
+
+## Step-by-step implementation batches
+
+Each numbered batch should be a separate reviewable implementation PR, after this
+plan is accepted. Migration PRs remain separate from runtime/UI changes. Steps
+that expose shared execution cannot ship until the context/privacy gates pass.
+
+### 1. Measure capacity and specify contracts
+
+**Owners:** backend/core. Read the current project's database/object/realtime usage;
+do not assume an empty 500 MB quota. In an isolated test database, load synthetic
+40-, 200-, and 1,000-message histories, run edits/deletes, and measure tables,
+indexes, retained events and physical growth. Test long text and multilingual UTF-8.
+Establish a conservative bytes-to-physical-size factor and admission reserve.
+
+Define versioned DTOs for Session, Member, MessageEvent, Run, QuotaReservation,
+ArchiveManifest and ArchiveReceipt. Specify error codes for quota, stale membership,
+revision conflicts, archived sessions and offline execution.
+
+**Gate:** reproducible capacity report, calibrated configuration and documented
+fixtures. No production writes or infrastructure upgrades implied by this plan.
+
+### 2. Add shared schema and access policies
+
+**Owner:** managed backend. Proposed new root `supabase/migrations/` owns schema and
+RLS; `supabase/functions/` will own edge handlers. Do not duplicate these migrations
+in the separately maintained website repository.
+
+Add organizations/memberships/invites; sessions/session members; attributed message
+events; runs/leases; devices; quota counters/reservations; archive manifests/receipts;
+inbox/outbox and tombstones. Store shared files in a private bucket with matching
+authorization. Add composite constraints preventing cross-organization references.
+
+Use existing account IDs. Organization membership permits directory discovery,
+not every chat. Enforce accepted session membership on content and realtime. Keep
+privileged fields, generated messages, run claims and archive receipts out of
+unrestricted client writes. Use explicit database grants plus RLS. Never expose
+service credentials through preload or renderer.
+
+**Gate:** two organizations and multiple users cannot cross-read, forge authors,
+grant membership, alter quota counters, publish results, or bypass archive receipts.
+
+### 3. Implement transactional sync commands
+
+**Owner:** backend. Provide authenticated commands for create/invite/accept,
+append/edit, read-after-cursor, claim/complete run, and request/ack archive.
+Atomically allocate per-session commit order, deduplicate immutable event IDs and
+reserve quota. Reject reused IDs with different payloads. Enforce expected revision
+on edits; preserve deletions as events/tombstones. Count the response budget before
+admitting a request. Derive requester identity from verified authentication.
+
+Publish realtime notifications after durable acceptance; notifications are hints,
+not the authoritative history. Add snapshot/high-water/cursor semantics that cannot
+miss writes during subscription. Rotate authorized topics on membership changes so
+old connections receive no new data; revalidate on commands and publication.
+
+**Gate:** lost acknowledgements and retries create one event/run; concurrent messages
+are retained; malicious old clients cannot append to archived or revoked sessions.
+
+### 4. Add local collaboration storage and transport
+
+**Owners:** core and Electron main. Add `collie_core/collaboration/` with local
+outbox, materializer, cursor store and archive manager. Keep personal SQL untouched
+except additive migrations. Persist local message plus outbox in one transaction;
+apply remote page plus cursor in one transaction. Reconnect/foreground reconciliation
+downloads missing events; do not send full histories repeatedly.
+
+Use narrow typed preload commands for authenticated shared operations. Keep account
+tokens in Electron protected storage. Separate private local events from shared
+publication so a generic existing IPC broadcast cannot leak private state.
+
+**Gate:** crash mid-download, lost response, duplicate notification and several days
+offline all converge to the same published state. Existing personal chat still works
+without sign-in or network. Show local-save versus cloud-acknowledged status.
+
+### 5. Build organization discovery and shared chat UI
+
+**Owner:** frontend. Add organization selection, invitation acceptance, participant
+avatars and a directory-backed `@` picker. Existing-member mentions notify; new-member
+mentions offer an explicit invitation. Only authorized members may invite. Show the
+history audience before sharing an existing personal conversation; publish an approved
+copy, not its private tool logs. Other contributors must consent to wider publication
+unless they accepted a clearly disclosed owner-managed audience policy.
+
+Reuse Sidebar, ChatScreen, MessageList and MessageBubble; extract the local/shared
+transport interface rather than forking the whole UI. Add names, requested-by labels,
+unread state, syncing/error state and view-only/archive states. Invitations carry stable
+IDs, not usernames as authority. Keep subgroup/team management optional for later.
+
+**Gate:** two people share one attributed transcript; a directory match alone grants
+no access; pending invitees receive no history or file URLs.
+
+### 6. Isolate shared and private model context
+
+**Owner:** core. Add an explicit audience/context mode at runtime entry. Shared turns
+use canonical published history through a recorded sequence and public product
+instructions; exclude personal bootstrap files, memories, private skill contents,
+private session summaries and tool traces. Disabling recent history alone is insufficient.
+
+Private-resource tasks run privately and publish only an explicitly authorized result.
+Prevent private token deltas, progress details, arguments, errors and attachment paths
+from reaching the shared publisher. Exclude shared history from automatic profile,
+Dream and Gardener ingestion. Explicit Remember for me remains requester-scoped.
+
+**Gate:** sentinel private data in every context source never appears in shared
+prompts/events; private tools remain usable through the private-result path.
+
+### 7. Bind execution and approvals to the requester
+
+**Owners:** core/backend. Add authenticated device enrollment, outbound job pickup,
+expiry, revocation, and executor-specific run leases/fencing. Only the requester's
+device may execute; its local permission engine revalidates every job. Do not accept
+remote permission overrides or caller-provided unrestricted local paths.
+
+Extend ExecutionContext with requester, credential owner, executor, session/audience
+revision and context cutoff. Session ownership manages membership, not tool authority.
+Approvals bind actor, exact action/version, expiry and resource. Publication is a
+separate authorization from reading a private resource. Keep one started run per
+shared session; only the requester can steer their authority-bearing run. An owner
+can stop without viewing private details. Resource conflicts need version checks.
+
+**Gate:** Alice cannot use Rick's tools, approve his action, or redirect his ongoing
+run. Two devices cannot execute one request. Offline/cloud-outage UI queues honestly;
+new shared runs wait for coordination, while private work can continue separately.
+
+### 8. Preserve feature parity through shared execution
+
+**Owner:** core/frontend. Propagate identity and audience through subagents,
+continuations, retries, skills, connector calls, local files, task cards and routines.
+Routines remain creator-owned, with shared delivery separately authorized. Private
+model/connector settings never become session-wide settings. Record provider payer
+per run without uploading credentials.
+
+Add a private approval/result drawer available only to the requesting person; shared
+participants receive a generic waiting state. Shared files are explicit versioned
+uploads, not another computer's path. Concurrent edits reject stale versions.
+
+**Gate:** a feature matrix proves tools, models, memory, subagents, plans, routines,
+artifacts, stop/retry and approvals work either directly with shared-safe inputs or
+through private publication. No claim of full parity based solely on text chat.
+
+### 9. Implement byte reservations and quota UX
+
+**Owners:** backend/frontend. Enforce all limits from the table, including message
+slots, events/revisions, attachments and in-flight reservations. Reconcile logical
+counters with physical database measurement; daily provider metrics alone are not
+an admission mechanism. Release unused reservations on completion/cancellation with
+crash recovery. Rate-limit transient progress and cap notification fan-out.
+
+Show used/remaining storage, participant/message limits and warnings before closing.
+Offer Start next conversation using a reviewed summary only when cloud capacity
+exists. Quota denial preserves the user's local draft and says it has not synced.
+
+**Gate:** simultaneous writers cannot overspend; maximum-size accepted responses can
+finish; quota failure cannot masquerade as delivery or erase pending local work.
+
+### 10. Implement durable local archives and acknowledgements
+
+**Owner:** core. Create versioned manifests, paginated downloads, file hashing,
+durable atomic writes, read-back verification and per-account device receipts.
+Add archive export/import and recovery validation. Archives survive sign-out,
+cache eviction and app restart, with access protected on the user's computer.
+
+**Gate:** interrupted writes, corrupt files, missing attachments and stale manifests
+never receive a successful archive acknowledgement. Valid archives render offline.
+
+### 11. Implement archive orchestration and cloud purge
+
+**Owner:** backend. Implement the state machine above using short scheduled/function
+batches with leases, retry checkpoints and audit records. Archive-limit triggers
+must not force completion of a run by deleting its state. Wait for receipts from
+all eligible participants, then idempotently remove payload and file objects.
+Keep minimal tombstones; block old clients from re-uploading deleted history.
+
+**Gate:** Alice offline blocks purge; after her verified copy, purge completes even
+if Rick is then offline. Test membership changes, partially deleted objects,
+worker crashes, quota pressure and duplicate acknowledgements. No archive-bypass
+fallback or automatic participant eviction is permitted.
+
+### 12. Add archive and continuation UI
+
+**Owner:** frontend. Add Local archives in the sidebar, read-only archive viewer,
+progress and waiting-for-participants status, export/import, local-copy location,
+storage-reclaimed state and Start next conversation. Explain that archived content
+is no longer recoverable from Supabase and existing Slack messages remain in Slack.
+
+**Gate:** users can distinguish closing, saved locally, waiting for others, purging
+and archived. A new computer sees an archive marker/recovery path, not an empty chat
+misrepresented as fully synchronized history.
+
+### 13. Add Slack over canonical shared sessions
+
+**Owners:** backend/core/frontend. Add install/callback/events/interactions handlers
+under `supabase/functions/`, with encrypted installation bot credentials. Validate
+OAuth state and signed raw-body events, durably deduplicate and acknowledge promptly.
+Map `(installation, channel, root_thread_ts)` to one session, including the first
+mention. Link Slack senders to their own verified Collie account/executor.
+
+Add Add to Slack and selected-channel settings, reciprocal links and visible channel
+audience. Do not mirror private desktop history into a wider channel automatically.
+Defer Slack Connect and unlinked/guest personal execution. Use rate-aware context
+backfill, an outbound outbox and bot-echo suppression. An archived Slack mapping
+must request an explicit new continuation, not recreate old content from Slack history.
+
+**Gate:** two Slack authors plus desktop share the same canonical transcript and
+request ownership. Revocation/uninstall stops execution; retries do not duplicate
+work; private responses remain private; archive receipt policy is satisfiable.
+
+### 14. Run fault-injection, regression and pilot rollout
+
+**Owners:** core/frontend/backend. Add end-to-end tests for concurrent/offline devices,
+lost acknowledgements, cursor gaps, run lease loss, duplicate Slack delivery, quota
+exhaustion, stale edits, permission revocation and archive corruption/purge recovery.
+External writes use operation-specific idempotency/reconciliation; exactly-once
+message insertion does not guarantee exactly-once email delivery.
+
+Run relevant Python IPC/permissions/memory/subagent/routine/Telegram tests, desktop
+tests/typecheck/build, packaged-core checks for changed packaging, and hosted RLS/
+function tests in an isolated project. Run a real two-computer acceptance pass and
+then a real Slack test-workspace pass. Use per-user/organization feature flags with
+separate shared-text, shared-execution, archive and Slack release gates.
+
+Start with a controlled group. Measure database/objects/egress, active connections,
+sync lag, dedup retries, archive-pending bytes, oldest unsynced member, and purge
+failures using content-free telemetry. Pause new admissions if capacity is unsafe.
+Rollback disables new shared work while preserving read/export/archive recovery;
+do not roll back by dropping data tables. Never disable authorization to recover
+availability. Preserve local-only behavior throughout rollout.
+
+## Documentation and release responsibilities
+
+The monorepo owns core, desktop and proposed Supabase collaboration definitions.
+Website-only routing/invitation landing pages, if needed, are a later separate PR;
+they must reuse this authority model. At implementation time update PROJECT_MAP
+when ownership changes, the account/cloud-backup docs with the opt-in shared-session
+exception, and the nearest component instructions as needed. Do not rewrite current
+VISION/release claims to describe an unimplemented feature. Regenerate the repository
+snapshot when structure or canonical documentation changes.
+
+## Platform references and evidence limits
+
+- [Supabase database size](https://supabase.com/docs/guides/platform/database-size):
+  database usage includes indexes; new projects occupy baseline space; free projects
+  can become read-only above 500 MB; deletion does not necessarily shrink usage immediately.
+- [Supabase pricing](https://supabase.com/pricing): Free currently includes 500 MB
+  database, 1 GB file storage and limited egress/realtime; recheck before deployment.
+- [Realtime authorization](https://supabase.com/docs/guides/realtime/authorization):
+  use private authorized channels in addition to durable, authorized history reads.
+- [Slack events](https://docs.slack.dev/apis/events-api/),
+  [OAuth](https://docs.slack.dev/tools/bolt-js/concepts/authenticating-oauth/), and
+  [history limits](https://docs.slack.dev/reference/methods/conversations.replies/):
+  installation, acknowledgements, retries and commercial-distribution constraints.
+
+Storage averages are estimates until step 1. No live customer data has been sampled
+for this plan. Free-tier operation is a bounded pilot, not an availability or
+unlimited-retention promise. Archived local copies cannot be recovered after every
+holder loses them, and cloud deletion cannot revoke previously downloaded copies.

--- a/docs/product/features/shared-sessions-implementation-plan.md
+++ b/docs/product/features/shared-sessions-implementation-plan.md
@@ -1,6 +1,8 @@
 # Shared sessions: implementation plan
 
-**Status:** proposed implementation plan; no feature implementation in this PR.
+**Status:** implemented behind disabled release flags. Hosted rollback validation
+and synthetic capacity checks pass; multi-computer/Slack acceptance remain release gates. See
+[authority and recovery](../../engineering/architecture/shared-sessions.md).
 **Date:** 2026-09-09
 **Scope:** Python core, Electron/React desktop, managed Supabase coordination, then Slack.
 **Source baseline:** `b54311aaae24d12f92832fcfc68167c8fe2c81c6`.
@@ -28,8 +30,9 @@ history to make a free tier appear unlimited.
 
 This direction supersedes the no-account, Telegram-owner-execution defaults in
 [the parked Share Collie proposal](share-collie.md). It does not activate that
-proposal or change existing Telegram behavior. The present PR adds a plan only:
-no migrations, runtime changes, credentials, deployments, or feature flags enabled.
+proposal or change existing Telegram behavior. The original plan PR was
+documentation-only. Implementation follows below with separate migration and
+runtime changes; deployments and feature-flag enablement require the release gates.
 
 ## Existing code to preserve and extend
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,17 @@
+project_id = "collie-collaboration"
+
+# Slack signatures/OAuth state and worker secrets are verified inside the handlers.
+[functions.slack-install]
+verify_jwt = false
+[functions.slack-callback]
+verify_jwt = false
+[functions.slack-events]
+verify_jwt = false
+[functions.slack-interactions]
+verify_jwt = false
+[functions.slack-worker]
+verify_jwt = false
+[functions.archive-worker]
+verify_jwt = false
+[functions.collaboration-files]
+verify_jwt = false

--- a/supabase/functions/_shared/backend.ts
+++ b/supabase/functions/_shared/backend.ts
@@ -1,0 +1,47 @@
+export type Payload = Record<string, unknown>
+export function env(name: string): string {
+  const value = Deno.env.get(name)
+  if (!value) throw new Error('Service configuration is incomplete')
+  return value
+}
+export function json(value: unknown, status = 200): Response {
+  return Response.json(value, { status, headers: { 'Cache-Control': 'no-store' } })
+}
+export async function bodyText(request: Request, limit = 262144): Promise<string> {
+  if (Number(request.headers.get('content-length') || 0) > limit) throw new Error('Request too large')
+  const reader = request.body?.getReader()
+  if (!reader) return ''
+  const chunks: Uint8Array[] = []
+  let length = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    length += value.byteLength
+    if (length > limit) { await reader.cancel(); throw new Error('Request too large') }
+    chunks.push(value)
+  }
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.length }
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+}
+export async function rpc(command: string, payload: Payload, timeout = 15000): Promise<any> {
+  const key = env('SUPABASE_SERVICE_ROLE_KEY')
+  const response = await fetch(`${env('SUPABASE_URL')}/rest/v1/rpc/collaboration_slack_command`, {
+    method: 'POST', headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ p_command: command, p_payload: payload }), signal: AbortSignal.timeout(timeout),
+  })
+  if (!response.ok) throw new Error('Coordination unavailable')
+  return await response.json()
+}
+export async function authenticatedUser(request: Request): Promise<string> {
+  const authorization = request.headers.get('authorization') || ''
+  if (!/^Bearer \S+$/.test(authorization)) throw new Error('Sign in required')
+  const response = await fetch(`${env('SUPABASE_URL')}/auth/v1/user`, {
+    headers: { apikey: env('SUPABASE_ANON_KEY'), Authorization: authorization }, signal: AbortSignal.timeout(10000),
+  })
+  if (!response.ok) throw new Error('Sign in required')
+  const user = await response.json()
+  if (!user.id || user.is_anonymous) throw new Error('Sign in required')
+  return user.id
+}

--- a/supabase/functions/_shared/slack-security.test.ts
+++ b/supabase/functions/_shared/slack-security.test.ts
@@ -1,0 +1,25 @@
+import { hex, openToken, sealToken, verifySlack } from './slack-security.ts'
+
+function assert(value: unknown, message = 'assertion failed'): asserts value { if (!value) throw new Error(message) }
+Deno.test('Slack signs exact raw bytes; rejects stale and altered requests', async () => {
+  const timestamp = '1788923000'
+  const body = '{ "text":"hello 世界" }'
+  const secret = 'test-only-signing-secret'
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const signature = 'v0=' + hex(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`v0:${timestamp}:${body}`)))
+  assert(await verifySlack(body, timestamp, signature, secret, Number(timestamp) * 1000))
+  assert(!await verifySlack(body + ' ', timestamp, signature, secret, Number(timestamp) * 1000))
+  assert(!await verifySlack(body, timestamp, signature, secret, Number(timestamp) * 1000 + 301000))
+  assert(!await verifySlack(body, 'NaN', signature, secret))
+})
+Deno.test('Installation encryption binds the workspace and detects corrupt ciphertext', async () => {
+  const key = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
+  const encrypted = await sealToken('test-only-bot-credential', key, 'T1')
+  assert(!encrypted.includes('test-only'))
+  assert(await openToken(encrypted, key, 'T1') === 'test-only-bot-credential')
+  for (const [value, team] of [[encrypted, 'T2'], [encrypted.slice(0, -4) + 'AAAA', 'T1']]) {
+    let rejected = false
+    try { await openToken(value, key, team) } catch { rejected = true }
+    assert(rejected)
+  }
+})

--- a/supabase/functions/_shared/slack-security.ts
+++ b/supabase/functions/_shared/slack-security.ts
@@ -1,0 +1,45 @@
+/** Raw-body verification and credential encryption. No client receives bot tokens. */
+const encoder = new TextEncoder()
+export function hex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), value => value.toString(16).padStart(2, '0')).join('')
+}
+export async function sha256(value: string): Promise<string> {
+  return hex(await crypto.subtle.digest('SHA-256', encoder.encode(value)))
+}
+export function constantEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false
+  let difference = 0
+  for (let i = 0; i < left.length; i++) difference |= left.charCodeAt(i) ^ right.charCodeAt(i)
+  return difference === 0
+}
+export async function verifySlack(
+  body: string, timestamp: string | null, signature: string | null, secret: string,
+  now = Date.now(),
+): Promise<boolean> {
+  if (!timestamp || !/^\d+$/.test(timestamp) || !signature || !/^v0=[a-f0-9]{64}$/.test(signature)) return false
+  if (Math.abs(now / 1000 - Number(timestamp)) > 300) return false
+  const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const expected = 'v0=' + hex(await crypto.subtle.sign('HMAC', key, encoder.encode(`v0:${timestamp}:${body}`)))
+  return constantEqual(expected, signature)
+}
+function decode64(value: string): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(atob(value), c => c.charCodeAt(0))
+}
+function encode64(value: Uint8Array): string {
+  return btoa(String.fromCharCode(...value))
+}
+async function encryptionKey(secret: string): Promise<CryptoKey> {
+  const bytes = decode64(secret)
+  if (bytes.length !== 32) throw new Error('Invalid credential key configuration')
+  return await crypto.subtle.importKey('raw', bytes, 'AES-GCM', false, ['encrypt', 'decrypt'])
+}
+export async function sealToken(token: string, secret: string, team: string): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const data = await crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData: encoder.encode(team) }, await encryptionKey(secret), encoder.encode(token))
+  return `v1.${encode64(iv)}.${encode64(new Uint8Array(data))}`
+}
+export async function openToken(ciphertext: string, secret: string, team: string): Promise<string> {
+  const [version, iv, data, extra] = ciphertext.split('.')
+  if (version !== 'v1' || !iv || !data || extra) throw new Error('Invalid encrypted credential')
+  return new TextDecoder().decode(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: decode64(iv), additionalData: encoder.encode(team) }, await encryptionKey(secret), decode64(data)))
+}

--- a/supabase/functions/archive-worker/index.test.ts
+++ b/supabase/functions/archive-worker/index.test.ts
@@ -1,0 +1,64 @@
+import { handleArchiveWorker } from './index.ts'
+
+Deno.test('expired upload cleanup checkpoints only after successful storage deletion', async () => {
+  const original = globalThis.fetch
+  Deno.env.set('SUPABASE_URL', 'https://fixture.invalid')
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'fixture-only')
+  Deno.env.set('COLLABORATION_WORKER_SECRET', 'worker-fixture')
+  try {
+    for (const status of [503, 404, 200]) {
+      const calls: string[] = []
+      globalThis.fetch = async (url, init) => {
+        if (String(url).includes('/storage/')) { calls.push('delete'); return Response.json({}, { status }) }
+        const body = JSON.parse(String(init?.body)); calls.push(body.p_command)
+        if (body.p_command === 'advance_archives') return Response.json({ file_cleanup: { objects: [{ file_id: 'f1', bucket: 'collaboration-files', path: 's1/f1' }] } })
+        return Response.json(null)
+      }
+      const response = await handleArchiveWorker(new Request('https://fixture.invalid', { method: 'POST', headers: { Authorization: 'Bearer worker-fixture' } }))
+      assert(response.status === (status === 503 ? 503 : 200))
+      assert(calls.includes('checkpoint_file_cleanup') === (status !== 503))
+      if (status !== 503) assert(calls.indexOf('delete') < calls.indexOf('checkpoint_file_cleanup'))
+    }
+  } finally {
+    globalThis.fetch = original
+    for (const key of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'COLLABORATION_WORKER_SECRET']) Deno.env.delete(key)
+  }
+})
+
+function assert(value: unknown): asserts value { if (!value) throw new Error('assertion failed') }
+Deno.test('purge authorization is checked before object deletion and failed deletes never finish', async () => {
+  const original = globalThis.fetch
+  Deno.env.set('SUPABASE_URL', 'https://fixture.invalid')
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'fixture-only')
+  Deno.env.set('COLLABORATION_WORKER_SECRET', 'worker-fixture')
+  try {
+    for (const failure of ['check', 'delete']) {
+      const calls: string[] = []
+      let claimed = false
+      globalThis.fetch = async (url, init) => {
+        const body = JSON.parse(String(init?.body))
+        if (String(url).includes('/storage/')) {
+          calls.push('delete_object')
+          return Response.json({}, { status: 503 })
+        }
+        calls.push(body.p_command)
+        if (body.p_command === 'claim_purge') {
+          if (claimed) return Response.json(null)
+          claimed = true
+          return Response.json({ session_id: 's1', fence: 1, manifest_digest: 'digest', objects: [{ id: 'f1', bucket: 'collaboration-files', path: 's1/f1' }] })
+        }
+        if (body.p_command === 'check_purge' && failure === 'check') return Response.json({}, { status: 403 })
+        return Response.json({ ok: true })
+      }
+      const response = await handleArchiveWorker(new Request('https://fixture.invalid', { method: 'POST', headers: { Authorization: 'Bearer worker-fixture' } }))
+      assert(response.status === 200)
+      assert(!calls.includes('finish_purge'))
+      assert(calls.includes('retry_purge'))
+      assert(calls.includes('delete_object') === (failure === 'delete'))
+      if (failure === 'delete') assert(calls.indexOf('check_purge') < calls.indexOf('delete_object'))
+    }
+  } finally {
+    globalThis.fetch = original
+    for (const key of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'COLLABORATION_WORKER_SECRET']) Deno.env.delete(key)
+  }
+})

--- a/supabase/functions/archive-worker/index.ts
+++ b/supabase/functions/archive-worker/index.ts
@@ -1,0 +1,56 @@
+import { env, json } from '../_shared/backend.ts'
+import { constantEqual } from '../_shared/slack-security.ts'
+
+async function maintenance(command: string, payload: Record<string, unknown>): Promise<any> {
+  const key = env('SUPABASE_SERVICE_ROLE_KEY')
+  const response = await fetch(`${env('SUPABASE_URL')}/rest/v1/rpc/collaboration_maintenance_command`, {
+    method: 'POST', headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ p_command: command, p_payload: payload }), signal: AbortSignal.timeout(15000),
+  })
+  if (!response.ok) throw new Error('Archive coordination unavailable')
+  return await response.json()
+}
+
+export async function handleArchiveWorker(request: Request): Promise<Response> {
+  if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405)
+  if (!constantEqual(request.headers.get('authorization') || '', `Bearer ${env('COLLABORATION_WORKER_SECRET')}`)) return json({ error: 'unauthorized' }, 401)
+  try {
+    const advanced = await maintenance('advance_archives', { limit: 10 })
+    for (const object of advanced?.file_cleanup?.objects || []) {
+      // These are expired, unpublished uploads; SQL excludes verified shared files.
+      if (object.bucket !== 'collaboration-files' || typeof object.path !== 'string' || !object.path || object.path.includes('..') || !object.file_id) throw new Error('Invalid expired upload')
+      const key = env('SUPABASE_SERVICE_ROLE_KEY')
+      const response = await fetch(`${env('SUPABASE_URL')}/storage/v1/object/${object.bucket}`, {
+        method: 'DELETE', headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prefixes: [object.path] }), signal: AbortSignal.timeout(15000),
+      })
+      if (!response.ok && response.status !== 404) throw new Error('Expired upload deletion needs retry')
+      await maintenance('checkpoint_file_cleanup', { file_id: object.file_id })
+    }
+    let completed = 0
+    for (let i = 0; i < 10; i++) {
+      const job = await maintenance('claim_purge', {})
+      if (!job?.session_id) break
+      try {
+        for (const object of job.objects || []) {
+          // Authorization is rechecked before each irreversible external step.
+          await maintenance('check_purge', { session_id: job.session_id, fence: job.fence, manifest_digest: job.manifest_digest, object_id: object.id })
+          if (object.bucket !== 'collaboration-files' || typeof object.path !== 'string' || !object.path || object.path.includes('..')) throw new Error('Invalid archive object')
+          const key = env('SUPABASE_SERVICE_ROLE_KEY')
+          const response = await fetch(`${env('SUPABASE_URL')}/storage/v1/object/${object.bucket}`, {
+            method: 'DELETE', headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prefixes: [object.path] }), signal: AbortSignal.timeout(15000),
+          })
+          if (!response.ok && response.status !== 404) throw new Error('Object deletion needs retry')
+          await maintenance('checkpoint_purge', { session_id: job.session_id, fence: job.fence, object_id: object.id, manifest_digest: job.manifest_digest })
+        }
+        await maintenance('finish_purge', { session_id: job.session_id, fence: job.fence, manifest_digest: job.manifest_digest })
+        completed++
+      } catch {
+        await maintenance('retry_purge', { session_id: job.session_id, fence: job.fence })
+      }
+    }
+    return json({ completed })
+  } catch { return json({ error: 'archive_worker_retry_required' }, 503) }
+}
+if (import.meta.main) Deno.serve(handleArchiveWorker)

--- a/supabase/functions/collaboration-files/index.test.ts
+++ b/supabase/functions/collaboration-files/index.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from 'jsr:@std/assert@1.0.14'
+import { handleCollaborationFiles } from './index.ts'
+
+const originalFetch = globalThis.fetch
+Deno.env.set('SUPABASE_URL', 'https://example.supabase.co')
+Deno.env.set('SUPABASE_ANON_KEY', 'anon-test')
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-test')
+
+function user(): Response {
+  return Response.json({ id: '10000000-0000-4000-8000-000000000001', is_anonymous: false })
+}
+
+Deno.test('an account cannot upload another member file reservation', async () => {
+  globalThis.fetch = (input) => {
+    const url = String(input)
+    if (url.endsWith('/auth/v1/user')) return Promise.resolve(user())
+    return Promise.resolve(Response.json({ message: 'UPLOAD_NOT_AUTHORIZED' }, { status: 400 }))
+  }
+  try {
+    const response = await handleCollaborationFiles(new Request(
+      'https://edge.test/collaboration-files?file_id=40000000-0000-4000-8000-000000000001',
+      { method: 'PUT', headers: { Authorization: 'Bearer account-token' }, body: new Uint8Array([1]) },
+    ))
+    assertEquals(response.status, 403)
+    assertEquals((await response.json()).error, 'UPLOAD_NOT_AUTHORIZED')
+  } finally { globalThis.fetch = originalFetch }
+})
+
+Deno.test('reservation quota errors are preserved for the desktop', async () => {
+  globalThis.fetch = (input) => {
+    const url = String(input)
+    if (url.endsWith('/auth/v1/user')) return Promise.resolve(user())
+    return Promise.resolve(Response.json({ message: 'FILE_QUOTA_EXCEEDED' }, { status: 400 }))
+  }
+  try {
+    const response = await handleCollaborationFiles(new Request('https://edge.test/collaboration-files', {
+      method: 'POST', headers: { Authorization: 'Bearer account-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'reserve', session_id: crypto.randomUUID() }),
+    }))
+    assertEquals(response.status, 409)
+    assertEquals((await response.json()).error, 'FILE_QUOTA_EXCEEDED')
+  } finally { globalThis.fetch = originalFetch }
+})
+
+Deno.test('claimed digest mismatch fails before object upload and releases the reservation', async () => {
+  let storageWrites = 0
+  let verificationCalls = 0
+  globalThis.fetch = async (input, init) => {
+    const url = String(input)
+    if (url.endsWith('/auth/v1/user')) return user()
+    if (url.endsWith('/rpc/collaboration_files_command')) return Response.json({
+      file_id: '40000000-0000-4000-8000-000000000001', object_path: 'org/session/user/file/v1',
+      byte_length: 3, sha256: '00'.repeat(32), content_type: 'application/octet-stream', name: 'bad.bin', version: 1,
+    })
+    if (url.endsWith('/rpc/collaboration_files_verify')) {
+      verificationCalls++
+      const body = JSON.parse(String(init?.body))
+      assertEquals(body.p_byte_length, 3)
+      return Response.json({ ok: false, status: 'failed' })
+    }
+    if (url.endsWith('/rpc/collaboration_files_cleanup_complete')) return Response.json({ ok: true })
+    if (url.includes('/storage/v1/object/')) storageWrites++
+    return Response.json({})
+  }
+  try {
+    const response = await handleCollaborationFiles(new Request(
+      'https://edge.test/collaboration-files?file_id=40000000-0000-4000-8000-000000000001',
+      { method: 'PUT', headers: { Authorization: 'Bearer account-token', 'Content-Type': 'application/octet-stream' }, body: new Uint8Array([1, 2, 3]) },
+    ))
+    assertEquals(response.status, 422)
+    assertEquals(verificationCalls, 1)
+    assertEquals(storageWrites, 0)
+  } finally { globalThis.fetch = originalFetch }
+})

--- a/supabase/functions/collaboration-files/index.ts
+++ b/supabase/functions/collaboration-files/index.ts
@@ -1,0 +1,143 @@
+import { authenticatedUser, bodyText, env, json } from '../_shared/backend.ts'
+
+const MAX_FILE_BYTES = 5 * 1024 * 1024
+
+async function command(authorization: string, commandName: string, payload: Record<string, unknown>): Promise<any> {
+  const response = await fetch(`${env('SUPABASE_URL')}/rest/v1/rpc/collaboration_files_command`, {
+    method: 'POST',
+    headers: { apikey: env('SUPABASE_ANON_KEY'), Authorization: authorization, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ p_command: commandName, p_payload: payload }),
+    signal: AbortSignal.timeout(15000),
+  })
+  const value = await response.json().catch(() => null)
+  if (!response.ok) throw new Error(typeof value?.message === 'string' ? value.message : 'FILE_COMMAND_FAILED')
+  return value
+}
+
+async function serviceRpc(name: string, body: Record<string, unknown>): Promise<any> {
+  const key = env('SUPABASE_SERVICE_ROLE_KEY')
+  const response = await fetch(`${env('SUPABASE_URL')}/rest/v1/rpc/${name}`, {
+    method: 'POST', headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body), signal: AbortSignal.timeout(15000),
+  })
+  if (!response.ok) throw new Error('FILE_COORDINATION_FAILED')
+  return await response.json()
+}
+
+async function readBytes(request: Request, expected: number): Promise<Uint8Array<ArrayBuffer>> {
+  if (!Number.isSafeInteger(expected) || expected < 1 || expected > MAX_FILE_BYTES) throw new Error('INVALID_FILE')
+  const declared = Number(request.headers.get('content-length') || 0)
+  if (declared && declared !== expected) throw new Error('CONTENT_MISMATCH')
+  const reader = request.body?.getReader()
+  if (!reader) throw new Error('CONTENT_MISMATCH')
+  const chunks: Uint8Array[] = []
+  let length = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    length += value.byteLength
+    if (length > expected || length > MAX_FILE_BYTES) { await reader.cancel(); throw new Error('CONTENT_MISMATCH') }
+    chunks.push(value)
+  }
+  if (length !== expected) throw new Error('CONTENT_MISMATCH')
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength }
+  return bytes
+}
+
+async function digest(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  return [...new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))]
+    .map((value) => value.toString(16).padStart(2, '0')).join('')
+}
+
+async function readStored(response: Response): Promise<Uint8Array<ArrayBuffer>> {
+  const declared = Number(response.headers.get('content-length') || 0)
+  if (declared > MAX_FILE_BYTES) throw new Error('STORED_FILE_INVALID')
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error('STORED_FILE_INVALID')
+  const chunks: Uint8Array[] = []
+  let length = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    length += value.byteLength
+    if (length > MAX_FILE_BYTES) { await reader.cancel(); throw new Error('STORED_FILE_INVALID') }
+    chunks.push(value)
+  }
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength }
+  return bytes
+}
+
+async function storage(path: string, init: RequestInit): Promise<Response> {
+  const key = env('SUPABASE_SERVICE_ROLE_KEY')
+  return fetch(`${env('SUPABASE_URL')}/storage/v1/object/collaboration-files/${path.split('/').map(encodeURIComponent).join('/')}`, {
+    ...init, headers: { apikey: key, Authorization: `Bearer ${key}`, ...(init.headers || {}) }, signal: AbortSignal.timeout(30000),
+  })
+}
+
+function safeName(value: unknown): string {
+  const name = String(value || '').replace(/[\\/]/g, '_')
+  return name && name.length <= 255 ? name : 'shared-file'
+}
+
+export async function handleCollaborationFiles(request: Request): Promise<Response> {
+  if (!['POST', 'PUT', 'GET'].includes(request.method)) return json({ error: 'method_not_allowed' }, 405)
+  const authorization = request.headers.get('authorization') || ''
+  try {
+    await authenticatedUser(request)
+    if (request.method === 'POST') {
+      const body = JSON.parse(await bodyText(request, 16384))
+      if (!body || typeof body !== 'object' || !['reserve', 'list', 'cancel'].includes(body.action)) return json({ error: 'invalid_request' }, 400)
+      const { action, ...payload } = body
+      return json(await command(authorization, action, payload))
+    }
+    const fileId = new URL(request.url).searchParams.get('file_id') || ''
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(fileId)) return json({ error: 'invalid_file_id' }, 400)
+    const metadata = await command(authorization, request.method === 'PUT' ? 'authorize_upload' : 'authorize_download', { file_id: fileId })
+    if (request.method === 'GET') {
+      const response = await storage(metadata.object_path, { method: 'GET' })
+      if (!response.ok || !response.body) return json({ error: 'file_unavailable' }, response.status === 404 ? 404 : 503)
+      return new Response(response.body, { headers: {
+        'Content-Type': metadata.content_type || 'application/octet-stream', 'Content-Length': String(metadata.byte_length),
+        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(safeName(metadata.name))}`,
+        'Cache-Control': 'private, no-store', 'X-Content-Type-Options': 'nosniff',
+      } })
+    }
+
+    const incoming = await readBytes(request, Number(metadata.byte_length))
+    const incomingDigest = await digest(incoming)
+    if (incomingDigest !== metadata.sha256) {
+      await serviceRpc('collaboration_files_verify', { p_file_id: fileId, p_byte_length: incoming.byteLength, p_sha256: incomingDigest })
+      await serviceRpc('collaboration_files_cleanup_complete', { p_file_id: fileId })
+      return json({ error: 'content_mismatch' }, 422)
+    }
+    const uploaded = await storage(metadata.object_path, { method: 'POST', headers: { 'Content-Type': metadata.content_type, 'x-upsert': 'false' }, body: incoming })
+    if (!uploaded.ok) {
+      if (uploaded.status !== 409) return json({ error: 'upload_retry_required' }, 503)
+    }
+    // Verify the bytes retrieved from Storage, including after the first write.
+    // This also recovers a prior invocation that uploaded but lost its response.
+    const existing = await storage(metadata.object_path, { method: 'GET' })
+    if (!existing.ok) return json({ error: 'upload_retry_required' }, 503)
+    const stored = await readStored(existing)
+    const storedDigest = await digest(stored)
+    const result = await serviceRpc('collaboration_files_verify', { p_file_id: fileId, p_byte_length: stored.byteLength, p_sha256: storedDigest })
+    if (!result.ok) {
+      const removed = await storage(metadata.object_path, { method: 'DELETE' }).catch(() => null)
+      if (removed && (removed.ok || removed.status === 404)) {
+        await serviceRpc('collaboration_files_cleanup_complete', { p_file_id: fileId })
+      }
+      return json({ error: 'content_mismatch' }, 422)
+    }
+    return json({ ...result, name: metadata.name, content_type: metadata.content_type, version: metadata.version })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'FILE_REQUEST_FAILED'
+    const status = /FORBIDDEN|NOT_AUTHORIZED/.test(message) ? 403 : /AUTH_REQUIRED|Sign in/.test(message) ? 401 : /NOT_FOUND/.test(message) ? 404 : /QUOTA/.test(message) ? 409 : 400
+    return json({ error: message }, status)
+  }
+}
+
+if (import.meta.main) Deno.serve(handleCollaborationFiles)

--- a/supabase/functions/slack-callback/index.ts
+++ b/supabase/functions/slack-callback/index.ts
@@ -1,0 +1,22 @@
+import { env, json, rpc } from '../_shared/backend.ts'
+import { sealToken, sha256 } from '../_shared/slack-security.ts'
+
+Deno.serve(async request => {
+  if (request.method !== 'GET') return json({ error: 'method_not_allowed' }, 405)
+  try {
+    const query = new URL(request.url).searchParams
+    const state = query.get('state') || ''
+    const code = query.get('code') || ''
+    if (!/^[a-f0-9]{64}$/.test(state) || !code || code.length > 2048) return json({ error: 'invalid_callback' }, 400)
+    // Consume before exchanging; a replay cannot bind an installation twice.
+    const pending = await rpc('consume_install', { state_hash: await sha256(state) })
+    const response = await fetch('https://slack.com/api/oauth.v2.access', {
+      method: 'POST', body: new URLSearchParams({ code, client_id: env('SLACK_CLIENT_ID'), client_secret: env('SLACK_CLIENT_SECRET'), redirect_uri: env('SLACK_REDIRECT_URI') }),
+      signal: AbortSignal.timeout(10000),
+    })
+    const result = await response.json()
+    if (!response.ok || !result.ok || !result.access_token || !result.team?.id || result.is_enterprise_install) throw new Error('Install unavailable')
+    await rpc('save_install', { org_id: pending.org_id, actor_id: pending.actor_id, state_hash: await sha256(state), team_id: result.team.id, slack_user_id: result.authed_user?.id, bot_user_id: result.bot_user_id, token_ciphertext: await sealToken(result.access_token, env('SLACK_TOKEN_ENCRYPTION_KEY'), result.team.id) })
+    return new Response('<!doctype html><meta charset="utf-8"><title>Collie and Slack</title><h1>Slack is connected</h1><p>Return to Collie to select a channel and link your own account. Shared conversations require linked desktop participants. Archiving in Collie does not delete Slack messages.</p>', { headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store', 'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'" } })
+  } catch { return json({ error: 'slack_callback_failed_start_again' }, 400) }
+})

--- a/supabase/functions/slack-events/index.test.ts
+++ b/supabase/functions/slack-events/index.test.ts
@@ -1,0 +1,34 @@
+import { handleSlackEvent } from './index.ts'
+import { hex } from '../_shared/slack-security.ts'
+
+function assert(value: unknown): asserts value { if (!value) throw new Error('assertion failed') }
+async function signed(body: string): Promise<Request> {
+  const timestamp = String(Math.floor(Date.now() / 1000))
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode('fixture'), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const signature = 'v0=' + hex(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`v0:${timestamp}:${body}`)))
+  return new Request('https://example.invalid/slack-events', { method: 'POST', body, headers: { 'x-slack-request-timestamp': timestamp, 'x-slack-signature': signature } })
+}
+Deno.test('durable intake is required before acknowledging a signed Slack event', async () => {
+  Deno.env.set('SLACK_SIGNING_SECRET', 'fixture')
+  Deno.env.set('SUPABASE_URL', 'https://fixture.invalid')
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'fixture-only')
+  const original = globalThis.fetch
+  const calls: any[] = []
+  const body = JSON.stringify({ type: 'event_callback', team_id: 'T1', event_id: 'Ev1', event: { type: 'app_mention', text: 'hello' } })
+  try {
+    globalThis.fetch = async (_url, init) => {
+      calls.push(JSON.parse(String(init?.body)))
+      return Response.json({ ok: true })
+    }
+    assert((await handleSlackEvent(await signed(body))).status === 200)
+    assert(calls.length === 1 && calls[0].p_command === 'enqueue_event')
+    assert(calls[0].p_payload.event.event.text === 'hello')
+    globalThis.fetch = async () => Response.json({}, { status: 503 })
+    assert((await handleSlackEvent(await signed(body))).status === 503)
+    const forged = new Request('https://example.invalid', { method: 'POST', body })
+    assert((await handleSlackEvent(forged)).status === 401)
+  } finally {
+    globalThis.fetch = original
+    for (const key of ['SLACK_SIGNING_SECRET', 'SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']) Deno.env.delete(key)
+  }
+})

--- a/supabase/functions/slack-events/index.ts
+++ b/supabase/functions/slack-events/index.ts
@@ -1,0 +1,17 @@
+import { bodyText, env, json, rpc } from '../_shared/backend.ts'
+import { verifySlack } from '../_shared/slack-security.ts'
+
+export async function handleSlackEvent(request: Request): Promise<Response> {
+  if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405)
+  try {
+    const raw = await bodyText(request)
+    if (!await verifySlack(raw, request.headers.get('x-slack-request-timestamp'), request.headers.get('x-slack-signature'), env('SLACK_SIGNING_SECRET'))) return json({ error: 'invalid_signature' }, 401)
+    const event = JSON.parse(raw)
+    if (event.type === 'url_verification' && typeof event.challenge === 'string') return json({ challenge: event.challenge })
+    if (event.type !== 'event_callback' || typeof event.event_id !== 'string' || typeof event.team_id !== 'string') return json({ error: 'invalid_event' }, 400)
+    // Only durable intake occurs before acknowledgement. All API/model work is in the worker.
+    await rpc('enqueue_event', { team_id: event.team_id, event_id: event.event_id, event }, 2000)
+    return json({ ok: true })
+  } catch { return json({ error: 'retry_delivery' }, 503) }
+}
+if (import.meta.main) Deno.serve(handleSlackEvent)

--- a/supabase/functions/slack-install/index.ts
+++ b/supabase/functions/slack-install/index.ts
@@ -1,0 +1,16 @@
+import { authenticatedUser, bodyText, env, json, rpc } from '../_shared/backend.ts'
+import { sha256 } from '../_shared/slack-security.ts'
+
+Deno.serve(async request => {
+  if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405)
+  try {
+    const actor_id = await authenticatedUser(request)
+    const { org_id } = JSON.parse(await bodyText(request, 4096))
+    if (typeof org_id !== 'string') return json({ error: 'invalid_organization' }, 400)
+    const state = Array.from(crypto.getRandomValues(new Uint8Array(32)), b => b.toString(16).padStart(2, '0')).join('')
+    await rpc('begin_install', { actor_id, org_id, state_hash: await sha256(state), expires_at: new Date(Date.now() + 600000).toISOString() })
+    const url = new URL('https://slack.com/oauth/v2/authorize')
+    url.search = new URLSearchParams({ client_id: env('SLACK_CLIENT_ID'), scope: 'app_mentions:read,chat:write,channels:history,channels:read,users:read', state, redirect_uri: env('SLACK_REDIRECT_URI') }).toString()
+    return json({ url: url.toString() })
+  } catch { return json({ error: 'slack_install_unavailable' }, 403) }
+})

--- a/supabase/functions/slack-interactions/index.ts
+++ b/supabase/functions/slack-interactions/index.ts
@@ -1,0 +1,15 @@
+import { bodyText, env, json, rpc } from '../_shared/backend.ts'
+import { sha256, verifySlack } from '../_shared/slack-security.ts'
+
+Deno.serve(async request => {
+  if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405)
+  try {
+    const raw = await bodyText(request)
+    if (!await verifySlack(raw, request.headers.get('x-slack-request-timestamp'), request.headers.get('x-slack-signature'), env('SLACK_SIGNING_SECRET'))) return json({ error: 'invalid_signature' }, 401)
+    const payload = JSON.parse(new URLSearchParams(raw).get('payload') || '{}')
+    if (!payload.team?.id || !payload.user?.id) return json({ error: 'invalid_interaction' }, 400)
+    // Slack buttons never approve private tools. The desktop must perform that approval.
+    await rpc('enqueue_event', { team_id: payload.team.id, event_id: `interaction:${await sha256(raw)}`, event: { type: 'interaction', payload } }, 2000)
+    return json({ response_type: 'ephemeral', text: 'Open Collie to review this request with your own permissions.' })
+  } catch { return json({ error: 'retry_delivery' }, 503) }
+})

--- a/supabase/functions/slack-worker/index.ts
+++ b/supabase/functions/slack-worker/index.ts
@@ -1,0 +1,78 @@
+import { env, json, rpc } from '../_shared/backend.ts'
+import { constantEqual, openToken } from '../_shared/slack-security.ts'
+
+class RetryLater extends Error { constructor(public seconds: number) { super('retry_later') } }
+async function slack(method: string, token: string, data: Record<string, unknown>): Promise<any> {
+  const response = await fetch(`https://slack.com/api/${method}`, {
+    method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(data), signal: AbortSignal.timeout(10000),
+  })
+  if (response.status === 429) throw new RetryLater(Math.max(1, Math.min(86400, Number(response.headers.get('retry-after')) || 60)))
+  const result = await response.json()
+  if (!response.ok || !result.ok) throw new Error('Slack result requires reconciliation')
+  return result
+}
+
+/** Scheduled, bounded worker. Inbox and outbound claims are durable/fenced in SQL. */
+Deno.serve(async request => {
+  if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405)
+  if (!constantEqual(request.headers.get('authorization') || '', `Bearer ${env('COLLABORATION_WORKER_SECRET')}`)) return json({ error: 'unauthorized' }, 401)
+  let incoming = 0
+  let outgoing = 0
+  try {
+    for (let i = 0; i < 10; i++) {
+      const job = await rpc('claim_inbox', {})
+      if (!job?.id) break
+      try {
+        const event = job.event?.event
+        if (event?.type === 'app_uninstalled' || event?.type === 'tokens_revoked') {
+          await rpc('uninstall', { team_id: job.team_id })
+        } else if (event && ['app_mention', 'message'].includes(event.type) && !event.bot_id && !event.subtype && !event.hidden) {
+          const token = await openToken(job.token_ciphertext, env('SLACK_TOKEN_ENCRYPTION_KEY'), job.team_id)
+          const [user, channel] = await Promise.all([
+            slack('users.info', token, { user: event.user }),
+            slack('conversations.info', token, { channel: event.channel }),
+          ])
+          // External organizations/guests are outside the first pilot authority model.
+          if (!user.user?.deleted && !user.user?.is_bot && !user.user?.is_restricted && !user.user?.is_ultra_restricted && !user.user?.is_stranger && user.user?.team_id === job.team_id && !channel.channel?.is_shared && !channel.channel?.is_ext_shared) {
+            const link = String(event.text || '').match(/^(?:<@[A-Z0-9]+>\s*)?link\s+([A-Za-z0-9_-]{20,128})\s*$/i)
+            if (link) await rpc('redeem_link', { team_id: job.team_id, slack_user_id: event.user, code: link[1] })
+            else {
+              const accepted = await rpc('ingest_message', { installation_id: job.installation_id, channel_id: event.channel, thread_ts: event.thread_ts || event.ts, slack_user_id: event.user, event_id: job.event_id, content: event.text || '', source_ts: event.ts, is_mention: event.type === 'app_mention' })
+              if (accepted?.waiting_for_executor) throw new RetryLater(60)
+            }
+          }
+        }
+        await rpc('finish_inbox', { id: job.id, fence: job.fence, status: 'complete' })
+        incoming++
+      } catch (error) {
+        await rpc('finish_inbox', { id: job.id, fence: job.fence, status: 'retry', retry_after: error instanceof RetryLater ? error.seconds : 60 })
+      }
+    }
+    for (let i = 0; i < 10; i++) {
+      const job = await rpc('claim_outbox', {})
+      if (!job?.id) break
+      try {
+        const token = await openToken(job.token_ciphertext, env('SLACK_TOKEN_ENCRYPTION_KEY'), job.team_id)
+        if (job.status === 'uncertain') {
+          // Rate-aware bounded backfill, used only to reconcile our own operation.
+          // Never import a purged transcript from Slack history.
+          const history = await slack('conversations.replies', token, { channel: job.channel_id, ts: job.thread_ts, limit: 15, cursor: job.reconcile_cursor || undefined })
+          const delivered = history.messages?.find((message: any) => message.client_msg_id === job.id)
+          const next = history.response_metadata?.next_cursor || ''
+          await rpc('complete_outbox', { id: job.id, fence: job.fence, status: delivered ? 'complete' : next ? 'uncertain' : 'manual_review', slack_ts: delivered?.ts, reconcile_cursor: next, retry_after: 60 })
+          continue
+        }
+        // A deterministic client_msg_id lets reconciliation identify an uncertain send.
+        const result = await slack('chat.postMessage', token, { channel: job.channel_id, thread_ts: job.thread_ts, text: job.content, client_msg_id: job.id, unfurl_links: false, unfurl_media: false })
+        await rpc('complete_outbox', { id: job.id, fence: job.fence, status: 'complete', slack_ts: result.ts })
+        outgoing++
+      } catch (error) {
+        // Network failures can follow successful delivery. Quarantine for reconciliation,
+        // never blindly repeat an external write on the basis of an absent response.
+        await rpc('complete_outbox', { id: job.id, fence: job.fence, status: error instanceof RetryLater ? 'retry' : 'uncertain', retry_after: error instanceof RetryLater ? error.seconds : 60 })
+      }
+    }
+    return json({ incoming, outgoing })
+  } catch { return json({ error: 'worker_retry_required' }, 503) }
+})

--- a/supabase/migrations/20260909024910_shared_sessions_backend.sql
+++ b/supabase/migrations/20260909024910_shared_sessions_backend.sql
@@ -1,0 +1,620 @@
+-- Shared-session coordination authority. Feature gates default off; applying this
+-- migration does not enable collaboration or perform any production writes.
+create extension if not exists pgcrypto;
+create schema if not exists collaboration_private;
+revoke all on schema collaboration_private from public, anon, authenticated;
+grant usage on schema collaboration_private to authenticated, service_role;
+
+create table public.collaboration_config (
+  singleton boolean primary key default true check (singleton),
+  shared_text_enabled boolean not null default false,
+  shared_execution_enabled boolean not null default false,
+  archive_enabled boolean not null default false,
+  slack_enabled boolean not null default false,
+  max_participants integer not null default 5 check (max_participants between 1 and 50),
+  max_sessions_per_org integer not null default 5 check (max_sessions_per_org > 0),
+  max_messages_per_session integer not null default 200 check (max_messages_per_session > 0),
+  session_warn_bytes bigint not null default 1572864 check (session_warn_bytes > 0),
+  session_limit_bytes bigint not null default 2097152 check (session_limit_bytes >= session_warn_bytes),
+  org_limit_bytes bigint not null default 10485760 check (org_limit_bytes > 0),
+  project_logical_limit_bytes bigint not null default 104857600 check (project_logical_limit_bytes > 0),
+  project_physical_stop_bytes bigint not null default 419430400 check (project_physical_stop_bytes > 0),
+  admission_reserve_bytes bigint not null default 52428800 check (admission_reserve_bytes >= 0),
+  max_file_bytes bigint not null default 5242880,
+  max_session_file_bytes bigint not null default 20971520,
+  max_project_file_bytes bigint not null default 104857600,
+  default_response_reservation_bytes bigint not null default 262144,
+  updated_at timestamptz not null default now()
+);
+insert into public.collaboration_config default values;
+
+create table public.collaboration_organizations (
+  org_id uuid primary key default gen_random_uuid(),
+  name text not null check (length(btrim(name)) between 1 and 120),
+  owner_id uuid not null references auth.users(id),
+  revision bigint not null default 1 check (revision > 0),
+  created_at timestamptz not null default now()
+);
+create table public.collaboration_org_members (
+  org_id uuid not null references public.collaboration_organizations(org_id) on delete cascade,
+  user_id uuid not null references auth.users(id),
+  display_name text not null check (length(btrim(display_name)) between 1 and 120),
+  role text not null check (role in ('owner','admin','member')),
+  status text not null default 'active' check (status in ('active','revoked')),
+  revision bigint not null default 1,
+  joined_at timestamptz not null default now(), revoked_at timestamptz,
+  primary key (org_id,user_id)
+);
+create table public.collaboration_org_invites (
+  invite_id uuid primary key, org_id uuid not null references public.collaboration_organizations(org_id) on delete cascade,
+  invited_user_id uuid not null references auth.users(id), invited_by uuid not null references auth.users(id),
+  display_name text not null check(length(btrim(display_name)) between 1 and 120),
+  status text not null default 'pending' check(status in ('pending','accepted','revoked')),
+  created_at timestamptz not null default now(), accepted_at timestamptz, unique(org_id,invited_user_id)
+);
+create table public.collaboration_capacity_measurements (
+  measurement_id bigint generated always as identity primary key,
+  database_bytes bigint not null check(database_bytes>=0), collaboration_bytes bigint not null check(collaboration_bytes>=0),
+  storage_bytes bigint not null check(storage_bytes>=0), measured_at timestamptz not null default now()
+);
+create table public.collaboration_sessions (
+  session_id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.collaboration_organizations(org_id) on delete cascade,
+  created_by uuid not null references auth.users(id),
+  continuation_of uuid references public.collaboration_sessions(session_id),
+  title text check(title is null or length(title)<=200),
+  status text not null default 'active' check (status in ('active','closing','archive_pending','purging','archived_local')),
+  revision bigint not null default 1,
+  membership_revision bigint not null default 1,
+  next_seq bigint not null default 1,
+  final_seq bigint,
+  message_count integer not null default 0,
+  logical_bytes bigint not null default 0,
+  reserved_bytes bigint not null default 0,
+  shared_file_bytes bigint not null default 0,
+  last_published_at timestamptz not null default now(),
+  created_at timestamptz not null default now(), archived_at timestamptz,
+  unique (org_id,session_id)
+);
+alter table public.collaboration_sessions add constraint collaboration_continuation_not_self check (continuation_of is null or continuation_of <> session_id);
+alter table public.collaboration_sessions add constraint collaboration_continuation_scope_fk foreign key(org_id,continuation_of) references public.collaboration_sessions(org_id,session_id);
+create table public.collaboration_session_members (
+  org_id uuid not null,
+  session_id uuid not null,
+  user_id uuid not null references auth.users(id),
+  role text not null check (role in ('owner','member')),
+  status text not null default 'active' check (status in ('invited','active','revoked')),
+  invite_id uuid,
+  joined_at timestamptz, revoked_at timestamptz,
+  primary key(session_id,user_id),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade,
+  foreign key(org_id,user_id) references public.collaboration_org_members(org_id,user_id)
+);
+create table public.collaboration_invites (
+  invite_id uuid primary key,
+  org_id uuid not null,
+  session_id uuid not null,
+  invited_user_id uuid not null references auth.users(id),
+  invited_by uuid not null references auth.users(id),
+  status text not null default 'pending' check(status in ('pending','accepted','revoked')),
+  created_at timestamptz not null default now(), accepted_at timestamptz,
+  unique(session_id,invited_user_id),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade,
+  foreign key(org_id,invited_user_id) references public.collaboration_org_members(org_id,user_id)
+);
+create table public.collaboration_events (
+  event_id uuid primary key,
+  org_id uuid not null,
+  session_id uuid not null,
+  seq bigint not null,
+  kind text not null check(kind in ('message','edit','delete')),
+  message_id uuid not null,
+  author_id uuid not null references auth.users(id),
+  role text not null check(role in ('user','assistant','system')),
+  content text,
+  revision integer not null check(revision > 0),
+  logical_bytes bigint not null check(logical_bytes >= 0),
+  request_hash text not null,
+  created_at timestamptz not null default now(),
+  unique(session_id,seq), unique(session_id,event_id),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade
+);
+create table public.collaboration_messages (
+  org_id uuid not null, session_id uuid not null, message_id uuid not null,
+  author_id uuid not null references auth.users(id), role text not null,
+  content text, revision integer not null, deleted boolean not null default false,
+  latest_event_id uuid not null, created_at timestamptz not null, updated_at timestamptz not null,
+  primary key(session_id,message_id),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade,
+  foreign key(session_id,latest_event_id) references public.collaboration_events(session_id,event_id)
+);
+create table public.collaboration_routine_publications (
+  event_id uuid primary key, org_id uuid not null, session_id uuid not null,
+  routine_id uuid not null, creator_id uuid not null references auth.users(id),
+  audience_revision bigint not null, created_at timestamptz not null default now(),
+  foreign key(session_id,event_id) references public.collaboration_events(session_id,event_id) on delete cascade,
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade
+);
+create table public.collaboration_devices (
+  device_id uuid primary key, user_id uuid not null references auth.users(id),
+  label text not null check(length(btrim(label)) between 1 and 120),
+  public_key text not null, fence bigint not null default 1,
+  status text not null default 'active' check(status in ('active','revoked')),
+  enrolled_at timestamptz not null default now(), last_seen_at timestamptz not null default now(),
+  unique(user_id,device_id)
+);
+create table public.collaboration_runs (
+  run_id uuid primary key, org_id uuid not null, session_id uuid not null,
+  request_event_id uuid not null, requester_id uuid not null references auth.users(id),
+  provider_payer_id uuid not null references auth.users(id),
+  audience_revision bigint not null,
+  device_id uuid references public.collaboration_devices(device_id),
+  status text not null default 'queued' check(status in ('queued','leased','completed','cancelled','needs_reconciliation')),
+  lease_token uuid, lease_fence bigint, lease_expires_at timestamptz,
+  response_reservation_id uuid, result_event_id uuid, created_at timestamptz not null default now(), completed_at timestamptz,
+  unique(session_id,request_event_id),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade
+);
+create unique index collaboration_one_started_run on public.collaboration_runs(session_id) where status='leased';
+create table public.collaboration_quota_counters (
+  org_id uuid primary key references public.collaboration_organizations(org_id) on delete cascade,
+  logical_bytes bigint not null default 0, reserved_bytes bigint not null default 0,
+  shared_file_bytes bigint not null default 0, updated_at timestamptz not null default now()
+);
+create table public.collaboration_quota_reservations (
+  reservation_id uuid primary key, org_id uuid not null, session_id uuid not null,
+  run_id uuid, kind text not null check(kind in ('response','file')),
+  reserved_bytes bigint not null check(reserved_bytes > 0), used_bytes bigint not null default 0,
+  status text not null default 'active' check(status in ('active','settled','released','expired')),
+  expires_at timestamptz not null, created_at timestamptz not null default now(), settled_at timestamptz,
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade
+);
+alter table public.collaboration_quota_reservations add constraint collaboration_reservation_scope_uq unique(org_id,session_id,reservation_id);
+alter table public.collaboration_runs add constraint collaboration_run_reservation_fk foreign key(response_reservation_id) references public.collaboration_quota_reservations(reservation_id);
+alter table public.collaboration_quota_reservations add constraint collaboration_reservation_run_fk foreign key(run_id) references public.collaboration_runs(run_id) deferrable initially deferred;
+alter table public.collaboration_runs add constraint collaboration_run_request_event_fk foreign key(session_id,request_event_id) references public.collaboration_events(session_id,event_id);
+alter table public.collaboration_runs add constraint collaboration_run_result_event_fk foreign key(session_id,result_event_id) references public.collaboration_events(session_id,event_id);
+alter table public.collaboration_runs add constraint collaboration_run_device_fk foreign key(requester_id,device_id) references public.collaboration_devices(user_id,device_id);
+alter table public.collaboration_runs add constraint collaboration_run_reservation_scope_fk foreign key(org_id,session_id,response_reservation_id) references public.collaboration_quota_reservations(org_id,session_id,reservation_id) deferrable initially deferred;
+create table public.collaboration_file_reservations (
+  file_id uuid primary key, reservation_id uuid not null unique references public.collaboration_quota_reservations(reservation_id),
+  org_id uuid not null, session_id uuid not null, uploader_id uuid not null references auth.users(id),
+  object_path text not null unique, expected_bytes bigint not null, sha256 text,
+  status text not null default 'reserved' check(status in ('reserved','uploaded','purged')),
+  created_at timestamptz not null default now(),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id) on delete cascade
+);
+create table public.collaboration_archive_manifests (
+  session_id uuid not null references public.collaboration_sessions(session_id) on delete cascade,
+  archive_revision bigint not null, membership_revision bigint not null, final_seq bigint not null,
+  manifest_json text not null, digest text not null check(digest ~ '^[0-9a-f]{64}$'),
+  byte_length bigint not null, status text not null default 'pending' check(status in ('pending','ready','purging','purged')),
+  created_at timestamptz not null default now(), primary key(session_id,archive_revision),
+  unique(session_id,digest)
+);
+create table public.collaboration_archive_recipients (
+  session_id uuid not null, archive_revision bigint not null, user_id uuid not null references auth.users(id),
+  eligible boolean not null default true, receipt_required boolean not null default true,
+  primary key(session_id,archive_revision,user_id),
+  foreign key(session_id,archive_revision) references public.collaboration_archive_manifests(session_id,archive_revision) on delete cascade
+);
+create table public.collaboration_archive_receipts (
+  session_id uuid not null, archive_revision bigint not null, user_id uuid not null,
+  device_id uuid not null references public.collaboration_devices(device_id), digest text not null,
+  byte_length bigint not null, final_seq bigint not null, verified_at timestamptz not null default now(),
+  primary key(session_id,archive_revision,user_id,device_id),
+  foreign key(session_id,archive_revision,user_id) references public.collaboration_archive_recipients(session_id,archive_revision,user_id)
+);
+create table public.collaboration_purge_jobs (
+  session_id uuid primary key references public.collaboration_sessions(session_id) on delete cascade,
+  archive_revision bigint not null, status text not null default 'waiting' check(status in ('waiting','claimed','database_done','objects_done','complete','failed')),
+  lease_token uuid, fence bigint not null default 0, lease_expires_at timestamptz, attempts integer not null default 0,
+  db_checkpoint jsonb not null default '{}'::jsonb, object_checkpoint jsonb not null default '{}'::jsonb,
+  last_error_code text, updated_at timestamptz not null default now()
+);
+create table public.collaboration_tombstones (
+  session_id uuid primary key, org_id uuid not null, final_seq bigint not null, digest text not null,
+  archive_revision bigint not null, eligible_user_ids uuid[] not null, receipt_evidence jsonb not null,
+  archived_at timestamptz not null, purge_completed_at timestamptz not null
+);
+create table public.collaboration_audit (
+  audit_id bigint generated always as identity primary key, org_id uuid, session_id uuid,
+  actor_id uuid, action text not null, detail jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+create table public.collaboration_outbox (
+  outbox_id uuid primary key, org_id uuid not null, session_id uuid,
+  kind text not null, payload jsonb not null, dedup_key text not null unique,
+  status text not null default 'pending' check(status in ('pending','claimed','sent','failed','uncertain','manual_review')),
+  attempts integer not null default 0, fence bigint not null default 0, lease_token uuid, lease_expires_at timestamptz,
+  retry_after timestamptz, slack_ts text, reconcile_cursor text, created_at timestamptz not null default now(), completed_at timestamptz
+);
+
+-- Slack authority. Raw signing verification and encryption happen in the edge function.
+create table public.collaboration_slack_oauth_states (
+  state_hash text primary key, actor_id uuid not null references auth.users(id), org_id uuid not null references public.collaboration_organizations(org_id),
+  expires_at timestamptz not null, consumed_at timestamptz, created_at timestamptz not null default now()
+);
+create table public.collaboration_slack_installations (
+  installation_id uuid primary key default gen_random_uuid(), org_id uuid not null references public.collaboration_organizations(org_id),
+  team_id text not null unique, bot_user_id text not null, token_ciphertext text not null,
+  status text not null default 'active' check(status in ('active','revoked')),
+  installed_at timestamptz not null default now(), revoked_at timestamptz
+);
+alter table public.collaboration_slack_installations add constraint collaboration_slack_install_scope_uq unique(org_id,installation_id);
+create table public.collaboration_slack_sender_links (
+  installation_id uuid not null references public.collaboration_slack_installations(installation_id),
+  slack_user_id text not null, user_id uuid not null references auth.users(id), linked_at timestamptz not null default now(),
+  primary key(installation_id,slack_user_id), unique(installation_id,user_id)
+);
+create table public.collaboration_slack_link_challenges (
+  code_hash text primary key, installation_id uuid not null references public.collaboration_slack_installations(installation_id),
+  user_id uuid not null references auth.users(id), expires_at timestamptz not null,
+  consumed_at timestamptz, created_at timestamptz not null default now()
+);
+create table public.collaboration_slack_channels (
+  installation_id uuid not null references public.collaboration_slack_installations(installation_id),
+  channel_id text not null, org_id uuid not null references public.collaboration_organizations(org_id), selected_by uuid not null references auth.users(id),
+  selected_at timestamptz not null default now(), primary key(installation_id,channel_id),
+  unique(org_id,installation_id,channel_id), foreign key(org_id,installation_id) references public.collaboration_slack_installations(org_id,installation_id)
+);
+create table public.collaboration_slack_threads (
+  org_id uuid not null, installation_id uuid not null, channel_id text not null, root_thread_ts text not null,
+  session_id uuid not null, created_at timestamptz not null default now(),
+  primary key(installation_id,channel_id,root_thread_ts), unique(session_id),
+  foreign key(org_id,installation_id,channel_id) references public.collaboration_slack_channels(org_id,installation_id,channel_id),
+  foreign key(org_id,session_id) references public.collaboration_sessions(org_id,session_id)
+);
+create table public.collaboration_slack_inbox (
+  inbox_id uuid not null default gen_random_uuid() unique, installation_id uuid not null references public.collaboration_slack_installations(installation_id), event_id text not null,
+  event jsonb not null, status text not null default 'pending' check(status in ('pending','claimed','processed','failed')),
+  fence bigint not null default 0, lease_token uuid, lease_expires_at timestamptz, retry_after timestamptz, attempts integer not null default 0, last_error_code text,
+  received_at timestamptz not null default now(), completed_at timestamptz, primary key(installation_id,event_id)
+);
+
+create index collaboration_events_cursor_idx on public.collaboration_events(session_id,seq);
+create index collaboration_members_user_idx on public.collaboration_session_members(user_id,session_id) where status='active';
+create index collaboration_runs_pickup_idx on public.collaboration_runs(requester_id,status,created_at);
+create index collaboration_reservations_expiry_idx on public.collaboration_quota_reservations(status,expires_at);
+create index collaboration_outbox_pickup_idx on public.collaboration_outbox(status,created_at);
+
+-- No table is a direct client mutation surface. Selected membership-scoped rows
+-- are readable; all writes pass through guarded commands.
+do $enable_rls$
+declare r record;
+begin
+  for r in select tablename from pg_tables where schemaname='public' and tablename like 'collaboration_%' loop
+    execute format('alter table public.%I enable row level security',r.tablename);
+    execute format('revoke all on table public.%I from public, anon, authenticated',r.tablename);
+  end loop;
+end $enable_rls$;
+grant select on public.collaboration_config to authenticated;
+grant select on public.collaboration_organizations, public.collaboration_org_members,
+  public.collaboration_sessions, public.collaboration_session_members,
+  public.collaboration_events, public.collaboration_messages, public.collaboration_routine_publications,
+  public.collaboration_runs, public.collaboration_archive_manifests,
+  public.collaboration_archive_recipients, public.collaboration_archive_receipts,
+  public.collaboration_tombstones to authenticated;
+
+create function collaboration_private.is_org_member(p_org_id uuid,p_user_id uuid)
+returns boolean language sql stable security definer set search_path='' as $$
+ select exists(select 1 from public.collaboration_org_members m where m.org_id=p_org_id and m.user_id=p_user_id and m.status='active')
+$$;
+create function collaboration_private.is_session_member(p_session_id uuid,p_user_id uuid)
+returns boolean language sql stable security definer set search_path='' as $$
+ select exists(select 1 from public.collaboration_session_members m join public.collaboration_org_members om on om.org_id=m.org_id and om.user_id=m.user_id and om.status='active' where m.session_id=p_session_id and m.user_id=p_user_id and m.status='active')
+$$;
+create function collaboration_private.can_access_file(p_name text,p_write boolean) returns boolean language sql stable security definer set search_path='' as $$
+ select exists(select 1 from public.collaboration_file_reservations f join public.collaboration_quota_reservations q using(reservation_id) join public.collaboration_sessions s on s.session_id=f.session_id where f.object_path=p_name and collaboration_private.is_session_member(f.session_id,(select auth.uid())) and (not p_write or (f.uploader_id=(select auth.uid()) and f.status='reserved' and q.status='active' and q.expires_at>now() and s.status='active')))
+$$;
+revoke all on function collaboration_private.is_org_member(uuid,uuid), collaboration_private.is_session_member(uuid,uuid), collaboration_private.can_access_file(text,boolean) from public;
+grant execute on function collaboration_private.is_org_member(uuid,uuid), collaboration_private.is_session_member(uuid,uuid), collaboration_private.can_access_file(text,boolean) to authenticated;
+
+create policy collaboration_org_read on public.collaboration_organizations for select to authenticated
+ using ((select collaboration_private.is_org_member(org_id,(select auth.uid()))));
+create policy collaboration_config_read on public.collaboration_config for select to authenticated using (true);
+create policy collaboration_org_member_read on public.collaboration_org_members for select to authenticated
+ using ((select collaboration_private.is_org_member(org_id,(select auth.uid()))));
+create policy collaboration_session_read on public.collaboration_sessions for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_session_member_read on public.collaboration_session_members for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_event_read on public.collaboration_events for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_message_read on public.collaboration_messages for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_routine_publication_read on public.collaboration_routine_publications for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_run_read on public.collaboration_runs for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_manifest_read on public.collaboration_archive_manifests for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_recipient_read on public.collaboration_archive_recipients for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_receipt_read on public.collaboration_archive_receipts for select to authenticated
+ using ((select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+create policy collaboration_tombstone_read on public.collaboration_tombstones for select to authenticated
+ using ((select auth.uid())=any(eligible_user_ids));
+
+-- Private shared-file bucket. Object path is exactly org/session/file UUIDs;
+-- inserts require an active reservation, and reads require session membership.
+insert into storage.buckets(id,name,public,file_size_limit)
+values('collaboration-files','collaboration-files',false,5242880)
+on conflict(id) do update set public=false,file_size_limit=excluded.file_size_limit;
+create policy collaboration_files_read on storage.objects for select to authenticated using (
+ bucket_id='collaboration-files' and (select collaboration_private.can_access_file(name,false)));
+create policy collaboration_files_insert on storage.objects for insert to authenticated with check (
+ bucket_id='collaboration-files' and (select collaboration_private.can_access_file(name,true)));
+
+-- Realtime is only a wake-up hint. Topics include the current membership
+-- revision, so revocation rotates the authorized topic immediately.
+do $realtime_policy$
+begin
+ if to_regclass('realtime.messages') is not null then
+   execute $policy$create policy collaboration_realtime_receive on realtime.messages
+     for select to authenticated using (
+       realtime.topic() ~ '^collaboration:[0-9a-f-]{36}:[0-9]+$'
+       and exists (
+         select 1 from public.collaboration_sessions s
+         where s.session_id=split_part(realtime.topic(),':',2)::uuid
+           and s.membership_revision=split_part(realtime.topic(),':',3)::bigint
+           and collaboration_private.is_session_member(s.session_id,(select auth.uid()))
+       )
+     )$policy$;
+ end if;
+end $realtime_policy$;
+
+create function collaboration_private.fail(p_code text,p_detail text default null) returns jsonb
+language plpgsql volatile security invoker set search_path='' as $$ begin
+ raise exception '%',p_code using errcode='P0001',detail=coalesce(p_detail,''); end $$;
+
+create function collaboration_private.command(p_actor uuid,p_command text,p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare
+ cfg public.collaboration_config%rowtype; s public.collaboration_sessions%rowtype; m public.collaboration_messages%rowtype;
+ v_org uuid; v_session uuid; v_event uuid; v_message uuid; v_run uuid; v_invite uuid; v_device uuid; v_res uuid;
+ v_expected bigint; v_seq bigint; v_bytes bigint; v_cursor bigint; v_limit int; v_count int; v_hash text; v_role text; v_content text;
+ v_manifest text; v_digest text; v_archive_rev bigint; v_result jsonb; v_fence bigint; v_expiry timestamptz;
+begin
+ if p_actor is null or p_actor is distinct from (select auth.uid()) then perform collaboration_private.fail('UNAUTHENTICATED'); end if;
+ if p_payload is null or jsonb_typeof(p_payload)<>'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+ select * into cfg from public.collaboration_config where singleton for share;
+ if p_command='bootstrap' then
+   return jsonb_build_object('ok',true,'gates',jsonb_build_object('shared_text',cfg.shared_text_enabled,'shared_execution',cfg.shared_execution_enabled,'archive',cfg.archive_enabled,'slack',cfg.slack_enabled),
+    'organizations',coalesce((select jsonb_agg(jsonb_build_object('org_id',o.org_id,'name',o.name,'revision',o.revision)) from public.collaboration_organizations o join public.collaboration_org_members om using(org_id) where om.user_id=p_actor and om.status='active'),'[]'::jsonb),
+    'sessions',coalesce((select jsonb_agg(jsonb_build_object('session_id',bs.session_id,'org_id',bs.org_id,'title',bs.title,'status',bs.status,'revision',bs.revision,'membership_revision',bs.membership_revision,'high_water',bs.next_seq-1,'message_count',bs.message_count,'logical_bytes',bs.logical_bytes,'reserved_bytes',bs.reserved_bytes,'warning',bs.logical_bytes+bs.reserved_bytes>=cfg.session_warn_bytes,'run_state',(select jsonb_build_object('run_id',r.run_id,'status',case when r.status='leased' then 'running' else r.status end,'requested_by',r.requester_id,'created_at',r.created_at) from public.collaboration_runs r where r.session_id=bs.session_id and r.status in('queued','leased','needs_reconciliation') order by r.created_at limit 1),'members',coalesce((select jsonb_agg(jsonb_build_object('user_id',sm2.user_id,'display_name',om.display_name,'role',sm2.role,'status',sm2.status)) from public.collaboration_session_members sm2 join public.collaboration_org_members om on om.org_id=sm2.org_id and om.user_id=sm2.user_id where sm2.session_id=bs.session_id),'[]'::jsonb))) from public.collaboration_sessions bs join public.collaboration_session_members sm using(session_id) where sm.user_id=p_actor and sm.status='active'),'[]'::jsonb),
+    'invites',coalesce((select jsonb_agg(x) from (select jsonb_build_object('kind','session','invite_id',i.invite_id,'org_id',i.org_id,'session_id',i.session_id,'invited_by',i.invited_by) x from public.collaboration_invites i where i.invited_user_id=p_actor and i.status='pending' union all select jsonb_build_object('kind','organization','invite_id',oi.invite_id,'org_id',oi.org_id,'invited_by',oi.invited_by,'display_name',oi.display_name) from public.collaboration_org_invites oi where oi.invited_user_id=p_actor and oi.status='pending') q),'[]'::jsonb),
+    'queued_runs',coalesce((select jsonb_agg(jsonb_build_object('run_id',r.run_id,'session_id',r.session_id,'provider_payer_id',r.provider_payer_id,'created_at',r.created_at)) from public.collaboration_runs r where r.requester_id=p_actor and r.status='queued' and collaboration_private.is_session_member(r.session_id,p_actor)),'[]'::jsonb));
+ end if;
+ if not cfg.shared_text_enabled and p_command in ('create_organization','invite_organization','accept_organization_invite','create_session','invite','accept_invite','append_message','edit_message','delete_message','publish_routine','claim_run','renew_run','complete_run','continue_session','begin_slack_link','select_slack_channel') then perform collaboration_private.fail('FEATURE_DISABLED'); end if;
+ if p_command='create_organization' then
+   v_org:=coalesce((p_payload->>'org_id')::uuid,gen_random_uuid());
+   insert into public.collaboration_organizations(org_id,name,owner_id) values(v_org,p_payload->>'name',p_actor);
+   insert into public.collaboration_org_members(org_id,user_id,display_name,role) values(v_org,p_actor,coalesce(nullif(p_payload->>'display_name',''),p_payload->>'name'),'owner');
+   insert into public.collaboration_quota_counters(org_id) values(v_org); return jsonb_build_object('ok',true,'org_id',v_org,'revision',1);
+ elsif p_command='invite_organization' then
+   v_org:=(p_payload->>'org_id')::uuid; if not exists(select 1 from public.collaboration_org_members where org_id=v_org and user_id=p_actor and status='active' and role in('owner','admin')) then perform collaboration_private.fail('FORBIDDEN'); end if; v_invite:=(p_payload->>'invite_id')::uuid; insert into public.collaboration_org_invites values(v_invite,v_org,(p_payload->>'user_id')::uuid,p_actor,p_payload->>'display_name','pending',now(),null); return jsonb_build_object('ok',true,'invite_id',v_invite);
+ elsif p_command='accept_organization_invite' then
+   v_invite:=(p_payload->>'invite_id')::uuid; update public.collaboration_org_invites set status='accepted',accepted_at=now() where invite_id=v_invite and invited_user_id=p_actor and status='pending' returning org_id,display_name into v_org,v_content; if not found then perform collaboration_private.fail('NOT_FOUND'); end if; insert into public.collaboration_org_members(org_id,user_id,display_name,role) values(v_org,p_actor,v_content,'member'); return jsonb_build_object('ok',true,'org_id',v_org);
+ elsif p_command='directory' then
+   v_org:=(p_payload->>'org_id')::uuid; if not collaboration_private.is_org_member(v_org,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   return jsonb_build_object('ok',true,'members',coalesce((select jsonb_agg(jsonb_build_object('user_id',user_id,'display_name',display_name,'role',role,'revision',revision)) from public.collaboration_org_members where org_id=v_org and status='active'),'[]'::jsonb));
+ elsif p_command='slack_settings' then
+   v_org:=(p_payload->>'org_id')::uuid; if not collaboration_private.is_org_member(v_org,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if; return jsonb_build_object('ok',true,'installations',coalesce((select jsonb_agg(jsonb_build_object('installation_id',i.installation_id,'team_id',i.team_id,'status',i.status,'linked_current_user',exists(select 1 from public.collaboration_slack_sender_links l where l.installation_id=i.installation_id and l.user_id=p_actor),'selected_channels',coalesce((select jsonb_agg(c.channel_id) from public.collaboration_slack_channels c where c.installation_id=i.installation_id),'[]'::jsonb))) from public.collaboration_slack_installations i where i.org_id=v_org),'[]'::jsonb));
+ elsif p_command='create_session' then
+   v_org:=(p_payload->>'org_id')::uuid; if not collaboration_private.is_org_member(v_org,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   perform 1 from public.collaboration_quota_counters where org_id=v_org for update;
+   if not exists(select 1 from (select * from public.collaboration_capacity_measurements order by measured_at desc limit 1) latest where latest.measured_at>now()-interval '36 hours' and latest.database_bytes+cfg.admission_reserve_bytes<cfg.project_physical_stop_bytes and latest.collaboration_bytes<262144000) then perform collaboration_private.fail('CAPACITY_UNMEASURED'); end if;
+   select count(*) into v_count from public.collaboration_sessions where org_id=v_org and status<>'archived_local'; if v_count>=cfg.max_sessions_per_org then perform collaboration_private.fail('QUOTA_EXCEEDED','session_count'); end if;
+   v_session:=coalesce((p_payload->>'session_id')::uuid,gen_random_uuid()); insert into public.collaboration_sessions(session_id,org_id,created_by,title) values(v_session,v_org,p_actor,nullif(p_payload->>'title',''));
+   insert into public.collaboration_session_members(org_id,session_id,user_id,role,status,joined_at) values(v_org,v_session,p_actor,'owner','active',now()); return jsonb_build_object('ok',true,'session_id',v_session,'org_id',v_org,'revision',1);
+ elsif p_command='invite' then
+   v_session:=(p_payload->>'session_id')::uuid; select * into s from public.collaboration_sessions where session_id=v_session for update; if not found then perform collaboration_private.fail('NOT_FOUND'); end if; if s.status<>'active' then perform collaboration_private.fail('SESSION_CLOSED'); end if;
+   if not exists(select 1 from public.collaboration_session_members where session_id=v_session and user_id=p_actor and status='active' and role='owner') then perform collaboration_private.fail('FORBIDDEN'); end if;
+   select count(*) into v_count from public.collaboration_session_members where session_id=v_session and status in ('active','invited'); if v_count>=cfg.max_participants then perform collaboration_private.fail('QUOTA_EXCEEDED','participants'); end if;
+   v_invite:=(p_payload->>'invite_id')::uuid; insert into public.collaboration_invites(invite_id,org_id,session_id,invited_user_id,invited_by) values(v_invite,s.org_id,v_session,(p_payload->>'user_id')::uuid,p_actor);
+   insert into public.collaboration_session_members(org_id,session_id,user_id,role,status,invite_id) values(s.org_id,v_session,(p_payload->>'user_id')::uuid,'member','invited',v_invite); update public.collaboration_sessions set membership_revision=membership_revision+1,revision=revision+1 where session_id=v_session;
+   return jsonb_build_object('ok',true,'invite_id',v_invite);
+ elsif p_command='accept_invite' then
+   v_invite:=(p_payload->>'invite_id')::uuid; update public.collaboration_invites i set status='accepted',accepted_at=now() from public.collaboration_sessions target_session where i.invite_id=v_invite and i.invited_user_id=p_actor and i.status='pending' and target_session.session_id=i.session_id and target_session.status='active' returning i.session_id into v_session; if not found then perform collaboration_private.fail('NOT_FOUND'); end if;
+   update public.collaboration_session_members set status='active',joined_at=now() where invite_id=v_invite and user_id=p_actor; update public.collaboration_sessions set membership_revision=membership_revision+1,revision=revision+1 where session_id=v_session; return jsonb_build_object('ok',true,'session_id',v_session);
+ elsif p_command='read_events' then
+   v_session:=(p_payload->>'session_id')::uuid; if not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   v_cursor:=coalesce((p_payload->>'cursor')::bigint,0); v_limit:=least(greatest(coalesce((p_payload->>'limit')::int,100),1),500);
+   select next_seq-1 into v_seq from public.collaboration_sessions where session_id=v_session;
+   return jsonb_build_object('ok',true,'events',coalesce((select jsonb_agg(x.obj order by x.seq) from (select e.seq,jsonb_build_object('event_id',e.event_id,'session_id',e.session_id,'seq',e.seq,'kind',e.kind,'message_id',e.message_id,'author_id',e.author_id,'role',e.role,'content',e.content,'revision',e.revision,'created_at',e.created_at) obj from public.collaboration_events e where e.session_id=v_session and e.seq>v_cursor and e.seq<=v_seq order by e.seq limit v_limit)x),'[]'::jsonb),'next_cursor',coalesce((select max(seq) from (select seq from public.collaboration_events where session_id=v_session and seq>v_cursor and seq<=v_seq order by seq limit v_limit)q),v_cursor),'high_water',v_seq,'run_state',(select jsonb_build_object('run_id',r.run_id,'status',case when r.status='leased' then 'running' else r.status end,'requested_by',r.requester_id,'created_at',r.created_at) from public.collaboration_runs r where r.session_id=v_session and r.status in('queued','leased','needs_reconciliation') order by r.created_at limit 1));
+ elsif p_command='list_pending_runs' then
+   return jsonb_build_object('ok',true,'runs',coalesce((select jsonb_agg(jsonb_build_object('run_id',r.run_id,'session_id',r.session_id,'request_event_id',r.request_event_id,'provider_payer_id',r.provider_payer_id,'created_at',r.created_at) order by r.created_at) from public.collaboration_runs r where r.requester_id=p_actor and r.status='queued' and collaboration_private.is_session_member(r.session_id,p_actor)),'[]'::jsonb));
+ elsif p_command in ('append_message','edit_message','delete_message') then
+   v_session:=(p_payload->>'session_id')::uuid; v_event:=(p_payload->>'event_id')::uuid; v_message:=(p_payload->>'message_id')::uuid; v_content:=p_payload->>'content'; v_hash:=encode(extensions.digest(convert_to(p_actor::text||':'||p_command||':'||p_payload::text,'UTF8'),'sha256'),'hex');
+   select * into s from public.collaboration_sessions where session_id=v_session for update; if not found or not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   if exists(select 1 from public.collaboration_events where event_id=v_event) then if exists(select 1 from public.collaboration_events where event_id=v_event and request_hash=v_hash) then return (select jsonb_build_object('ok',true,'deduplicated',true,'event_id',e.event_id,'session_id',e.session_id,'seq',e.seq,'message_id',e.message_id,'revision',e.revision,'run_id',r.run_id,'reservation_id',r.response_reservation_id) from public.collaboration_events e left join public.collaboration_runs r on r.session_id=e.session_id and r.request_event_id=e.event_id where e.event_id=v_event); else perform collaboration_private.fail('IDEMPOTENCY_CONFLICT'); end if; end if;
+   if s.status<>'active' then perform collaboration_private.fail('SESSION_CLOSED'); end if;
+   v_role:=coalesce(p_payload->>'role','user'); if v_role<>'user' then perform collaboration_private.fail('FORBIDDEN','client_author_role'); end if;
+   if p_command='append_message' then
+     if s.message_count+1+(select count(*) from public.collaboration_runs where session_id=v_session and status in('queued','leased'))+(case when coalesce((p_payload->>'request_run')::boolean,false) then 1 else 0 end)>cfg.max_messages_per_session then perform collaboration_private.fail('QUOTA_EXCEEDED','reserved_message_slot'); end if; v_expected:=1;
+   else
+     select * into m from public.collaboration_messages where session_id=v_session and message_id=v_message for update; if not found then perform collaboration_private.fail('NOT_FOUND'); end if; if m.author_id<>p_actor then perform collaboration_private.fail('FORBIDDEN'); end if;
+     if m.revision is distinct from (p_payload->>'expected_revision')::bigint then perform collaboration_private.fail('REVISION_CONFLICT'); end if; v_expected:=m.revision+1;
+   end if;
+   -- Includes conservative event/index plus canonical-manifest headroom.
+   v_bytes:=octet_length(convert_to(coalesce(v_content,''),'UTF8'))+640;
+   perform 1 from public.collaboration_quota_counters where org_id=s.org_id for update;
+   if s.logical_bytes+s.reserved_bytes+v_bytes>cfg.session_limit_bytes or (select logical_bytes+reserved_bytes from public.collaboration_quota_counters where org_id=s.org_id)+v_bytes>cfg.org_limit_bytes or (select coalesce(sum(logical_bytes+reserved_bytes),0) from public.collaboration_quota_counters)+v_bytes>cfg.project_logical_limit_bytes then perform collaboration_private.fail('QUOTA_EXCEEDED','bytes'); end if;
+   v_seq:=s.next_seq; insert into public.collaboration_events(event_id,org_id,session_id,seq,kind,message_id,author_id,role,content,revision,logical_bytes,request_hash) values(v_event,s.org_id,v_session,v_seq,case p_command when 'append_message' then 'message' when 'edit_message' then 'edit' else 'delete' end,v_message,p_actor,v_role,case when p_command='delete_message' then null else v_content end,v_expected,v_bytes,v_hash);
+   if p_command='append_message' then insert into public.collaboration_messages values(s.org_id,v_session,v_message,p_actor,v_role,v_content,1,false,v_event,now(),now()); else update public.collaboration_messages set content=case when p_command='delete_message' then null else v_content end,deleted=(p_command='delete_message'),revision=v_expected,latest_event_id=v_event,updated_at=now() where session_id=v_session and message_id=v_message; end if;
+   update public.collaboration_sessions set next_seq=next_seq+1,message_count=message_count+(case when p_command='append_message' then 1 else 0 end),logical_bytes=logical_bytes+v_bytes,last_published_at=now(),revision=revision+1 where session_id=v_session;
+   update public.collaboration_quota_counters set logical_bytes=logical_bytes+v_bytes,updated_at=now() where org_id=s.org_id;
+   if p_command='append_message' and coalesce((p_payload->>'request_run')::boolean,false) then
+     if not cfg.shared_execution_enabled then perform collaboration_private.fail('FEATURE_DISABLED','shared_execution'); end if;
+     v_run:=coalesce((p_payload->>'run_id')::uuid,gen_random_uuid()); v_res:=coalesce((p_payload->>'reservation_id')::uuid,gen_random_uuid()); v_bytes:=least(coalesce((p_payload->>'response_reservation_bytes')::bigint,cfg.default_response_reservation_bytes),cfg.session_limit_bytes);
+     if s.logical_bytes+s.reserved_bytes+(octet_length(convert_to(coalesce(v_content,''),'UTF8'))+640)+v_bytes>cfg.session_limit_bytes
+        or (select logical_bytes+reserved_bytes from public.collaboration_quota_counters where org_id=s.org_id)+v_bytes+(octet_length(convert_to(coalesce(v_content,''),'UTF8'))+640)>cfg.org_limit_bytes
+        or (select coalesce(sum(logical_bytes+reserved_bytes),0) from public.collaboration_quota_counters)+v_bytes>cfg.project_logical_limit_bytes then perform collaboration_private.fail('QUOTA_EXCEEDED','response_reservation'); end if;
+     insert into public.collaboration_quota_reservations(reservation_id,org_id,session_id,run_id,kind,reserved_bytes,expires_at) values(v_res,s.org_id,v_session,v_run,'response',v_bytes,now()+interval '2 hours');
+     insert into public.collaboration_runs(run_id,org_id,session_id,request_event_id,requester_id,provider_payer_id,audience_revision,response_reservation_id) values(v_run,s.org_id,v_session,v_event,p_actor,p_actor,s.membership_revision,v_res);
+     update public.collaboration_sessions set reserved_bytes=reserved_bytes+v_bytes where session_id=v_session; update public.collaboration_quota_counters set reserved_bytes=reserved_bytes+v_bytes where org_id=s.org_id;
+   end if;
+   perform pg_catalog.pg_notify('collaboration_hint',jsonb_build_object('session_id',v_session,'high_water',v_seq,'membership_revision',s.membership_revision)::text);
+   return jsonb_build_object('ok',true,'event_id',v_event,'session_id',v_session,'seq',v_seq,'message_id',v_message,'revision',v_expected,'run_id',v_run,'reservation_id',v_res,'warning',case when s.logical_bytes+v_bytes>=cfg.session_warn_bytes then 'SESSION_STORAGE_WARNING' else null end);
+ elsif p_command='publish_routine' then
+   v_session:=(p_payload->>'session_id')::uuid; v_event:=(p_payload->>'event_id')::uuid; v_message:=(p_payload->>'message_id')::uuid; v_content:=p_payload->>'content'; v_hash:=encode(extensions.digest(convert_to(p_actor::text||':publish_routine:'||p_payload::text,'UTF8'),'sha256'),'hex'); select * into s from public.collaboration_sessions where session_id=v_session for update; if not found or not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   if exists(select 1 from public.collaboration_events where event_id=v_event) then if exists(select 1 from public.collaboration_events where event_id=v_event and request_hash=v_hash and author_id=p_actor) then return (select jsonb_build_object('ok',true,'deduplicated',true,'event',jsonb_build_object('event_id',event_id,'session_id',session_id,'seq',seq,'kind',kind,'message_id',message_id,'author_id',author_id,'role',role,'content',content,'revision',revision,'created_at',created_at)) from public.collaboration_events where event_id=v_event); else perform collaboration_private.fail('IDEMPOTENCY_CONFLICT'); end if; end if;
+   if s.status<>'active' then perform collaboration_private.fail('SESSION_CLOSED'); end if; if s.membership_revision is distinct from (p_payload->>'audience_revision')::bigint then perform collaboration_private.fail('STALE_MEMBERSHIP'); end if;
+   if s.message_count+1+(select count(*) from public.collaboration_runs where session_id=v_session and status in('queued','leased'))>cfg.max_messages_per_session then perform collaboration_private.fail('QUOTA_EXCEEDED','reserved_message_slot'); end if; v_bytes:=octet_length(convert_to(coalesce(v_content,''),'UTF8'))+640; perform 1 from public.collaboration_quota_counters where org_id=s.org_id for update; if s.logical_bytes+s.reserved_bytes+v_bytes>cfg.session_limit_bytes or (select logical_bytes+reserved_bytes from public.collaboration_quota_counters where org_id=s.org_id)+v_bytes>cfg.org_limit_bytes or (select coalesce(sum(logical_bytes+reserved_bytes),0) from public.collaboration_quota_counters)+v_bytes>cfg.project_logical_limit_bytes then perform collaboration_private.fail('QUOTA_EXCEEDED','bytes'); end if;
+   v_seq:=s.next_seq; insert into public.collaboration_events values(v_event,s.org_id,v_session,v_seq,'message',v_message,p_actor,'assistant',v_content,1,v_bytes,v_hash,now()); insert into public.collaboration_messages values(s.org_id,v_session,v_message,p_actor,'assistant',v_content,1,false,v_event,now(),now()); insert into public.collaboration_routine_publications(event_id,org_id,session_id,routine_id,creator_id,audience_revision) values(v_event,s.org_id,v_session,(p_payload->>'routine_id')::uuid,p_actor,s.membership_revision); update public.collaboration_sessions set next_seq=next_seq+1,message_count=message_count+1,logical_bytes=logical_bytes+v_bytes,last_published_at=now(),revision=revision+1 where session_id=v_session; update public.collaboration_quota_counters set logical_bytes=logical_bytes+v_bytes,updated_at=now() where org_id=s.org_id; if exists(select 1 from public.collaboration_slack_threads where session_id=v_session) then insert into public.collaboration_outbox(outbox_id,org_id,session_id,kind,payload,dedup_key) values(gen_random_uuid(),s.org_id,v_session,'slack_message',jsonb_build_object('content',v_content,'event_id',v_event,'routine_id',p_payload->>'routine_id'),v_event::text) on conflict(dedup_key) do nothing; end if; perform pg_catalog.pg_notify('collaboration_hint',jsonb_build_object('session_id',v_session,'high_water',v_seq,'membership_revision',s.membership_revision)::text); return jsonb_build_object('ok',true,'event',jsonb_build_object('event_id',v_event,'session_id',v_session,'seq',v_seq,'kind','message','message_id',v_message,'author_id',p_actor,'role','assistant','content',v_content,'revision',1,'created_at',now()));
+ elsif p_command='enroll_device' then
+   v_device:=(p_payload->>'device_id')::uuid; insert into public.collaboration_devices(device_id,user_id,label,public_key) values(v_device,p_actor,p_payload->>'label',p_payload->>'public_key') on conflict(device_id) do update set label=excluded.label,last_seen_at=now() where collaboration_devices.user_id=p_actor and collaboration_devices.public_key=excluded.public_key returning fence into v_fence; if not found then perform collaboration_private.fail('DEVICE_KEY_MISMATCH'); end if; return jsonb_build_object('ok',true,'device_id',v_device,'fence',v_fence);
+ elsif p_command='claim_run' then
+   if not cfg.shared_execution_enabled then perform collaboration_private.fail('FEATURE_DISABLED'); end if; v_run:=(p_payload->>'run_id')::uuid; v_device:=(p_payload->>'device_id')::uuid;
+   select fence into v_fence from public.collaboration_devices where device_id=v_device and user_id=p_actor and status='active' for update; if not found then perform collaboration_private.fail('DEVICE_FENCED'); end if;
+   update public.collaboration_devices set last_seen_at=now() where device_id=v_device returning fence into v_fence;
+   update public.collaboration_runs r set status='leased',device_id=v_device,lease_token=gen_random_uuid(),lease_fence=v_fence,lease_expires_at=now()+interval '2 minutes' where r.run_id=v_run and r.requester_id=p_actor and (r.status='queued' or (r.status='leased' and r.lease_expires_at<now())) and exists(select 1 from public.collaboration_sessions ss where ss.session_id=r.session_id and ss.status in('active','closing') and ss.membership_revision=r.audience_revision) and collaboration_private.is_session_member(r.session_id,p_actor) and not exists(select 1 from public.collaboration_runs other where other.session_id=r.session_id and other.run_id<>r.run_id and other.status='leased' and other.lease_expires_at>now()) returning r.lease_token,r.session_id into v_res,v_session; if not found then perform collaboration_private.fail('RUN_UNAVAILABLE'); end if;
+   return jsonb_build_object('ok',true,'run_id',v_run,'lease_token',v_res,'fence',v_fence,'lease_expires_at',(select lease_expires_at from public.collaboration_runs where run_id=v_run),'session_id',v_session,'requester_id',(select requester_id from public.collaboration_runs where run_id=v_run),'credential_owner_id',(select provider_payer_id from public.collaboration_runs where run_id=v_run),'provider_payer_id',(select provider_payer_id from public.collaboration_runs where run_id=v_run),'executor_device_id',v_device,'audience_revision',(select audience_revision from public.collaboration_runs where run_id=v_run),'request_event_id',(select request_event_id from public.collaboration_runs where run_id=v_run),'request_content',(select e.content from public.collaboration_runs r join public.collaboration_events e on e.session_id=r.session_id and e.event_id=r.request_event_id where r.run_id=v_run),'context_cutoff',(select next_seq-1 from public.collaboration_sessions where session_id=v_session),'events',coalesce((select jsonb_agg(jsonb_build_object('event_id',e.event_id,'session_id',e.session_id,'seq',e.seq,'kind',e.kind,'message_id',e.message_id,'author_id',e.author_id,'role',e.role,'content',e.content,'revision',e.revision,'created_at',e.created_at) order by e.seq) from public.collaboration_events e where e.session_id=v_session),'[]'::jsonb));
+ elsif p_command='renew_run' then
+   v_run:=(p_payload->>'run_id')::uuid; v_device:=(p_payload->>'device_id')::uuid; update public.collaboration_runs r set lease_expires_at=now()+interval '2 minutes' from public.collaboration_devices d,public.collaboration_sessions renew_session where r.run_id=v_run and r.requester_id=p_actor and r.device_id=v_device and r.lease_token=(p_payload->>'lease_token')::uuid and r.status='leased' and r.lease_expires_at>now() and d.device_id=v_device and d.user_id=p_actor and d.status='active' and d.fence=r.lease_fence and renew_session.session_id=r.session_id and renew_session.status in('active','closing') and renew_session.membership_revision=r.audience_revision and collaboration_private.is_session_member(r.session_id,p_actor) returning r.lease_expires_at into v_expiry; if not found then perform collaboration_private.fail('DEVICE_FENCED'); end if; return jsonb_build_object('ok',true,'lease_expires_at',v_expiry);
+ elsif p_command='cancel_run' then
+   v_run:=(p_payload->>'run_id')::uuid; update public.collaboration_runs set status=case when status='queued' then 'cancelled' else 'needs_reconciliation' end,completed_at=now(),lease_token=null,lease_expires_at=null where run_id=v_run and requester_id=p_actor and status in('queued','leased') and (status='queued' or lease_token=(p_payload->>'lease_token')::uuid) returning response_reservation_id into v_res; if not found then perform collaboration_private.fail('RUN_UNAVAILABLE'); end if; select reserved_bytes,session_id,org_id into v_bytes,v_session,v_org from public.collaboration_quota_reservations where reservation_id=v_res and status='active' for update; if found then update public.collaboration_sessions set reserved_bytes=greatest(0,reserved_bytes-v_bytes) where session_id=v_session; update public.collaboration_quota_counters set reserved_bytes=greatest(0,reserved_bytes-v_bytes) where org_id=v_org; update public.collaboration_quota_reservations set status='released',settled_at=now() where reservation_id=v_res; end if; return jsonb_build_object('ok',true,'run_id',v_run,'needs_reconciliation',(select status='needs_reconciliation' from public.collaboration_runs where run_id=v_run));
+ elsif p_command='stop_session_run' then
+   v_session:=(p_payload->>'session_id')::uuid; if not exists(select 1 from public.collaboration_session_members where session_id=v_session and user_id=p_actor and status='active') then perform collaboration_private.fail('FORBIDDEN'); end if; update public.collaboration_runs r set status=case when r.status='leased' then 'needs_reconciliation' else 'cancelled' end,completed_at=now(),lease_token=null,lease_expires_at=null where r.run_id=(select rr.run_id from public.collaboration_runs rr where rr.session_id=v_session and rr.status in('queued','leased') and (rr.requester_id=p_actor or exists(select 1 from public.collaboration_session_members sm where sm.session_id=v_session and sm.user_id=p_actor and sm.role='owner' and sm.status='active')) order by rr.created_at limit 1 for update skip locked) returning r.run_id,r.response_reservation_id into v_run,v_res; if not found then return jsonb_build_object('ok',true,'stopped',false); end if; select reserved_bytes,org_id into v_bytes,v_org from public.collaboration_quota_reservations where reservation_id=v_res and status='active' for update; if found then update public.collaboration_sessions set reserved_bytes=greatest(0,reserved_bytes-v_bytes) where session_id=v_session; update public.collaboration_quota_counters set reserved_bytes=greatest(0,reserved_bytes-v_bytes) where org_id=v_org; update public.collaboration_quota_reservations set status='released',settled_at=now() where reservation_id=v_res; end if; return jsonb_build_object('ok',true,'stopped',true,'run_id',v_run,'needs_reconciliation',(select status='needs_reconciliation' from public.collaboration_runs where run_id=v_run));
+ elsif p_command='resolve_reconciliation' then
+   v_run:=(p_payload->>'run_id')::uuid; update public.collaboration_runs set status='cancelled',completed_at=now() where run_id=v_run and requester_id=p_actor and status='needs_reconciliation'; if not found then perform collaboration_private.fail('RUN_UNAVAILABLE'); end if; return jsonb_build_object('ok',true,'run_id',v_run,'status','cancelled');
+ elsif p_command='revoke_device' then
+   v_device:=(p_payload->>'device_id')::uuid; update public.collaboration_devices set status='revoked',fence=fence+1 where device_id=v_device and user_id=p_actor; if not found then perform collaboration_private.fail('NOT_FOUND'); end if; update public.collaboration_runs set status='needs_reconciliation',lease_token=null,lease_expires_at=null where device_id=v_device and status='leased'; return jsonb_build_object('ok',true,'device_id',v_device);
+ elsif p_command='complete_run' then
+   v_run:=(p_payload->>'run_id')::uuid; select * into s from public.collaboration_sessions where session_id=(select session_id from public.collaboration_runs where run_id=v_run) for update;
+   if exists(select 1 from public.collaboration_runs where run_id=v_run and requester_id=p_actor and status='completed') then return jsonb_build_object('ok',true,'deduplicated',true,'event_id',(select result_event_id from public.collaboration_runs where run_id=v_run)); end if;
+   perform 1 from public.collaboration_runs r join public.collaboration_devices d on d.device_id=r.device_id join public.collaboration_sessions ss on ss.session_id=r.session_id where r.run_id=v_run and r.requester_id=p_actor and r.status='leased' and r.lease_token=(p_payload->>'lease_token')::uuid and r.lease_expires_at>now() and d.fence=r.lease_fence and d.status='active' and ss.status in('active','closing') and ss.membership_revision=r.audience_revision and collaboration_private.is_session_member(r.session_id,p_actor); if not found then perform collaboration_private.fail('DEVICE_FENCED'); end if;
+   v_event:=(p_payload->>'event_id')::uuid; v_message:=(p_payload->>'message_id')::uuid; v_content:=p_payload->>'content'; v_bytes:=octet_length(convert_to(v_content,'UTF8'))+640;
+   select response_reservation_id into v_res from public.collaboration_runs where run_id=v_run; if v_bytes>(select reserved_bytes from public.collaboration_quota_reservations where reservation_id=v_res and status='active') then perform collaboration_private.fail('QUOTA_EXCEEDED','reserved_response'); end if;
+   v_seq:=s.next_seq; insert into public.collaboration_events values(v_event,s.org_id,s.session_id,v_seq,'message',v_message,p_actor,'assistant',v_content,1,v_bytes,encode(extensions.digest(convert_to(p_payload::text,'UTF8'),'sha256'),'hex'),now()); insert into public.collaboration_messages values(s.org_id,s.session_id,v_message,p_actor,'assistant',v_content,1,false,v_event,now(),now());
+   update public.collaboration_quota_reservations set status='settled',used_bytes=v_bytes,settled_at=now() where reservation_id=v_res; update public.collaboration_runs set status='completed',result_event_id=v_event,completed_at=now(),lease_token=null,lease_expires_at=null where run_id=v_run;
+   update public.collaboration_sessions set next_seq=next_seq+1,message_count=message_count+1,logical_bytes=logical_bytes+v_bytes,reserved_bytes=reserved_bytes-(select reserved_bytes from public.collaboration_quota_reservations where reservation_id=v_res),last_published_at=now(),revision=revision+1,status=case when message_count+1>=cfg.max_messages_per_session or logical_bytes+v_bytes>=cfg.session_limit_bytes then 'closing' else status end,final_seq=case when message_count+1>=cfg.max_messages_per_session or logical_bytes+v_bytes>=cfg.session_limit_bytes then next_seq else final_seq end where session_id=s.session_id;
+   update public.collaboration_quota_counters set logical_bytes=logical_bytes+v_bytes,reserved_bytes=reserved_bytes-(select reserved_bytes from public.collaboration_quota_reservations where reservation_id=v_res) where org_id=s.org_id;
+   if exists(select 1 from public.collaboration_slack_threads where session_id=s.session_id) then insert into public.collaboration_outbox(outbox_id,org_id,session_id,kind,payload,dedup_key) values(gen_random_uuid(),s.org_id,s.session_id,'slack_message',jsonb_build_object('content',v_content,'event_id',v_event),v_event::text) on conflict(dedup_key) do nothing; end if;
+   perform pg_catalog.pg_notify('collaboration_hint',jsonb_build_object('session_id',s.session_id,'high_water',v_seq,'membership_revision',s.membership_revision)::text);
+   return jsonb_build_object('ok',true,'event_id',v_event,'seq',v_seq);
+ elsif p_command='request_archive' then
+   if not cfg.archive_enabled then perform collaboration_private.fail('FEATURE_DISABLED'); end if; v_session:=(p_payload->>'session_id')::uuid; select * into s from public.collaboration_sessions where session_id=v_session for update;
+   if not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if; if s.status not in ('active','closing') then perform collaboration_private.fail('INVALID_STATE'); end if; if exists(select 1 from public.collaboration_runs where session_id=v_session and status='needs_reconciliation') then perform collaboration_private.fail('RUN_ACTIVE'); end if;
+   update public.collaboration_sessions set status='closing',final_seq=next_seq-1,revision=revision+1 where session_id=v_session; return jsonb_build_object('ok',true,'session_id',v_session,'status','closing','final_seq',s.next_seq-1);
+ elsif p_command='archive_manifest' then
+   v_session:=(p_payload->>'session_id')::uuid; if not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   select manifest_json,digest,archive_revision,final_seq into v_manifest,v_digest,v_archive_rev,v_seq from public.collaboration_archive_manifests where session_id=v_session order by archive_revision desc limit 1; if not found then perform collaboration_private.fail('ARCHIVE_PENDING'); end if;
+   return jsonb_build_object('ok',true,'session_id',v_session,'archive_revision',v_archive_rev,'manifest_json',v_manifest,'digest',v_digest,'byte_length',octet_length(convert_to(v_manifest,'UTF8')),'final_seq',v_seq);
+ elsif p_command='ack_archive' then
+   v_session:=(p_payload->>'session_id')::uuid; v_archive_rev:=(p_payload->>'archive_revision')::bigint; v_device:=(p_payload->>'device_id')::uuid; v_digest:=p_payload->>'digest';
+   if exists(select 1 from public.collaboration_archive_receipts where session_id=v_session and archive_revision=v_archive_rev and user_id=p_actor and device_id=v_device and digest=v_digest and byte_length=(p_payload->>'byte_length')::bigint and final_seq=(p_payload->>'final_seq')::bigint) then return jsonb_build_object('ok',true,'deduplicated',true); end if;
+   perform 1 from public.collaboration_sessions where session_id=v_session and status='archive_pending' for update; if not found then perform collaboration_private.fail('INVALID_STATE'); end if;
+   perform 1 from public.collaboration_archive_recipients ar join public.collaboration_archive_manifests am using(session_id,archive_revision) join public.collaboration_devices d on d.device_id=v_device where ar.session_id=v_session and ar.archive_revision=v_archive_rev and ar.user_id=p_actor and ar.eligible and d.user_id=p_actor and d.status='active' and am.status='pending' and am.membership_revision=(select membership_revision from public.collaboration_sessions where session_id=v_session) and am.digest=v_digest and am.byte_length=(p_payload->>'byte_length')::bigint and am.final_seq=(p_payload->>'final_seq')::bigint; if not found then perform collaboration_private.fail('ARCHIVE_RECEIPT_INVALID'); end if;
+   insert into public.collaboration_archive_receipts values(v_session,v_archive_rev,p_actor,v_device,v_digest,(p_payload->>'byte_length')::bigint,(p_payload->>'final_seq')::bigint,now()) on conflict(session_id,archive_revision,user_id,device_id) do update set verified_at=excluded.verified_at,digest=excluded.digest,byte_length=excluded.byte_length,final_seq=excluded.final_seq;
+   if not exists(select 1 from public.collaboration_archive_recipients ar where ar.session_id=v_session and ar.archive_revision=v_archive_rev and ar.eligible and ar.receipt_required and not exists(select 1 from public.collaboration_archive_receipts rr where rr.session_id=ar.session_id and rr.archive_revision=ar.archive_revision and rr.user_id=ar.user_id)) then update public.collaboration_archive_manifests set status='ready' where session_id=v_session and archive_revision=v_archive_rev; update public.collaboration_sessions set status='archive_pending' where session_id=v_session; insert into public.collaboration_purge_jobs(session_id,archive_revision) values(v_session,v_archive_rev) on conflict do nothing; end if; return jsonb_build_object('ok',true);
+ elsif p_command='archive_status' then
+   v_session:=(p_payload->>'session_id')::uuid; if not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   return jsonb_build_object('ok',true,'session_id',v_session,'session_status',(select status from public.collaboration_sessions where session_id=v_session),'recipients',coalesce((select jsonb_agg(jsonb_build_object('user_id',ar.user_id,'received',exists(select 1 from public.collaboration_archive_receipts rr where rr.session_id=ar.session_id and rr.archive_revision=ar.archive_revision and rr.user_id=ar.user_id))) from public.collaboration_archive_recipients ar where ar.session_id=v_session and ar.archive_revision=(select max(archive_revision) from public.collaboration_archive_manifests where session_id=v_session)),'[]'::jsonb));
+ elsif p_command='continue_session' then
+   v_session:=(p_payload->>'session_id')::uuid; select * into s from public.collaboration_sessions where session_id=v_session; if not collaboration_private.is_session_member(v_session,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if; if s.status='active' then perform collaboration_private.fail('INVALID_STATE'); end if;
+   v_event:=coalesce((p_payload->>'new_session_id')::uuid,gen_random_uuid()); perform 1 from public.collaboration_quota_counters where org_id=s.org_id for update; select count(*) into v_count from public.collaboration_sessions where org_id=s.org_id and status<>'archived_local'; if v_count>=cfg.max_sessions_per_org then perform collaboration_private.fail('QUOTA_EXCEEDED','session_count'); end if;
+   insert into public.collaboration_sessions(session_id,org_id,created_by,continuation_of,title) values(v_event,s.org_id,p_actor,v_session,nullif(p_payload->>'title','')); insert into public.collaboration_session_members(org_id,session_id,user_id,role,status,joined_at) select s.org_id,v_event,user_id,case when user_id=p_actor then 'owner' else 'member' end,'active',now() from public.collaboration_session_members where session_id=v_session and status='active'; return jsonb_build_object('ok',true,'session_id',v_event,'continuation_of',v_session);
+ elsif p_command='revoke_member' then
+   v_session:=(p_payload->>'session_id')::uuid; select * into s from public.collaboration_sessions where session_id=v_session for update; if not exists(select 1 from public.collaboration_session_members where session_id=v_session and user_id=p_actor and role='owner' and status='active') then perform collaboration_private.fail('FORBIDDEN'); end if;
+   update public.collaboration_session_members set status='revoked',revoked_at=now() where session_id=v_session and user_id=(p_payload->>'user_id')::uuid and role<>'owner' and status<>'revoked'; if not found then perform collaboration_private.fail('NOT_FOUND'); end if; update public.collaboration_sessions set membership_revision=membership_revision+1,revision=revision+1 where session_id=v_session;
+   update public.collaboration_invites set status='revoked' where session_id=v_session and invited_user_id=(p_payload->>'user_id')::uuid and status='pending';
+   if s.status='purging' then perform collaboration_private.fail('INVALID_STATE','purge_in_progress'); end if;
+   if s.status in ('closing','archive_pending') then delete from public.collaboration_purge_jobs where session_id=v_session; delete from public.collaboration_archive_receipts where session_id=v_session; delete from public.collaboration_archive_recipients where session_id=v_session; delete from public.collaboration_archive_manifests where session_id=v_session; update public.collaboration_sessions set status='closing' where session_id=v_session; end if; return jsonb_build_object('ok',true);
+ elsif p_command='begin_slack_link' then
+   v_content:=replace(replace(encode(extensions.gen_random_bytes(18),'base64'),'/','_'),'+','-'); v_content:=replace(v_content,'=',''); v_hash:=encode(extensions.digest(convert_to(v_content,'UTF8'),'sha256'),'hex'); insert into public.collaboration_slack_link_challenges(code_hash,installation_id,user_id,expires_at) select v_hash,(p_payload->>'installation_id')::uuid,p_actor,now()+interval '10 minutes' from public.collaboration_slack_installations i where i.installation_id=(p_payload->>'installation_id')::uuid and i.status='active' and collaboration_private.is_org_member(i.org_id,p_actor); if not found then perform collaboration_private.fail('FORBIDDEN'); end if; return jsonb_build_object('ok',true,'code',v_content,'expires_in',600);
+ elsif p_command='select_slack_channel' then
+   v_org:=(p_payload->>'org_id')::uuid; if not exists(select 1 from public.collaboration_slack_installations i join public.collaboration_org_members om on om.org_id=i.org_id where i.installation_id=(p_payload->>'installation_id')::uuid and i.org_id=v_org and i.status='active' and om.user_id=p_actor and om.status='active' and om.role in('owner','admin')) then perform collaboration_private.fail('FORBIDDEN'); end if; insert into public.collaboration_slack_channels values((p_payload->>'installation_id')::uuid,p_payload->>'channel_id',v_org,p_actor,now()) on conflict(installation_id,channel_id) do update set selected_by=excluded.selected_by,selected_at=now() where collaboration_slack_channels.org_id=excluded.org_id; return jsonb_build_object('ok',true);
+ else perform collaboration_private.fail('UNKNOWN_COMMAND'); end if;
+ return '{}'::jsonb;
+end $$;
+revoke all on function collaboration_private.command(uuid,text,jsonb) from public;
+grant execute on function collaboration_private.command(uuid,text,jsonb) to authenticated;
+create function public.collaboration_command(p_command text,p_payload jsonb) returns jsonb language sql security invoker set search_path='' as $$ select collaboration_private.command((select auth.uid()),p_command,p_payload) $$;
+revoke all on function public.collaboration_command(text,jsonb) from public,anon;
+grant execute on function public.collaboration_command(text,jsonb) to authenticated;
+
+-- Archive worker creates the exact canonical UTF-8 payload once and persists
+-- that same string. Clients hash those exact bytes rather than reserializing JSON.
+create function collaboration_private.prepare_archive(p_session uuid) returns jsonb language plpgsql security definer set search_path='' as $$
+declare s public.collaboration_sessions%rowtype; v_rev bigint; v_text text; v_digest text;
+begin
+ select * into s from public.collaboration_sessions where session_id=p_session for update; if not found or s.status<>'closing' then perform collaboration_private.fail('INVALID_STATE'); end if;
+ if exists(select 1 from public.collaboration_runs where session_id=p_session and status in ('queued','leased')) then perform collaboration_private.fail('RUN_ACTIVE'); end if;
+ v_rev:=s.membership_revision; v_text:=jsonb_build_object('version',1,'session_id',s.session_id,'org_id',s.org_id,'final_seq',s.final_seq,'membership_revision',s.membership_revision,'events',coalesce((select jsonb_agg(jsonb_build_object('event_id',e.event_id,'session_id',e.session_id,'seq',e.seq,'kind',e.kind,'message_id',e.message_id,'author_id',e.author_id,'role',e.role,'content',e.content,'revision',e.revision,'created_at',e.created_at) order by e.seq) from public.collaboration_events e where e.session_id=p_session and e.seq<=s.final_seq),'[]'::jsonb),'files',coalesce((select jsonb_agg(jsonb_build_object('file_id',f.file_id,'sha256',f.sha256,'byte_length',f.expected_bytes)) from public.collaboration_file_reservations f where f.session_id=p_session and f.status='uploaded'),'[]'::jsonb))::text;
+ v_digest:=encode(extensions.digest(convert_to(v_text,'UTF8'),'sha256'),'hex'); insert into public.collaboration_archive_manifests(session_id,archive_revision,membership_revision,final_seq,manifest_json,digest,byte_length) values(p_session,v_rev,s.membership_revision,s.final_seq,v_text,v_digest,octet_length(convert_to(v_text,'UTF8')));
+ insert into public.collaboration_archive_recipients(session_id,archive_revision,user_id) select p_session,v_rev,user_id from public.collaboration_session_members where session_id=p_session and status='active'; update public.collaboration_sessions set status='archive_pending' where session_id=p_session; return jsonb_build_object('session_id',p_session,'archive_revision',v_rev,'digest',v_digest);
+end $$;
+revoke all on function collaboration_private.prepare_archive(uuid) from public,anon,authenticated;
+grant execute on function collaboration_private.prepare_archive(uuid) to service_role;
+
+create function collaboration_private.release_expired_reservations(p_limit integer default 100) returns integer language plpgsql security definer set search_path='' as $$
+declare r record; n int:=0; begin for r in select * from public.collaboration_quota_reservations where kind='response' and status='active' and expires_at<now() order by expires_at for update skip locked limit least(p_limit,1000) loop update public.collaboration_quota_reservations set status='expired',settled_at=now() where reservation_id=r.reservation_id; update public.collaboration_sessions set reserved_bytes=greatest(0,reserved_bytes-r.reserved_bytes) where session_id=r.session_id; update public.collaboration_quota_counters set reserved_bytes=greatest(0,reserved_bytes-r.reserved_bytes) where org_id=r.org_id; update public.collaboration_runs set status=case when status='leased' then 'needs_reconciliation' else 'cancelled' end,completed_at=now(),lease_token=null,lease_expires_at=null where run_id=r.run_id and status in('queued','leased'); n:=n+1; end loop; return n; end $$;
+revoke all on function collaboration_private.release_expired_reservations(integer) from public,anon,authenticated; grant execute on function collaboration_private.release_expired_reservations(integer) to service_role;
+
+create function collaboration_private.claim_purge(p_worker uuid) returns jsonb language plpgsql security definer set search_path='' as $$
+declare j public.collaboration_purge_jobs%rowtype; begin select * into j from public.collaboration_purge_jobs where status in('waiting','failed','database_done','objects_done') and (lease_expires_at is null or lease_expires_at<now()) and not exists(select 1 from public.collaboration_archive_recipients ar where ar.session_id=collaboration_purge_jobs.session_id and ar.archive_revision=collaboration_purge_jobs.archive_revision and ar.eligible and ar.receipt_required and not exists(select 1 from public.collaboration_archive_receipts rr where rr.session_id=ar.session_id and rr.archive_revision=ar.archive_revision and rr.user_id=ar.user_id)) order by updated_at for update skip locked limit 1; if not found then return null; end if; update public.collaboration_purge_jobs set status='claimed',lease_token=p_worker,lease_expires_at=now()+interval '2 minutes',attempts=attempts+1,updated_at=now() where session_id=j.session_id; update public.collaboration_sessions set status='purging' where session_id=j.session_id; return jsonb_build_object('session_id',j.session_id,'archive_revision',j.archive_revision,'db_checkpoint',j.db_checkpoint,'object_checkpoint',j.object_checkpoint); end $$;
+create function collaboration_private.finish_purge_step(p_worker uuid,p_session uuid,p_step text,p_checkpoint jsonb default '{}'::jsonb) returns jsonb language plpgsql security definer set search_path='' as $$
+declare j public.collaboration_purge_jobs%rowtype; a public.collaboration_archive_manifests%rowtype; s public.collaboration_sessions%rowtype; begin select * into j from public.collaboration_purge_jobs where session_id=p_session and lease_token=p_worker and lease_expires_at>now() for update; if not found then perform collaboration_private.fail('LEASE_LOST'); end if; if p_step='database' then delete from public.collaboration_messages where session_id=p_session; delete from public.collaboration_events where session_id=p_session; update public.collaboration_purge_jobs set status='database_done',db_checkpoint=p_checkpoint,lease_expires_at=now()+interval '2 minutes',updated_at=now() where session_id=p_session; elsif p_step='objects' then update public.collaboration_file_reservations set status='purged' where session_id=p_session; update public.collaboration_purge_jobs set status='objects_done',object_checkpoint=p_checkpoint,lease_expires_at=now()+interval '2 minutes',updated_at=now() where session_id=p_session; elsif p_step='complete' then select * into a from public.collaboration_archive_manifests where session_id=p_session and archive_revision=j.archive_revision; select * into s from public.collaboration_sessions where session_id=p_session; if j.status not in('database_done','objects_done') or exists(select 1 from public.collaboration_events where session_id=p_session) or exists(select 1 from public.collaboration_file_reservations where session_id=p_session and status='uploaded') then perform collaboration_private.fail('PURGE_INCOMPLETE'); end if; insert into public.collaboration_tombstones values(p_session,s.org_id,a.final_seq,a.digest,a.archive_revision,array(select user_id from public.collaboration_archive_recipients where session_id=p_session and archive_revision=a.archive_revision and eligible),coalesce((select jsonb_agg(jsonb_build_object('user_id',user_id,'device_id',device_id,'verified_at',verified_at)) from public.collaboration_archive_receipts where session_id=p_session and archive_revision=a.archive_revision),'[]'::jsonb),now(),now()); update public.collaboration_archive_manifests set manifest_json='{}',status='purged' where session_id=p_session and archive_revision=a.archive_revision; update public.collaboration_sessions set title=null,status='archived_local',logical_bytes=0,reserved_bytes=0,shared_file_bytes=0,archived_at=now() where session_id=p_session; update public.collaboration_quota_counters set logical_bytes=greatest(0,logical_bytes-s.logical_bytes),reserved_bytes=greatest(0,reserved_bytes-s.reserved_bytes),shared_file_bytes=greatest(0,shared_file_bytes-s.shared_file_bytes) where org_id=s.org_id; update public.collaboration_purge_jobs set status='complete',lease_token=null,lease_expires_at=null,updated_at=now() where session_id=p_session; else perform collaboration_private.fail('INVALID_STEP'); end if; return jsonb_build_object('ok',true,'step',p_step); end $$;
+revoke all on function collaboration_private.claim_purge(uuid), collaboration_private.finish_purge_step(uuid,uuid,text,jsonb) from public,anon,authenticated; grant execute on function collaboration_private.claim_purge(uuid), collaboration_private.finish_purge_step(uuid,uuid,text,jsonb) to service_role;
+
+create function collaboration_private.slack_command(p_command text,p_payload jsonb) returns jsonb language plpgsql security definer set search_path='' as $$
+declare i public.collaboration_slack_installations%rowtype; s public.collaboration_sessions%rowtype; cfg public.collaboration_config%rowtype; v_id uuid; v_token uuid; v_row record; v_hash text; v_session uuid; v_event uuid; v_message uuid; v_run uuid; v_res uuid; v_content text; v_bytes bigint; v_response_bytes bigint; v_fence bigint; v_count integer; begin
+ if p_command='begin_install' then insert into public.collaboration_slack_oauth_states(state_hash,actor_id,org_id,expires_at) values(p_payload->>'state_hash',(p_payload->>'actor_id')::uuid,(p_payload->>'org_id')::uuid,(p_payload->>'expires_at')::timestamptz); return jsonb_build_object('ok',true);
+ elsif p_command='consume_install' then update public.collaboration_slack_oauth_states set consumed_at=now() where state_hash=p_payload->>'state_hash' and consumed_at is null and expires_at>now() returning actor_id,org_id into v_row; if not found then perform collaboration_private.fail('OAUTH_STATE_INVALID'); end if; return jsonb_build_object('ok',true,'actor_id',v_row.actor_id,'org_id',v_row.org_id);
+ elsif p_command='save_install' then
+   perform 1 from public.collaboration_slack_oauth_states where state_hash=p_payload->>'state_hash' and actor_id=(p_payload->>'actor_id')::uuid and org_id=(p_payload->>'org_id')::uuid and consumed_at is not null; if not found then perform collaboration_private.fail('OAUTH_STATE_INVALID'); end if;
+   insert into public.collaboration_slack_installations(org_id,team_id,bot_user_id,token_ciphertext) values((p_payload->>'org_id')::uuid,p_payload->>'team_id',p_payload->>'bot_user_id',p_payload->>'token_ciphertext') on conflict(team_id) do update set org_id=excluded.org_id,bot_user_id=excluded.bot_user_id,token_ciphertext=excluded.token_ciphertext,status='active',revoked_at=null returning installation_id into v_id;
+   if nullif(p_payload->>'authed_slack_user_id','') is not null then insert into public.collaboration_slack_sender_links values(v_id,p_payload->>'authed_slack_user_id',(p_payload->>'actor_id')::uuid,now()) on conflict(installation_id,slack_user_id) do update set user_id=excluded.user_id,linked_at=now(); end if; delete from public.collaboration_slack_oauth_states where state_hash=p_payload->>'state_hash'; return jsonb_build_object('ok',true,'installation_id',v_id);
+ elsif p_command='redeem_link' then
+   if coalesce(p_payload->>'code','') !~ '^[A-Za-z0-9_-]{20,128}$' then perform collaboration_private.fail('LINK_CODE_INVALID'); end if; v_hash:=encode(extensions.digest(convert_to(p_payload->>'code','UTF8'),'sha256'),'hex');
+   update public.collaboration_slack_link_challenges c set consumed_at=now() from public.collaboration_slack_installations i where c.code_hash=v_hash and c.installation_id=i.installation_id and i.team_id=p_payload->>'team_id' and c.consumed_at is null and c.expires_at>now() returning c.installation_id,c.user_id into v_row; if not found then perform collaboration_private.fail('LINK_CODE_INVALID'); end if; insert into public.collaboration_slack_sender_links values(v_row.installation_id,p_payload->>'slack_user_id',v_row.user_id,now()) on conflict(installation_id,slack_user_id) do update set user_id=excluded.user_id,linked_at=now(); return jsonb_build_object('ok',true,'user_id',v_row.user_id);
+ elsif p_command='enqueue_event' then select * into i from public.collaboration_slack_installations where team_id=p_payload->>'team_id' and status='active'; if not found then perform collaboration_private.fail('INSTALLATION_NOT_FOUND'); end if; if octet_length(convert_to((p_payload->'event')::text,'UTF8'))>65536 then perform collaboration_private.fail('PAYLOAD_TOO_LARGE'); end if; insert into public.collaboration_slack_inbox(installation_id,event_id,event) values(i.installation_id,p_payload->>'event_id',p_payload->'event') on conflict do nothing; return jsonb_build_object('ok',true,'accepted',true);
+ elsif p_command='ingest_message' then
+   select * into cfg from public.collaboration_config where singleton for share; if not cfg.shared_text_enabled or not cfg.shared_execution_enabled or not cfg.slack_enabled then perform collaboration_private.fail('FEATURE_DISABLED'); end if;
+   select i.* into i from public.collaboration_slack_installations i where i.installation_id=(p_payload->>'installation_id')::uuid and i.status='active'; if not found then perform collaboration_private.fail('INSTALLATION_NOT_FOUND'); end if;
+   select l.user_id into v_row from public.collaboration_slack_sender_links l join public.collaboration_org_members om on om.org_id=i.org_id and om.user_id=l.user_id and om.status='active' where l.installation_id=i.installation_id and l.slack_user_id=p_payload->>'slack_user_id'; if not found then return jsonb_build_object('ok',true,'ignored',true,'needs_link',true); end if;
+   if not exists(select 1 from public.collaboration_devices where user_id=v_row.user_id and status='active') then return jsonb_build_object('ok',true,'waiting_for_executor',true); end if;
+   select t.session_id into v_session from public.collaboration_slack_threads t where t.installation_id=i.installation_id and t.channel_id=p_payload->>'channel_id' and t.root_thread_ts=p_payload->>'thread_ts';
+   if not found then
+     if not coalesce((p_payload->>'is_mention')::boolean,false) or not exists(select 1 from public.collaboration_slack_channels where installation_id=i.installation_id and channel_id=p_payload->>'channel_id' and org_id=i.org_id) then return jsonb_build_object('ok',true,'ignored',true); end if;
+     perform 1 from public.collaboration_quota_counters where org_id=i.org_id for update;
+     if not exists(select 1 from (select * from public.collaboration_capacity_measurements order by measured_at desc limit 1) latest where latest.measured_at>now()-interval '36 hours' and latest.database_bytes+cfg.admission_reserve_bytes<cfg.project_physical_stop_bytes and latest.collaboration_bytes<262144000) then perform collaboration_private.fail('CAPACITY_UNMEASURED'); end if;
+     select count(*) into v_count from public.collaboration_sessions where org_id=i.org_id and status<>'archived_local'; if v_count>=cfg.max_sessions_per_org then perform collaboration_private.fail('QUOTA_EXCEEDED','session_count'); end if;
+     v_session:=gen_random_uuid(); insert into public.collaboration_sessions(session_id,org_id,created_by,title) values(v_session,i.org_id,v_row.user_id,'Slack conversation'); insert into public.collaboration_session_members values(i.org_id,v_session,v_row.user_id,'owner','active',null,now(),null); insert into public.collaboration_slack_threads values(i.org_id,i.installation_id,p_payload->>'channel_id',p_payload->>'thread_ts',v_session,now());
+   elsif not collaboration_private.is_session_member(v_session,v_row.user_id) then perform collaboration_private.fail('FORBIDDEN'); end if;
+   v_event:=(p_payload->>'event_id')::uuid; v_message:=coalesce((p_payload->>'message_id')::uuid,v_event); v_run:=coalesce((p_payload->>'run_id')::uuid,gen_random_uuid()); v_res:=coalesce((p_payload->>'reservation_id')::uuid,gen_random_uuid()); v_content:=p_payload->>'content'; v_bytes:=octet_length(convert_to(v_content,'UTF8'))+640; v_response_bytes:=least(coalesce((p_payload->>'response_reservation_bytes')::bigint,cfg.default_response_reservation_bytes),cfg.session_limit_bytes); v_hash:=encode(extensions.digest(convert_to(v_row.user_id::text||':slack:'||p_payload::text,'UTF8'),'sha256'),'hex');
+   select * into s from public.collaboration_sessions where session_id=v_session for update; if s.status<>'active' then perform collaboration_private.fail('SESSION_CLOSED'); end if;
+   if exists(select 1 from public.collaboration_events where event_id=v_event) then if exists(select 1 from public.collaboration_events where event_id=v_event and request_hash=v_hash and author_id=v_row.user_id) then return (select jsonb_build_object('ok',true,'deduplicated',true,'session_id',e.session_id,'event_id',e.event_id,'seq',e.seq,'message_id',e.message_id,'run_id',r.run_id,'reservation_id',r.response_reservation_id) from public.collaboration_events e left join public.collaboration_runs r on r.session_id=e.session_id and r.request_event_id=e.event_id where e.event_id=v_event); else perform collaboration_private.fail('IDEMPOTENCY_CONFLICT'); end if; end if;
+   perform 1 from public.collaboration_quota_counters where org_id=i.org_id for update;
+   if s.message_count+2+(select count(*) from public.collaboration_runs where session_id=v_session and status in('queued','leased'))>cfg.max_messages_per_session then perform collaboration_private.fail('QUOTA_EXCEEDED','reserved_message_slot'); end if;
+   if s.logical_bytes+s.reserved_bytes+v_bytes+v_response_bytes>cfg.session_limit_bytes or (select logical_bytes+reserved_bytes from public.collaboration_quota_counters where org_id=i.org_id)+v_bytes+v_response_bytes>cfg.org_limit_bytes or (select coalesce(sum(logical_bytes+reserved_bytes),0) from public.collaboration_quota_counters)+v_bytes+v_response_bytes>cfg.project_logical_limit_bytes then perform collaboration_private.fail('QUOTA_EXCEEDED','bytes'); end if;
+   insert into public.collaboration_events values(v_event,i.org_id,v_session,s.next_seq,'message',v_message,v_row.user_id,'user',v_content,1,v_bytes,v_hash,now()); insert into public.collaboration_messages values(i.org_id,v_session,v_message,v_row.user_id,'user',v_content,1,false,v_event,now(),now());
+   insert into public.collaboration_quota_reservations(reservation_id,org_id,session_id,run_id,kind,reserved_bytes,expires_at) values(v_res,i.org_id,v_session,v_run,'response',v_response_bytes,now()+interval '2 hours'); insert into public.collaboration_runs(run_id,org_id,session_id,request_event_id,requester_id,provider_payer_id,audience_revision,response_reservation_id) values(v_run,i.org_id,v_session,v_event,v_row.user_id,v_row.user_id,s.membership_revision,v_res);
+   update public.collaboration_sessions set next_seq=next_seq+1,message_count=message_count+1,logical_bytes=logical_bytes+v_bytes,reserved_bytes=reserved_bytes+v_response_bytes,last_published_at=now(),revision=revision+1 where session_id=v_session; update public.collaboration_quota_counters set logical_bytes=logical_bytes+v_bytes,reserved_bytes=reserved_bytes+v_response_bytes where org_id=i.org_id;
+   perform pg_catalog.pg_notify('collaboration_hint',jsonb_build_object('session_id',v_session,'high_water',s.next_seq,'membership_revision',s.membership_revision)::text);
+   return jsonb_build_object('ok',true,'session_id',v_session,'event_id',v_event,'seq',s.next_seq,'message_id',v_message,'run_id',v_run,'reservation_id',v_res);
+ elsif p_command='claim_inbox' then
+   select x.*,i.team_id,i.token_ciphertext into v_row from public.collaboration_slack_inbox x join public.collaboration_slack_installations i using(installation_id) where i.status='active' and (x.status='pending' or (x.status='failed' and coalesce(x.retry_after,now())<=now()) or (x.status='claimed' and x.lease_expires_at<now())) order by x.received_at for update of x skip locked limit 1; if not found then return null; end if; v_token:=gen_random_uuid(); update public.collaboration_slack_inbox set status='claimed',lease_token=v_token,lease_expires_at=now()+interval '2 minutes',attempts=attempts+1,fence=fence+1 where inbox_id=v_row.inbox_id returning fence into v_fence; return jsonb_build_object('id',v_row.inbox_id,'fence',v_fence,'event',v_row.event,'team_id',v_row.team_id,'installation_id',v_row.installation_id,'token_ciphertext',v_row.token_ciphertext,'event_id',v_row.event_id);
+ elsif p_command='finish_inbox' then
+   update public.collaboration_slack_inbox set status=case p_payload->>'status' when 'complete' then 'processed' when 'retry' then 'failed' else status end,retry_after=case when p_payload->>'status'='retry' then coalesce((p_payload->>'retry_after')::timestamptz,now()+interval '1 minute') else null end,last_error_code=p_payload->>'error_code',completed_at=case when p_payload->>'status'='complete' then now() else null end,lease_token=null,lease_expires_at=null where inbox_id=(p_payload->>'id')::uuid and fence=(p_payload->>'fence')::bigint and status='claimed'; if not found then perform collaboration_private.fail('LEASE_LOST'); end if; return jsonb_build_object('ok',true);
+ elsif p_command='claim_outbox' then
+   update public.collaboration_outbox set status='uncertain',lease_token=null,lease_expires_at=null where status='claimed' and lease_expires_at<now();
+   select o.*,i.team_id,i.token_ciphertext,t.channel_id,t.root_thread_ts into v_row from public.collaboration_outbox o join public.collaboration_slack_threads t on t.session_id=o.session_id join public.collaboration_slack_installations i on i.installation_id=t.installation_id where i.status='active' and (o.status in('pending','uncertain') or (o.status='failed' and coalesce(o.retry_after,now())<=now())) order by o.created_at for update of o skip locked limit 1; if not found then return null; end if; v_token:=gen_random_uuid(); update public.collaboration_outbox set status=case when v_row.status='uncertain' then 'uncertain' else 'claimed' end,lease_token=v_token,lease_expires_at=now()+interval '2 minutes',attempts=attempts+1,fence=fence+1 where outbox_id=v_row.outbox_id returning fence into v_fence; return jsonb_build_object('id',v_row.outbox_id,'fence',v_fence,'team_id',v_row.team_id,'token_ciphertext',v_row.token_ciphertext,'channel_id',v_row.channel_id,'thread_ts',v_row.root_thread_ts,'content',v_row.payload->>'content','client_msg_id',v_row.dedup_key,'status',v_row.status,'reconcile_cursor',v_row.reconcile_cursor);
+ elsif p_command='complete_outbox' then
+   if p_payload->>'status' not in('complete','retry','uncertain','manual_review') then perform collaboration_private.fail('INVALID_STATUS'); end if; update public.collaboration_outbox set status=case p_payload->>'status' when 'complete' then 'sent' when 'retry' then 'failed' when 'uncertain' then 'uncertain' else 'manual_review' end,retry_after=case when p_payload->>'status'='retry' then coalesce((p_payload->>'retry_after')::timestamptz,now()+interval '1 minute') else null end,slack_ts=coalesce(p_payload->>'slack_ts',slack_ts),reconcile_cursor=coalesce(p_payload->>'reconcile_cursor',reconcile_cursor),completed_at=case when p_payload->>'status'='complete' then now() else null end,lease_token=null,lease_expires_at=null where outbox_id=(p_payload->>'id')::uuid and fence=(p_payload->>'fence')::bigint and status in('claimed','uncertain'); if not found then perform collaboration_private.fail('LEASE_LOST'); end if; return jsonb_build_object('ok',true);
+ elsif p_command='uninstall' then update public.collaboration_slack_installations set status='revoked',token_ciphertext='',revoked_at=now() where team_id=p_payload->>'team_id'; return jsonb_build_object('ok',true);
+ else perform collaboration_private.fail('UNKNOWN_COMMAND'); end if; return '{}'::jsonb; end $$;
+revoke all on function collaboration_private.slack_command(text,jsonb) from public,anon,authenticated; grant execute on function collaboration_private.slack_command(text,jsonb) to service_role;
+create function public.collaboration_slack_command(p_command text,p_payload jsonb) returns jsonb language sql security invoker set search_path='' as $$ select collaboration_private.slack_command(p_command,p_payload) $$;
+revoke all on function public.collaboration_slack_command(text,jsonb) from public,anon,authenticated; grant execute on function public.collaboration_slack_command(text,jsonb) to service_role;
+
+create function public.collaboration_capacity_command(p_database_bytes bigint,p_collaboration_bytes bigint,p_storage_bytes bigint)
+returns jsonb language plpgsql security invoker set search_path='' as $$
+declare v_id bigint; begin if p_database_bytes<0 or p_collaboration_bytes<0 or p_storage_bytes<0 then perform collaboration_private.fail('INVALID_MEASUREMENT'); end if; insert into public.collaboration_capacity_measurements(database_bytes,collaboration_bytes,storage_bytes) values(p_database_bytes,p_collaboration_bytes,p_storage_bytes) returning measurement_id into v_id; return jsonb_build_object('ok',true,'measurement_id',v_id,'measured_at',now()); end $$;
+revoke all on function public.collaboration_capacity_command(bigint,bigint,bigint) from public,anon,authenticated; grant execute on function public.collaboration_capacity_command(bigint,bigint,bigint) to service_role;
+
+revoke all on all functions in schema collaboration_private from public,anon,authenticated;
+grant execute on function collaboration_private.command(uuid,text,jsonb), collaboration_private.is_org_member(uuid,uuid), collaboration_private.is_session_member(uuid,uuid) to authenticated;
+grant execute on all functions in schema collaboration_private to service_role;

--- a/supabase/migrations/20260909030450_shared_archive_orchestration.sql
+++ b/supabase/migrations/20260909030450_shared_archive_orchestration.sql
@@ -1,0 +1,434 @@
+-- Durable archive orchestration. This migration deliberately exposes one
+-- service-role-only maintenance RPC; clients continue to use collaboration_command.
+
+alter table public.collaboration_sessions
+  add column archive_warning_at timestamptz,
+  add column archive_manifest_bytes bigint not null default 0 check (archive_manifest_bytes >= 0);
+
+alter table public.collaboration_archive_recipients
+  add column membership_revision bigint;
+update public.collaboration_archive_recipients ar
+set membership_revision = am.membership_revision
+from public.collaboration_archive_manifests am
+where am.session_id = ar.session_id and am.archive_revision = ar.archive_revision;
+alter table public.collaboration_archive_recipients alter column membership_revision set not null;
+
+alter table public.collaboration_purge_jobs
+  drop constraint collaboration_purge_jobs_status_check;
+alter table public.collaboration_purge_jobs
+  add constraint collaboration_purge_jobs_status_check
+  check (status in ('waiting','claimed','objects_done','complete','failed'));
+
+-- Once an object-deletion lease is claimed the frozen recipient set must be
+-- immutable until the lease is retried or purge finishes. This closes the
+-- check -> Storage API delete race for every SQL mutation path, not only the
+-- authenticated command implementation.
+create function collaboration_private.prevent_purging_membership_change()
+returns trigger language plpgsql security definer set search_path = '' as $$
+declare v_session uuid;
+begin
+  if tg_op = 'DELETE' then v_session := old.session_id; else v_session := new.session_id; end if;
+  if exists (select 1 from public.collaboration_sessions
+    where session_id = v_session and status = 'purging')
+  then perform collaboration_private.fail('PURGE_MEMBERSHIP_FROZEN'); end if;
+  if tg_op = 'DELETE' then return old; else return new; end if;
+end $$;
+revoke all on function collaboration_private.prevent_purging_membership_change() from public, anon, authenticated, service_role;
+drop trigger if exists collaboration_freeze_purging_membership on public.collaboration_session_members;
+create trigger collaboration_freeze_purging_membership
+before insert or update or delete on public.collaboration_session_members
+for each row execute function collaboration_private.prevent_purging_membership_change();
+
+-- Preserve evidence when the authenticated command invalidates an archive due
+-- to a membership revocation, before the legacy command removes stale rows.
+create function collaboration_private.audit_archive_recipient_invalidation()
+returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if old.status <> 'revoked' and new.status = 'revoked' then
+    insert into public.collaboration_audit(org_id, session_id, actor_id, action, detail)
+    select new.org_id, new.session_id, (select auth.uid()), 'archive_recipients_invalidated',
+      jsonb_build_object(
+        'revoked_user_id', new.user_id,
+        'old_membership_revision', s.membership_revision,
+        'recipient_ledgers', coalesce((
+          select jsonb_agg(jsonb_build_object(
+            'archive_revision', ar.archive_revision,
+            'membership_revision', ar.membership_revision,
+            'user_id', ar.user_id,
+            'eligible', ar.eligible,
+            'receipt_required', ar.receipt_required,
+            'received', exists (
+              select 1 from public.collaboration_archive_receipts rr
+              where rr.session_id = ar.session_id
+                and rr.archive_revision = ar.archive_revision
+                and rr.user_id = ar.user_id)))
+          from public.collaboration_archive_recipients ar
+          where ar.session_id = new.session_id), '[]'::jsonb))
+    from public.collaboration_sessions s where s.session_id = new.session_id;
+  end if;
+  return new;
+end $$;
+revoke all on function collaboration_private.audit_archive_recipient_invalidation() from public, anon, authenticated, service_role;
+drop trigger if exists collaboration_audit_archive_recipient_invalidation on public.collaboration_session_members;
+create trigger collaboration_audit_archive_recipient_invalidation
+before update of status on public.collaboration_session_members
+for each row execute function collaboration_private.audit_archive_recipient_invalidation();
+
+create or replace function collaboration_private.prepare_archive(p_session uuid)
+returns jsonb language plpgsql security definer set search_path = '' as $$
+declare
+  s public.collaboration_sessions%rowtype;
+  cfg public.collaboration_config%rowtype;
+  v_rev bigint;
+  v_text text;
+  v_digest text;
+  v_bytes bigint;
+  v_event_count bigint;
+  v_max_seq bigint;
+begin
+  select * into s from public.collaboration_sessions where session_id = p_session for update;
+  if not found or s.status <> 'closing' then perform collaboration_private.fail('INVALID_STATE'); end if;
+  select * into cfg from public.collaboration_config where singleton for share;
+  if exists (select 1 from public.collaboration_runs where session_id = p_session and status in ('queued','leased','needs_reconciliation'))
+     or exists (select 1 from public.collaboration_quota_reservations where session_id = p_session and status = 'active')
+     or exists (select 1 from public.collaboration_outbox where session_id = p_session and status in ('pending','claimed','failed','uncertain','manual_review'))
+  then perform collaboration_private.fail('ARCHIVE_WORK_ACTIVE'); end if;
+
+  -- Closing stops new admissions, but already accepted work may still publish.
+  -- Freeze only here, after all such work has settled, at the authoritative
+  -- canonical high-water mark.
+  s.final_seq := s.next_seq - 1;
+  select count(*), coalesce(max(seq), 0) into v_event_count, v_max_seq
+  from public.collaboration_events where session_id = p_session;
+  if v_event_count <> s.final_seq or v_max_seq <> s.final_seq
+  then perform collaboration_private.fail('ARCHIVE_HISTORY_INCOMPLETE'); end if;
+  update public.collaboration_sessions
+  set final_seq = s.final_seq, revision = revision + 1
+  where session_id = p_session;
+  v_rev := s.membership_revision;
+  v_text := jsonb_build_object(
+    'version', 1, 'session_id', s.session_id, 'org_id', s.org_id,
+    'final_seq', s.final_seq, 'final_sequence', s.final_seq,
+    'membership_revision', s.membership_revision,
+    'events', coalesce((select jsonb_agg(jsonb_build_object(
+      'event_id', e.event_id, 'session_id', e.session_id, 'seq', e.seq,
+      'kind', e.kind, 'message_id', e.message_id, 'author_id', e.author_id,
+      'role', e.role, 'content', e.content, 'revision', e.revision,
+      'created_at', e.created_at) order by e.seq)
+      from public.collaboration_events e
+      where e.session_id = p_session and e.seq <= s.final_seq), '[]'::jsonb),
+    'files', coalesce((select jsonb_agg(jsonb_build_object(
+      'id', f.file_id, 'bucket', 'collaboration-files', 'path', f.object_path,
+      'sha256', f.sha256, 'byte_length', f.expected_bytes) order by f.file_id)
+      from public.collaboration_file_reservations f
+      where f.session_id = p_session and f.status = 'uploaded'), '[]'::jsonb),
+    'recipients', coalesce((select jsonb_agg(jsonb_build_object('user_id', sm.user_id) order by sm.user_id)
+      from public.collaboration_session_members sm
+      join public.collaboration_org_members om on om.org_id = sm.org_id and om.user_id = sm.user_id
+      where sm.session_id = p_session and sm.status = 'active' and om.status = 'active'), '[]'::jsonb)
+  )::text;
+  v_bytes := octet_length(convert_to(v_text, 'UTF8'));
+  v_digest := encode(extensions.digest(convert_to(v_text, 'UTF8'), 'sha256'), 'hex');
+
+  -- Archive completion may consume the already reserved admission headroom.
+  -- A physical-capacity measurement is still required before duplicating data.
+  if not coalesce((select
+      measured_at > now() - interval '36 hours'
+      and database_bytes + cfg.admission_reserve_bytes < cfg.project_physical_stop_bytes
+    from public.collaboration_capacity_measurements
+    order by measured_at desc limit 1), false)
+  then perform collaboration_private.fail('CAPACITY_UNMEASURED'); end if;
+
+  insert into public.collaboration_archive_manifests(
+    session_id, archive_revision, membership_revision, final_seq,
+    manifest_json, digest, byte_length, status)
+  values (p_session, v_rev, v_rev, s.final_seq, v_text, v_digest, v_bytes, 'pending');
+  insert into public.collaboration_archive_recipients(
+    session_id, archive_revision, user_id, eligible, receipt_required, membership_revision)
+  select p_session, v_rev, sm.user_id, true, true, v_rev
+  from public.collaboration_session_members sm
+  join public.collaboration_org_members om on om.org_id = sm.org_id and om.user_id = sm.user_id
+  where sm.session_id = p_session and sm.status = 'active' and om.status = 'active';
+
+  -- The initial command migration charged conservative canonical-manifest
+  -- headroom with each event before accepting it. Record the exact manifest
+  -- size without charging the duplicated payload a second time.
+  update public.collaboration_sessions
+  set status = 'archive_pending', archive_manifest_bytes = v_bytes
+  where session_id = p_session;
+  return jsonb_build_object('session_id', p_session, 'archive_revision', v_rev,
+    'manifest_digest', v_digest, 'byte_length', v_bytes, 'final_seq', s.final_seq);
+end $$;
+revoke all on function collaboration_private.prepare_archive(uuid) from public, anon, authenticated, service_role;
+
+create function collaboration_private.archive_guard(
+  p_session uuid, p_fence bigint, p_digest text, p_require_claim boolean default true)
+returns public.collaboration_purge_jobs language plpgsql security definer set search_path = '' as $$
+declare j public.collaboration_purge_jobs%rowtype; s public.collaboration_sessions%rowtype;
+begin
+  select * into j from public.collaboration_purge_jobs where session_id = p_session for update;
+  if not found or (p_require_claim and (j.status <> 'claimed' or j.fence <> p_fence or j.lease_expires_at <= now()))
+  then perform collaboration_private.fail('LEASE_LOST'); end if;
+  select * into s from public.collaboration_sessions where session_id = p_session for update;
+  if s.status <> 'purging'
+    or not exists (select 1 from public.collaboration_archive_manifests am
+      where am.session_id = p_session and am.archive_revision = j.archive_revision
+        and am.membership_revision = s.membership_revision and am.digest = p_digest
+        and am.final_seq = s.final_seq and s.final_seq = s.next_seq - 1
+        and am.status in ('ready','purging'))
+    or exists (select 1 from public.collaboration_events e
+      where e.session_id = p_session and e.seq > s.final_seq)
+    or (select count(*) from public.collaboration_events e where e.session_id = p_session) <> s.final_seq
+    or (select coalesce(max(e.seq), 0) from public.collaboration_events e where e.session_id = p_session) <> s.final_seq
+    or exists (select 1 from public.collaboration_runs where session_id = p_session and status in ('queued','leased','needs_reconciliation'))
+    or exists (select 1 from public.collaboration_quota_reservations where session_id = p_session and status = 'active')
+    or exists (select 1 from public.collaboration_outbox where session_id = p_session and status in ('pending','claimed','failed','uncertain','manual_review'))
+    or exists (select 1 from public.collaboration_archive_recipients ar
+      where ar.session_id = p_session and ar.archive_revision = j.archive_revision
+        and ar.membership_revision = s.membership_revision and ar.eligible and ar.receipt_required
+        and not exists (select 1 from public.collaboration_archive_receipts rr
+          where rr.session_id = ar.session_id and rr.archive_revision = ar.archive_revision
+            and rr.user_id = ar.user_id and rr.digest = p_digest))
+  then perform collaboration_private.fail('PURGE_GUARD_FAILED'); end if;
+  return j;
+end $$;
+revoke all on function collaboration_private.archive_guard(uuid,bigint,text,boolean) from public, anon, authenticated, service_role;
+
+create function collaboration_private.maintenance_command(p_command text, p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path = '' as $$
+declare
+  cfg public.collaboration_config%rowtype;
+  s public.collaboration_sessions%rowtype;
+  j public.collaboration_purge_jobs%rowtype;
+  a public.collaboration_archive_manifests%rowtype;
+  v_session uuid;
+  v_fence bigint;
+  v_digest text;
+  v_object uuid;
+  v_limit integer;
+  v_count integer := 0;
+  v_receipts jsonb;
+  v_retained bigint;
+  v_file_cleanup jsonb;
+begin
+  if p_payload is null or jsonb_typeof(p_payload) <> 'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+  select * into cfg from public.collaboration_config where singleton for share;
+
+  if p_command = 'advance_archives' then
+    v_limit := least(greatest(coalesce((p_payload->>'limit')::integer, 10), 1), 100);
+    perform collaboration_private.release_expired_reservations(v_limit * 10);
+    select public.collaboration_files_release_expired(v_limit * 10) into v_file_cleanup;
+
+    if cfg.archive_enabled then
+    with warned as (
+      update public.collaboration_sessions x set archive_warning_at = now(), revision = revision + 1
+      where x.session_id in (select session_id from public.collaboration_sessions
+        where status = 'active' and archive_warning_at is null
+          and last_published_at <= now() - interval '13 days'
+        order by last_published_at for update skip locked limit v_limit)
+      returning x.org_id, x.session_id, x.last_published_at
+    )
+    insert into public.collaboration_audit(org_id, session_id, action, detail)
+    select org_id, session_id, 'archive_warning', jsonb_build_object('last_published_at', last_published_at) from warned;
+
+    for s in
+      select * from public.collaboration_sessions x
+      where x.status = 'active'
+        and (x.last_published_at <= now() - interval '14 days'
+          or x.message_count >= cfg.max_messages_per_session
+          or x.logical_bytes + x.reserved_bytes >= cfg.session_limit_bytes)
+        and not exists (select 1 from public.collaboration_runs r where r.session_id = x.session_id and r.status in ('queued','leased','needs_reconciliation'))
+        and not exists (select 1 from public.collaboration_quota_reservations q where q.session_id = x.session_id and q.status = 'active')
+        and not exists (select 1 from public.collaboration_outbox o where o.session_id = x.session_id and o.status in ('pending','claimed','failed','uncertain','manual_review'))
+      order by x.last_published_at for update skip locked limit v_limit
+    loop
+      update public.collaboration_invites set status = 'revoked'
+        where session_id = s.session_id and status = 'pending';
+      update public.collaboration_session_members set status = 'revoked', revoked_at = now()
+        where session_id = s.session_id and status = 'invited';
+      update public.collaboration_sessions set status = 'closing', final_seq = next_seq - 1,
+        membership_revision = membership_revision + 1, revision = revision + 1
+        where session_id = s.session_id;
+      v_count := v_count + 1;
+    end loop;
+    end if;
+
+    for s in select * from public.collaboration_sessions x where x.status = 'closing'
+      order by x.last_published_at for update skip locked limit v_limit
+    loop
+      begin perform collaboration_private.prepare_archive(s.session_id); v_count := v_count + 1;
+      exception when sqlstate 'P0001' then null; end;
+    end loop;
+    return jsonb_build_object('ok', true, 'advanced', v_count,
+      'file_cleanup', coalesce(v_file_cleanup, jsonb_build_object('released', 0, 'objects', '[]'::jsonb)));
+
+  elsif p_command = 'checkpoint_file_cleanup' then
+    return public.collaboration_files_cleanup_complete((p_payload->>'file_id')::uuid);
+
+  elsif p_command = 'claim_purge' then
+    select * into j from public.collaboration_purge_jobs x
+    where (x.status in ('waiting','failed') or (x.status = 'claimed' and x.lease_expires_at < now()))
+      and exists (select 1 from public.collaboration_archive_manifests am
+        join public.collaboration_sessions ss using(session_id)
+        where am.session_id = x.session_id and am.archive_revision = x.archive_revision
+          and (am.status = 'ready' or (x.status = 'claimed' and x.lease_expires_at < now() and am.status = 'purging'))
+          and am.membership_revision = ss.membership_revision
+          and am.final_seq = ss.final_seq and ss.final_seq = ss.next_seq - 1
+          and ss.status in ('archive_pending','purging'))
+      and not exists (select 1 from public.collaboration_events e
+        join public.collaboration_sessions ss on ss.session_id = e.session_id
+        where e.session_id = x.session_id and e.seq > ss.final_seq)
+      and (select count(*) from public.collaboration_events e where e.session_id = x.session_id) =
+        (select ss.final_seq from public.collaboration_sessions ss where ss.session_id = x.session_id)
+      and (select coalesce(max(e.seq), 0) from public.collaboration_events e where e.session_id = x.session_id) =
+        (select ss.final_seq from public.collaboration_sessions ss where ss.session_id = x.session_id)
+      and not exists (select 1 from public.collaboration_archive_recipients ar
+        where ar.session_id = x.session_id and ar.archive_revision = x.archive_revision
+          and ar.eligible and ar.receipt_required and not exists (
+            select 1 from public.collaboration_archive_receipts rr
+            where rr.session_id = ar.session_id and rr.archive_revision = ar.archive_revision
+              and rr.user_id = ar.user_id))
+    order by x.updated_at for update skip locked limit 1;
+    if not found then return null; end if;
+    update public.collaboration_purge_jobs set status = 'claimed', fence = fence + 1,
+      lease_token = gen_random_uuid(), lease_expires_at = now() + interval '2 minutes',
+      attempts = attempts + 1, last_error_code = null, updated_at = now()
+      where session_id = j.session_id returning * into j;
+    update public.collaboration_sessions set status = 'purging' where session_id = j.session_id;
+    update public.collaboration_archive_manifests set status = 'purging'
+      where session_id = j.session_id and archive_revision = j.archive_revision returning * into a;
+    return jsonb_build_object('session_id', j.session_id, 'fence', j.fence,
+      'manifest_digest', a.digest, 'objects', coalesce((select jsonb_agg(jsonb_build_object(
+        'id', f.file_id, 'bucket', 'collaboration-files', 'path', f.object_path) order by f.file_id)
+        from public.collaboration_file_reservations f
+        where f.session_id = j.session_id and f.status = 'uploaded'
+          and not (j.object_checkpoint ? f.file_id::text)), '[]'::jsonb));
+
+  elsif p_command in ('check_purge','checkpoint_purge','finish_purge') then
+    v_session := (p_payload->>'session_id')::uuid;
+    v_fence := (p_payload->>'fence')::bigint;
+    v_digest := p_payload->>'manifest_digest';
+    j := collaboration_private.archive_guard(v_session, v_fence, v_digest, true);
+
+    if p_command = 'check_purge' then
+      v_object := (p_payload->>'object_id')::uuid;
+      perform 1 from public.collaboration_file_reservations f
+      where f.file_id = v_object and f.session_id = v_session and f.status = 'uploaded'
+        and not (j.object_checkpoint ? f.file_id::text)
+        and not exists (select 1 from public.collaboration_file_reservations other
+          where other.object_path = f.object_path and other.session_id <> v_session and other.status <> 'purged');
+      if not found then perform collaboration_private.fail('OBJECT_NOT_EXCLUSIVE'); end if;
+      update public.collaboration_purge_jobs set lease_expires_at = now() + interval '2 minutes', updated_at = now()
+        where session_id = v_session;
+      return jsonb_build_object('ok', true);
+    elsif p_command = 'checkpoint_purge' then
+      v_object := (p_payload->>'object_id')::uuid;
+      perform 1 from public.collaboration_file_reservations
+        where file_id = v_object and session_id = v_session and status = 'uploaded';
+      if not found and not (j.object_checkpoint ? v_object::text) then perform collaboration_private.fail('OBJECT_NOT_FOUND'); end if;
+      update public.collaboration_file_reservations set status = 'purged'
+        where file_id = v_object and session_id = v_session;
+      update public.collaboration_purge_jobs
+      set object_checkpoint = object_checkpoint || jsonb_build_object(v_object::text, true),
+        lease_expires_at = now() + interval '2 minutes', updated_at = now()
+      where session_id = v_session;
+      return jsonb_build_object('ok', true);
+    else
+      if exists (select 1 from public.collaboration_file_reservations
+        where session_id = v_session and status = 'uploaded')
+      then perform collaboration_private.fail('PURGE_INCOMPLETE'); end if;
+      select * into s from public.collaboration_sessions where session_id = v_session for update;
+      select * into a from public.collaboration_archive_manifests
+        where session_id = v_session and archive_revision = j.archive_revision;
+      select coalesce(jsonb_agg(jsonb_build_object('user_id', rr.user_id,
+        'device_id', rr.device_id, 'verified_at', rr.verified_at)), '[]'::jsonb)
+        into v_receipts from public.collaboration_archive_receipts rr
+        where rr.session_id = v_session and rr.archive_revision = j.archive_revision;
+      insert into public.collaboration_tombstones(session_id, org_id, final_seq, digest,
+        archive_revision, eligible_user_ids, receipt_evidence, archived_at, purge_completed_at)
+      values(v_session, s.org_id, a.final_seq, a.digest, a.archive_revision,
+        array(select ar.user_id from public.collaboration_archive_recipients ar
+          where ar.session_id = v_session and ar.archive_revision = a.archive_revision and ar.eligible),
+        v_receipts, now(), now())
+      on conflict(session_id) do update set final_seq = excluded.final_seq, digest = excluded.digest,
+        archive_revision = excluded.archive_revision, eligible_user_ids = excluded.eligible_user_ids,
+        receipt_evidence = excluded.receipt_evidence, archived_at = excluded.archived_at,
+        purge_completed_at = excluded.purge_completed_at;
+
+      -- This is the only command that erases database payload. Minimal receipt,
+      -- recipient, tombstone, session, audit, and completed-job metadata remains.
+      delete from public.collaboration_file_reservations where session_id = v_session;
+      delete from public.collaboration_messages where session_id = v_session;
+      delete from public.collaboration_runs where session_id = v_session;
+      delete from public.collaboration_events where session_id = v_session;
+      delete from public.collaboration_quota_reservations where session_id = v_session;
+      delete from public.collaboration_outbox where session_id = v_session;
+      delete from public.collaboration_slack_inbox si using public.collaboration_slack_threads st
+        where st.session_id = v_session and si.installation_id = st.installation_id
+          and (si.event->>'session_id' = v_session::text
+            or si.event#>>'{event,session_id}' = v_session::text
+            or ((si.event->>'channel_id' = st.channel_id or si.event#>>'{event,channel}' = st.channel_id)
+              and (si.event->>'root_thread_ts' = st.root_thread_ts
+                or coalesce(si.event#>>'{event,thread_ts}', si.event#>>'{event,ts}') = st.root_thread_ts)));
+      update public.collaboration_archive_manifests set manifest_json = '{}', byte_length = 0, status = 'purged'
+        where session_id = v_session;
+      update public.collaboration_sessions set title = null, status = 'archived_local',
+        reserved_bytes = 0, archive_manifest_bytes = 0,
+        shared_file_bytes = 0, archived_at = now(), revision = revision + 1
+        where session_id = v_session;
+      update public.collaboration_purge_jobs set status = 'complete', lease_token = null,
+        lease_expires_at = null, updated_at = now() where session_id = v_session;
+      select coalesce(sum(retained_bytes), 0)::bigint into v_retained from (
+        select pg_column_size(to_jsonb(x))::bigint retained_bytes from public.collaboration_sessions x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_session_members x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_archive_manifests x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_archive_recipients x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_archive_receipts x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_tombstones x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_purge_jobs x where x.session_id = v_session
+        union all select pg_column_size(to_jsonb(x))::bigint from public.collaboration_audit x where x.session_id = v_session
+      ) retained;
+      update public.collaboration_sessions set logical_bytes = v_retained where session_id = v_session;
+      update public.collaboration_quota_counters set
+        logical_bytes = greatest(0, logical_bytes - s.logical_bytes + v_retained),
+        reserved_bytes = greatest(0, reserved_bytes - s.reserved_bytes),
+        shared_file_bytes = greatest(0, shared_file_bytes - s.shared_file_bytes), updated_at = now()
+        where org_id = s.org_id;
+      return jsonb_build_object('ok', true, 'session_id', v_session, 'status', 'archived_local');
+    end if;
+
+  elsif p_command = 'retry_purge' then
+    v_session := (p_payload->>'session_id')::uuid;
+    v_fence := (p_payload->>'fence')::bigint;
+    update public.collaboration_purge_jobs set status = 'failed', lease_token = null,
+      lease_expires_at = null, last_error_code = 'WORKER_RETRY', updated_at = now()
+      where session_id = v_session and status = 'claimed' and fence = v_fence
+        and exists (select 1 from public.collaboration_sessions ss
+          join public.collaboration_archive_manifests am on am.session_id = ss.session_id
+          where ss.session_id = v_session and ss.status = 'purging'
+            and am.archive_revision = collaboration_purge_jobs.archive_revision
+            and am.membership_revision = ss.membership_revision
+            and am.status = 'purging');
+    if not found then perform collaboration_private.fail('LEASE_LOST'); end if;
+    update public.collaboration_archive_manifests am set status = 'ready'
+      where am.session_id = v_session and am.archive_revision = (
+        select archive_revision from public.collaboration_purge_jobs where session_id = v_session);
+    update public.collaboration_sessions set status = 'archive_pending' where session_id = v_session;
+    return jsonb_build_object('ok', true);
+  else
+    perform collaboration_private.fail('UNKNOWN_COMMAND');
+  end if;
+end $$;
+revoke all on function collaboration_private.maintenance_command(text,jsonb) from public, anon, authenticated, service_role;
+
+create function public.collaboration_maintenance_command(p_command text, p_payload jsonb)
+returns jsonb language sql security definer set search_path = '' as $$
+  select collaboration_private.maintenance_command(p_command, p_payload)
+$$;
+revoke all on function public.collaboration_maintenance_command(text,jsonb) from public, anon, authenticated;
+grant execute on function public.collaboration_maintenance_command(text,jsonb) to service_role;
+
+-- Retire the first migration's coarse maintenance entry points. They could
+-- erase relational payload before object deletion and did not revalidate a fence.
+revoke all on function collaboration_private.claim_purge(uuid) from public, anon, authenticated, service_role;
+revoke all on function collaboration_private.finish_purge_step(uuid,uuid,text,jsonb) from public, anon, authenticated, service_role;

--- a/supabase/migrations/20260909031444_collaboration_shared_files.sql
+++ b/supabase/migrations/20260909031444_collaboration_shared_files.sql
@@ -1,0 +1,179 @@
+-- Complete shared-file lifecycle. File capacity is held at the configured
+-- maximum until trusted verification observes the stored object.
+alter table public.collaboration_sessions
+  add column file_reserved_bytes bigint not null default 0 check (file_reserved_bytes >= 0);
+alter table public.collaboration_quota_counters
+  add column file_reserved_bytes bigint not null default 0 check (file_reserved_bytes >= 0);
+alter table public.collaboration_file_reservations
+  add column display_name text,
+  add column content_type text,
+  add column verified_bytes bigint,
+  add column version integer not null default 1 check (version = 1),
+  add column reserved_session_revision bigint,
+  add column reserved_membership_revision bigint,
+  add column uploaded_at timestamptz,
+  add column failed_at timestamptz,
+  add column failure_code text;
+alter table public.collaboration_file_reservations
+  drop constraint collaboration_file_reservations_status_check;
+alter table public.collaboration_file_reservations
+  add constraint collaboration_file_reservations_status_check
+  check (status in ('reserved','uploaded','cleanup_pending','failed','cancelled','purged'));
+alter table public.collaboration_file_reservations
+  add constraint collaboration_file_expected_bytes_check check (expected_bytes between 1 and 5242880),
+  add constraint collaboration_file_verified_bytes_check check (verified_bytes is null or verified_bytes between 1 and 5242880),
+  add constraint collaboration_file_sha256_check check (sha256 is null or sha256 ~ '^[0-9a-f]{64}$'),
+  add constraint collaboration_file_display_name_check check (display_name is null or (length(display_name) between 1 and 255 and display_name !~ '[[:cntrl:]]'));
+
+create index collaboration_files_session_status_idx
+  on public.collaboration_file_reservations(session_id,status,created_at);
+-- Uploads pass through the trusted Edge handler so claimed metadata can never
+-- mark an unchecked object complete.
+drop policy if exists collaboration_files_insert on storage.objects;
+grant select on public.collaboration_file_reservations to authenticated;
+alter table public.collaboration_file_reservations enable row level security;
+create policy collaboration_file_metadata_read on public.collaboration_file_reservations
+  for select to authenticated
+  using (status = 'uploaded' and (select collaboration_private.is_session_member(session_id,(select auth.uid()))));
+
+create function collaboration_private.release_file_reservation(p_file_id uuid,p_status text,p_failure text default null)
+returns void language plpgsql security definer set search_path='' as $$
+declare f public.collaboration_file_reservations%rowtype;
+begin
+  select * into f from public.collaboration_file_reservations where file_id=p_file_id for update;
+  if not found or f.status <> 'reserved' then return; end if;
+  update public.collaboration_file_reservations set status=p_status, failed_at=case when p_status='failed' then now() end,
+    failure_code=p_failure where file_id=p_file_id;
+  update public.collaboration_quota_reservations set status='released',settled_at=now() where reservation_id=f.reservation_id and status='active';
+  update public.collaboration_sessions set file_reserved_bytes=greatest(0,file_reserved_bytes-(select max_file_bytes from public.collaboration_config where singleton))
+    where session_id=f.session_id;
+  update public.collaboration_quota_counters set file_reserved_bytes=greatest(0,file_reserved_bytes-(select max_file_bytes from public.collaboration_config where singleton)),updated_at=now()
+    where org_id=f.org_id;
+end $$;
+revoke all on function collaboration_private.release_file_reservation(uuid,text,text) from public,anon,authenticated,service_role;
+
+create function collaboration_private.file_command(p_actor uuid,p_command text,p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare cfg public.collaboration_config%rowtype; s public.collaboration_sessions%rowtype;
+ f public.collaboration_file_reservations%rowtype; v_file uuid; v_res uuid; v_bytes bigint;
+ v_name text; v_type text; v_hash text; v_project bigint;
+begin
+  if p_actor is null then perform collaboration_private.fail('AUTH_REQUIRED'); end if;
+  if p_payload is null or jsonb_typeof(p_payload)<>'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+  select * into cfg from public.collaboration_config where singleton for update;
+  if p_command='reserve' then
+    v_file=(p_payload->>'file_id')::uuid; v_bytes=(p_payload->>'byte_length')::bigint;
+    v_name=nullif(btrim(p_payload->>'name'),''); v_type=left(coalesce(nullif(btrim(p_payload->>'content_type'),''),'application/octet-stream'),255);
+    v_hash=lower(p_payload->>'sha256');
+    if v_name is null or length(v_name)>255 or v_name ~ '[[:cntrl:]]' or v_type ~ '[[:cntrl:]]'
+      or v_bytes<1 or v_bytes>least(cfg.max_file_bytes,5242880) or v_hash !~ '^[0-9a-f]{64}$' then
+      perform collaboration_private.fail('INVALID_FILE');
+    end if;
+    select * into s from public.collaboration_sessions where session_id=(p_payload->>'session_id')::uuid for update;
+    if not found or s.status<>'active' then perform collaboration_private.fail('SESSION_NOT_ACTIVE'); end if;
+    if s.revision is distinct from (p_payload->>'expected_session_revision')::bigint
+      or s.membership_revision is distinct from (p_payload->>'membership_revision')::bigint then perform collaboration_private.fail('REVISION_CONFLICT'); end if;
+    if not collaboration_private.is_session_member(s.session_id,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+    -- Serialize all project-wide file admission beneath the singleton config lock.
+    perform 1 from public.collaboration_quota_counters order by org_id for update;
+    select coalesce(sum(shared_file_bytes+file_reserved_bytes),0) into v_project from public.collaboration_quota_counters;
+    if s.shared_file_bytes+s.file_reserved_bytes+cfg.max_file_bytes>cfg.max_session_file_bytes
+      or v_project+cfg.max_file_bytes>cfg.max_project_file_bytes then perform collaboration_private.fail('FILE_QUOTA_EXCEEDED'); end if;
+    select * into f from public.collaboration_file_reservations where file_id=v_file;
+    if found then
+      if f.session_id=s.session_id and f.uploader_id=p_actor and f.expected_bytes=v_bytes and f.sha256=v_hash and f.display_name=v_name then
+        return jsonb_build_object('ok',true,'file_id',f.file_id,'object_path',f.object_path,'status',f.status,'version',f.version);
+      end if;
+      perform collaboration_private.fail('IDEMPOTENCY_CONFLICT');
+    end if;
+    v_res=gen_random_uuid();
+    insert into public.collaboration_quota_reservations(reservation_id,org_id,session_id,kind,reserved_bytes,expires_at)
+      values(v_res,s.org_id,s.session_id,'file',cfg.max_file_bytes,now()+interval '30 minutes');
+    insert into public.collaboration_file_reservations(file_id,reservation_id,org_id,session_id,uploader_id,object_path,expected_bytes,sha256,display_name,content_type,reserved_session_revision,reserved_membership_revision)
+      values(v_file,v_res,s.org_id,s.session_id,p_actor,s.org_id::text||'/'||s.session_id::text||'/'||p_actor::text||'/'||v_file::text||'/v1',v_bytes,v_hash,v_name,v_type,s.revision,s.membership_revision)
+      returning * into f;
+    update public.collaboration_sessions set file_reserved_bytes=file_reserved_bytes+cfg.max_file_bytes where session_id=s.session_id;
+    update public.collaboration_quota_counters set file_reserved_bytes=file_reserved_bytes+cfg.max_file_bytes,updated_at=now() where org_id=s.org_id;
+    return jsonb_build_object('ok',true,'file_id',f.file_id,'object_path',f.object_path,'status','reserved','version',1,'expires_at',now()+interval '30 minutes');
+  elsif p_command in ('authorize_upload','authorize_download') then
+    select * into f from public.collaboration_file_reservations where file_id=(p_payload->>'file_id')::uuid for share;
+    if not found then perform collaboration_private.fail('FILE_NOT_FOUND'); end if;
+    select * into s from public.collaboration_sessions where session_id=f.session_id for share;
+    if p_command='authorize_upload' then
+      if f.uploader_id<>p_actor or f.status<>'reserved' or s.status<>'active'
+        or s.membership_revision<>f.reserved_membership_revision
+        or not collaboration_private.is_session_member(f.session_id,p_actor)
+        or not exists(select 1 from public.collaboration_quota_reservations q where q.reservation_id=f.reservation_id and q.status='active' and q.expires_at>now())
+      then perform collaboration_private.fail('UPLOAD_NOT_AUTHORIZED'); end if;
+    else
+      if f.status<>'uploaded' or not collaboration_private.is_session_member(f.session_id,p_actor) then perform collaboration_private.fail('DOWNLOAD_NOT_AUTHORIZED'); end if;
+    end if;
+    return jsonb_build_object('ok',true,'file_id',f.file_id,'object_path',f.object_path,'name',f.display_name,'content_type',f.content_type,
+      'byte_length',coalesce(f.verified_bytes,f.expected_bytes),'sha256',f.sha256,'version',f.version);
+  elsif p_command='cancel' then
+    v_file=(p_payload->>'file_id')::uuid;
+    select * into f from public.collaboration_file_reservations where file_id=v_file for update;
+    if not found or f.uploader_id<>p_actor then perform collaboration_private.fail('FILE_NOT_FOUND'); end if;
+    perform collaboration_private.release_file_reservation(v_file,'cleanup_pending');
+    return jsonb_build_object('ok',true);
+  elsif p_command='list' then
+    if not collaboration_private.is_session_member((p_payload->>'session_id')::uuid,p_actor) then perform collaboration_private.fail('FORBIDDEN'); end if;
+    return jsonb_build_object('ok',true,'files',coalesce((select jsonb_agg(jsonb_build_object('file_id',x.file_id,'name',x.display_name,'content_type',x.content_type,'byte_length',x.verified_bytes,'sha256',x.sha256,'version',x.version,'uploader_id',x.uploader_id,'uploaded_at',x.uploaded_at) order by x.uploaded_at,x.file_id) from public.collaboration_file_reservations x where x.session_id=(p_payload->>'session_id')::uuid and x.status='uploaded'),'[]'::jsonb));
+  else perform collaboration_private.fail('UNKNOWN_COMMAND'); end if;
+end $$;
+revoke all on function collaboration_private.file_command(uuid,text,jsonb) from public,anon,authenticated,service_role;
+
+create function public.collaboration_files_command(p_command text,p_payload jsonb)
+returns jsonb language sql security definer set search_path='' as $$ select collaboration_private.file_command((select auth.uid()),p_command,p_payload) $$;
+revoke all on function public.collaboration_files_command(text,jsonb) from public,anon;
+grant execute on function public.collaboration_files_command(text,jsonb) to authenticated;
+
+create function public.collaboration_files_verify(p_file_id uuid,p_byte_length bigint,p_sha256 text)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare f public.collaboration_file_reservations%rowtype; cfg public.collaboration_config%rowtype;
+begin
+  select * into cfg from public.collaboration_config where singleton for update;
+  select * into f from public.collaboration_file_reservations where file_id=p_file_id for update;
+  if not found then perform collaboration_private.fail('FILE_NOT_FOUND'); end if;
+  if f.status='uploaded' and f.verified_bytes=p_byte_length and f.sha256=lower(p_sha256) then return jsonb_build_object('ok',true,'status','uploaded'); end if;
+  if f.status<>'reserved' then perform collaboration_private.fail('FILE_NOT_RESERVED'); end if;
+  if not exists(select 1 from public.collaboration_quota_reservations q where q.reservation_id=f.reservation_id and q.status='active' and q.expires_at>now()) then
+    perform collaboration_private.release_file_reservation(p_file_id,'cleanup_pending','RESERVATION_EXPIRED'); return jsonb_build_object('ok',false,'status','cleanup_pending');
+  end if;
+  if p_byte_length<>f.expected_bytes or p_byte_length>cfg.max_file_bytes or lower(p_sha256)<>f.sha256 then
+    perform collaboration_private.release_file_reservation(p_file_id,'cleanup_pending','CONTENT_MISMATCH'); return jsonb_build_object('ok',false,'status','cleanup_pending');
+  end if;
+  update public.collaboration_file_reservations set status='uploaded',verified_bytes=p_byte_length,uploaded_at=now() where file_id=p_file_id;
+  update public.collaboration_quota_reservations set status='settled',used_bytes=p_byte_length,settled_at=now() where reservation_id=f.reservation_id;
+  update public.collaboration_sessions set file_reserved_bytes=greatest(0,file_reserved_bytes-cfg.max_file_bytes),shared_file_bytes=shared_file_bytes+p_byte_length where session_id=f.session_id;
+  update public.collaboration_quota_counters set file_reserved_bytes=greatest(0,file_reserved_bytes-cfg.max_file_bytes),shared_file_bytes=shared_file_bytes+p_byte_length,updated_at=now() where org_id=f.org_id;
+  return jsonb_build_object('ok',true,'status','uploaded','file_id',f.file_id,'byte_length',p_byte_length,'sha256',lower(p_sha256));
+end $$;
+revoke all on function public.collaboration_files_verify(uuid,bigint,text) from public,anon,authenticated;
+grant execute on function public.collaboration_files_verify(uuid,bigint,text) to service_role;
+
+create function public.collaboration_files_release_expired(p_limit integer default 100)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare x record; n integer:=0; v_limit integer:=least(greatest(p_limit,1),500); v_objects jsonb;
+begin
+  for x in select f.file_id from public.collaboration_file_reservations f join public.collaboration_quota_reservations q using(reservation_id)
+    where f.status='reserved' and q.status='active' and q.expires_at<=now() order by q.expires_at for update skip locked limit v_limit
+  loop perform collaboration_private.release_file_reservation(x.file_id,'cleanup_pending','RESERVATION_EXPIRED'); n:=n+1; end loop;
+  select coalesce(jsonb_agg(jsonb_build_object('file_id',f.file_id,'bucket','collaboration-files','path',f.object_path) order by f.created_at,f.file_id),'[]'::jsonb)
+    into v_objects from (select * from public.collaboration_file_reservations where status='cleanup_pending' order by created_at,file_id limit v_limit) f;
+  return jsonb_build_object('released',n,'objects',v_objects);
+end $$;
+revoke all on function public.collaboration_files_release_expired(integer) from public,anon,authenticated;
+grant execute on function public.collaboration_files_release_expired(integer) to service_role;
+
+create function public.collaboration_files_cleanup_complete(p_file_id uuid)
+returns jsonb language plpgsql security definer set search_path='' as $$
+begin
+  update public.collaboration_file_reservations set status=case when failure_code is null then 'cancelled' else 'failed' end
+    where file_id=p_file_id and status='cleanup_pending';
+  if not found and not exists(select 1 from public.collaboration_file_reservations where file_id=p_file_id and status in ('failed','cancelled','purged'))
+    then perform collaboration_private.fail('CLEANUP_NOT_PENDING'); end if;
+  return jsonb_build_object('ok',true);
+end $$;
+revoke all on function public.collaboration_files_cleanup_complete(uuid) from public,anon,authenticated;
+grant execute on function public.collaboration_files_cleanup_complete(uuid) to service_role;

--- a/supabase/migrations/20260909033000_shared_rollout_audience_notifications.sql
+++ b/supabase/migrations/20260909033000_shared_rollout_audience_notifications.sql
@@ -1,0 +1,276 @@
+-- Per-tenant rollout, explicit audience consent, and durable mention/invite notifications.
+-- Global collaboration_config switches remain authoritative in the base command.
+
+create table public.collaboration_user_rollouts (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  enabled boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+create table public.collaboration_org_rollouts (
+  org_id uuid primary key references public.collaboration_organizations(org_id) on delete cascade,
+  enabled boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.collaboration_invites
+  add column audience_policy jsonb,
+  add column audience_policy_version integer,
+  add column consent_required boolean not null default true,
+  add column audience_consented_at timestamptz,
+  add column audience_consented_version integer;
+alter table public.collaboration_invites add constraint collaboration_invite_audience_policy_check
+  check (audience_policy is null or (jsonb_typeof(audience_policy)='object'
+    and jsonb_typeof(audience_policy->'summary')='string'
+    and jsonb_typeof(audience_policy->'includes_existing_history')='boolean'));
+
+create table public.collaboration_session_audience_consents (
+  session_id uuid not null,
+  user_id uuid not null,
+  policy_version integer not null check(policy_version=1),
+  consented_at timestamptz not null default now(),
+  primary key(session_id,user_id),
+  foreign key(session_id,user_id) references public.collaboration_session_members(session_id,user_id) on delete cascade
+);
+
+create table public.collaboration_notifications (
+  notification_id bigint generated always as identity primary key,
+  recipient_id uuid not null references auth.users(id) on delete cascade,
+  org_id uuid not null references public.collaboration_organizations(org_id) on delete cascade,
+  session_id uuid references public.collaboration_sessions(session_id) on delete cascade,
+  kind text not null check(kind in ('session_invite','mention')),
+  actor_id uuid not null references auth.users(id),
+  event_id uuid references public.collaboration_events(event_id) on delete cascade,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  read_at timestamptz,
+  unique(recipient_id,kind,event_id),
+  check(kind='mention' or event_id is null)
+);
+create index collaboration_notifications_recipient_cursor_idx
+  on public.collaboration_notifications(recipient_id,notification_id);
+
+alter table public.collaboration_user_rollouts enable row level security;
+alter table public.collaboration_org_rollouts enable row level security;
+alter table public.collaboration_notifications enable row level security;
+alter table public.collaboration_session_audience_consents enable row level security;
+revoke all on public.collaboration_user_rollouts,public.collaboration_org_rollouts,public.collaboration_notifications
+  from public,anon,authenticated;
+revoke all on public.collaboration_session_audience_consents from public,anon,authenticated;
+grant select on public.collaboration_user_rollouts,public.collaboration_org_rollouts,public.collaboration_notifications to authenticated;
+grant select on public.collaboration_session_audience_consents to authenticated;
+create policy collaboration_user_rollout_read on public.collaboration_user_rollouts for select to authenticated
+  using(user_id=(select auth.uid()));
+create policy collaboration_org_rollout_read on public.collaboration_org_rollouts for select to authenticated
+  using(collaboration_private.is_org_member(org_id,(select auth.uid())));
+create policy collaboration_notification_read on public.collaboration_notifications for select to authenticated
+  using(recipient_id=(select auth.uid()));
+create policy collaboration_audience_consent_read on public.collaboration_session_audience_consents for select to authenticated
+  using(collaboration_private.is_session_member(session_id,(select auth.uid())));
+
+create function collaboration_private.rollout_enabled(p_actor uuid,p_org uuid default null)
+returns boolean language sql stable security definer set search_path='' as $$
+  select exists(select 1 from public.collaboration_user_rollouts u where u.user_id=p_actor and u.enabled)
+    and (p_org is null or exists(select 1 from public.collaboration_org_rollouts o where o.org_id=p_org and o.enabled))
+$$;
+revoke all on function collaboration_private.rollout_enabled(uuid,uuid) from public,anon,authenticated,service_role;
+
+create function collaboration_private.command_with_rollout(p_actor uuid,p_command text,p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare v_org uuid; v_session uuid; v_result jsonb; v_event uuid; v_invite uuid;
+ v_cursor bigint; v_limit integer; v_high bigint; v_policy jsonb; v_policy_version integer;
+begin
+  if p_actor is null or p_actor is distinct from (select auth.uid()) then perform collaboration_private.fail('UNAUTHENTICATED'); end if;
+  if p_payload is null or jsonb_typeof(p_payload)<>'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+
+  if p_command='notifications' then
+    if not collaboration_private.rollout_enabled(p_actor,null) then perform collaboration_private.fail('ROLLOUT_DISABLED'); end if;
+    v_cursor:=coalesce((p_payload->>'cursor')::bigint,0);
+    v_limit:=least(greatest(coalesce((p_payload->>'limit')::integer,100),1),500);
+    select coalesce(max(notification_id),v_cursor) into v_high from public.collaboration_notifications where recipient_id=p_actor;
+    return jsonb_build_object('ok',true,'notifications',coalesce((select jsonb_agg(jsonb_build_object(
+      'notification_id',n.notification_id,'org_id',n.org_id,'session_id',n.session_id,'kind',n.kind,
+      'actor_id',n.actor_id,'event_id',n.event_id,'payload',n.payload,'created_at',n.created_at,'read_at',n.read_at)
+      order by n.notification_id) from (select * from public.collaboration_notifications
+        where recipient_id=p_actor and notification_id>v_cursor order by notification_id limit v_limit)n),'[]'::jsonb),
+      'next_cursor',coalesce((select max(notification_id) from (select notification_id from public.collaboration_notifications
+        where recipient_id=p_actor and notification_id>v_cursor order by notification_id limit v_limit)x),v_cursor),'high_water',v_high);
+  elsif p_command='ack_notifications' then
+    if not collaboration_private.rollout_enabled(p_actor,null) then perform collaboration_private.fail('ROLLOUT_DISABLED'); end if;
+    v_high:=(p_payload->>'through')::bigint;
+    update public.collaboration_notifications set read_at=coalesce(read_at,now())
+      where recipient_id=p_actor and notification_id<=v_high;
+    return jsonb_build_object('ok',true,'through',v_high);
+  end if;
+
+  if p_command='create_organization' then
+    if not collaboration_private.rollout_enabled(p_actor,null) then perform collaboration_private.fail('ROLLOUT_DISABLED'); end if;
+  elsif p_command in ('bootstrap','directory','read_events','list_pending_runs','archive_manifest','archive_status',
+    'ack_archive','stop_session_run','resolve_reconciliation','cancel_run','revoke_member','request_archive') then
+    null; -- Preserve read, recovery, revocation, and archive access during rollback.
+  else
+    if p_command in ('claim_run','renew_run','complete_run') then
+      select org_id into v_org from public.collaboration_runs where run_id=(p_payload->>'run_id')::uuid;
+    elsif p_command='accept_invite' then
+      select org_id into v_org from public.collaboration_invites where invite_id=(p_payload->>'invite_id')::uuid;
+    elsif p_command='accept_organization_invite' then
+      select org_id into v_org from public.collaboration_org_invites where invite_id=(p_payload->>'invite_id')::uuid;
+    elsif p_command in ('begin_slack_link','select_slack_channel') then
+      select org_id into v_org from public.collaboration_slack_installations where installation_id=(p_payload->>'installation_id')::uuid;
+    elsif p_command in ('invite','append_message','edit_message','delete_message','continue_session','publish_routine') then
+      v_session:=(p_payload->>'session_id')::uuid;
+      select org_id into v_org from public.collaboration_sessions where session_id=v_session;
+    elsif p_command in ('create_session','invite_organization') then v_org:=(p_payload->>'org_id')::uuid;
+    end if;
+    if not collaboration_private.rollout_enabled(p_actor,v_org) then perform collaboration_private.fail('ROLLOUT_DISABLED'); end if;
+  end if;
+
+  if p_command='invite' then
+    v_policy:=p_payload->'audience_policy';
+    v_policy_version:=coalesce((p_payload->>'audience_policy_version')::integer,1);
+    if jsonb_typeof(v_policy) is distinct from 'object'
+      or v_policy->>'summary' is distinct from 'Owners may invite additional participants who can read all published history.'
+      or coalesce((v_policy->>'includes_existing_history')::boolean,false) is not true
+      or v_policy_version<>1
+    then perform collaboration_private.fail('AUDIENCE_POLICY_REQUIRED'); end if;
+    if exists(select 1 from public.collaboration_session_members sm where sm.session_id=(p_payload->>'session_id')::uuid
+      and sm.status='active' and not exists(select 1 from public.collaboration_session_audience_consents c
+        where c.session_id=sm.session_id and c.user_id=sm.user_id and c.policy_version=1))
+    then perform collaboration_private.fail('AUDIENCE_CONSENT_REQUIRED','existing_participant'); end if;
+    v_result:=collaboration_private.command(p_actor,p_command,p_payload);
+    v_invite:=(v_result->>'invite_id')::uuid;
+    update public.collaboration_invites set audience_policy=v_policy,audience_policy_version=v_policy_version,
+      consent_required=true where invite_id=v_invite;
+    insert into public.collaboration_notifications(recipient_id,org_id,session_id,kind,actor_id,payload)
+      select invited_user_id,org_id,session_id,'session_invite',p_actor,jsonb_build_object(
+        'invite_id',invite_id,'audience_policy',v_policy,'audience_policy_version',v_policy_version,'consent_required',true)
+      from public.collaboration_invites where invite_id=v_invite;
+    return v_result || jsonb_build_object('audience_policy',v_policy,'audience_policy_version',v_policy_version,'consent_required',true);
+  elsif p_command='accept_invite' then
+    v_invite:=(p_payload->>'invite_id')::uuid;
+    select audience_policy_version into v_policy_version from public.collaboration_invites
+      where invite_id=v_invite and invited_user_id=p_actor and status='pending';
+    if not found then perform collaboration_private.fail('NOT_FOUND'); end if;
+    if not coalesce((p_payload->>'audience_consent')::boolean,false)
+      or (p_payload->>'audience_policy_version')::integer is distinct from v_policy_version
+      or v_policy_version is distinct from 1
+    then perform collaboration_private.fail('AUDIENCE_CONSENT_REQUIRED'); end if;
+    v_result:=collaboration_private.command(p_actor,p_command,p_payload);
+    update public.collaboration_invites set audience_consented_at=now(),audience_consented_version=v_policy_version
+      where invite_id=v_invite;
+    insert into public.collaboration_session_audience_consents(session_id,user_id,policy_version)
+      values((v_result->>'session_id')::uuid,p_actor,v_policy_version)
+      on conflict(session_id,user_id) do update set policy_version=excluded.policy_version,consented_at=now();
+    return v_result || jsonb_build_object('audience_consented_version',v_policy_version);
+  end if;
+
+  v_result:=collaboration_private.command(p_actor,p_command,p_payload);
+  if p_command='bootstrap' then
+    return jsonb_set(v_result,'{invites}',coalesce((select jsonb_agg(x) from (
+      select jsonb_build_object('kind','session','invite_id',i.invite_id,'org_id',i.org_id,
+        'session_id',i.session_id,'invited_by',i.invited_by,'audience_policy',i.audience_policy,
+        'audience_policy_version',i.audience_policy_version,'consent_required',i.consent_required) x
+      from public.collaboration_invites i where i.invited_user_id=p_actor and i.status='pending'
+      union all
+      select jsonb_build_object('kind','organization','invite_id',oi.invite_id,'org_id',oi.org_id,
+        'invited_by',oi.invited_by,'display_name',oi.display_name)
+      from public.collaboration_org_invites oi where oi.invited_user_id=p_actor and oi.status='pending')q),'[]'::jsonb),true)
+      || jsonb_build_object('rollout',jsonb_build_object('user_enabled',collaboration_private.rollout_enabled(p_actor,null)));
+  elsif p_command='create_organization' then
+    insert into public.collaboration_org_rollouts(org_id,enabled) values((v_result->>'org_id')::uuid,false)
+      on conflict(org_id) do nothing;
+  elsif p_command='create_session' then
+    insert into public.collaboration_session_audience_consents(session_id,user_id,policy_version)
+      values((v_result->>'session_id')::uuid,p_actor,1) on conflict do nothing;
+  elsif p_command='append_message' and p_payload ? 'mentioned_user_ids' then
+    v_event:=(v_result->>'event_id')::uuid; v_session=(v_result->>'session_id')::uuid;
+    if jsonb_typeof(p_payload->'mentioned_user_ids')<>'array' then perform collaboration_private.fail('INVALID_MENTIONS'); end if;
+    insert into public.collaboration_notifications(recipient_id,org_id,session_id,kind,actor_id,event_id,payload)
+      select sm.user_id,sm.org_id,sm.session_id,'mention',p_actor,v_event,
+        jsonb_build_object('message_id',v_result->>'message_id','seq',(v_result->>'seq')::bigint)
+      from public.collaboration_session_members sm
+      join (select distinct value::uuid user_id from jsonb_array_elements_text(p_payload->'mentioned_user_ids')) requested using(user_id)
+      where sm.session_id=v_session and sm.status='active' and sm.user_id<>p_actor
+      on conflict(recipient_id,kind,event_id) do nothing;
+  end if;
+  return v_result;
+end $$;
+revoke all on function collaboration_private.command_with_rollout(uuid,text,jsonb) from public,anon,authenticated,service_role;
+grant execute on function collaboration_private.command_with_rollout(uuid,text,jsonb) to authenticated;
+revoke execute on function collaboration_private.command(uuid,text,jsonb) from authenticated;
+
+create or replace function public.collaboration_command(p_command text,p_payload jsonb)
+returns jsonb language sql security invoker set search_path='' as $$
+  select collaboration_private.command_with_rollout((select auth.uid()),p_command,p_payload)
+$$;
+revoke all on function public.collaboration_command(text,jsonb) from public,anon;
+grant execute on function public.collaboration_command(text,jsonb) to authenticated;
+
+create function public.collaboration_rollout_command(p_command text,p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path='' as $$
+begin
+  if p_payload is null or jsonb_typeof(p_payload)<>'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+  if p_command='set_user' then
+    insert into public.collaboration_user_rollouts(user_id,enabled) values((p_payload->>'user_id')::uuid,(p_payload->>'enabled')::boolean)
+      on conflict(user_id) do update set enabled=excluded.enabled,updated_at=now();
+  elsif p_command='set_organization' then
+    insert into public.collaboration_org_rollouts(org_id,enabled) values((p_payload->>'org_id')::uuid,(p_payload->>'enabled')::boolean)
+      on conflict(org_id) do update set enabled=excluded.enabled,updated_at=now();
+  else perform collaboration_private.fail('UNKNOWN_COMMAND'); end if;
+  return jsonb_build_object('ok',true);
+end $$;
+revoke all on function public.collaboration_rollout_command(text,jsonb) from public,anon,authenticated;
+grant execute on function public.collaboration_rollout_command(text,jsonb) to service_role;
+
+create function collaboration_private.file_command_with_rollout(p_actor uuid,p_command text,p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare v_org uuid; v_session uuid;
+begin
+  if p_actor is null or p_actor is distinct from (select auth.uid()) then perform collaboration_private.fail('UNAUTHENTICATED'); end if;
+  if p_payload is null or jsonb_typeof(p_payload)<>'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+  if p_command not in ('authorize_download','list','cancel') then
+    if p_command='reserve' then v_session=(p_payload->>'session_id')::uuid;
+    else select session_id into v_session from public.collaboration_file_reservations where file_id=(p_payload->>'file_id')::uuid;
+    end if;
+    select org_id into v_org from public.collaboration_sessions where session_id=v_session;
+    if not collaboration_private.rollout_enabled(p_actor,v_org) then perform collaboration_private.fail('ROLLOUT_DISABLED'); end if;
+  end if;
+  return collaboration_private.file_command(p_actor,p_command,p_payload);
+end $$;
+revoke all on function collaboration_private.file_command_with_rollout(uuid,text,jsonb) from public,anon,authenticated,service_role;
+grant execute on function collaboration_private.file_command_with_rollout(uuid,text,jsonb) to authenticated;
+revoke execute on function collaboration_private.file_command(uuid,text,jsonb) from authenticated;
+create or replace function public.collaboration_files_command(p_command text,p_payload jsonb)
+returns jsonb language sql security invoker set search_path='' as $$
+  select collaboration_private.file_command_with_rollout((select auth.uid()),p_command,p_payload)
+$$;
+revoke all on function public.collaboration_files_command(text,jsonb) from public,anon;
+grant execute on function public.collaboration_files_command(text,jsonb) to authenticated;
+
+create function collaboration_private.slack_command_with_rollout(p_command text,p_payload jsonb)
+returns jsonb language plpgsql security definer set search_path='' as $$
+declare v_org uuid; v_actor uuid; v_result jsonb;
+begin
+  if p_payload is null or jsonb_typeof(p_payload)<>'object' then perform collaboration_private.fail('INVALID_PAYLOAD'); end if;
+  if p_command='ingest_message' then
+    select i.org_id,l.user_id into v_org,v_actor from public.collaboration_slack_installations i
+      join public.collaboration_slack_sender_links l on l.installation_id=i.installation_id
+      where i.installation_id=(p_payload->>'installation_id')::uuid and i.status='active'
+        and l.slack_user_id=p_payload->>'slack_user_id';
+    if found and not collaboration_private.rollout_enabled(v_actor,v_org) then perform collaboration_private.fail('ROLLOUT_DISABLED'); end if;
+  end if;
+  v_result:=collaboration_private.slack_command(p_command,p_payload);
+  if p_command='ingest_message' and v_actor is not null and v_result ? 'session_id' then
+    insert into public.collaboration_session_audience_consents(session_id,user_id,policy_version)
+      values((v_result->>'session_id')::uuid,v_actor,1) on conflict do nothing;
+  end if;
+  return v_result;
+end $$;
+revoke all on function collaboration_private.slack_command_with_rollout(text,jsonb) from public,anon,authenticated,service_role;
+grant execute on function collaboration_private.slack_command_with_rollout(text,jsonb) to service_role;
+revoke execute on function collaboration_private.slack_command(text,jsonb) from service_role;
+create or replace function public.collaboration_slack_command(p_command text,p_payload jsonb)
+returns jsonb language sql security invoker set search_path='' as $$
+  select collaboration_private.slack_command_with_rollout(p_command,p_payload)
+$$;
+revoke all on function public.collaboration_slack_command(text,jsonb) from public,anon,authenticated;
+grant execute on function public.collaboration_slack_command(text,jsonb) to service_role;

--- a/supabase/tests/collaboration_backend.sql
+++ b/supabase/tests/collaboration_backend.sql
@@ -1,0 +1,27 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(19);
+
+select has_schema('collaboration_private','private authority schema exists');
+select has_table('public','collaboration_organizations','organizations table exists');
+select has_table('public','collaboration_sessions','sessions table exists');
+select has_table('public','collaboration_events','canonical events table exists');
+select has_table('public','collaboration_quota_reservations','quota reservations table exists');
+select has_table('public','collaboration_archive_receipts','archive receipts table exists');
+select has_table('public','collaboration_tombstones','archive tombstones table exists');
+select has_column('public','collaboration_runs','provider_payer_id','runs record the requester as provider payer');
+select has_function('public','collaboration_command',array['text','jsonb'],'single authenticated RPC exists');
+select has_function('public','collaboration_slack_command',array['text','jsonb'],'service Slack RPC exists');
+
+select ok((select relrowsecurity from pg_class where oid='public.collaboration_events'::regclass),'events have RLS');
+select ok((select relrowsecurity from pg_class where oid='public.collaboration_sessions'::regclass),'sessions have RLS');
+select ok(not has_table_privilege('anon','public.collaboration_events','SELECT'),'anonymous event reads are revoked');
+select ok(not has_table_privilege('authenticated','public.collaboration_events','INSERT'),'clients cannot forge events directly');
+select ok(has_function_privilege('authenticated','public.collaboration_command(text,jsonb)','EXECUTE'),'authenticated may call narrow RPC');
+select ok(not has_function_privilege('anon','public.collaboration_command(text,jsonb)','EXECUTE'),'anonymous cannot call collaboration RPC');
+select ok(not has_function_privilege('authenticated','public.collaboration_slack_command(text,jsonb)','EXECUTE'),'clients cannot call Slack worker RPC');
+select ok(has_function_privilege('service_role','public.collaboration_slack_command(text,jsonb)','EXECUTE'),'service role may call Slack worker RPC');
+select is((select shared_text_enabled or shared_execution_enabled or archive_enabled or slack_enabled from public.collaboration_config where singleton),false,'all collaboration gates default disabled');
+
+select * from finish();
+rollback;

--- a/supabase/tests/collaboration_hosted.sql
+++ b/supabase/tests/collaboration_hosted.sql
@@ -1,0 +1,247 @@
+
+-- Hosted collaboration validation. Everything below, including fixture users,
+-- is rolled back by the final statement.
+create temporary table hosted_validation_results(name text primary key, passed boolean not null default true) on commit drop;
+create temporary table hosted_run_lease(result jsonb not null) on commit drop;
+grant select,insert on hosted_validation_results to authenticated,service_role;
+grant select,insert on hosted_run_lease to authenticated,service_role;
+
+insert into auth.users(id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at)
+values
+ ('a1000000-0000-4000-8000-000000000001','authenticated','authenticated','collab-a-rollback@example.invalid','',now(),'{}','{}',now(),now()),
+ ('a1000000-0000-4000-8000-000000000002','authenticated','authenticated','collab-b-rollback@example.invalid','',now(),'{}','{}',now(),now()),
+ ('a1000000-0000-4000-8000-000000000003','authenticated','authenticated','collab-x-rollback@example.invalid','',now(),'{}','{}',now(),now());
+
+update public.collaboration_config set shared_text_enabled=true,shared_execution_enabled=true,
+ archive_enabled=true,slack_enabled=true,session_warn_bytes=300000,session_limit_bytes=400000,
+ org_limit_bytes=1200000,default_response_reservation_bytes=70000;
+
+set local role service_role;
+do $$
+declare capacity jsonb;
+begin
+ select public.collaboration_capacity_command(12000000,0,0) into capacity;
+ if not coalesce((capacity->>'ok')::boolean,false) or capacity->>'measurement_id' is null
+  then raise exception 'capacity fixture was not accepted: %',capacity; end if;
+end $$;
+insert into hosted_validation_results values('capacity_measurement_fixture',true);
+select public.collaboration_rollout_command('set_user',jsonb_build_object('user_id','a1000000-0000-4000-8000-000000000001','enabled',true));
+select public.collaboration_rollout_command('set_user',jsonb_build_object('user_id','a1000000-0000-4000-8000-000000000002','enabled',true));
+select public.collaboration_rollout_command('set_user',jsonb_build_object('user_id','a1000000-0000-4000-8000-000000000003','enabled',true));
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+select public.collaboration_command('create_organization','{"org_id":"a2000000-0000-4000-8000-000000000001","name":"Rollback Org A","display_name":"Alice"}');
+reset role;
+set local role service_role;
+select public.collaboration_rollout_command('set_organization','{"org_id":"a2000000-0000-4000-8000-000000000001","enabled":true}');
+reset role;
+insert into public.collaboration_org_members(org_id,user_id,display_name,role) values
+ ('a2000000-0000-4000-8000-000000000001','a1000000-0000-4000-8000-000000000002','Bob','member');
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+select public.collaboration_command('create_session','{"org_id":"a2000000-0000-4000-8000-000000000001","session_id":"a3000000-0000-4000-8000-000000000001","title":"rollback validation"}');
+do $$
+declare ok boolean:=false; msg text;
+begin
+ begin perform public.collaboration_command('invite','{"session_id":"a3000000-0000-4000-8000-000000000001","invite_id":"a4000000-0000-4000-8000-000000000001","user_id":"a1000000-0000-4000-8000-000000000002"}');
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='AUDIENCE_POLICY_REQUIRED'; end;
+ if not ok then raise exception 'audience policy was not required'; end if;
+end $$;
+select public.collaboration_command('invite',jsonb_build_object('session_id','a3000000-0000-4000-8000-000000000001',
+ 'invite_id','a4000000-0000-4000-8000-000000000001','user_id','a1000000-0000-4000-8000-000000000002',
+ 'audience_policy',jsonb_build_object('summary','Owners may invite additional participants who can read all published history.','includes_existing_history',true),
+ 'audience_policy_version',1));
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000002',true);
+set local role authenticated;
+do $$
+declare ok boolean:=false; msg text;
+begin
+ begin perform public.collaboration_command('accept_invite','{"invite_id":"a4000000-0000-4000-8000-000000000001"}');
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='AUDIENCE_CONSENT_REQUIRED'; end;
+ if not ok then raise exception 'audience consent was not required'; end if;
+end $$;
+select public.collaboration_command('accept_invite','{"invite_id":"a4000000-0000-4000-8000-000000000001","audience_consent":true,"audience_policy_version":1}');
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+select public.collaboration_command('append_message',jsonb_build_object('session_id','a3000000-0000-4000-8000-000000000001',
+ 'event_id','a5000000-0000-4000-8000-000000000001','message_id','a6000000-0000-4000-8000-000000000001',
+ 'content','hello hosted rollback','role','user','author_id','a1000000-0000-4000-8000-000000000002',
+ 'mentioned_user_ids',jsonb_build_array('a1000000-0000-4000-8000-000000000002')));
+do $$
+declare stored uuid;
+begin select author_id into stored from public.collaboration_events where event_id='a5000000-0000-4000-8000-000000000001';
+ if stored<>'a1000000-0000-4000-8000-000000000001' then raise exception 'caller forged event author'; end if;
+end $$;
+do $$
+declare ok boolean:=false; msg text;
+begin
+ begin perform public.collaboration_command('append_message','{"session_id":"a3000000-0000-4000-8000-000000000001","event_id":"a5000000-0000-4000-8000-000000000001","message_id":"a6000000-0000-4000-8000-000000000001","content":"different","role":"user"}');
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='IDEMPOTENCY_CONFLICT'; end;
+ if not ok then raise exception 'event payload mismatch was accepted'; end if;
+end $$;
+do $$
+declare ok boolean:=false; msg text;
+begin
+ begin perform public.collaboration_command('append_message',jsonb_build_object(
+  'session_id','a3000000-0000-4000-8000-000000000001','event_id','a5000000-0000-4000-8000-000000000099',
+  'message_id','a6000000-0000-4000-8000-000000000099','content',repeat('x',450000),'role','user'));
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='QUOTA_EXCEEDED'; end;
+ if not ok then raise exception 'oversized message bypassed byte quota'; end if;
+ if exists(select 1 from public.collaboration_events where event_id='a5000000-0000-4000-8000-000000000099')
+  then raise exception 'failed quota command retained an event'; end if;
+end $$;
+insert into hosted_validation_results values('audience_consent_and_event_dedup',true);
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000003',true);
+set local role authenticated;
+do $$
+declare ok boolean:=false; msg text;
+begin
+ begin perform public.collaboration_command('read_events','{"session_id":"a3000000-0000-4000-8000-000000000001"}');
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='FORBIDDEN'; end;
+ if not ok then raise exception 'cross-user read was not denied'; end if;
+end $$;
+do $$
+declare n bigint;
+begin select count(*) into n from public.collaboration_events where session_id='a3000000-0000-4000-8000-000000000001';
+ if n<>0 then raise exception 'RLS exposed collaboration events'; end if;
+end $$;
+insert into hosted_validation_results values('cross_user_command_and_rls',true);
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000002',true);
+set local role authenticated;
+do $$
+declare payload jsonb;
+begin
+ select public.collaboration_command('notifications','{"cursor":0,"limit":20}') into payload;
+ if jsonb_array_length(payload->'notifications')<>2 then raise exception 'expected invite and mention notifications: %',payload; end if;
+ perform public.collaboration_command('ack_notifications',jsonb_build_object('through',(payload->>'high_water')::bigint));
+end $$;
+insert into hosted_validation_results values('notification_fanout_and_ack',true);
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+select public.collaboration_command('append_message',jsonb_build_object('session_id','a3000000-0000-4000-8000-000000000001',
+ 'event_id','a5000000-0000-4000-8000-000000000002','message_id','a6000000-0000-4000-8000-000000000002',
+ 'content','run request','role','user','request_run',true,'run_id','a7000000-0000-4000-8000-000000000001',
+ 'reservation_id','a8000000-0000-4000-8000-000000000001','response_reservation_bytes',70000));
+do $$
+declare payload jsonb;
+begin select public.collaboration_command('list_pending_runs','{}') into payload;
+ if jsonb_array_length(payload->'runs')<>1 then raise exception 'queued requester run missing: %',payload; end if;
+end $$;
+select public.collaboration_command('enroll_device','{"device_id":"a9000000-0000-4000-8000-000000000001","label":"hosted rollback","public_key":"key-a"}');
+insert into hosted_validation_results values('quota_reservation_and_requester_queue',true);
+reset role;
+
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000002',true);
+set local role authenticated;
+select public.collaboration_command('enroll_device','{"device_id":"a9000000-0000-4000-8000-000000000002","label":"hosted rollback b","public_key":"key-b"}');
+do $$
+declare ok boolean:=false; msg text;
+begin
+ begin perform public.collaboration_command('claim_run','{"run_id":"a7000000-0000-4000-8000-000000000001","device_id":"a9000000-0000-4000-8000-000000000002"}');
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='RUN_UNAVAILABLE'; end;
+ if not ok then raise exception 'nonrequester claimed requester run'; end if;
+end $$;
+insert into hosted_validation_results values('requester_claim_binding',true);
+reset role;
+
+-- Closing freezes new submissions but an already accepted requester run must
+-- still claim, renew, and publish its bounded completion.
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+select public.collaboration_command('request_archive','{"session_id":"a3000000-0000-4000-8000-000000000001"}');
+insert into hosted_run_lease
+select public.collaboration_command('claim_run','{"run_id":"a7000000-0000-4000-8000-000000000001","device_id":"a9000000-0000-4000-8000-000000000001"}');
+do $$
+declare claim jsonb;
+begin
+ select result into claim from hosted_run_lease;
+ if claim->>'session_id' is distinct from 'a3000000-0000-4000-8000-000000000001'
+  or claim->>'requester_id' is distinct from 'a1000000-0000-4000-8000-000000000001'
+  or claim->>'credential_owner_id' is distinct from 'a1000000-0000-4000-8000-000000000001'
+  or claim->>'executor_device_id' is distinct from 'a9000000-0000-4000-8000-000000000001'
+  or claim->>'run_id' is distinct from 'a7000000-0000-4000-8000-000000000001'
+  or claim->>'audience_revision' is null or claim->>'context_cutoff' is null
+  or claim->>'lease_token' is null or claim->>'lease_expires_at' is null
+ then raise exception 'claim_run core DTO incomplete: %',claim; end if;
+end $$;
+select public.collaboration_command('renew_run',jsonb_build_object('run_id','a7000000-0000-4000-8000-000000000001',
+ 'device_id','a9000000-0000-4000-8000-000000000001','lease_token',(select result->>'lease_token' from hosted_run_lease)));
+select public.collaboration_command('complete_run',jsonb_build_object('run_id','a7000000-0000-4000-8000-000000000001',
+ 'lease_token',(select result->>'lease_token' from hosted_run_lease),'event_id','a5000000-0000-4000-8000-000000000003',
+ 'message_id','a6000000-0000-4000-8000-000000000003','content','bounded completion while closing'));
+insert into hosted_validation_results values('accepted_run_completes_while_closing',true);
+reset role;
+set local role service_role;
+select public.collaboration_maintenance_command('advance_archives','{"limit":10}');
+do $$
+declare s record; m record; body jsonb; event_count bigint;
+begin
+ select final_seq,next_seq into s from public.collaboration_sessions
+  where session_id='a3000000-0000-4000-8000-000000000001';
+ select final_seq,manifest_json into m from public.collaboration_archive_manifests
+  where session_id='a3000000-0000-4000-8000-000000000001' order by archive_revision desc limit 1;
+ select count(*) into event_count from public.collaboration_events
+  where session_id='a3000000-0000-4000-8000-000000000001';
+ body:=m.manifest_json::jsonb;
+ if s.final_seq<>s.next_seq-1 or s.final_seq<>3 or m.final_seq<>s.final_seq
+  or (body->>'final_seq')::bigint<>s.final_seq or (body->>'final_sequence')::bigint<>s.final_seq
+  or jsonb_array_length(body->'events')<>event_count or event_count<>3
+  or not exists(select 1 from jsonb_array_elements(body->'events') e
+    where e->>'event_id'='a5000000-0000-4000-8000-000000000003')
+ then raise exception 'archive freeze omitted accepted completion: session %, manifest %, body %',s,m,body; end if;
+end $$;
+insert into hosted_validation_results values('archive_freeze_includes_closing_completion',true);
+reset role;
+select set_config('request.jwt.claim.sub','a1000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+do $$
+declare m record; ok boolean:=false; msg text;
+begin
+ select archive_revision,byte_length,final_seq into m from public.collaboration_archive_manifests
+  where session_id='a3000000-0000-4000-8000-000000000001' order by archive_revision desc limit 1;
+ begin perform public.collaboration_command('ack_archive',jsonb_build_object(
+  'session_id','a3000000-0000-4000-8000-000000000001','archive_revision',m.archive_revision,
+  'device_id','a9000000-0000-4000-8000-000000000001','digest',repeat('0',64),
+  'byte_length',m.byte_length,'final_seq',m.final_seq));
+ exception when sqlstate 'P0001' then get stacked diagnostics msg=message_text; ok:=msg='ARCHIVE_RECEIPT_INVALID'; end;
+ if not ok then raise exception 'corrupt archive receipt was accepted'; end if;
+end $$;
+reset role;
+set local role service_role;
+do $$
+declare claimed jsonb;
+begin select public.collaboration_maintenance_command('claim_purge','{}') into claimed;
+ if claimed is not null then raise exception 'purge claimed before all participant receipts'; end if;
+end $$;
+insert into hosted_validation_results values('zero_deletion_without_all_receipts',true);
+reset role;
+
+-- Verify real pgcrypto produced the canonical SHA-256 archive digest.
+do $$
+declare bad bigint;
+begin select count(*) into bad from public.collaboration_archive_manifests
+ where digest !~ '^[0-9a-f]{64}$' or digest<>encode(extensions.digest(convert_to(manifest_json,'UTF8'),'sha256'),'hex');
+ if bad<>0 then raise exception 'archive digest mismatch'; end if;
+end $$;
+insert into hosted_validation_results values('real_pgcrypto_archive_digest',true);
+
+select jsonb_build_object('ok',bool_and(passed),'checks',jsonb_agg(name order by name),
+ 'archive_fixture',(select jsonb_build_object('session_id',m.session_id,'archive_revision',m.archive_revision,
+   'manifest_json',m.manifest_json,'digest',m.digest,'byte_length',m.byte_length,'final_seq',m.final_seq)
+  from public.collaboration_archive_manifests m
+  where m.session_id='a3000000-0000-4000-8000-000000000001'
+  order by m.archive_revision desc limit 1)) as hosted_collaboration_validation
+from hosted_validation_results;

--- a/supabase/tests/shared_archive.sql
+++ b/supabase/tests/shared_archive.sql
@@ -1,0 +1,29 @@
+begin;
+
+-- Static contract checks that do not require feature flags or external Storage.
+do $$
+begin
+  if has_function_privilege('anon', 'public.collaboration_maintenance_command(text,jsonb)', 'execute')
+     or has_function_privilege('authenticated', 'public.collaboration_maintenance_command(text,jsonb)', 'execute') then
+    raise exception 'maintenance RPC leaked to clients';
+  end if;
+  if not has_function_privilege('service_role', 'public.collaboration_maintenance_command(text,jsonb)', 'execute') then
+    raise exception 'service role cannot invoke maintenance RPC';
+  end if;
+  if has_function_privilege('service_role', 'collaboration_private.claim_purge(uuid)', 'execute')
+     or has_function_privilege('service_role', 'collaboration_private.finish_purge_step(uuid,uuid,text,jsonb)', 'execute') then
+    raise exception 'legacy unsafe purge functions remain callable';
+  end if;
+end $$;
+
+-- The worker DTO must stay stable: no job is represented as JSON null.
+set local role service_role;
+do $$
+declare result jsonb;
+begin
+  result := public.collaboration_maintenance_command('claim_purge', '{}'::jsonb);
+  if result is not null then raise exception 'unexpected purge job in empty fixture'; end if;
+end $$;
+reset role;
+
+rollback;

--- a/supabase/tests/shared_files.sql
+++ b/supabase/tests/shared_files.sql
@@ -1,0 +1,98 @@
+begin;
+
+do $$
+begin
+  if has_function_privilege('anon','public.collaboration_files_command(text,jsonb)','execute') then
+    raise exception 'anonymous file command access leaked';
+  end if;
+  if has_function_privilege('authenticated','public.collaboration_files_verify(uuid,bigint,text)','execute') then
+    raise exception 'trusted verification leaked to clients';
+  end if;
+  if not has_function_privilege('service_role','public.collaboration_files_verify(uuid,bigint,text)','execute') then
+    raise exception 'service verification unavailable';
+  end if;
+end $$;
+
+insert into auth.users(id) values
+  ('10000000-0000-4000-8000-000000000001'),
+  ('10000000-0000-4000-8000-000000000002');
+insert into public.collaboration_organizations(org_id,name,owner_id)
+values('20000000-0000-4000-8000-000000000001','Files test','10000000-0000-4000-8000-000000000001');
+insert into public.collaboration_org_members(org_id,user_id,display_name,role) values
+  ('20000000-0000-4000-8000-000000000001','10000000-0000-4000-8000-000000000001','Owner','owner'),
+  ('20000000-0000-4000-8000-000000000001','10000000-0000-4000-8000-000000000002','Reader','member');
+insert into public.collaboration_quota_counters(org_id) values('20000000-0000-4000-8000-000000000001');
+insert into public.collaboration_sessions(session_id,org_id,created_by) values
+  ('30000000-0000-4000-8000-000000000001','20000000-0000-4000-8000-000000000001','10000000-0000-4000-8000-000000000001');
+insert into public.collaboration_session_members(org_id,session_id,user_id,role,status,joined_at) values
+  ('20000000-0000-4000-8000-000000000001','30000000-0000-4000-8000-000000000001','10000000-0000-4000-8000-000000000001','owner','active',now()),
+  ('20000000-0000-4000-8000-000000000001','30000000-0000-4000-8000-000000000001','10000000-0000-4000-8000-000000000002','member','active',now());
+
+select set_config('request.jwt.claim.sub','10000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+do $$ begin
+  begin
+    perform public.collaboration_files_command('reserve',jsonb_build_object(
+      'session_id','30000000-0000-4000-8000-000000000001','file_id','40000000-0000-4000-8000-000000000099',
+      'name','missing-revision.txt','content_type','text/plain','byte_length',1,'sha256',repeat('c',64)));
+    raise exception 'missing revisions unexpectedly accepted';
+  exception when sqlstate 'P0001' then
+    if sqlerrm <> 'REVISION_CONFLICT' then raise; end if;
+  end;
+end $$;
+select public.collaboration_files_command('reserve',jsonb_build_object(
+  'session_id','30000000-0000-4000-8000-000000000001','file_id','40000000-0000-4000-8000-000000000001',
+  'name','notes.txt','content_type','text/plain','byte_length',5,'sha256',repeat('a',64),
+  'expected_session_revision',1,'membership_revision',1));
+-- Lost acknowledgements retry the same immutable reservation.
+select public.collaboration_files_command('reserve',jsonb_build_object(
+  'session_id','30000000-0000-4000-8000-000000000001','file_id','40000000-0000-4000-8000-000000000001',
+  'name','notes.txt','content_type','text/plain','byte_length',5,'sha256',repeat('a',64),
+  'expected_session_revision',1,'membership_revision',1));
+reset role;
+
+do $$ begin
+  assert (select file_reserved_bytes=5242880 and shared_file_bytes=0 from public.collaboration_sessions where session_id='30000000-0000-4000-8000-000000000001');
+  assert (select count(*)=1 from public.collaboration_file_reservations where file_id='40000000-0000-4000-8000-000000000001');
+end $$;
+
+set local role service_role;
+select public.collaboration_files_verify('40000000-0000-4000-8000-000000000001',5,repeat('a',64));
+reset role;
+do $$ begin
+  assert (select file_reserved_bytes=0 and shared_file_bytes=5 from public.collaboration_sessions where session_id='30000000-0000-4000-8000-000000000001');
+  assert (select status='uploaded' and verified_bytes=5 from public.collaboration_file_reservations where file_id='40000000-0000-4000-8000-000000000001');
+end $$;
+
+-- Every accepted member may list and authorize a verified download.
+select set_config('request.jwt.claim.sub','10000000-0000-4000-8000-000000000002',true);
+set local role authenticated;
+select public.collaboration_files_command('list','{"session_id":"30000000-0000-4000-8000-000000000001"}'::jsonb);
+select public.collaboration_files_command('authorize_download','{"file_id":"40000000-0000-4000-8000-000000000001"}'::jsonb);
+reset role;
+
+-- A second reservation demonstrates recovery of an abandoned upload.
+select set_config('request.jwt.claim.sub','10000000-0000-4000-8000-000000000001',true);
+set local role authenticated;
+select public.collaboration_files_command('reserve',jsonb_build_object(
+  'session_id','30000000-0000-4000-8000-000000000001','file_id','40000000-0000-4000-8000-000000000002',
+  'name','abandoned.bin','content_type','application/octet-stream','byte_length',1,'sha256',repeat('b',64),
+  'expected_session_revision',1,'membership_revision',1));
+reset role;
+update public.collaboration_quota_reservations set expires_at=now()-interval '1 second'
+where reservation_id=(select reservation_id from public.collaboration_file_reservations where file_id='40000000-0000-4000-8000-000000000002');
+set local role service_role;
+select public.collaboration_files_release_expired(10);
+reset role;
+do $$ begin
+  assert (select status='cleanup_pending' and failure_code='RESERVATION_EXPIRED' from public.collaboration_file_reservations where file_id='40000000-0000-4000-8000-000000000002');
+  assert (select file_reserved_bytes=0 and shared_file_bytes=5 from public.collaboration_sessions where session_id='30000000-0000-4000-8000-000000000001');
+end $$;
+set local role service_role;
+select public.collaboration_files_cleanup_complete('40000000-0000-4000-8000-000000000002');
+reset role;
+do $$ begin
+  assert (select status='failed' from public.collaboration_file_reservations where file_id='40000000-0000-4000-8000-000000000002');
+end $$;
+
+rollback;

--- a/tools/build_hosted_collaboration_validation.mjs
+++ b/tools/build_hosted_collaboration_validation.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const migrationsDir = resolve(root, 'supabase/migrations');
+const testsPath = resolve(root, 'supabase/tests/collaboration_hosted.sql');
+const outputPath = resolve(root, '.tmp/hosted-collaboration-validation.sql');
+const migrations = (await readdir(migrationsDir))
+  .filter(name => /shared.*\.sql$/i.test(name))
+  .sort();
+
+if (migrations.length !== 4) {
+  throw new Error(`Expected exactly four shared migrations, found ${migrations.length}: ${migrations.join(', ')}`);
+}
+
+const migrationSql = await Promise.all(migrations.map(name => readFile(resolve(migrationsDir, name), 'utf8')));
+const tests = await readFile(testsPath, 'utf8');
+const output = [
+  'begin;',
+  "set local lock_timeout = '5s';",
+  "set local statement_timeout = '90s';",
+  ...migrationSql,
+  tests,
+  'rollback;',
+  '',
+].join('\n\n');
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, output, 'utf8');
+console.log(`built ${outputPath} from ${migrations.length} migrations`);

--- a/tools/collaboration_capacity.sql
+++ b/tools/collaboration_capacity.sql
@@ -1,0 +1,44 @@
+-- Run only against an isolated Supabase project. The transaction rolls back all
+-- synthetic content. Capture each SELECT result in the capacity review artifact.
+begin;
+create temporary table collaboration_capacity_samples (
+  fixture text primary key, messages integer not null, utf8_bytes bigint not null,
+  table_bytes bigint not null, index_bytes bigint not null, total_bytes bigint not null
+);
+create temporary table collaboration_capacity_fixture (
+  event_id uuid primary key, session_id uuid not null, seq bigint not null,
+  kind text not null, message_id uuid not null, author_id uuid not null,
+  role text not null, content text, revision integer not null, created_at timestamptz not null default now(),
+  unique(session_id,seq)
+);
+do $fixtures$
+declare n integer; label text; sid uuid; before_total bigint; after_total bigint; payload text;
+begin
+  foreach n in array array[40,200,1000] loop
+    label:=n::text||'_messages'; sid:=gen_random_uuid();
+    before_total:=pg_total_relation_size('pg_temp.collaboration_capacity_fixture');
+    insert into collaboration_capacity_fixture(event_id,session_id,seq,kind,message_id,author_id,role,content,revision)
+    select gen_random_uuid(),sid,g,'message',gen_random_uuid(),gen_random_uuid(),case when g%2=0 then 'assistant' else 'user' end,
+      repeat(case when g%3=0 then '你好 🐕 résumé ' else 'bounded response ' end,64),1 from generate_series(1,n) g;
+    -- Retained edit and delete events exercise revision/index growth.
+    insert into collaboration_capacity_fixture(event_id,session_id,seq,kind,message_id,author_id,role,content,revision)
+    select gen_random_uuid(),sid,n+row_number() over(order by seq),'edit',message_id,author_id,role,content||' edited',2 from collaboration_capacity_fixture where session_id=sid and seq<=greatest(1,n/10);
+    insert into collaboration_capacity_fixture(event_id,session_id,seq,kind,message_id,author_id,role,content,revision)
+    select gen_random_uuid(),sid,n+(n/10)+row_number() over(order by seq),'delete',message_id,author_id,role,null,3 from collaboration_capacity_fixture where session_id=sid and seq<=greatest(1,n/20);
+    after_total:=pg_total_relation_size('pg_temp.collaboration_capacity_fixture');
+    select string_agg(coalesce(content,''),'') into payload from collaboration_capacity_fixture where session_id=sid;
+    insert into collaboration_capacity_samples values(label,n,octet_length(convert_to(payload,'UTF8')),
+      pg_table_size('pg_temp.collaboration_capacity_fixture'),pg_indexes_size('pg_temp.collaboration_capacity_fixture'),after_total-before_total);
+  end loop;
+end $fixtures$;
+select jsonb_build_object(
+  'samples',(select jsonb_agg(to_jsonb(sample) order by messages) from (
+    select fixture,messages,utf8_bytes,table_bytes,index_bytes,total_bytes,
+      round(total_bytes::numeric/greatest(utf8_bytes,1),2) as physical_to_payload_factor
+    from collaboration_capacity_samples
+  ) sample),
+  'database_bytes',pg_database_size(current_database()),
+  'collaboration_bytes',coalesce((select sum(pg_total_relation_size(format('%I.%I',schemaname,tablename)::regclass)) from pg_tables where schemaname='public' and tablename like 'collaboration_%'),0),
+  'measured_at',now()
+) as capacity_calibration;
+rollback;

--- a/tools/collaboration_capacity_README.md
+++ b/tools/collaboration_capacity_README.md
@@ -1,0 +1,5 @@
+# Collaboration capacity calibration
+
+Run `collaboration_capacity.sql` only in an isolated Supabase project after applying the collaboration migration. It creates 40-, 200-, and 1,000-message fixtures with retained edits, deletes, long text, and multilingual UTF-8, reports table/index/total growth, and rolls the transaction back.
+
+Record the measured database, collaboration, and Storage byte totals through a service-only maintenance operation before enabling admissions. The migration requires a measurement newer than 36 hours, keeps a 50 MiB admission reserve, stops before 400 MiB total database use, and caps measured collaboration relations at 250 MiB. These are conservative pilot defaults until hosted measurements are captured. Do not run this against production or infer provider Storage/Reatime usage from Postgres relation sizes.

--- a/tools/install_collaboration_workers.sql
+++ b/tools/install_collaboration_workers.sql
@@ -1,0 +1,42 @@
+-- Run as the project administrator only after deploying the Edge functions.
+-- Create Vault entries via the dashboard before running this script:
+-- collaboration_project_url = the project's HTTPS origin
+-- collaboration_worker_secret = the deployed COLLABORATION_WORKER_SECRET
+-- No secret values are embedded in job definitions or returned by this script.
+-- This does not enable feature flags or replace pilot capacity calibration.
+begin;
+create extension if not exists pg_cron with schema pg_catalog;
+create extension if not exists pg_net with schema extensions;
+do $$ begin
+  if (select count(*) from vault.decrypted_secrets where name='collaboration_project_url'
+      and decrypted_secret ~ '^https://[a-z0-9]+\.supabase\.co/?$')<>1
+    or (select count(*) from vault.decrypted_secrets where name='collaboration_worker_secret'
+      and length(decrypted_secret)>=32)<>1 then
+    raise exception 'Configure unique collaboration project URL and worker secret in Vault first';
+  end if;
+end $$;
+
+select cron.schedule('collaboration-archive-worker','* * * * *',$job$
+  select net.http_post(
+    url:=rtrim((select decrypted_secret from vault.decrypted_secrets where name='collaboration_project_url'),'/')||'/functions/v1/archive-worker',
+    headers:=jsonb_build_object('Content-Type','application/json','Authorization','Bearer '||(select decrypted_secret from vault.decrypted_secrets where name='collaboration_worker_secret')),
+    body:='{}'::jsonb, timeout_milliseconds:=30000
+  );
+$job$);
+select cron.schedule('collaboration-slack-worker','* * * * *',$job$
+  select net.http_post(
+    url:=rtrim((select decrypted_secret from vault.decrypted_secrets where name='collaboration_project_url'),'/')||'/functions/v1/slack-worker',
+    headers:=jsonb_build_object('Content-Type','application/json','Authorization','Bearer '||(select decrypted_secret from vault.decrypted_secrets where name='collaboration_worker_secret')),
+    body:='{}'::jsonb, timeout_milliseconds:=30000
+  );
+$job$);
+select cron.schedule('collaboration-capacity-snapshot','15 */6 * * *',$job$
+  select public.collaboration_capacity_command(
+    pg_database_size(current_database()),
+    coalesce((select sum(pg_total_relation_size(format('%I.%I',schemaname,tablename)::regclass))::bigint
+      from pg_tables where schemaname='public' and tablename like 'collaboration_%'),0),
+    coalesce((select sum(case when metadata->>'size' ~ '^[0-9]+$' then (metadata->>'size')::bigint else 0 end)::bigint
+      from storage.objects),0)
+  );
+$job$);
+commit;

--- a/tools/test_collaboration_backend.mjs
+++ b/tools/test_collaboration_backend.mjs
@@ -1,0 +1,560 @@
+#!/usr/bin/env node
+/**
+ * Runtime validation for the shared-session migration using an isolated PGlite DB.
+ *
+ * Run from the repository root:
+ *   node tools/test_collaboration_backend.mjs
+ *
+ * PGlite 0.3.14 does not ship pgcrypto. The loader below replaces only
+ * `create extension pgcrypto`, maps digest(..., 'sha256') to PGlite's core
+ * sha256(bytea), and supplies deterministic random bytes for link-code tests.
+ * These tests validate SQL authorization, constraints, transactionality, quota,
+ * identity binding, archive receipts, and purge gates; they do not validate the
+ * cryptographic implementation supplied by hosted PostgreSQL/Supabase.
+ */
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { PGlite } from '../.tmp/collaboration-validation/node_modules/@electric-sql/pglite/dist/index.js';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const migrationsDir = resolve(root, 'supabase/migrations');
+
+const ids = {
+  alice: '00000000-0000-4000-8000-000000000001',
+  bob: '00000000-0000-4000-8000-000000000002',
+  mallory: '00000000-0000-4000-8000-000000000003',
+  orgA: '10000000-0000-4000-8000-000000000001',
+  orgB: '10000000-0000-4000-8000-000000000002',
+  sessionA: '20000000-0000-4000-8000-000000000001',
+  sessionArchive: '20000000-0000-4000-8000-000000000002',
+  sessionStale: '20000000-0000-4000-8000-000000000003',
+  archiveFile: '25000000-0000-4000-8000-000000000001',
+  archiveFileReservation: '26000000-0000-4000-8000-000000000001',
+  lifecycleFile: '25000000-0000-4000-8000-000000000002',
+  eventA: '30000000-0000-4000-8000-000000000001',
+  messageA: '40000000-0000-4000-8000-000000000001',
+  runA: '50000000-0000-4000-8000-000000000001',
+  reservationA: '60000000-0000-4000-8000-000000000001',
+  aliceDevice: '70000000-0000-4000-8000-000000000001',
+  bobDevice: '70000000-0000-4000-8000-000000000002',
+  worker: '80000000-0000-4000-8000-000000000001',
+};
+
+const db = new PGlite();
+let currentStep = 'startup';
+
+async function sql(text, params = []) {
+  return db.query(text, params);
+}
+
+async function scalar(text, params = []) {
+  const result = await sql(text, params);
+  return Object.values(result.rows[0] ?? {})[0];
+}
+
+async function asActor(actor, text, params = []) {
+  await sql("select set_config('request.jwt.claim.sub',$1,false)", [actor]);
+  await sql('set role authenticated');
+  try {
+    return await sql(text, params);
+  } finally {
+    await sql('reset role');
+  }
+}
+
+async function command(actor, name, payload) {
+  currentStep = `actor ${actor} command ${name}`;
+  const result = await asActor(actor, 'select public.collaboration_command($1,$2::jsonb) as value', [name, JSON.stringify(payload)]);
+  return result.rows[0].value;
+}
+
+async function maintenanceCommand(name, payload) {
+  currentStep = `maintenance command ${name}`;
+  await sql('set role service_role');
+  try {
+    const result = await sql('select public.collaboration_maintenance_command($1,$2::jsonb) as value', [name, JSON.stringify(payload)]);
+    return result.rows[0].value;
+  } finally {
+    await sql('reset role');
+  }
+}
+
+async function rolloutCommand(name, payload) {
+  currentStep = `rollout command ${name}`;
+  await sql('set role service_role');
+  try {
+    const result = await sql('select public.collaboration_rollout_command($1,$2::jsonb) as value', [name, JSON.stringify(payload)]);
+    return result.rows[0].value;
+  } finally {
+    await sql('reset role');
+  }
+}
+
+async function filesCommand(actor, name, payload) {
+  currentStep = `actor ${actor} files command ${name}`;
+  const result = await asActor(actor, 'select public.collaboration_files_command($1,$2::jsonb) as value', [name, JSON.stringify(payload)]);
+  return result.rows[0].value;
+}
+
+async function verifyFile(fileId, byteLength, sha256) {
+  currentStep = `service verify file ${fileId}`;
+  await sql('set role service_role');
+  try {
+    const result = await sql('select public.collaboration_files_verify($1,$2,$3) as value', [fileId, byteLength, sha256]);
+    return result.rows[0].value;
+  } finally {
+    await sql('reset role');
+  }
+}
+
+async function slackCommand(name, payload) {
+  currentStep = `slack command ${name}`;
+  await sql('set role service_role');
+  try {
+    const result = await sql('select public.collaboration_slack_command($1,$2::jsonb) as value', [name, JSON.stringify(payload)]);
+    return result.rows[0].value;
+  } finally {
+    await sql('reset role');
+  }
+}
+
+async function rejectsCode(operation, code) {
+  await assert.rejects(operation, error => {
+    assert.match(String(error?.message ?? error), new RegExp(`\\b${code}\\b`));
+    return true;
+  });
+}
+
+async function installMigration() {
+  await db.exec(`
+    create role anon nologin;
+    create role authenticated nologin;
+    create role service_role nologin bypassrls;
+    create schema auth;
+    create table auth.users(id uuid primary key);
+    create function auth.uid() returns uuid language sql stable as $$
+      select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid
+    $$;
+    create schema storage;
+    create table storage.buckets(id text primary key, name text not null, public boolean not null default false, file_size_limit bigint);
+    create table storage.objects(id uuid primary key default gen_random_uuid(), bucket_id text not null, name text not null);
+    grant usage on schema auth, storage, public to anon, authenticated, service_role;
+    grant select, insert on storage.objects to authenticated;
+  `);
+  const names = (await readdir(migrationsDir))
+    .filter(name => /shared.*\.sql$/i.test(name))
+    .sort();
+  assert.ok(names.length > 0, 'expected at least one shared-session migration');
+  for (const name of names) {
+    let migration = await readFile(resolve(migrationsDir, name), 'utf8');
+    migration = migration.replace(/create\s+extension\s+(?:if\s+not\s+exists\s+)?pgcrypto(?:\s+with\s+schema\s+\w+)?\s*;/ig, () => `
+    create schema if not exists extensions;
+    create or replace function extensions.digest(value bytea, algorithm text) returns bytea
+    language sql immutable strict as $$
+      select case lower(algorithm) when 'sha256' then sha256(value)
+        else null end
+    $$;
+    create or replace function extensions.gen_random_bytes(length integer) returns bytea
+    language sql volatile strict as $$
+      select decode(repeat('ab', length), 'hex')
+    $$;
+    `);
+    try {
+      await db.exec(migration);
+    } catch (error) {
+      error.migrationName = name;
+      throw error;
+    }
+  }
+  await sql('insert into auth.users(id) values ($1),($2),($3)', [ids.alice, ids.bob, ids.mallory]);
+  for (const userId of [ids.alice, ids.bob, ids.mallory]) {
+    await rolloutCommand('set_user', { user_id: userId, enabled: true });
+  }
+  await sql(`update public.collaboration_config set
+    shared_text_enabled=true, shared_execution_enabled=true, archive_enabled=true,
+    session_warn_bytes=3000, session_limit_bytes=4096, org_limit_bytes=12000,
+    default_response_reservation_bytes=700`);
+  await sql(`insert into public.collaboration_capacity_measurements
+    (database_bytes,collaboration_bytes,storage_bytes) values(0,0,0)`);
+}
+
+async function createOrg(actor, orgId, name) {
+  const result = await command(actor, 'create_organization', { org_id: orgId, name, display_name: actor === ids.alice ? 'Alice' : 'Mallory' });
+  await rolloutCommand('set_organization', { org_id: orgId, enabled: true });
+  return result;
+}
+
+async function addOrgMember(orgId, userId, displayName) {
+  await sql(`insert into public.collaboration_org_members(org_id,user_id,display_name,role)
+    values($1,$2,$3,'member')`, [orgId, userId, displayName]);
+}
+
+async function createSession(actor, orgId, sessionId, title = 'validation') {
+  return command(actor, 'create_session', { org_id: orgId, session_id: sessionId, title });
+}
+
+async function inviteAndAccept(sessionId, invitee, suffix) {
+  const inviteId = `90000000-0000-4000-8000-${suffix.padStart(12, '0')}`;
+  await rejectsCode(command(ids.alice, 'invite', { session_id: sessionId, invite_id: inviteId, user_id: invitee }),
+    'AUDIENCE_POLICY_REQUIRED');
+  await command(ids.alice, 'invite', { session_id: sessionId, invite_id: inviteId, user_id: invitee,
+    audience_policy: { summary: 'Owners may invite additional participants who can read all published history.', includes_existing_history: true },
+    audience_policy_version: 1 });
+  const pending = (await command(invitee, 'bootstrap', {})).invites.find(item => item.invite_id === inviteId);
+  assert.equal(pending.consent_required, true);
+  assert.equal(pending.audience_policy_version, 1);
+  await rejectsCode(command(invitee, 'accept_invite', { invite_id: inviteId }), 'AUDIENCE_CONSENT_REQUIRED');
+  await command(invitee, 'accept_invite', { invite_id: inviteId, audience_consent: true, audience_policy_version: 1 });
+}
+
+async function append(actor, sessionId, eventId, messageId, extra = {}) {
+  return command(actor, 'append_message', {
+    session_id: sessionId,
+    event_id: eventId,
+    message_id: messageId,
+    content: 'hello',
+    role: 'user',
+    ...extra,
+  });
+}
+
+async function testAuthorizationAndDedup() {
+  await createOrg(ids.alice, ids.orgA, 'Org A');
+  await addOrgMember(ids.orgA, ids.bob, 'Bob');
+  await createOrg(ids.mallory, ids.orgB, 'Org B');
+  await createSession(ids.alice, ids.orgA, ids.sessionA);
+  await inviteAndAccept(ids.sessionA, ids.bob, '1');
+
+  await sql('delete from public.collaboration_session_audience_consents where session_id=$1 and user_id=$2', [ids.sessionA, ids.bob]);
+  await rejectsCode(command(ids.alice, 'invite', {
+    session_id: ids.sessionA, invite_id: '90000000-0000-4000-8000-000000000098', user_id: ids.mallory,
+    audience_policy: { summary: 'Owners may invite additional participants who can read all published history.', includes_existing_history: true },
+    audience_policy_version: 1,
+  }), 'AUDIENCE_CONSENT_REQUIRED');
+  await sql(`insert into public.collaboration_session_audience_consents(session_id,user_id,policy_version)
+    values($1,$2,1)`, [ids.sessionA, ids.bob]);
+
+  await rejectsCode(command(ids.mallory, 'read_events', { session_id: ids.sessionA }), 'FORBIDDEN');
+  await rejectsCode(append(ids.mallory, ids.sessionA, '30000000-0000-4000-8000-000000000099', '40000000-0000-4000-8000-000000000099'), 'FORBIDDEN');
+  await rejectsCode(command(ids.alice, 'invite', {
+    session_id: ids.sessionA, invite_id: '90000000-0000-4000-8000-000000000099', user_id: ids.mallory,
+    audience_policy: { summary: 'Owners may invite additional participants who can read all published history.', includes_existing_history: true },
+    audience_policy_version: 1,
+  }), 'foreign key');
+
+  const first = await append(ids.alice, ids.sessionA, ids.eventA, ids.messageA, {
+    author_id: ids.bob, mentioned_user_ids: [ids.bob, ids.mallory],
+  });
+  assert.equal(first.seq, 1);
+  const author = await scalar('select author_id from public.collaboration_events where event_id=$1', [ids.eventA]);
+  assert.equal(author, ids.alice, 'the command must derive event authorship from authentication');
+  assert.equal((await append(ids.alice, ids.sessionA, ids.eventA, ids.messageA, {
+    author_id: ids.bob, mentioned_user_ids: [ids.bob, ids.mallory],
+  })).deduplicated, true);
+  await rejectsCode(append(ids.alice, ids.sessionA, ids.eventA, ids.messageA, { content: 'changed payload' }), 'IDEMPOTENCY_CONFLICT');
+  await rejectsCode(append(ids.alice, ids.sessionA, '30000000-0000-4000-8000-000000000098', '40000000-0000-4000-8000-000000000098', { role: 'assistant' }), 'FORBIDDEN');
+
+  const notifications = await command(ids.bob, 'notifications', { cursor: 0, limit: 20 });
+  assert.deepEqual(notifications.notifications.map(item => item.kind), ['session_invite', 'mention']);
+  assert.equal(notifications.notifications[1].event_id, ids.eventA);
+  assert.equal(notifications.notifications.some(item => item.actor_id !== ids.alice), false);
+  await command(ids.bob, 'ack_notifications', { through: notifications.high_water });
+  assert.equal(Number(await scalar(`select count(*) from public.collaboration_notifications
+    where recipient_id=$1 and read_at is null`, [ids.bob])), 0);
+  assert.equal((await command(ids.mallory, 'notifications', { cursor: 0 })).notifications.length, 0,
+    'mentions must not notify directory members outside the session');
+
+  const hidden = await asActor(ids.mallory, 'select count(*)::int as n from public.collaboration_events where session_id=$1', [ids.sessionA]);
+  assert.equal(hidden.rows[0].n, 0, 'RLS must hide another session');
+  await rejectsCode(asActor(ids.alice, `insert into public.collaboration_events
+    (event_id,org_id,session_id,seq,kind,message_id,author_id,role,content,revision,logical_bytes,request_hash)
+    values(gen_random_uuid(),$1,$2,99,'message',gen_random_uuid(),$3,'user','forged',1,1,'x')`,
+    [ids.orgA, ids.sessionA, ids.bob]), 'permission denied');
+}
+
+async function testQuotaReservationsAndRequesterClaims() {
+  // A committed reservation is visible to the next writer, modeling the serialized
+  // result guaranteed by the quota-counter/session row locks under a real race.
+  const accepted = await append(ids.alice, ids.sessionA,
+    '30000000-0000-4000-8000-000000000002', '40000000-0000-4000-8000-000000000002', {
+      request_run: true, run_id: ids.runA, reservation_id: ids.reservationA,
+      response_reservation_bytes: 700,
+    });
+  assert.equal(accepted.run_id, ids.runA);
+  await rejectsCode(append(ids.bob, ids.sessionA,
+    '30000000-0000-4000-8000-000000000003', '40000000-0000-4000-8000-000000000003', {
+      request_run: true, run_id: '50000000-0000-4000-8000-000000000002',
+      reservation_id: '60000000-0000-4000-8000-000000000002', response_reservation_bytes: 3500,
+    }), 'QUOTA_EXCEEDED');
+  const quota = (await sql(`select reserved_bytes,archive_manifest_bytes
+    from public.collaboration_sessions where session_id=$1`, [ids.sessionA])).rows[0];
+  assert.equal(Number(quota.reserved_bytes) - Number(quota.archive_manifest_bytes), 700,
+    'a rejected competing request must leave only the accepted response reservation');
+  assert.equal(Number(await scalar(`select count(*) from public.collaboration_quota_reservations
+    where session_id=$1 and kind='response' and status='active'`, [ids.sessionA])), 1);
+
+  // A failed command transaction must not retain its event or consume logical quota.
+  const before = Number(await scalar('select logical_bytes from public.collaboration_sessions where session_id=$1', [ids.sessionA]));
+  await rejectsCode(append(ids.bob, ids.sessionA,
+    '30000000-0000-4000-8000-000000000004', '40000000-0000-4000-8000-000000000004', {
+      content: 'x'.repeat(5000), request_run: true,
+    }), 'QUOTA_EXCEEDED');
+  assert.equal(Number(await scalar('select logical_bytes from public.collaboration_sessions where session_id=$1', [ids.sessionA])), before);
+
+  const enrolled = await command(ids.alice, 'enroll_device', { device_id: ids.aliceDevice, label: 'Alice laptop', public_key: 'alice-key' });
+  const reenrolled = await command(ids.alice, 'enroll_device', { device_id: ids.aliceDevice, label: 'Alice laptop renamed', public_key: 'alice-key' });
+  assert.equal(reenrolled.fence, enrolled.fence, 'idempotent enrollment must preserve the device fence');
+  await rejectsCode(command(ids.alice, 'enroll_device', {
+    device_id: ids.aliceDevice, label: 'attacker replacement', public_key: 'different-key',
+  }), 'DEVICE_KEY_MISMATCH');
+  await command(ids.bob, 'enroll_device', { device_id: ids.bobDevice, label: 'Bob laptop', public_key: 'bob-key' });
+  await rolloutCommand('set_organization', { org_id: ids.orgA, enabled: false });
+  await rejectsCode(command(ids.alice, 'claim_run', {
+    run_id: ids.runA, device_id: ids.aliceDevice,
+    session_id: '21000000-0000-4000-8000-000000000001', org_id: ids.orgB,
+  }), 'ROLLOUT_DISABLED');
+  await rolloutCommand('set_organization', { org_id: ids.orgA, enabled: true });
+  await rejectsCode(command(ids.bob, 'claim_run', { run_id: ids.runA, device_id: ids.bobDevice }), 'RUN_UNAVAILABLE');
+  await rejectsCode(command(ids.alice, 'claim_run', { run_id: ids.runA, device_id: ids.bobDevice }), 'DEVICE_FENCED');
+  const lease = await command(ids.alice, 'claim_run', { run_id: ids.runA, device_id: ids.aliceDevice });
+  assert.equal(lease.run_id, ids.runA);
+}
+
+async function testSharedFileLifecycle() {
+  const session = (await sql(`select revision,membership_revision from public.collaboration_sessions
+    where session_id=$1`, [ids.sessionA])).rows[0];
+  const payload = {
+    session_id: ids.sessionA,
+    file_id: ids.lifecycleFile,
+    byte_length: 16,
+    name: 'evidence.txt',
+    content_type: 'text/plain',
+    sha256: 'b'.repeat(64),
+    expected_session_revision: session.revision,
+    membership_revision: session.membership_revision,
+  };
+  await rejectsCode(filesCommand(ids.mallory, 'reserve', payload), 'FORBIDDEN');
+  const reserved = await filesCommand(ids.alice, 'reserve', payload);
+  assert.equal(reserved.status, 'reserved');
+  assert.match(reserved.object_path, new RegExp(`${ids.alice}/${ids.lifecycleFile}/v1$`));
+  assert.equal((await filesCommand(ids.alice, 'reserve', payload)).file_id, ids.lifecycleFile,
+    'an identical file reservation retry must deduplicate');
+  await rejectsCode(filesCommand(ids.alice, 'reserve', { ...payload, name: 'different.txt' }), 'IDEMPOTENCY_CONFLICT');
+  await rejectsCode(filesCommand(ids.bob, 'authorize_upload', { file_id: ids.lifecycleFile }), 'UPLOAD_NOT_AUTHORIZED');
+  await filesCommand(ids.alice, 'authorize_upload', { file_id: ids.lifecycleFile });
+  const verified = await verifyFile(ids.lifecycleFile, 16, 'b'.repeat(64));
+  assert.equal(verified.status, 'uploaded');
+  assert.equal((await filesCommand(ids.bob, 'authorize_download', { file_id: ids.lifecycleFile })).name, 'evidence.txt');
+  await rejectsCode(filesCommand(ids.mallory, 'authorize_download', { file_id: ids.lifecycleFile }), 'DOWNLOAD_NOT_AUTHORIZED');
+  const hidden = await asActor(ids.mallory, 'select count(*)::int as n from public.collaboration_file_reservations where file_id=$1', [ids.lifecycleFile]);
+  assert.equal(hidden.rows[0].n, 0, 'file metadata RLS must hide files from nonparticipants');
+}
+
+async function testClosingRunCanSettle() {
+  const sessionId = '21000000-0000-4000-8000-000000000099';
+  const eventId = '31000000-0000-4000-8000-000000000099';
+  const messageId = '41000000-0000-4000-8000-000000000099';
+  const runId = '51000000-0000-4000-8000-000000000099';
+  const reservationId = '61000000-0000-4000-8000-000000000099';
+  await createSession(ids.alice, ids.orgA, sessionId, 'closing-run');
+  await append(ids.alice, sessionId, eventId, messageId, {
+    request_run: true, run_id: runId, reservation_id: reservationId,
+  });
+  const lease = await command(ids.alice, 'claim_run', { run_id: runId, device_id: ids.aliceDevice });
+  for (const field of ['session_id','requester_id','credential_owner_id','executor_device_id',
+    'audience_revision','context_cutoff','run_id','lease_token','lease_expires_at']) {
+    assert.notEqual(lease[field], null, `claim must include ${field}`);
+    assert.notEqual(lease[field], undefined, `claim must include ${field}`);
+  }
+  await command(ids.alice, 'request_archive', { session_id: sessionId });
+  await command(ids.alice, 'renew_run', {
+    run_id: runId, device_id: ids.aliceDevice, lease_token: lease.lease_token,
+  });
+  await command(ids.alice, 'complete_run', {
+    run_id: runId, lease_token: lease.lease_token,
+    event_id: '71000000-0000-4000-8000-000000000099',
+    message_id: '81000000-0000-4000-8000-000000000099', content: 'settled while closing',
+  });
+  assert.equal(await scalar('select status from public.collaboration_sessions where session_id=$1', [sessionId]), 'closing');
+  const advanced = await maintenanceCommand('advance_archives', { limit: 10 });
+  assert.ok(advanced.advanced > 0, 'archive must progress after the accepted run settles');
+  const session = (await sql(`select final_seq,next_seq from public.collaboration_sessions
+    where session_id=$1`, [sessionId])).rows[0];
+  const row = (await sql(`select final_seq,manifest_json from public.collaboration_archive_manifests
+    where session_id=$1 order by archive_revision desc limit 1`, [sessionId])).rows[0];
+  const canonicalCount = Number(await scalar('select count(*) from public.collaboration_events where session_id=$1', [sessionId]));
+  const manifest = JSON.parse(row.manifest_json);
+  assert.equal(Number(session.final_seq), Number(session.next_seq) - 1);
+  assert.equal(Number(row.final_seq), Number(session.final_seq));
+  assert.equal(Number(manifest.final_seq), Number(session.final_seq));
+  assert.equal(Number(manifest.final_sequence), Number(session.final_seq));
+  assert.equal(manifest.events.length, canonicalCount);
+  assert.equal(manifest.events.some(event => event.event_id === '71000000-0000-4000-8000-000000000099'), true,
+    'the archive must contain the completion accepted while closing');
+}
+
+async function testSessionAdmissionCap() {
+  for (let index = 1; index <= 5; index += 1) {
+    await createSession(ids.mallory, ids.orgB, `21000000-0000-4000-8000-${String(index).padStart(12, '0')}`, `cap-${index}`);
+  }
+  await rejectsCode(createSession(ids.mallory, ids.orgB,
+    '21000000-0000-4000-8000-000000000006', 'over-cap'), 'QUOTA_EXCEEDED');
+  assert.equal(Number(await scalar(`select count(*) from public.collaboration_sessions
+    where org_id=$1 and status<>'archived_local'`, [ids.orgB])), 5);
+}
+
+async function testRolloutControls() {
+  await rejectsCode(asActor(ids.bob, `select collaboration_private.command_with_rollout($1,'read_events',$2::jsonb)`,
+    [ids.alice, JSON.stringify({ session_id: ids.sessionA })]), 'UNAUTHENTICATED');
+  await rolloutCommand('set_user', { user_id: ids.bob, enabled: false });
+  await rejectsCode(append(ids.bob, ids.sessionA,
+    '32000000-0000-4000-8000-000000000001', '42000000-0000-4000-8000-000000000001'), 'ROLLOUT_DISABLED');
+  assert.equal((await command(ids.bob, 'read_events', { session_id: ids.sessionA, cursor: 0 })).events.length, 1,
+    'rollout rollback must preserve access to existing history');
+  await rolloutCommand('set_user', { user_id: ids.bob, enabled: true });
+  await rolloutCommand('set_organization', { org_id: ids.orgA, enabled: false });
+  await rejectsCode(append(ids.alice, ids.sessionA,
+    '32000000-0000-4000-8000-000000000002', '42000000-0000-4000-8000-000000000002',
+    { org_id: ids.orgB }), 'ROLLOUT_DISABLED');
+  await rejectsCode(command(ids.bob, 'accept_invite', {
+    invite_id: '90000000-0000-4000-8000-000000000001',
+    session_id: '21000000-0000-4000-8000-000000000001', org_id: ids.orgB,
+    audience_consent: true, audience_policy_version: 1,
+  }), 'ROLLOUT_DISABLED');
+  assert.equal((await command(ids.alice, 'read_events', { session_id: ids.sessionA, cursor: 0 })).events.length, 1);
+  await rejectsCode(asActor(ids.alice, `select collaboration_private.command($1,'append_message',$2::jsonb)`,
+    [ids.alice, JSON.stringify({ session_id: ids.sessionA })]), 'permission denied');
+  const current = (await sql('select revision,membership_revision from public.collaboration_sessions where session_id=$1', [ids.sessionA])).rows[0];
+  await rejectsCode(filesCommand(ids.alice, 'reserve', {
+    session_id: ids.sessionA, file_id: '25000000-0000-4000-8000-000000000099', byte_length: 1,
+    org_id: ids.orgB,
+    name: 'blocked.txt', content_type: 'text/plain', sha256: 'c'.repeat(64),
+    expected_session_revision: current.revision, membership_revision: current.membership_revision,
+  }), 'ROLLOUT_DISABLED');
+  const installation = (await sql(`insert into public.collaboration_slack_installations(org_id,team_id,bot_user_id,token_ciphertext)
+    values($1,'T-rollout','B-rollout','ciphertext') returning installation_id`, [ids.orgA])).rows[0];
+  await sql(`insert into public.collaboration_slack_sender_links(installation_id,slack_user_id,user_id)
+    values($1,'U-bob',$2)`, [installation.installation_id, ids.bob]);
+  await rejectsCode(slackCommand('ingest_message', {
+    installation_id: installation.installation_id, slack_user_id: 'U-bob', channel_id: 'C1', thread_ts: '1.0',
+    event_id: '33000000-0000-4000-8000-000000000001', content: 'blocked', is_mention: false,
+  }), 'ROLLOUT_DISABLED');
+  await rolloutCommand('set_organization', { org_id: ids.orgA, enabled: true });
+  await sql('update public.collaboration_config set shared_text_enabled=false');
+  await rejectsCode(append(ids.alice, ids.sessionA,
+    '32000000-0000-4000-8000-000000000003', '42000000-0000-4000-8000-000000000003'), 'FEATURE_DISABLED');
+  await sql('update public.collaboration_config set shared_text_enabled=true');
+}
+
+async function makeArchiveSession(sessionId, suffix, withFile = false) {
+  await createSession(ids.alice, ids.orgA, sessionId, `archive-${suffix}`);
+  await inviteAndAccept(sessionId, ids.bob, suffix);
+  await append(ids.alice, sessionId,
+    `31000000-0000-4000-8000-${suffix.padStart(12, '0')}`,
+    `41000000-0000-4000-8000-${suffix.padStart(12, '0')}`);
+  if (withFile) {
+    await sql(`insert into public.collaboration_quota_reservations
+      (reservation_id,org_id,session_id,kind,reserved_bytes,used_bytes,status,expires_at,settled_at)
+      values($1,$2,$3,'file',16,16,'settled',now()+interval '1 hour',now())`,
+      [ids.archiveFileReservation, ids.orgA, sessionId]);
+    await sql(`insert into public.collaboration_file_reservations
+      (file_id,reservation_id,org_id,session_id,uploader_id,object_path,expected_bytes,sha256,status)
+      values($1,$2,$3,$4,$5,$6,16,$7,'uploaded')`, [ids.archiveFile, ids.archiveFileReservation,
+      ids.orgA, sessionId, ids.alice, `${ids.orgA}/${sessionId}/${ids.archiveFile}`, 'a'.repeat(64)]);
+  }
+  await command(ids.alice, 'request_archive', { session_id: sessionId });
+  const advanced = await maintenanceCommand('advance_archives', { limit: 10 });
+  assert.ok(advanced.advanced > 0);
+  const manifest = await command(ids.alice, 'archive_manifest', { session_id: sessionId });
+  return { session_id: sessionId, archive_revision: manifest.archive_revision };
+}
+
+async function receipt(actor, deviceId, manifest, overrides = {}) {
+  const details = (await command(actor, 'archive_manifest', { session_id: manifest.session_id }));
+  return command(actor, 'ack_archive', {
+    session_id: manifest.session_id,
+    archive_revision: manifest.archive_revision,
+    device_id: deviceId,
+    digest: details.digest,
+    byte_length: details.byte_length,
+    final_seq: details.final_seq,
+    ...overrides,
+  });
+}
+
+async function testArchiveReceiptAndPurgeGates() {
+  const manifest = await makeArchiveSession(ids.sessionArchive, '2', true);
+  assert.equal(await maintenanceCommand('claim_purge', {}), null);
+  assert.equal(Number(await scalar('select count(*) from public.collaboration_events where session_id=$1', [ids.sessionArchive])), 1);
+
+  await rejectsCode(receipt(ids.alice, ids.aliceDevice, manifest, { digest: '0'.repeat(64) }), 'ARCHIVE_RECEIPT_INVALID');
+  await rejectsCode(receipt(ids.alice, ids.aliceDevice, manifest, { final_seq: 999 }), 'ARCHIVE_RECEIPT_INVALID');
+  await receipt(ids.alice, ids.aliceDevice, manifest);
+  assert.equal(await maintenanceCommand('claim_purge', {}), null,
+    'an offline participant without a receipt must block purge');
+  assert.equal(Number(await scalar('select count(*) from public.collaboration_events where session_id=$1', [ids.sessionArchive])), 1,
+    'content must remain while any required receipt is absent');
+  await receipt(ids.bob, ids.bobDevice, manifest);
+  const claimed = await maintenanceCommand('claim_purge', {});
+  assert.equal(claimed.session_id, ids.sessionArchive);
+  assert.deepEqual(claimed.objects.map(object => object.id), [ids.archiveFile]);
+  await rejectsCode(maintenanceCommand('check_purge', {
+    session_id: claimed.session_id, fence: claimed.fence + 1,
+    manifest_digest: claimed.manifest_digest, object_id: ids.archiveFile,
+  }), 'LEASE_LOST');
+  await rejectsCode(maintenanceCommand('check_purge', {
+    session_id: claimed.session_id, fence: claimed.fence,
+    manifest_digest: '0'.repeat(64), object_id: ids.archiveFile,
+  }), 'PURGE_GUARD_FAILED');
+  await maintenanceCommand('check_purge', { ...claimed, object_id: ids.archiveFile });
+  await maintenanceCommand('checkpoint_purge', { ...claimed, object_id: ids.archiveFile });
+  const finished = await maintenanceCommand('finish_purge', claimed);
+  assert.equal(finished.status, 'archived_local');
+  assert.equal(Number(await scalar('select count(*) from public.collaboration_events where session_id=$1', [ids.sessionArchive])), 0);
+  assert.equal(await scalar('select status from public.collaboration_sessions where session_id=$1', [ids.sessionArchive]), 'archived_local');
+
+  const stale = await makeArchiveSession(ids.sessionStale, '3');
+  await receipt(ids.alice, ids.aliceDevice, stale);
+  await command(ids.alice, 'revoke_member', { session_id: ids.sessionStale, user_id: ids.bob });
+  assert.equal(Number(await scalar('select count(*) from public.collaboration_archive_manifests where session_id=$1', [ids.sessionStale])), 0,
+    'membership revision changes invalidate the frozen manifest and receipts');
+  const invalidation = await sql(`select detail from public.collaboration_audit
+    where session_id=$1 and action='archive_recipients_invalidated' order by audit_id desc limit 1`, [ids.sessionStale]);
+  assert.equal(invalidation.rows.length, 1, 'stale recipient evidence must remain in the audit ledger');
+  assert.equal(invalidation.rows[0].detail.recipient_ledgers.length, 2);
+  assert.equal(await maintenanceCommand('claim_purge', {}), null);
+  assert.equal(Number(await scalar('select count(*) from public.collaboration_events where session_id=$1', [ids.sessionStale])), 1);
+}
+
+async function main() {
+  await installMigration();
+  await testAuthorizationAndDedup();
+  await testSessionAdmissionCap();
+  await testRolloutControls();
+  await testSharedFileLifecycle();
+  await testQuotaReservationsAndRequesterClaims();
+  await testClosingRunCanSettle();
+  await testArchiveReceiptAndPurgeGates();
+  await db.close();
+  console.log('collaboration backend SQL validation passed');
+}
+
+main().catch(async error => {
+  const position = Number(error?.position);
+  const query = typeof error?.query === 'string' ? error.query : '';
+  const excerpt = query && Number.isFinite(position)
+    ? query.slice(Math.max(0, position - 121), Math.min(query.length, position + 120)).replace(/\s+/g, ' ')
+    : '';
+  console.error([
+    error?.migrationName ? `migration: ${error.migrationName}` : null,
+    `step: ${currentStep}`,
+    `error: ${error?.message ?? String(error)}`,
+    error?.code ? `code: ${error.code}` : null,
+    Number.isFinite(position) ? `position: ${position}` : null,
+    excerpt ? `query excerpt: ${excerpt}` : null,
+  ].filter(Boolean).join('\n'));
+  try { await db.close(); } catch {}
+  process.exitCode = 1;
+});

--- a/tools/verify_hosted_archive.py
+++ b/tools/verify_hosted_archive.py
@@ -1,0 +1,40 @@
+"""Verify a rolled-back Supabase fixture through the real Windows archive path."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "collie-core"))
+from collie_core.collaboration.archive import ArchiveManager  # noqa: E402
+
+
+def main() -> None:
+    log = Path(sys.argv[1]).read_text(encoding="utf-8-sig")
+    document, _ = json.JSONDecoder().raw_decode(log[log.index("{"):])
+    result = document["rows"][0]["hosted_collaboration_validation"]
+    assert result["ok"] is True
+    fixture = result["archive_fixture"]
+    with tempfile.TemporaryDirectory(prefix="collie-hosted-archive-") as directory:
+        root = Path(directory)
+        writer = ArchiveManager(root / "source")
+        writer.bind_account("hosted-fixture-owner")
+        receipt = writer.write(fixture["manifest_json"], fixture["digest"])
+        assert receipt["byte_length"] == fixture["byte_length"]
+        assert receipt["final_seq"] == fixture["final_seq"]
+        archive = Path(receipt["path"])
+        manifest = writer.verify(archive)
+        assert len(manifest["events"]) == fixture["final_seq"]
+        assert any(event.get("content") == "bounded completion while closing" for event in manifest["events"])
+        bundle = writer.export(archive, root / "roundtrip.zip")
+        reader = ArchiveManager(root / "destination")
+        reader.bind_account("hosted-fixture-recipient")
+        imported = reader.import_bundle(bundle)
+        assert imported["digest"] == fixture["digest"]
+        assert reader.verify(Path(imported["path"])) == manifest
+        print(json.dumps({"ok": True, "events": len(manifest["events"]), "digest": fixture["digest"], "durable_roundtrip": True}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Collie now supports organization discovery and invitations, shared conversations with durable offline sync, requester-owned model/tool execution, reviewed private results, explicit shared files, and creator-owned routine delivery. Slack intake and delivery use the same canonical sessions with signed events, encrypted installation credentials, bounded workers, and uncertain-send reconciliation.

Local archives are saved durably and reopened for verification before acknowledgement. Closing sessions finish accepted work before freezing the final sequence. Every remaining participant must supply a verified receipt before cloud purge; offline participants block deletion. Recovery, cancellation, audience consent, scoped rollout controls, and quota reservations are enforced across desktop/core/backend boundaries.

Database migrations are committed separately from the application implementation. This PR remains a draft with release flags disabled. No feature migrations, workers, or schedules were deployed to production. Two-computer and real Slack workspace pilot acceptance remain release gates.

Validation:
- Python: 3,707 passed, 6 skipped.
- Desktop: 510 passed, 1 skipped; TypeScript checks and production build passed.
- Edge functions: 8 tests passed; all entry points type-check.
- Isolated SQL harness passed; real Collie Supabase rollback tests passed authorization/RLS, quotas, consent, notifications, requester leases, closing completion, archive completeness, and deletion blocking.
- Real Supabase archive output passed Windows durable save/readback/export/import, including the completion accepted while closing.
- Hosted 40/200/1,000-message synthetic capacity fixtures ran in temporary tables. Hosted test transactions rolled back; existing account and Storage counts were unchanged.
- Shared-screen browser fixture verified sending, private review/publication, and archive-pending read-only state. Repository snapshot and whitespace checks passed.

See docs/engineering/architecture/shared-sessions.md for authority boundaries, validation limits, deployment configuration, and rollout gates.
