### PR TITLE
Support custom remote MCP connections (Step 3)

### DIFF
--- a/collie-core/AGENTS.md
+++ b/collie-core/AGENTS.md
@@ -94,7 +94,8 @@ schemas; `tests/collie/test_prompt_hashes.py` covers the hash telemetry
   tools (calendar, email, notes, smart home, documents) return guidance
   toward `mcp_<service>_*` tools once a service is connected.
 - **Connections**: `collie_core/connectors/` owns the curated catalogue,
-  official-MCP OAuth lifecycle, live probe, cached tool policy, and the sole
+  official-MCP OAuth lifecycle, custom no-auth remote HTTP/SSE lifecycle,
+  shared endpoint checks/discovery (`remote.py`), cached tool policy, and the sole
   runtime `ConnectorManager`. A catalogue entry is available only after the
   exact packaged artifact passes the complete provider acceptance matrix.
   `collie_core/services/` remains for one alpha as a compatibility shim for

--- a/collie-core/collie_core/connectors/auth.py
+++ b/collie-core/collie_core/connectors/auth.py
@@ -75,7 +75,9 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 class LoopbackOAuthReceiver:
     """Single-use loopback receiver with an OS-assigned random port."""
 
-    def __init__(self) -> None:
+    def __init__(self, server_url: str, *, allow_private_network: bool = False) -> None:
+        self.server_url = server_url
+        self.allow_private_network = allow_private_network
         handler = type(
             "_ConnectorCallback",
             (_CallbackHandler,),
@@ -87,6 +89,13 @@ class LoopbackOAuthReceiver:
         self._started = False
 
     async def redirect(self, authorization_url: str) -> None:
+        from collie_core.connectors.remote import validate_remote_endpoint
+
+        validate_remote_endpoint(
+            self.server_url,
+            authorization_url,
+            allow_private_network=self.allow_private_network,
+        )
         if not self._started:
             self._started = True
             threading.Thread(target=self.server.serve_forever, daemon=True).start()
@@ -116,6 +125,7 @@ def build_oauth_provider(
     *,
     scopes: tuple[str, ...] = (),
     interactive: bool,
+    allow_private_network: bool = False,
 ) -> Any:
     """Build the Python MCP SDK OAuth provider.
 
@@ -128,7 +138,10 @@ def build_oauth_provider(
 
     storage = CredentialStoreTokenStorage(store, connection_id)
     if interactive:
-        receiver = LoopbackOAuthReceiver()
+        receiver = LoopbackOAuthReceiver(
+            server_url,
+            allow_private_network=allow_private_network,
+        )
         redirect_uris = [receiver.redirect_uri]
         redirect_handler = receiver.redirect
         callback_handler = receiver.callback

--- a/collie-core/collie_core/connectors/drivers/__init__.py
+++ b/collie-core/collie_core/connectors/drivers/__init__.py
@@ -1,5 +1,6 @@
 """Connector driver implementations."""
 
 from collie_core.connectors.drivers.official_mcp import OfficialMcpDriver
+from collie_core.connectors.drivers.remote_mcp import RemoteMcpDriver
 
-__all__ = ["OfficialMcpDriver"]
+__all__ = ["OfficialMcpDriver", "RemoteMcpDriver"]

--- a/collie-core/collie_core/connectors/drivers/official_mcp.py
+++ b/collie-core/collie_core/connectors/drivers/official_mcp.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import httpx
-
 from collie_core.connectors.auth import build_oauth_provider
 from collie_core.connectors.models import (
     ConnectorDefinition,
@@ -14,6 +12,7 @@ from collie_core.connectors.models import (
     RemoteRevocationStatus,
 )
 from collie_core.connectors.policy import cached_tool
+from collie_core.connectors.remote import discover_all_tools, remote_mcp_session
 from collie_core.services.credentials import CredentialStore
 
 
@@ -34,35 +33,30 @@ class OfficialMcpDriver:
         *,
         interactive: bool,
     ) -> ProbeResult:
-        from mcp import ClientSession
-        from mcp.client.streamable_http import streamable_http_client
-
         auth = build_oauth_provider(
             connection_id,
             definition.endpoint,
             self.credentials,
             scopes=definition.scopes,
             interactive=interactive,
+            allow_private_network=definition.allow_private_network,
         )
-        async with (
-            httpx.AsyncClient(
-                auth=auth,
-                follow_redirects=True,
-                timeout=httpx.Timeout(30, connect=10),
-                headers={"Accept": "application/json, text/event-stream"},
-            ) as client,
-            streamable_http_client(definition.endpoint, http_client=client) as (read, write, _),
-            ClientSession(read, write) as session,
-        ):
-            await session.initialize()
-            result = await session.list_tools()
+        async with remote_mcp_session(
+            definition.endpoint,
+            transport=definition.transport.value,
+            auth=auth,
+            allow_private_network=definition.allow_private_network,
+            server_name=definition.id,
+            timeout=300.0 if interactive else 30.0,
+        ) as session:
+            discovered = await discover_all_tools(session)
             tools: list[dict[str, Any]] = [
                 cached_tool(
                     tool,
                     trusted=True,
                     overrides=definition.tool_overrides,
                 )
-                for tool in result.tools
+                for tool in discovered
             ]
         granted = list(definition.scopes)
         # Record the scopes the authorization server actually granted from

--- a/collie-core/collie_core/connectors/drivers/remote_mcp.py
+++ b/collie-core/collie_core/connectors/drivers/remote_mcp.py
@@ -1,0 +1,70 @@
+"""Driver for arbitrary validated remote MCP definitions."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from collie_core.connectors.models import (
+    ConnectorAuthStrategy,
+    ConnectorTransport,
+    ProbeResult,
+    RemoteRevocationStatus,
+)
+from collie_core.connectors.policy import cached_tool
+from collie_core.connectors.remote import discover_all_tools, remote_mcp_session
+
+
+class RemoteMcpDriver:
+    """Probe no-auth Streamable HTTP and explicit SSE definitions."""
+
+    def __init__(self, credentials: Any | None = None) -> None:
+        self.credentials = credentials
+
+    def connect_and_probe(self, definition: Any, connection_id: str) -> ProbeResult:
+        return asyncio.run(self._probe(definition, connection_id))
+
+    def probe(self, definition: Any, connection_id: str) -> ProbeResult:
+        return asyncio.run(self._probe(definition, connection_id))
+
+    async def _probe(self, definition: Any, connection_id: str) -> ProbeResult:
+        del connection_id
+        auth_strategy = getattr(definition, "auth_strategy", None)
+        if auth_strategy is None:
+            auth_strategy = getattr(definition, "auth_type", "none")
+        auth_value = getattr(auth_strategy, "value", auth_strategy)
+        if auth_value != ConnectorAuthStrategy.NONE.value:
+            raise ValueError(
+                "This remote connector auth strategy is not supported yet; use a no-auth endpoint."
+            )
+        if getattr(definition, "tool_overrides", {}):
+            raise ValueError("Custom remote connectors cannot declare trusted tool overrides.")
+        endpoint = getattr(definition, "endpoint", "")
+        transport = getattr(definition, "transport", ConnectorTransport.STREAMABLE_HTTP)
+        transport_value = getattr(transport, "value", transport)
+        if transport_value not in {
+            ConnectorTransport.STREAMABLE_HTTP.value,
+            ConnectorTransport.SSE.value,
+        }:
+            raise ValueError("Remote MCP supports Streamable HTTP or explicit SSE.")
+        async with remote_mcp_session(
+            endpoint,
+            transport=transport_value,
+            allow_private_network=bool(getattr(definition, "allow_private_network", False)),
+            server_name=getattr(definition, "id", "remote"),
+        ) as session:
+            discovered = await discover_all_tools(session)
+        return ProbeResult(
+            tools=[
+                cached_tool(
+                    tool,
+                    trusted=False,
+                    overrides=getattr(definition, "tool_overrides", {}),
+                )
+                for tool in discovered
+            ]
+        )
+
+    def revoke(self, definition: Any, connection_id: str) -> RemoteRevocationStatus:
+        del definition, connection_id
+        return RemoteRevocationStatus.NOT_APPLICABLE

--- a/collie-core/collie_core/connectors/manager.py
+++ b/collie-core/collie_core/connectors/manager.py
@@ -70,6 +70,10 @@ class ConnectorManager:
     def _default_driver(self, definition: ConnectorDefinition) -> Any:
         if definition.driver == ConnectorDriverKind.OFFICIAL_MCP:
             return OfficialMcpDriver(self.credentials)
+        if definition.driver == ConnectorDriverKind.CUSTOM_MCP:
+            from collie_core.connectors.drivers.remote_mcp import RemoteMcpDriver
+
+            return RemoteMcpDriver(self.credentials)
         raise ValueError(f"{definition.name}'s official connection is not ready yet.")
 
     def _migrate_legacy_credentials(self) -> None:
@@ -86,11 +90,27 @@ class ConnectorManager:
         """Resolve a connection against its installed snapshot when one is complete."""
         recipe = connector_def(str(row["provider_id"]))
         stored = self.db.get_connector_definition(str(row.get("definition_id") or ""))
-        if recipe is None or stored is None or stored.get("unresolved"):
+        if stored is None or stored.get("unresolved"):
             return recipe
-        if stored.get("provenance") != ConnectorProvenance.CURATED.value:
-            return None
         config = _json_value(stored.get("config_json"), {})
+        if stored.get("provenance") != ConnectorProvenance.CURATED.value:
+            if stored["driver"] != ConnectorDriverKind.CUSTOM_MCP.value:
+                return None
+            return ConnectorDefinition(
+                id=str(row["provider_id"]),
+                name=str(row.get("display_name") or "Custom connection"),
+                category="custom",
+                description="A remote connection added by you.",
+                driver=ConnectorDriverKind.CUSTOM_MCP,
+                auth_type=str(stored["auth_strategy"]),
+                endpoint=str(config.get("endpoint") or ""),
+                transport=ConnectorTransport(str(stored["transport"])),
+                allow_private_network=config.get("allow_private_network", False),
+                available=stored["auth_strategy"] == ConnectorAuthStrategy.NONE.value,
+                release_status="alpha",
+            )
+        if recipe is None:
+            return None
         return replace(
             recipe,
             driver=ConnectorDriverKind(str(stored["driver"])),
@@ -99,6 +119,8 @@ class ConnectorManager:
             scopes=tuple(config.get("scopes") or ()),
             trusted_hosts=tuple(config.get("trusted_hosts") or ()),
             tool_overrides=dict(config.get("tool_overrides") or {}),
+            transport=ConnectorTransport(str(stored["transport"])),
+            allow_private_network=config.get("allow_private_network", False),
         )
 
     def _resolve_migrated_definitions(self) -> None:
@@ -200,6 +222,9 @@ class ConnectorManager:
         """A connection is only genuinely connected when it holds a usable
         access token. Empty records, client-info-only entries, and token
         blobs without an ``access_token`` do not count."""
+        definition = self._definition_for_row(row)
+        if definition is not None and definition.auth_type == "none":
+            return True
         data = self.credentials.load(f"connector:{row['id']}") or {}
         tokens = data.get("tokens") or {}
         return bool(tokens.get("access_token"))
@@ -252,6 +277,8 @@ class ConnectorManager:
             "capabilities": list(definition.capabilities) if definition else [],
             "route": "Official MCP"
             if definition and definition.driver == "official_mcp"
+            else "Custom MCP"
+            if definition and definition.driver == "custom_mcp"
             else "Official API",
         }
 
@@ -283,6 +310,78 @@ class ConnectorManager:
             raise ValueError(f"I don't know a connector called '{provider_id}'.")
         if not definition.available:
             raise ValueError(f"{definition.name} is coming soon in this build.")
+        return self._connect(
+            definition,
+            origin=origin,
+            replace_connection_id=replace_connection_id,
+            connection_id=connection_id,
+        )
+
+    def connect_definition(
+        self,
+        installed: InstalledConnectorDefinition,
+        *,
+        display_name: str | None = None,
+        origin: str = "custom_connection",
+    ) -> dict[str, Any]:
+        """Connect a validated custom remote definition through the shared lifecycle.
+
+        This backend entry point precedes the desktop add/import flow. Each call
+        creates a distinct account, even when the same definition is reused.
+        """
+        installed = InstalledConnectorDefinition.from_dict(installed.to_dict())
+        if (
+            installed.driver is not ConnectorDriverKind.CUSTOM_MCP
+            or installed.provenance
+            not in (ConnectorProvenance.CUSTOM, ConnectorProvenance.IMPORTED)
+            or installed.transport
+            not in (ConnectorTransport.STREAMABLE_HTTP, ConnectorTransport.SSE)
+            or installed.unresolved
+        ):
+            raise ValueError("Choose a complete custom remote connection definition.")
+        if installed.auth_strategy is not ConnectorAuthStrategy.NONE:
+            raise ValueError("Custom sign-in strategies are not available yet.")
+        if installed.tool_overrides or installed.trusted_hosts:
+            raise ValueError("Custom connections cannot grant trusted tool or host overrides.")
+        connection_id = f"con_{uuid.uuid4().hex}"
+        # Caller-provided labels/recipe IDs cannot impersonate a curated route.
+        provider_id = f"custom_{uuid.uuid4().hex}"
+        installed = replace(
+            installed,
+            id=f"def_{connection_id}",
+            provider_id=provider_id,
+            recipe_id=None,
+            recipe_version=None,
+        )
+        definition = ConnectorDefinition(
+            id=provider_id,
+            name=(display_name or "Custom connection").strip() or "Custom connection",
+            category="custom",
+            description="A remote connection added by you.",
+            driver=ConnectorDriverKind.CUSTOM_MCP,
+            auth_type="none",
+            endpoint=installed.endpoint or "",
+            transport=installed.transport,
+            allow_private_network=installed.allow_private_network,
+            available=True,
+            release_status="alpha",
+        )
+        return self._connect(
+            definition,
+            origin=origin,
+            connection_id=connection_id,
+            installed=installed,
+        )
+
+    def _connect(
+        self,
+        definition: ConnectorDefinition,
+        *,
+        origin: str,
+        replace_connection_id: str | None = None,
+        connection_id: str | None = None,
+        installed: InstalledConnectorDefinition | None = None,
+    ) -> dict[str, Any]:
         with self._lock:
             existing = next(
                 (
@@ -316,7 +415,10 @@ class ConnectorManager:
                         last_error_message="The previous sign-in was interrupted.",
                     )
             connection_id = connection_id or f"con_{uuid.uuid4().hex}"
-            self._save_definition_snapshot(definition, connection_id)
+            if installed is None:
+                self._save_definition_snapshot(definition, connection_id)
+            else:
+                self.db.save_connector_definition(installed)
             self.db.upsert_connector_connection(
                 connection_id,
                 provider_id=definition.id,
@@ -328,45 +430,46 @@ class ConnectorManager:
             )
             self._connecting.add(connection_id)
 
-        driver = self._driver_factory(definition)
         try:
+            driver = self._driver_factory(definition)
             result: ProbeResult = driver.connect_and_probe(definition, connection_id)
-            if connection_id in self._cancelled:
-                raise RuntimeError("oauth cancelled")
-            # A concurrent remove() may have deleted the row while we probed.
-            if self.db.get_connector_connection(connection_id) is None:
-                raise RuntimeError("oauth cancelled")
-            self.db.upsert_connector_connection(
-                connection_id,
-                provider_id=definition.id,
-                driver=definition.driver.value,
-                auth_type=definition.auth_type,
-                status=ConnectionStatus.TESTING.value,
-            )
-            if not result.tools:
-                raise RuntimeError("The provider connected but returned no usable tools.")
-            policy = {tool["name"]: tool["risk"] for tool in result.tools}
-            enabled_tools = [tool["name"] for tool in result.tools]
-            self.db.replace_connector_tools(connection_id, result.tools)
-            # Second cancellation check: the flag may have been set while the
-            # probe ran — the CONNECTED upsert must not win the race.
-            if connection_id in self._cancelled:
-                raise RuntimeError("oauth cancelled")
-            row = self.db.upsert_connector_connection(
-                connection_id,
-                provider_id=definition.id,
-                display_name=definition.name,
-                account_label=result.account_label,
-                driver=definition.driver.value,
-                auth_type=definition.auth_type,
-                status=ConnectionStatus.CONNECTED.value,
-                granted_scopes=result.granted_scopes,
-                enabled_capabilities=list(definition.capabilities),
-                enabled_tools=enabled_tools,
-                tool_policy=policy,
-                remote_account_id=result.remote_account_id,
-                last_verified_at=utc_now(),
-            )
+            with self._lock:
+                if connection_id in self._cancelled:
+                    raise RuntimeError("oauth cancelled")
+                # A concurrent remove() may have deleted the row while we probed.
+                if self.db.get_connector_connection(connection_id) is None:
+                    raise RuntimeError("oauth cancelled")
+                self.db.upsert_connector_connection(
+                    connection_id,
+                    provider_id=definition.id,
+                    driver=definition.driver.value,
+                    auth_type=definition.auth_type,
+                    status=ConnectionStatus.TESTING.value,
+                )
+                if not result.tools:
+                    raise RuntimeError("The provider connected but returned no usable tools.")
+                policy = {tool["name"]: tool["risk"] for tool in result.tools}
+                enabled_tools = [tool["name"] for tool in result.tools]
+                self.db.replace_connector_tools(connection_id, result.tools)
+                # Second cancellation check: the flag may have been set while the
+                # probe ran — the CONNECTED upsert must not win the race.
+                if connection_id in self._cancelled:
+                    raise RuntimeError("oauth cancelled")
+                row = self.db.upsert_connector_connection(
+                    connection_id,
+                    provider_id=definition.id,
+                    display_name=definition.name,
+                    account_label=result.account_label,
+                    driver=definition.driver.value,
+                    auth_type=definition.auth_type,
+                    status=ConnectionStatus.CONNECTED.value,
+                    granted_scopes=result.granted_scopes,
+                    enabled_capabilities=list(definition.capabilities),
+                    enabled_tools=enabled_tools,
+                    tool_policy=policy,
+                    remote_account_id=result.remote_account_id,
+                    last_verified_at=utc_now(),
+                )
             if replace_connection_id and replace_connection_id != connection_id:
                 self.remove(replace_connection_id, origin=origin)
         except Exception as error:
@@ -376,15 +479,17 @@ class ConnectorManager:
             # cancellations or auth-level refusals.
             if code in _CREDENTIAL_DELETING_CODES:
                 self.credentials.delete(f"connector:{connection_id}")
-            self.db.upsert_connector_connection(
-                connection_id,
-                provider_id=definition.id,
-                driver=definition.driver.value,
-                auth_type=definition.auth_type,
-                status=ConnectionStatus.FAILED.value,
-                last_error_code=code,
-                last_error_message=self._friendly_error(code),
-            )
+            with self._lock:
+                if self.db.get_connector_connection(connection_id) is not None:
+                    self.db.upsert_connector_connection(
+                        connection_id,
+                        provider_id=definition.id,
+                        driver=definition.driver.value,
+                        auth_type=definition.auth_type,
+                        status=ConnectionStatus.FAILED.value,
+                        last_error_code=code,
+                        last_error_message=self._friendly_error(code),
+                    )
             raise ValueError(self._friendly_error(code)) from error
         finally:
             cancelled = connection_id in self._cancelled
@@ -428,54 +533,66 @@ class ConnectorManager:
             return {"connection_id": connection_id, "cancelled": True}
 
     def test(self, connection_id: str) -> dict[str, Any]:
-        row = self.db.get_connector_connection(connection_id)
-        if row is None:
-            raise ValueError("I couldn't find that connection.")
-        definition = self._definition_for_row(row)
-        if definition is None:
-            raise ValueError("That provider is no longer in this build.")
-        if not definition.available:
-            raise ValueError(f"{definition.name} is coming soon in this build.")
-        if row["driver"] != definition.driver.value:
-            raise ValueError(
-                "This saved connection no longer matches its provider route. Reconnect?"
-            )
-        self.db.upsert_connector_connection(
-            connection_id,
-            provider_id=definition.id,
-            driver=definition.driver.value,
-            auth_type=definition.auth_type,
-            status=ConnectionStatus.TESTING.value,
-        )
-        try:
-            result = self._driver_factory(definition).probe(definition, connection_id)
-            if not result.tools:
-                raise RuntimeError("No tools returned")
-            self.db.replace_connector_tools(connection_id, result.tools)
-            updated = self.db.upsert_connector_connection(
-                connection_id,
-                provider_id=definition.id,
-                driver=definition.driver.value,
-                auth_type=definition.auth_type,
-                status=ConnectionStatus.CONNECTED.value,
-                account_label=result.account_label,
-                granted_scopes=result.granted_scopes,
-                enabled_tools=[tool["name"] for tool in result.tools],
-                tool_policy={tool["name"]: tool["risk"] for tool in result.tools},
-                remote_account_id=result.remote_account_id,
-                last_verified_at=utc_now(),
-            )
-        except Exception as error:
-            code = self._error_code(error)
+        with self._lock:
+            row = self.db.get_connector_connection(connection_id)
+            if row is None:
+                raise ValueError("I couldn't find that connection.")
+            definition = self._definition_for_row(row)
+            if definition is None:
+                raise ValueError("That provider is no longer in this build.")
+            if not definition.available:
+                raise ValueError(f"{definition.name} is coming soon in this build.")
+            if row["driver"] != definition.driver.value:
+                raise ValueError(
+                    "This saved connection no longer matches its provider route. Reconnect?"
+                )
             self.db.upsert_connector_connection(
                 connection_id,
                 provider_id=definition.id,
                 driver=definition.driver.value,
                 auth_type=definition.auth_type,
-                status=ConnectionStatus.ATTENTION.value,
-                last_error_code=code,
-                last_error_message=self._friendly_error(code),
+                status=ConnectionStatus.TESTING.value,
             )
+        try:
+            result = self._driver_factory(definition).probe(definition, connection_id)
+            if not result.tools:
+                raise RuntimeError("No tools returned")
+            with self._lock:
+                current = self.db.get_connector_connection(connection_id)
+                if current is None or current["status"] == ConnectionStatus.REVOKING.value:
+                    raise RuntimeError("Connection test cancelled")
+                policy = {tool["name"]: tool["risk"] for tool in result.tools}
+                previous = _json_value(current.get("tool_policy_json"), {})
+                if "_approval_preference" in previous:
+                    policy["_approval_preference"] = previous["_approval_preference"]
+                self.db.replace_connector_tools(connection_id, result.tools)
+                updated = self.db.upsert_connector_connection(
+                    connection_id,
+                    provider_id=definition.id,
+                    driver=definition.driver.value,
+                    auth_type=definition.auth_type,
+                    status=ConnectionStatus.CONNECTED.value,
+                    account_label=result.account_label,
+                    granted_scopes=result.granted_scopes,
+                    enabled_tools=[tool["name"] for tool in result.tools],
+                    tool_policy=policy,
+                    remote_account_id=result.remote_account_id,
+                    last_verified_at=utc_now(),
+                )
+        except Exception as error:
+            code = self._error_code(error)
+            with self._lock:
+                current = self.db.get_connector_connection(connection_id)
+                if current is not None and current["status"] != ConnectionStatus.REVOKING.value:
+                    self.db.upsert_connector_connection(
+                        connection_id,
+                        provider_id=definition.id,
+                        driver=definition.driver.value,
+                        auth_type=definition.auth_type,
+                        status=ConnectionStatus.ATTENTION.value,
+                        last_error_code=code,
+                        last_error_message=self._friendly_error(code),
+                    )
             raise ValueError(self._friendly_error(code)) from error
         return self._connection_view(updated)
 
@@ -546,7 +663,8 @@ class ConnectorManager:
                 remote_revocation = RemoteRevocationStatus.FAILED
                 logger.warning("Remote connector revocation unavailable: {}", definition.id)
         with self._lock:
-            self._cancelled.discard(connection_id)
+            if connection_id not in self._connecting:
+                self._cancelled.discard(connection_id)
             self.credentials.delete(f"connector:{connection_id}")
             self.db.delete_connector_connection(connection_id)
         logger.info("Connector removed: {}", connection_id)
@@ -569,21 +687,27 @@ class ConnectorManager:
             if (
                 not definition
                 or not definition.available
-                or definition.driver != ConnectorDriverKind.OFFICIAL_MCP
+                or definition.driver
+                not in (ConnectorDriverKind.OFFICIAL_MCP, ConnectorDriverKind.CUSTOM_MCP)
                 or row["driver"] != definition.driver.value
                 or not self._has_credentials(row)
             ):
                 continue
-            name = f"{definition.id}_{str(row['id'])[-8:]}"
+            custom = definition.driver == ConnectorDriverKind.CUSTOM_MCP
+            name = str(row["id"]) if custom else f"{definition.id}_{str(row['id'])[-8:]}"
             policy = _json_value(row.get("tool_policy_json"), {})
             servers[name] = {
-                "type": "streamableHttp",
+                "type": "sse"
+                if definition.transport == ConnectorTransport.SSE
+                else "streamableHttp",
                 "url": definition.endpoint,
                 "toolTimeout": 60,
                 "enabledTools": _json_value(row.get("enabled_tools_json"), ["*"]),
-                "oauthConnectionId": row["id"],
+                "oauthConnectionId": row["id"] if definition.auth_type == "oauth" else "",
                 "connectorProviderId": definition.id,
-                "connectorTrusted": True,
+                "connectorTrusted": not custom,
+                "connectorEndpointPolicy": True,
+                "connectorAllowPrivateNetwork": definition.allow_private_network,
                 "connectorToolOverrides": definition.tool_overrides,
                 "connectorApprovalPreference": policy.get("_approval_preference", "important"),
             }

--- a/collie-core/collie_core/connectors/models.py
+++ b/collie-core/collie_core/connectors/models.py
@@ -68,6 +68,7 @@ class InstalledConnectorDefinition:
     trusted_hosts: tuple[str, ...] = ()
     tool_overrides: dict[str, str] = field(default_factory=dict)
     unresolved: bool = False
+    allow_private_network: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.id, str) or not self.id.strip():
@@ -111,6 +112,8 @@ class InstalledConnectorDefinition:
                 raise ValueError("Connector definition lists must contain non-empty strings.")
         if not isinstance(self.unresolved, bool):
             raise ValueError("unresolved must be a boolean.")
+        if not isinstance(self.allow_private_network, bool):
+            raise ValueError("allow_private_network must be a boolean.")
         if not isinstance(self.tool_overrides, dict) or not all(
             isinstance(key, str) and isinstance(value, str)
             for key, value in self.tool_overrides.items()
@@ -135,6 +138,7 @@ class InstalledConnectorDefinition:
             "trusted_hosts",
             "tool_overrides",
             "unresolved",
+            "allow_private_network",
         }
         unknown = set(value) - allowed
         if unknown:
@@ -168,6 +172,7 @@ class InstalledConnectorDefinition:
             trusted_hosts=tuple(value.get("trusted_hosts") or ()),
             tool_overrides=dict(overrides),
             unresolved=value.get("unresolved", False),
+            allow_private_network=value.get("allow_private_network", False),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -187,6 +192,7 @@ class InstalledConnectorDefinition:
             "trusted_hosts": list(self.trusted_hosts),
             "tool_overrides": dict(self.tool_overrides),
             "unresolved": self.unresolved,
+            "allow_private_network": self.allow_private_network,
         }
 
 
@@ -217,6 +223,8 @@ class ConnectorDefinition:
     note: str = ""
     trusted_hosts: tuple[str, ...] = ()
     tool_overrides: dict[str, str] = field(default_factory=dict)
+    transport: ConnectorTransport = ConnectorTransport.STREAMABLE_HTTP
+    allow_private_network: bool = False
 
 
 @dataclass(slots=True)

--- a/collie-core/collie_core/connectors/remote.py
+++ b/collie-core/collie_core/connectors/remote.py
@@ -73,11 +73,7 @@ def validate_remote_endpoint(
         raise ValueError(f"Blocked remote MCP endpoint address: {forbidden_even_with_opt_in}")
     if not permits_private:
         blocked = next(
-            (
-                address
-                for address in parsed_addresses
-                if not address.is_global
-            ),
+            (address for address in parsed_addresses if not address.is_global),
             None,
         )
         if blocked is not None:

--- a/collie-core/collie_core/connectors/remote.py
+++ b/collie-core/collie_core/connectors/remote.py
@@ -1,0 +1,301 @@
+"""Shared remote MCP transport, endpoint policy, and discovery helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from nanobot.security.network import (
+    env_proxy_applies_to_url,
+    httpx_env_proxy_mounts,
+)
+
+DEFAULT_PROTOCOL_TIMEOUT = 30.0
+MAX_DISCOVERY_PAGES = 100
+MAX_DISCOVERED_TOOLS = 10_000
+
+
+def _origin(url: str) -> tuple[str, str, int]:
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("Remote MCP endpoint must be an HTTP(S) URL.")
+    if parsed.username or parsed.password:
+        raise ValueError("Remote MCP endpoint must not contain credentials.")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return parsed.scheme, parsed.hostname.rstrip(".").lower(), port
+
+
+def validate_remote_endpoint(
+    initial_url: str,
+    candidate_url: str | None = None,
+    *,
+    allow_private_network: bool = False,
+) -> tuple[str, ...]:
+    """Validate an initial endpoint or a redirect/metadata request target.
+
+    Private access is deliberately tied to the exact origin the user selected.
+    A private opt-in therefore cannot be inherited by redirects or OAuth
+    metadata hosted elsewhere.
+    """
+    target = candidate_url or initial_url
+    initial_origin = _origin(initial_url)
+    target_origin = _origin(target)
+    try:
+        infos = socket.getaddrinfo(target_origin[1], None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"Remote MCP host cannot be resolved: {target_origin[1]}") from exc
+    parsed_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        try:
+            address = ipaddress.ip_address(info[4][0])
+        except ValueError:
+            continue
+        parsed_addresses.append(getattr(address, "ipv4_mapped", None) or address)
+    if not parsed_addresses:
+        raise ValueError(f"Remote MCP host cannot be resolved: {target_origin[1]}")
+    permits_private = allow_private_network and target_origin == initial_origin
+    forbidden_even_with_opt_in = next(
+        (
+            address
+            for address in parsed_addresses
+            if address.is_multicast or address.is_unspecified or address.is_reserved
+        ),
+        None,
+    )
+    if forbidden_even_with_opt_in is not None:
+        raise ValueError(f"Blocked remote MCP endpoint address: {forbidden_even_with_opt_in}")
+    if not permits_private:
+        blocked = next(
+            (
+                address
+                for address in parsed_addresses
+                if not address.is_global
+            ),
+            None,
+        )
+        if blocked is not None:
+            raise ValueError(
+                f"Blocked remote MCP endpoint: {target_origin[1]} resolves to "
+                f"private/internal address {blocked}"
+            )
+    return tuple(dict.fromkeys(str(address) for address in parsed_addresses))
+
+
+class RemoteEndpointTransport(httpx.AsyncBaseTransport):
+    """Apply endpoint policy and DNS pinning to every MCP HTTP request."""
+
+    def __init__(self, initial_url: str, *, allow_private_network: bool = False) -> None:
+        self.initial_url = initial_url
+        self.allow_private_network = allow_private_network
+        self._transports: dict[tuple[str, str, int], httpx.AsyncHTTPTransport] = {}
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        addresses = validate_remote_endpoint(
+            self.initial_url,
+            url,
+            allow_private_network=self.allow_private_network,
+        )
+        origin = _origin(url)
+        inner = self._transports.get(origin)
+        if inner is None:
+            inner = httpx.AsyncHTTPTransport()
+            self._transports[origin] = inner
+        headers = request.headers.copy()
+        headers["Host"] = request.url.netloc.decode("ascii")
+        last_error: httpx.ConnectError | httpx.ConnectTimeout | None = None
+        for address in addresses:
+            pinned_request = httpx.Request(
+                request.method,
+                request.url.copy_with(host=address),
+                headers=headers,
+                stream=request.stream,
+                extensions={**request.extensions, "sni_hostname": request.url.host},
+            )
+            try:
+                response = await inner.handle_async_request(pinned_request)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                last_error = exc
+                continue
+            response.request = request
+            return response
+        assert last_error is not None
+        raise last_error
+
+    async def aclose(self) -> None:
+        await asyncio.gather(*(transport.aclose() for transport in self._transports.values()))
+
+
+def _http_client_kwargs(initial_url: str, allow_private_network: bool) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "transport": RemoteEndpointTransport(
+            initial_url,
+            allow_private_network=allow_private_network,
+        )
+    }
+    # A configured proxy is itself the network boundary. Preserve existing MCP
+    # proxy behavior for public endpoints; private opt-in always stays direct.
+    if not allow_private_network and env_proxy_applies_to_url(initial_url):
+        mounts = httpx_env_proxy_mounts()
+        if mounts:
+            kwargs["mounts"] = mounts
+    return kwargs
+
+
+def _request_validator(
+    initial_url: str,
+    *,
+    allow_private_network: bool,
+    has_static_credentials: bool,
+):
+    async def validate(request: httpx.Request) -> None:
+        validate_remote_endpoint(
+            initial_url,
+            str(request.url),
+            allow_private_network=allow_private_network,
+        )
+        if has_static_credentials and _origin(str(request.url)) != _origin(initial_url):
+            raise httpx.RequestError(
+                "Remote MCP credentials cannot be sent to a different origin.",
+                request=request,
+            )
+
+    return validate
+
+
+@asynccontextmanager
+async def remote_mcp_session(
+    endpoint: str,
+    *,
+    transport: str,
+    headers: Mapping[str, str] | None = None,
+    auth: httpx.Auth | None = None,
+    allow_private_network: bool = False,
+    timeout: float = DEFAULT_PROTOCOL_TIMEOUT,
+    server_name: str = "remote",
+) -> AsyncIterator[Any]:
+    """Open an initialized MCP session for probing or runtime use."""
+    from mcp import ClientSession
+    from mcp.client.sse import sse_client
+    from mcp.client.streamable_http import streamable_http_client
+
+    from nanobot.agent.tools.mcp import _filter_malformed_mcp_progress_notifications
+
+    validate_remote_endpoint(endpoint, allow_private_network=allow_private_network)
+    normalized = transport.replace("-", "_").lower()
+    client_headers = {"Accept": "application/json, text/event-stream", **dict(headers or {})}
+    validate_request = _request_validator(
+        endpoint,
+        allow_private_network=allow_private_network,
+        has_static_credentials=bool(headers),
+    )
+
+    def client_factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            headers={**client_headers, **(headers or {})},
+            follow_redirects=True,
+            event_hooks={"request": [validate_request]},
+            timeout=timeout or httpx.Timeout(DEFAULT_PROTOCOL_TIMEOUT, connect=10),
+            auth=auth,
+            **_http_client_kwargs(endpoint, allow_private_network),
+        )
+
+    if normalized == "sse":
+        context = sse_client(
+            endpoint,
+            timeout=min(timeout, 30),
+            sse_read_timeout=timeout,
+            httpx_client_factory=client_factory,
+            auth=auth,
+        )
+        async with context as (read, write):
+            filtered = _filter_malformed_mcp_progress_notifications(read, server_name)
+            async with ClientSession(filtered, write) as session:
+                await asyncio.wait_for(session.initialize(), timeout=timeout)
+                yield session
+        return
+
+    if normalized not in {"streamable_http", "streamablehttp"}:
+        raise ValueError(f"Unsupported remote MCP transport: {transport}")
+    async with (
+        httpx.AsyncClient(
+            headers=client_headers,
+            follow_redirects=True,
+            event_hooks={"request": [validate_request]},
+            timeout=httpx.Timeout(timeout, connect=min(timeout, 10)),
+            auth=auth,
+            **_http_client_kwargs(endpoint, allow_private_network),
+        ) as client,
+        streamable_http_client(endpoint, http_client=client) as (read, write, _),
+    ):
+        filtered = _filter_malformed_mcp_progress_notifications(read, server_name)
+        async with ClientSession(filtered, write) as session:
+            await asyncio.wait_for(session.initialize(), timeout=timeout)
+            yield session
+
+
+async def discover_all_tools(
+    session: Any,
+    *,
+    timeout: float = DEFAULT_PROTOCOL_TIMEOUT,
+    max_pages: int = MAX_DISCOVERY_PAGES,
+    max_tools: int = MAX_DISCOVERED_TOOLS,
+) -> list[Any]:
+    """Return a complete, bounded, de-duplicated MCP tool inventory."""
+    if max_pages < 1 or max_tools < 1:
+        raise ValueError("Remote MCP discovery bounds must be positive.")
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    seen_names: set[str] = set()
+    seen_normalized_names: set[str] = set()
+    tools: list[Any] = []
+    for _page in range(max_pages):
+        request = session.list_tools() if cursor is None else session.list_tools(cursor=cursor)
+        result = await asyncio.wait_for(request, timeout=timeout)
+        page_tools = getattr(result, "tools", None)
+        if not isinstance(page_tools, list):
+            raise ValueError("Remote MCP server returned a malformed tool list.")
+        for tool in page_tools:
+            name = getattr(tool, "name", None)
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("Remote MCP server returned a tool without a valid name.")
+            if name in seen_names:
+                raise ValueError(f"Remote MCP server returned duplicate tool name: {name}")
+            input_schema = getattr(tool, "inputSchema", None)
+            if input_schema is None:
+                input_schema = getattr(tool, "input_schema", None)
+            if not isinstance(input_schema, Mapping):
+                raise ValueError(f"Remote MCP tool {name!r} has a malformed input schema.")
+            from nanobot.agent.tools.mcp import _sanitize_mcp_tool_name
+
+            normalized_name = _sanitize_mcp_tool_name(f"mcp_remote_{name}")
+            if normalized_name in seen_normalized_names:
+                raise ValueError(f"Remote MCP tool names collide after normalization: {name}")
+            seen_names.add(name)
+            seen_normalized_names.add(normalized_name)
+            tools.append(tool)
+            if len(tools) > max_tools:
+                raise ValueError("Remote MCP tool discovery exceeded its safe limit.")
+        next_cursor = getattr(result, "nextCursor", None)
+        if next_cursor is None:
+            next_cursor = getattr(result, "next_cursor", None)
+        if next_cursor in (None, ""):
+            return tools
+        if not isinstance(next_cursor, str):
+            raise ValueError("Remote MCP server returned a malformed pagination cursor.")
+        if next_cursor in seen_cursors:
+            raise ValueError("Remote MCP server repeated a pagination cursor.")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    raise ValueError("Remote MCP tool discovery exceeded its page limit.")

--- a/collie-core/collie_core/db.py
+++ b/collie-core/collie_core/db.py
@@ -3110,8 +3110,9 @@ class CollieDB:
                 "scopes",
                 "trusted_hosts",
                 "tool_overrides",
+                "allow_private_network",
             )
-            if value[key] not in (None, [], "")
+            if value[key] not in (None, [], "", False)
         }
         now = utc_now()
         with self._write() as conn:

--- a/collie-core/nanobot/agent/tools/mcp.py
+++ b/collie-core/nanobot/agent/tools/mcp.py
@@ -915,6 +915,8 @@ async def connect_mcp_servers(
     from mcp.client.stdio import stdio_client
     from mcp.client.streamable_http import streamable_http_client
 
+    from collie_core.connectors.remote import discover_all_tools, remote_mcp_session
+
     async def open_single_server(name: str, cfg) -> tuple[str, AsyncExitStack | None]:
         server_stack = AsyncExitStack()
         await server_stack.__aenter__()
@@ -933,7 +935,7 @@ async def connect_mcp_servers(
                     await server_stack.aclose()
                     return name, None
 
-            if transport_type in {"sse", "streamableHttp"}:
+            if transport_type in {"sse", "streamableHttp"} and not cfg.connector_endpoint_policy:
                 ok, error = validate_url_target(cfg.url)
                 if not ok:
                     logger.warning(
@@ -945,6 +947,7 @@ async def connect_mcp_servers(
                     await server_stack.aclose()
                     return name, None
 
+            session = None
             if transport_type == "stdio":
                 command, args, env = _normalize_windows_stdio_command(
                     cfg.command,
@@ -959,35 +962,47 @@ async def connect_mcp_servers(
                 )
                 read, write = await server_stack.enter_async_context(stdio_client(params))
             elif transport_type == "sse":
-                if not await _probe_http_url(cfg.url):
+                if cfg.connector_endpoint_policy:
+                    session = await server_stack.enter_async_context(
+                        remote_mcp_session(
+                            cfg.url,
+                            transport="sse",
+                            headers=cfg.headers,
+                            allow_private_network=cfg.connector_allow_private_network,
+                            timeout=float(cfg.tool_timeout),
+                            server_name=name,
+                        )
+                    )
+                elif not await _probe_http_url(cfg.url):
                     logger.warning("MCP server '{}': {} unreachable, skipping", name, _redact_url(cfg.url))
                     await server_stack.aclose()
                     return name, None
 
-                def httpx_client_factory(
-                    headers: dict[str, str] | None = None,
-                    timeout: httpx.Timeout | None = None,
-                    auth: httpx.Auth | None = None,
-                ) -> httpx.AsyncClient:
-                    merged_headers = {
-                        "Accept": "application/json, text/event-stream",
-                        **(cfg.headers or {}),
-                        **(headers or {}),
-                    }
-                    return httpx.AsyncClient(
-                        headers=merged_headers or None,
-                        event_hooks={"request": [_validate_mcp_request_url]},
-                        follow_redirects=True,
-                        timeout=timeout,
-                        auth=auth,
-                        **_pinned_transport_kwargs(),
-                    )
+                if session is None:
+                    def httpx_client_factory(
+                        headers: dict[str, str] | None = None,
+                        timeout: httpx.Timeout | None = None,
+                        auth: httpx.Auth | None = None,
+                    ) -> httpx.AsyncClient:
+                        merged_headers = {
+                            "Accept": "application/json, text/event-stream",
+                            **(cfg.headers or {}),
+                            **(headers or {}),
+                        }
+                        return httpx.AsyncClient(
+                            headers=merged_headers or None,
+                            event_hooks={"request": [_validate_mcp_request_url]},
+                            follow_redirects=True,
+                            timeout=timeout,
+                            auth=auth,
+                            **_pinned_transport_kwargs(),
+                        )
 
-                read, write = await server_stack.enter_async_context(
-                    sse_client(cfg.url, httpx_client_factory=httpx_client_factory)
-                )
+                    read, write = await server_stack.enter_async_context(
+                        sse_client(cfg.url, httpx_client_factory=httpx_client_factory)
+                    )
             elif transport_type == "streamableHttp":
-                if not await _probe_http_url(cfg.url):
+                if not cfg.connector_endpoint_policy and not await _probe_http_url(cfg.url):
                     logger.warning("MCP server '{}': {} unreachable, skipping", name, _redact_url(cfg.url))
                     await server_stack.aclose()
                     return name, None
@@ -1002,37 +1017,52 @@ async def connect_mcp_servers(
                         cfg.url,
                         CredentialStore(),
                         interactive=False,
+                        allow_private_network=cfg.connector_allow_private_network,
                     )
-                http_client = await server_stack.enter_async_context(
-                    httpx.AsyncClient(
-                        headers=cfg.headers or None,
-                        event_hooks={"request": [_validate_mcp_request_url]},
-                        follow_redirects=True,
-                        timeout=httpx.Timeout(30.0, connect=10.0),
-                        auth=oauth_auth,
-                        **_pinned_transport_kwargs(),
+                if cfg.connector_endpoint_policy:
+                    session = await server_stack.enter_async_context(
+                        remote_mcp_session(
+                            cfg.url,
+                            transport="streamable_http",
+                            headers=cfg.headers,
+                            auth=oauth_auth,
+                            allow_private_network=cfg.connector_allow_private_network,
+                            timeout=float(cfg.tool_timeout),
+                            server_name=name,
+                        )
                     )
-                )
-                read, write, _ = await server_stack.enter_async_context(
-                    streamable_http_client(cfg.url, http_client=http_client)
-                )
+                else:
+                    http_client = await server_stack.enter_async_context(
+                        httpx.AsyncClient(
+                            headers=cfg.headers or None,
+                            event_hooks={"request": [_validate_mcp_request_url]},
+                            follow_redirects=True,
+                            timeout=httpx.Timeout(30.0, connect=10.0),
+                            auth=oauth_auth,
+                            **_pinned_transport_kwargs(),
+                        )
+                    )
+                    read, write, _ = await server_stack.enter_async_context(
+                        streamable_http_client(cfg.url, http_client=http_client)
+                    )
             else:
                 logger.warning("MCP server '{}': unknown transport type '{}'", name, transport_type)
                 await server_stack.aclose()
                 return name, None
 
-            read = _filter_malformed_mcp_progress_notifications(read, name)
-            session = await server_stack.enter_async_context(ClientSession(read, write))
-            await session.initialize()
+            if session is None:
+                read = _filter_malformed_mcp_progress_notifications(read, name)
+                session = await server_stack.enter_async_context(ClientSession(read, write))
+                await session.initialize()
 
-            tools = await session.list_tools()
+            tool_defs = await discover_all_tools(session, timeout=float(cfg.tool_timeout))
             enabled_tools = set(cfg.enabled_tools)
             allow_all_tools = "*" in enabled_tools
             registered_count = 0
             matched_enabled_tools: set[str] = set()
-            available_raw_names = [tool_def.name for tool_def in tools.tools]
-            available_wrapped_names = [_sanitize_mcp_tool_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools]
-            for tool_def in tools.tools:
+            available_raw_names = [tool_def.name for tool_def in tool_defs]
+            available_wrapped_names = [_sanitize_mcp_tool_name(f"mcp_{name}_{tool_def.name}") for tool_def in tool_defs]
+            for tool_def in tool_defs:
                 wrapped_name = _sanitize_mcp_tool_name(f"mcp_{name}_{tool_def.name}")
                 if (
                     not allow_all_tools

--- a/collie-core/nanobot/config/schema.py
+++ b/collie-core/nanobot/config/schema.py
@@ -345,6 +345,8 @@ class MCPServerConfig(Base):
     connector_trusted: bool = False
     connector_tool_overrides: dict[str, str] = Field(default_factory=dict)
     connector_approval_preference: Literal["every_time", "changes", "important"] = "important"
+    connector_allow_private_network: bool = False
+    connector_endpoint_policy: bool = False
 
 
 def _lazy_default(module_path: str, class_name: str) -> Any:

--- a/collie-core/tests/collie/test_remote_connection_manager.py
+++ b/collie-core/tests/collie/test_remote_connection_manager.py
@@ -1,0 +1,186 @@
+"""Custom remote connections share the installed-account lifecycle."""
+
+from dataclasses import replace
+
+import pytest
+
+from collie_core.connectors.manager import ConnectorManager
+from collie_core.connectors.models import (
+    ConnectorAuthStrategy,
+    ConnectorDriverKind,
+    ConnectorProvenance,
+    ConnectorTransport,
+    InstalledConnectorDefinition,
+    ProbeResult,
+    RemoteRevocationStatus,
+)
+from collie_core.db import CollieDB
+from collie_core.services.credentials import CredentialStore
+from nanobot.config.schema import MCPServerConfig
+
+
+def definition(**changes):
+    return replace(
+        InstalledConnectorDefinition(
+            id="input_definition",
+            driver=ConnectorDriverKind.CUSTOM_MCP,
+            transport=ConnectorTransport.STREAMABLE_HTTP,
+            auth_strategy=ConnectorAuthStrategy.NONE,
+            provenance=ConnectorProvenance.CUSTOM,
+            endpoint="https://mcp.example.com/mcp",
+        ),
+        **changes,
+    )
+
+
+class Driver:
+    def __init__(self):
+        self.definitions = []
+        self.on_probe = None
+
+    def connect_and_probe(self, config, connection_id):
+        self.definitions.append(config)
+        if self.on_probe:
+            self.on_probe(connection_id)
+        return ProbeResult(
+            tools=[
+                {
+                    "name": "search",
+                    "risk": "change",
+                    "schema_hash": "schema",
+                    "annotations": {"readOnlyHint": True},
+                }
+            ]
+        )
+
+    probe = connect_and_probe
+
+    def revoke(self, config, connection_id):
+        return RemoteRevocationStatus.NOT_APPLICABLE
+
+
+@pytest.fixture
+def setup(tmp_path):
+    db = CollieDB(tmp_path / "collie.db")
+    store = CredentialStore(
+        tmp_path / "secrets", protect=lambda b: b[::-1], unprotect=lambda b: b[::-1]
+    )
+    driver = Driver()
+    manager = ConnectorManager(db, credentials=store, driver_factory=lambda _: driver)
+    yield manager, db, store, driver
+    db.close()
+
+
+@pytest.mark.parametrize("transport", [ConnectorTransport.STREAMABLE_HTTP, ConnectorTransport.SSE])
+def test_unknown_server_connect_restart_query_and_remove(setup, transport):
+    manager, db, store, driver = setup
+    result = manager.connect_definition(definition(transport=transport), display_name="My server")
+    connection_id = result["connection_id"]
+    assert result["status"] == "connected"
+    assert store.load(f"connector:{connection_id}") is None
+    assert manager.get_connection(connection_id)["route"] == "Custom MCP"
+    assert manager.get_connection(connection_id)["status"] == "connected"
+    restarted = ConnectorManager(db, credentials=store, driver_factory=lambda _: driver)
+    assert restarted.test(connection_id)["status"] == "connected"
+    servers = restarted.mcp_servers_for_config()
+    assert list(servers) == [connection_id]
+    config = servers[connection_id]
+    assert config["type"] == ("sse" if transport == ConnectorTransport.SSE else "streamableHttp")
+    assert config["connectorTrusted"] is False
+    assert config["oauthConnectionId"] == ""
+    assert config["enabledTools"] == ["search"]
+    assert MCPServerConfig.model_validate(config).url == definition().endpoint
+    assert restarted.remove(connection_id)["status"] == "disconnected"
+    assert restarted.mcp_servers_for_config() == {}
+    assert db.list_connector_definitions() == []
+    assert db.list_connector_tools(connection_id) == []
+
+
+def test_same_label_and_endpoint_have_independent_accounts_and_grants(setup):
+    manager, db, _, _ = setup
+    first = manager.connect_definition(definition(), display_name="Same name")["connection_id"]
+    second = manager.connect_definition(definition(), display_name="Same name")["connection_id"]
+    assert first != second
+    manager.update(first, approval_preference="every_time")
+    configs = manager.mcp_servers_for_config()
+    assert set(configs) == {first, second}
+    assert configs[first]["connectorApprovalPreference"] == "every_time"
+    assert configs[second]["connectorApprovalPreference"] == "important"
+    manager.remove(first)
+    assert list(manager.mcp_servers_for_config()) == [second]
+    assert len(db.list_connector_definitions()) == 1
+
+
+def test_private_network_choice_survives_restart(setup):
+    manager, db, store, driver = setup
+    result = manager.connect_definition(
+        definition(
+            endpoint="http://127.0.0.1:9876/mcp",
+            allow_private_network=True,
+        )
+    )
+    config = ConnectorManager(db, credentials=store).mcp_servers_for_config()[
+        result["connection_id"]
+    ]
+    assert config["connectorAllowPrivateNetwork"] is True
+    assert config["connectorEndpointPolicy"] is True
+    parsed = MCPServerConfig.model_validate(config)
+    assert parsed.connector_allow_private_network is True
+    assert parsed.connector_endpoint_policy is True
+    assert driver.definitions[0].allow_private_network is True
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"auth_strategy": ConnectorAuthStrategy.TOKEN},
+        {"transport": ConnectorTransport.STDIO},
+        {"provenance": ConnectorProvenance.CURATED},
+        {"tool_overrides": {"search": "read"}},
+        {"trusted_hosts": ("example.com",)},
+        {"unresolved": True},
+    ],
+)
+def test_unsupported_or_trust_promoting_definitions_do_not_start(setup, changes):
+    manager, db, _, driver = setup
+    with pytest.raises(ValueError):
+        manager.connect_definition(definition(**changes))
+    assert not driver.definitions
+    assert db.list_connector_connections() == []
+    assert db.list_connector_definitions() == []
+
+
+def test_removed_connection_cannot_return_from_late_probe(setup):
+    manager, db, _, driver = setup
+    driver.on_probe = lambda connection_id: manager.remove(connection_id)
+    with pytest.raises(ValueError, match="cancelled"):
+        manager.connect_definition(definition())
+    assert db.list_connector_connections() == []
+    assert db.list_connector_definitions() == []
+    assert manager.mcp_servers_for_config() == {}
+
+
+def test_private_choice_rejects_truthy_strings():
+    value = definition().to_dict()
+    value["allow_private_network"] = "false"
+    with pytest.raises(ValueError, match="boolean"):
+        InstalledConnectorDefinition.from_dict(value)
+
+
+def test_retest_preserves_approval_preference(setup):
+    manager, _, _, _ = setup
+    connection_id = manager.connect_definition(definition())["connection_id"]
+    manager.update(connection_id, approval_preference="every_time")
+    manager.test(connection_id)
+    config = manager.mcp_servers_for_config()[connection_id]
+    assert config["connectorApprovalPreference"] == "every_time"
+
+
+def test_removed_connection_cannot_return_from_late_retest(setup):
+    manager, db, _, driver = setup
+    connection_id = manager.connect_definition(definition())["connection_id"]
+    driver.on_probe = lambda account: manager.remove(account)
+    with pytest.raises(ValueError, match="cancelled"):
+        manager.test(connection_id)
+    assert db.list_connector_connections() == []
+    assert db.list_connector_definitions() == []

--- a/collie-core/tests/collie/test_remote_mcp.py
+++ b/collie-core/tests/collie/test_remote_mcp.py
@@ -115,9 +115,9 @@ def test_private_opt_in_is_limited_to_selected_origin(monkeypatch) -> None:
     monkeypatch.setattr(socket, "getaddrinfo", resolve)
     with pytest.raises(ValueError):
         validate_remote_endpoint("http://device.example/mcp")
-    assert validate_remote_endpoint(
-        "http://device.example/mcp", allow_private_network=True
-    ) == ("192.168.1.20",)
+    assert validate_remote_endpoint("http://device.example/mcp", allow_private_network=True) == (
+        "192.168.1.20",
+    )
     with pytest.raises(ValueError):
         validate_remote_endpoint(
             "http://device.example/mcp",

--- a/collie-core/tests/collie/test_remote_mcp.py
+++ b/collie-core/tests/collie/test_remote_mcp.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from collie_core.connectors.drivers.remote_mcp import RemoteMcpDriver
+from collie_core.connectors.models import (
+    ConnectorAuthStrategy,
+    ConnectorDriverKind,
+    ConnectorProvenance,
+    ConnectorTransport,
+    InstalledConnectorDefinition,
+)
+from collie_core.connectors.remote import (
+    _request_validator,
+    discover_all_tools,
+    validate_remote_endpoint,
+)
+
+
+def _definition(**changes):
+    values = {
+        "id": "custom",
+        "driver": ConnectorDriverKind.CUSTOM_MCP,
+        "transport": ConnectorTransport.STREAMABLE_HTTP,
+        "auth_strategy": ConnectorAuthStrategy.NONE,
+        "provenance": ConnectorProvenance.CUSTOM,
+        "endpoint": "https://mcp.example/mcp",
+    }
+    values.update(changes)
+    return InstalledConnectorDefinition(**values)
+
+
+@pytest.mark.asyncio
+async def test_discovery_follows_all_pages() -> None:
+    calls = []
+
+    class Session:
+        async def list_tools(self, cursor=None):
+            calls.append(cursor)
+            if cursor is None:
+                return SimpleNamespace(
+                    tools=[SimpleNamespace(name="one", inputSchema={})],
+                    nextCursor="second",
+                )
+            return SimpleNamespace(
+                tools=[SimpleNamespace(name="two", inputSchema={})],
+                nextCursor=None,
+            )
+
+    assert [tool.name for tool in await discover_all_tools(Session())] == ["one", "two"]
+    assert calls == [None, "second"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["duplicate", "cursor", "malformed"])
+async def test_discovery_rejects_invalid_or_nonterminating_results(failure: str) -> None:
+    class Session:
+        async def list_tools(self, cursor=None):
+            if failure == "malformed":
+                return SimpleNamespace(tools=None, nextCursor=None)
+            if failure == "cursor":
+                return SimpleNamespace(tools=[], nextCursor="repeat")
+            return SimpleNamespace(
+                tools=[SimpleNamespace(name="same", inputSchema={})],
+                nextCursor="again" if cursor is None else None,
+            )
+
+    with pytest.raises(ValueError):
+        await discover_all_tools(Session(), max_pages=3)
+
+
+@pytest.mark.asyncio
+async def test_discovery_timeout_cancels_request() -> None:
+    cancelled = asyncio.Event()
+
+    class Session:
+        async def list_tools(self, cursor=None):
+            try:
+                await asyncio.sleep(10)
+            finally:
+                cancelled.set()
+
+    with pytest.raises(TimeoutError):
+        await discover_all_tools(Session(), timeout=0.01)
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_discovery_rejects_normalized_name_collisions() -> None:
+    class Session:
+        async def list_tools(self):
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(name="search", inputSchema={}),
+                    SimpleNamespace(name="_search", inputSchema={}),
+                ],
+                nextCursor=None,
+            )
+
+    with pytest.raises(ValueError, match="collide"):
+        await discover_all_tools(Session())
+
+
+def test_private_opt_in_is_limited_to_selected_origin(monkeypatch) -> None:
+    def resolve(host, *_args, **_kwargs):
+        address = "192.168.1.20" if host.endswith("example") else "127.0.0.1"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (address, 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", resolve)
+    with pytest.raises(ValueError):
+        validate_remote_endpoint("http://device.example/mcp")
+    assert validate_remote_endpoint(
+        "http://device.example/mcp", allow_private_network=True
+    ) == ("192.168.1.20",)
+    with pytest.raises(ValueError):
+        validate_remote_endpoint(
+            "http://device.example/mcp",
+            "http://redirect.example/mcp",
+            allow_private_network=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_static_credentials_cannot_follow_cross_origin_redirect(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "collie_core.connectors.remote.validate_remote_endpoint", lambda *_a, **_k: ("1.1.1.1",)
+    )
+    validate = _request_validator(
+        "https://mcp.example/mcp",
+        allow_private_network=False,
+        has_static_credentials=True,
+    )
+    with pytest.raises(httpx.RequestError):
+        await validate(httpx.Request("GET", "https://other.example/mcp"))
+
+
+def test_custom_driver_rejects_auth_and_trust_overrides() -> None:
+    driver = RemoteMcpDriver()
+    with pytest.raises(ValueError, match="auth strategy"):
+        driver.probe(_definition(auth_strategy=ConnectorAuthStrategy.TOKEN), "connection")
+    with pytest.raises(ValueError, match="trusted tool overrides"):
+        driver.probe(_definition(tool_overrides={"send": "read"}), "connection")
+
+
+def test_custom_driver_supports_explicit_sse(monkeypatch) -> None:
+    observed = {}
+
+    @asynccontextmanager
+    async def session(endpoint, **kwargs):
+        observed.update(endpoint=endpoint, **kwargs)
+        yield SimpleNamespace()
+
+    async def discover(_session):
+        return []
+
+    monkeypatch.setattr("collie_core.connectors.drivers.remote_mcp.remote_mcp_session", session)
+    monkeypatch.setattr("collie_core.connectors.drivers.remote_mcp.discover_all_tools", discover)
+    result = RemoteMcpDriver().probe(
+        _definition(transport=ConnectorTransport.SSE, allow_private_network=True), "connection"
+    )
+    assert result.tools == []
+    assert observed["transport"] == "sse"
+    assert observed["allow_private_network"] is True

--- a/collie-core/tests/collie/test_remote_mcp_boundaries.py
+++ b/collie-core/tests/collie/test_remote_mcp_boundaries.py
@@ -1,0 +1,232 @@
+"""Adversarial protocol and endpoint boundaries for remote MCP connectors."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from collie_core.connectors.models import (
+    ConnectorAuthStrategy,
+    ConnectorDefinition,
+    ConnectorDriverKind,
+    ConnectorTransport,
+)
+
+
+def _definition(**overrides: object) -> ConnectorDefinition:
+    values: dict[str, object] = {
+        "id": "custom",
+        "name": "Custom MCP",
+        "category": "custom",
+        "description": "test server",
+        "driver": ConnectorDriverKind.CUSTOM_MCP,
+        "auth_type": ConnectorAuthStrategy.NONE.value,
+        "endpoint": "https://mcp.example.test/mcp",
+        "available": True,
+        "transport": ConnectorTransport.STREAMABLE_HTTP,
+    }
+    values.update(overrides)
+    return ConnectorDefinition(**values)
+
+
+class _PagedSession:
+    def __init__(self, pages: list[object]) -> None:
+        self.pages = iter(pages)
+        self.cursors: list[str | None] = []
+
+    async def list_tools(self, *, cursor: str | None = None) -> object:
+        self.cursors.append(cursor)
+        return next(self.pages)
+
+
+@pytest.mark.asyncio
+async def test_tool_discovery_follows_cursors_deduplicates_and_bounds_pages() -> None:
+    """A hostile server cannot create an unbounded discovery loop or duplicate tools."""
+    from collie_core.connectors.remote import discover_all_tools
+
+    session = _PagedSession(
+        [
+            SimpleNamespace(
+                tools=[SimpleNamespace(name="search", description="one", inputSchema={})],
+                nextCursor="page-2",
+            ),
+            SimpleNamespace(
+                tools=[
+                    SimpleNamespace(name="write", description="two", inputSchema={}),
+                ],
+                nextCursor=None,
+            ),
+        ]
+    )
+
+    tools = await discover_all_tools(session, max_pages=4)
+
+    assert [tool.name for tool in tools] == ["search", "write"]
+    assert session.cursors == [None, "page-2"]
+
+    looping = _PagedSession([SimpleNamespace(tools=[], nextCursor="same")] * 3)
+    with pytest.raises(ValueError, match="pagination|cursor|loop|bound"):
+        await discover_all_tools(looping, max_pages=2)
+
+
+@pytest.mark.asyncio
+async def test_tool_discovery_rejects_malformed_and_duplicate_names() -> None:
+    from collie_core.connectors.remote import discover_all_tools
+
+    session = _PagedSession(
+        [
+            SimpleNamespace(
+                tools=[
+                    SimpleNamespace(name="", description="empty"),
+                    SimpleNamespace(name="search", description="ok"),
+                    SimpleNamespace(name="search", description="duplicate"),
+                    SimpleNamespace(name=None, description="wrong type"),
+                    object(),
+                ],
+                nextCursor=None,
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="tool|name|malformed|duplicate"):
+        await discover_all_tools(session)
+
+
+@pytest.mark.asyncio
+async def test_tool_discovery_timeout_and_tool_count_are_bounded() -> None:
+    from collie_core.connectors.remote import discover_all_tools
+
+    class SlowSession:
+        async def list_tools(self, *, cursor: str | None = None) -> object:
+            del cursor
+            import asyncio
+
+            await asyncio.sleep(0.05)
+            return SimpleNamespace(tools=[], nextCursor=None)
+
+    with pytest.raises(TimeoutError):
+        await discover_all_tools(SlowSession(), timeout=0.001)
+
+    too_many = _PagedSession(
+        [SimpleNamespace(tools=[SimpleNamespace(name="one")], nextCursor=None)]
+    )
+    with pytest.raises(ValueError, match="bounds|limit"):
+        await discover_all_tools(too_many, max_tools=0)
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "allow_private", "allowed"),
+    [
+        ("https://mcp.example.test/mcp", False, True),
+        ("http://127.0.0.1:8765/mcp", False, False),
+        ("http://127.0.0.1:8765/mcp", True, True),
+        ("http://10.0.0.4/mcp", False, False),
+        ("http://10.0.0.4/mcp", True, True),
+    ],
+)
+def test_endpoint_policy_requires_explicit_private_network_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+    allow_private: bool,
+    allowed: bool,
+) -> None:
+    import collie_core.connectors.remote as remote
+
+    monkeypatch.setattr(
+        remote.socket,
+        "getaddrinfo",
+        lambda host, *args: [
+            (0, 0, 0, "", ("127.0.0.1" if host.startswith(("127.", "10.")) else "8.8.8.8", 0))
+        ],
+    )
+    try:
+        remote.validate_remote_endpoint(endpoint, allow_private_network=allow_private)
+    except ValueError:
+        assert not allowed
+    else:
+        assert allowed
+
+
+def test_endpoint_policy_rechecks_redirect_destination(monkeypatch: pytest.MonkeyPatch) -> None:
+    import collie_core.connectors.remote as remote
+
+    monkeypatch.setattr(
+        remote.socket,
+        "getaddrinfo",
+        lambda host, *args: [(0, 0, 0, "", ("127.0.0.1", 0))],
+    )
+    with pytest.raises(ValueError, match="Blocked"):
+        remote.validate_remote_endpoint(
+            "https://mcp.example.test/mcp",
+            "http://127.0.0.1:8765/mcp",
+        )
+    # A private opt-in applies only to the exact selected origin.
+    with pytest.raises(ValueError, match="Blocked"):
+        remote.validate_remote_endpoint(
+            "http://127.0.0.1:8765/mcp",
+            "http://127.0.0.2:8765/mcp",
+            allow_private_network=True,
+        )
+
+
+def test_remote_driver_rejects_unsupported_auth_before_network() -> None:
+    from collie_core.connectors.drivers.remote_mcp import RemoteMcpDriver
+
+    definition = _definition(auth_type="oauth")
+    with pytest.raises(ValueError, match="auth strategy|no-auth"):
+        RemoteMcpDriver().connect_and_probe(definition, "connection-1")
+
+
+@pytest.mark.asyncio
+async def test_request_transport_revalidates_each_redirect_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-request hook must remain active even when HTTPX follows redirects."""
+    import collie_core.connectors.remote as remote
+
+    seen: list[str] = []
+
+    def validate(initial: str, candidate: str | None = None, **kwargs: object) -> tuple[str, ...]:
+        del initial, kwargs
+        seen.append(candidate or "")
+        if candidate and "127.0.0.1" in candidate:
+            raise ValueError("Blocked remote MCP endpoint: private address")
+        return ("203.0.113.10",)
+
+    class Inner:
+        async def handle_async_request(self, request: object) -> object:
+            return SimpleNamespace(status_code=200)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(remote, "validate_remote_endpoint", validate)
+    monkeypatch.setattr(remote.httpx, "AsyncHTTPTransport", Inner)
+    transport = remote.RemoteEndpointTransport("https://mcp.example.test/mcp")
+    request = httpx.Request("GET", "https://mcp.example.test/mcp")
+    await transport.handle_async_request(request)
+    assert seen == ["https://mcp.example.test/mcp"]
+    request = httpx.Request("GET", "http://127.0.0.1:8765/mcp")
+    with pytest.raises(ValueError, match="Blocked"):
+        await transport.handle_async_request(request)
+
+
+@pytest.mark.asyncio
+async def test_static_credentials_are_blocked_after_cross_origin_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import collie_core.connectors.remote as remote
+
+    monkeypatch.setattr(
+        remote, "validate_remote_endpoint", lambda *args, **kwargs: ("203.0.113.10",)
+    )
+    validate = remote._request_validator(
+        "https://mcp.example.test/mcp",
+        allow_private_network=False,
+        has_static_credentials=True,
+    )
+    request = httpx.Request("GET", "https://evil.example/mcp")
+    with pytest.raises(httpx.RequestError, match="different origin"):
+        await validate(request)

--- a/collie-core/tests/collie/test_remote_mcp_runtime.py
+++ b/collie-core/tests/collie/test_remote_mcp_runtime.py
@@ -1,0 +1,147 @@
+"""Runtime attachment and account isolation for custom remote MCP connections."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from mcp import types
+
+from collie_core.connectors.manager import ConnectorManager
+from collie_core.connectors.models import (
+    ConnectorAuthStrategy,
+    ConnectorDriverKind,
+    ConnectorProvenance,
+    ConnectorTransport,
+    InstalledConnectorDefinition,
+    ProbeResult,
+)
+from collie_core.db import CollieDB
+from nanobot.agent.tools.mcp import connect_mcp_servers
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.config.schema import MCPServerConfig
+
+
+def _installed(endpoint: str, transport: ConnectorTransport) -> InstalledConnectorDefinition:
+    return InstalledConnectorDefinition(
+        id="custom-definition",
+        driver=ConnectorDriverKind.CUSTOM_MCP,
+        transport=transport,
+        auth_strategy=ConnectorAuthStrategy.NONE,
+        provenance=ConnectorProvenance.CUSTOM,
+        endpoint=endpoint,
+    )
+
+
+class _Driver:
+    def connect_and_probe(self, definition, connection_id: str) -> ProbeResult:
+        return ProbeResult(
+            tools=[
+                {
+                    "name": "lookup",
+                    "description": "Look up an item",
+                    "inputSchema": {"type": "object", "properties": {"item": {"type": "string"}}},
+                    "schema_hash": "lookup-schema-v1",
+                    "input_schema": {"type": "object", "properties": {"item": {"type": "string"}}},
+                    "risk": "read",
+                }
+            ]
+        )
+
+
+class _Session:
+    def __init__(self, account: str) -> None:
+        self.account = account
+        self.calls: list[tuple[str, dict]] = []
+
+    async def initialize(self) -> None:
+        return None
+
+    async def list_tools(self, *, cursor=None):
+        return SimpleNamespace(
+            tools=[
+                types.Tool(
+                    name="lookup",
+                    description="Look up an item",
+                    inputSchema={"type": "object", "properties": {"item": {"type": "string"}}},
+                )
+            ],
+            nextCursor=None,
+        )
+
+    async def call_tool(self, name: str, arguments: dict):
+        self.calls.append((name, arguments))
+        return SimpleNamespace(
+            content=[types.TextContent(type="text", text=f"{self.account}:{arguments['item']}")],
+            isError=False,
+        )
+
+    async def list_resources(self):
+        return SimpleNamespace(resources=[])
+
+    async def list_prompts(self):
+        return SimpleNamespace(prompts=[])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", [ConnectorTransport.STREAMABLE_HTTP, ConnectorTransport.SSE])
+async def test_custom_manager_connection_attaches_and_executes_selected_account(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    transport: ConnectorTransport,
+) -> None:
+    db = CollieDB(tmp_path / "collie.db")
+    manager = ConnectorManager(db, driver_factory=lambda _definition: _Driver())
+    connected = manager.connect_definition(
+        _installed(f"https://{transport.value}.example/mcp", transport)
+    )
+    second = manager.connect_definition(
+        _installed(f"https://other-{transport.value}.example/mcp", transport)
+    )
+    config = manager.mcp_servers_for_config()
+    assert connected["connection_id"] in config
+    assert second["connection_id"] in config
+    assert connected["connection_id"] != second["connection_id"]
+    server_name = connected["connection_id"]
+    cfg = MCPServerConfig.model_validate(config[server_name])
+    assert cfg.type == ("sse" if transport is ConnectorTransport.SSE else "streamableHttp")
+
+    sessions: dict[str, _Session] = {}
+
+    @asynccontextmanager
+    async def fake_session(endpoint: str, **kwargs):
+        session = _Session(endpoint)
+        sessions[endpoint] = session
+        yield session
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp._probe_http_url", lambda _url: _async_true())
+    monkeypatch.setattr("collie_core.connectors.remote.remote_mcp_session", fake_session)
+    registry = ToolRegistry()
+    configs = {name: MCPServerConfig.model_validate(value) for name, value in config.items()}
+    stacks = await connect_mcp_servers(configs, registry)
+    try:
+        assert set(stacks) == set(configs)
+        tool = registry.get(f"mcp_{server_name}_lookup")
+        assert tool is not None
+        assert tool.read_only is False
+        result = await tool.execute(item="chosen")
+        assert f"{cfg.url}:chosen" in result
+        assert sessions[cfg.url].calls == [("lookup", {"item": "chosen"})]
+        other_name = second["connection_id"]
+        other_tool = registry.get(f"mcp_{other_name}_lookup")
+        assert other_tool is not None
+        assert other_tool.permission_request({}).resource != tool.permission_request({}).resource
+        other_cfg = configs[other_name]
+        assert sessions[other_cfg.url].calls == []
+        assert f"{other_cfg.url}:other" in await other_tool.execute(item="other")
+        assert sessions[cfg.url].calls == [("lookup", {"item": "chosen"})]
+    finally:
+        for stack in stacks.values():
+            await stack.aclose()
+    db.close()
+
+
+async def _async_true() -> bool:
+    return True

--- a/collie-core/tests/collie/test_remote_mcp_sdk.py
+++ b/collie-core/tests/collie/test_remote_mcp_sdk.py
@@ -1,0 +1,143 @@
+"""Exercise the installed MCP SDK against deterministic HTTP protocol responses."""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from collie_core.connectors import remote
+from collie_core.connectors.manager import ConnectorManager
+from collie_core.connectors.models import InstalledConnectorDefinition
+from collie_core.db import CollieDB
+from collie_core.services.credentials import CredentialStore
+from nanobot.agent.tools import mcp as runtime
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.config.schema import MCPServerConfig
+
+
+class EventStream(httpx.AsyncByteStream):
+    def __init__(self, session_id):
+        self.session_id = session_id
+        self.messages = asyncio.Queue()
+
+    async def __aiter__(self):
+        yield f"event: endpoint\ndata: /messages?session_id={self.session_id}\n\n".encode()
+        while True:
+            message = await self.messages.get()
+            yield f"event: message\ndata: {json.dumps(message)}\n\n".encode()
+
+
+@pytest.mark.parametrize("transport", ["streamable_http", "sse"])
+def test_unknown_server_real_sdk_discovers_all_pages_and_calls_tool(
+    tmp_path, monkeypatch, transport
+):
+    requests = []
+    streams = {}
+
+    def respond(request):
+        if request.method == "GET":
+            if transport == "sse":
+                session_id = str(len(streams))
+                stream = EventStream(session_id)
+                streams[session_id] = stream
+                return httpx.Response(
+                    200, headers={"Content-Type": "text/event-stream"}, stream=stream
+                )
+            return httpx.Response(405)
+        if request.method == "DELETE":
+            return httpx.Response(200)
+        message = json.loads(request.content)
+        requests.append(message)
+        if "id" not in message:
+            return httpx.Response(202)
+        method = message["method"]
+        if method == "initialize":
+            result = {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "Unknown server", "version": "1.0"},
+            }
+        elif method == "tools/list":
+            second = message.get("params", {}).get("cursor") == "next-page"
+            result = {
+                "tools": [
+                    {
+                        "name": "read_second" if second else "read_first",
+                        "description": "Read a value",
+                        "inputSchema": {"type": "object", "properties": {}},
+                        "annotations": {"readOnlyHint": True},
+                    }
+                ]
+            }
+            if not second:
+                result["nextCursor"] = "next-page"
+        elif method == "tools/call":
+            result = {"content": [{"type": "text", "text": message["params"]["name"]}]}
+        else:
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": message["id"],
+                    "error": {"code": -32601, "message": "Method not supported"},
+                },
+            )
+        response = {"jsonrpc": "2.0", "id": message["id"], "result": result}
+        if transport == "sse":
+            streams[request.url.params["session_id"]].messages.put_nowait(response)
+            return httpx.Response(202)
+        return httpx.Response(200, json=response)
+
+    monkeypatch.setattr(remote, "validate_remote_endpoint", lambda *a, **kw: ("8.8.8.8",))
+    monkeypatch.setattr(
+        remote,
+        "_http_client_kwargs",
+        lambda *a, **kw: {
+            "transport": httpx.MockTransport(respond),
+            "trust_env": False,
+        },
+    )
+    store = CredentialStore(tmp_path / "secrets", protect=lambda b: b, unprotect=lambda b: b)
+    with CollieDB(tmp_path / "collie.db") as db:
+        manager = ConnectorManager(db, credentials=store)
+        definition = InstalledConnectorDefinition.from_dict(
+            {
+                "id": "input",
+                "driver": "custom_mcp",
+                "transport": transport,
+                "auth_strategy": "none",
+                "provenance": "custom",
+                "endpoint": "https://example.test/mcp",
+            }
+        )
+        connection_id = manager.connect_definition(definition)["connection_id"]
+        assert {t["remote_tool_name"] for t in db.list_connector_tools(connection_id)} == {
+            "read_first",
+            "read_second",
+        }
+        assert set(manager.get_connection(connection_id)["tool_policy"].values()) == {"change"}
+
+        async def use():
+            registry = ToolRegistry()
+            configs = {
+                name: MCPServerConfig.model_validate(config)
+                for name, config in manager.mcp_servers_for_config().items()
+            }
+            connections = await runtime.connect_mcp_servers(configs, registry)
+            try:
+                assert set(connections) == {connection_id}
+                tool = registry.get(f"mcp_{connection_id}_read_second")
+                assert tool is not None
+                assert not tool.read_only
+                assert tool.permission_request({}) is not None
+                assert "read_second" in await tool.execute()
+            finally:
+                for connection in connections.values():
+                    await connection.aclose()
+
+        asyncio.run(use())
+        manager.remove(connection_id)
+        assert manager.mcp_servers_for_config() == {}
+    assert any(request["method"] == "tools/call" for request in requests)
+    assert sum(request["method"] == "initialize" for request in requests) == 2

--- a/collie-core/tests/collie/test_remote_mcp_transport.py
+++ b/collie-core/tests/collie/test_remote_mcp_transport.py
@@ -1,0 +1,94 @@
+"""Direct remote requests retain origin identity without process-global DNS state."""
+
+import asyncio
+import socket
+
+import httpx
+import pytest
+
+from collie_core.connectors import remote
+
+
+def test_pinned_transport_supports_concurrent_requests_across_probe_loops(monkeypatch):
+    original_resolver = socket.getaddrinfo
+    observed = []
+    pools = []
+
+    class Inner:
+        def __init__(self):
+            pools.append(self)
+
+        async def handle_async_request(self, request):
+            await asyncio.sleep(0.001)
+            assert socket.getaddrinfo is original_resolver
+            observed.append(
+                (
+                    self,
+                    request.url.host,
+                    request.headers["Host"],
+                    request.extensions["sni_hostname"],
+                )
+            )
+            return httpx.Response(200)
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(remote.httpx, "AsyncHTTPTransport", Inner)
+    monkeypatch.setattr(remote, "validate_remote_endpoint", lambda *a, **kw: ("8.8.8.8",))
+
+    async def run():
+        transport = remote.RemoteEndpointTransport("https://one.example/mcp")
+        try:
+            requests = [
+                httpx.Request("POST", f"https://{host}/mcp", content=b"request")
+                for host in ["one.example", "one.example", "two.example"]
+            ]
+            responses = await asyncio.gather(*(transport.handle_async_request(r) for r in requests))
+            assert [response.request for response in responses] == requests
+        finally:
+            await transport.aclose()
+
+    asyncio.run(run())
+    asyncio.run(run())
+    assert len(pools) == 4
+    assert all(address == "8.8.8.8" and host == sni for _, address, host, sni in observed)
+    for pool in pools:
+        assert len({host for candidate, _, host, _ in observed if candidate is pool}) == 1
+
+
+@pytest.mark.asyncio
+async def test_pinned_transport_falls_back_only_before_request_is_sent(monkeypatch):
+    attempts = []
+    failure = httpx.ConnectError
+
+    class Inner:
+        async def handle_async_request(self, request):
+            attempts.append(request.url.host)
+            if request.url.host == "2001:4860:4860::8888":
+                raise failure("test transport failure", request=request)
+            return httpx.Response(200)
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(remote.httpx, "AsyncHTTPTransport", Inner)
+    monkeypatch.setattr(
+        remote,
+        "validate_remote_endpoint",
+        lambda *a, **kw: (
+            "2001:4860:4860::8888",
+            "8.8.8.8",
+        ),
+    )
+    transport = remote.RemoteEndpointTransport("https://one.example/mcp")
+    try:
+        await transport.handle_async_request(httpx.Request("POST", "https://one.example/mcp"))
+        assert attempts == ["2001:4860:4860::8888", "8.8.8.8"]
+        attempts.clear()
+        failure = httpx.ReadError
+        with pytest.raises(httpx.ReadError):
+            await transport.handle_async_request(httpx.Request("POST", "https://one.example/mcp"))
+        assert attempts == ["2001:4860:4860::8888"]
+    finally:
+        await transport.aclose()

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -98,7 +98,10 @@ React renderer
 Connection recipes remain in `collie_core/connectors/catalog.py`. Installed
 configuration snapshots and account/tool inventory live in SQLite through
 `collie_core/db.py`; `ConnectorManager` resolves existing accounts against those
-snapshots while retaining catalogue availability controls. Credential references
+snapshots while retaining catalogue availability controls for curated accounts.
+Custom no-auth HTTP/SSE accounts use the same manager;
+`connectors/remote.py` owns shared remote discovery and endpoint checks, used by
+connector drivers and the adapted MCP runtime. Credential references
 point to the existing protected store. The connection specification in
 `docs/product/features/connectors.md` separates this foundation from later driver
 and desktop delivery.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,8 +11,8 @@
 
 ## Source inventory
 
-- Core Python files: **528**
-- Core Python test files: **243**
+- Core Python files: **536**
+- Core Python test files: **249**
 - Desktop TypeScript/TSX files: **190**
 - Desktop test files: **70**
 - Active Markdown docs: **36**

--- a/docs/product/features/connectors.md
+++ b/docs/product/features/connectors.md
@@ -28,7 +28,7 @@ Broad compatibility does not imply every service exposes an API/MCP, every accou
 
 Cline accepts remote endpoints and local server configurations, including credentials. Claude Code accepts arbitrary HTTP/stdio servers, imports MCP configurations, and supports OAuth and pre-registered clients. Collie should offer comparable interoperability behind a graphical and conversational setup flow. [Cline](https://github.com/cline/cline/blob/main/docs/mcp/mcp-overview.mdx), [Claude Code](https://code.claude.com/docs/en/mcp)
 
-The live Collie connection manager currently implements only its official MCP driver. Custom MCP, bundled MCP, and API kinds exist as declarations, but are not complete driver paths. The underlying engine already supports multiple transports. Reuse that engine; complete the connection management layer rather than creating a second agent runtime. [Manager](https://github.com/FoxRick/Collie/blob/b54311aaae24d12f92832fcfc68167c8fe2c81c6/collie-core/collie_core/connectors/manager.py), [Engine transport support](https://github.com/FoxRick/Collie/blob/b54311aaae24d12f92832fcfc68167c8fe2c81c6/collie-core/nanobot/agent/tools/mcp.py)
+The baseline connection manager implemented only its official MCP driver. Step 3 adds a custom remote MCP driver and shared remote discovery while preserving the existing engine runtime. Bundled MCP and API drivers remain later delivery steps. [Manager](https://github.com/FoxRick/Collie/blob/b54311aaae24d12f92832fcfc68167c8fe2c81c6/collie-core/collie_core/connectors/manager.py), [Engine transport support](https://github.com/FoxRick/Collie/blob/b54311aaae24d12f92832fcfc68167c8fe2c81c6/collie-core/nanobot/agent/tools/mcp.py)
 
 ## 3. Architecture and ownership
 
@@ -313,3 +313,40 @@ leave newly added metadata inconsistent. Use a V16-compatible corrective build,
 or restore the complete pre-upgrade backup with the app closed, accepting that
 post-backup user changes are lost. Export any new definitions before a deliberate
 restore. No automatic destructive downgrade is introduced.
+
+
+## 10. Remote backend delivery (Step 3)
+
+`ConnectorManager.connect_definition` accepts validated custom/imported no-auth
+remote definitions. It creates an installed account through the existing lifecycle,
+without a bundled catalogue entry. Streamable HTTP and explicitly selected legacy
+SSE share transport/discovery helpers with the official driver and runtime. The
+backend can connect, retest, restore after restart, and remove these accounts.
+Desktop and chat add/import commands remain Steps 6–7; this backend entry point is
+not yet a user-facing setup flow.
+
+Each custom account gets its own full connection namespace and permission resource,
+including when two accounts have the same endpoint or display name. Custom servers
+remain untrusted: tool hints cannot grant read authority, and imported host/tool
+trust overrides are rejected. Existing curated accounts keep their runtime names
+and pinned snapshots. No-auth accounts do not require a credential blob; custom
+token/header/OAuth strategies are rejected until Step 4 implements them.
+
+The private-network choice is an explicit boolean persisted in the immutable
+definition's existing configuration JSON; it needs no additional schema migration.
+It applies only to the selected origin, including its scheme and port. Redirects
+and discovered authorization destinations do not inherit private access merely
+because the starting endpoint has it. Direct requests connect to a validated IP
+while preserving the original HTTP host and TLS identity. Existing system-proxy
+routes retain per-request URL checks; the configured proxy controls destination
+DNS resolution on those routes.
+
+Discovery follows pagination with bounded page/tool counts. Duplicate identities,
+malformed inventories, and incomplete pagination fail discovery rather than
+publishing a partial inventory. Each server attaches independently, so one failed
+server does not prevent unrelated connections from attaching. Initialization,
+discovery, cancellation, and runtime reconnects use the shared SDK/engine path.
+
+Deterministic fake-server and transport tests establish backend behavior. They do
+not establish real-provider authentication, installer acceptance, or universal MCP
+compatibility. Steps 4–8 remain the next delivery sequence.


### PR DESCRIPTION
An unknown remote MCP server can now connect through the existing backend lifecycle without adding a catalogue entry. This PR is stacked on #173 and should be reviewed against that foundation branch.

- Support custom no-auth Streamable HTTP and explicit legacy SSE: connect, complete paginated discovery, retest, restart, runtime tool calls, and removal.
- Keep accounts in separate namespaces and permission resources. Custom tool hints remain untrusted; existing curated snapshots and protected credentials are preserved. Retesting retains approval preferences, and late probes cannot restore removed accounts.
- Check initial URLs, redirects, OAuth metadata requests, and browser authorization URLs. Private access requires an explicit choice scoped to the selected origin. Direct requests use validated IPs with original Host/TLS identity and separate origin pools; proxy routes retain request checks with proxy-controlled DNS.
- Reject malformed inventories, pagination loops, and normalized tool-name collisions. Update the canonical specification and repository snapshot.

Validation: 320 affected tests passed on Windows/Python 3.12. Coverage includes real MCP SDK HTTP/SSE negotiation, pagination and tool calls over deterministic HTTP transports; account isolation, endpoint boundaries, successive event loops, reconnect/retry, storage, settings, IPC and Phase 3 end-to-end checks. Focused Ruff, whitespace and generated snapshot checks pass. Two existing pytest-timeout configuration warnings remain. Sol implemented the transport/driver, Luna added boundary/runtime tests, and Astra reviewed the combined changes; all findings were fixed and verified.

Backend delivery only: custom token/header/OAuth strategies are Step 4; desktop/chat add-import flows remain Steps 6–7. No new real-provider or packaged acceptance is claimed.
