### PR TITLE
Add gated Collie AI managed inference alongside BYOK

### DIFF
--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1055,7 +1055,38 @@ class CollieIPCServer:
             self._apply_provider_settings(self.db.get_provider(provider_id))
         return {"provider": self.db.get_provider(provider_id)}
 
+    async def _cmd_activate_managed_provider(
+        self, connection: ServerConnection, frame: dict
+    ) -> dict:
+        from collie_core.providers.managed import MODEL, managed_transport
+
+        managed_transport()
+        if any(not task.done() for task in self._chat_tasks.values()):
+            raise ValueError("Finish or stop the current task before switching providers.")
+        if self._on_configure is None:
+            raise ValueError("Provider configuration is not available.")
+        previous = self.db.default_provider()
+        created = self.db.get_provider("collie-managed") is None
+        if created:
+            self.db.upsert_provider(
+                "collie-managed", name="Collie AI", auth_type="collie-managed",
+                model=MODEL, runtime_name="custom", protocol="openai",
+                api_base=None, secret_name="collie-managed", is_default=False,
+            )
+        result = await self._cmd_activate_provider(
+            connection, {"provider_id": "collie-managed"}
+        )
+        if not result.get("configured") and created:
+            self.db.delete_provider("collie-managed")
+            self._apply_provider_settings(previous)
+            if previous:
+                self.db.set_default_provider(str(previous["id"]))
+            await self._on_configure()
+        return result
+
     async def _cmd_activate_provider(self, connection: ServerConnection, frame: dict) -> dict:
+        if any(not task.done() for task in self._chat_tasks.values()):
+            raise ValueError("Finish or stop the current task before switching providers.")
         provider_id = str(frame.get("provider_id") or "").strip()
         provider = self.db.get_provider(provider_id)
         if provider is None:

--- a/collie-core/collie_core/ipc/server.py
+++ b/collie-core/collie_core/ipc/server.py
@@ -1069,13 +1069,17 @@ class CollieIPCServer:
         created = self.db.get_provider("collie-managed") is None
         if created:
             self.db.upsert_provider(
-                "collie-managed", name="Collie AI", auth_type="collie-managed",
-                model=MODEL, runtime_name="custom", protocol="openai",
-                api_base=None, secret_name="collie-managed", is_default=False,
+                "collie-managed",
+                name="Collie AI",
+                auth_type="collie-managed",
+                model=MODEL,
+                runtime_name="custom",
+                protocol="openai",
+                api_base=None,
+                secret_name="collie-managed",
+                is_default=False,
             )
-        result = await self._cmd_activate_provider(
-            connection, {"provider_id": "collie-managed"}
-        )
+        result = await self._cmd_activate_provider(connection, {"provider_id": "collie-managed"})
         if not result.get("configured") and created:
             self.db.delete_provider("collie-managed")
             self._apply_provider_settings(previous)

--- a/collie-core/collie_core/providers/managed.py
+++ b/collie-core/collie_core/providers/managed.py
@@ -1,0 +1,46 @@
+"""Collie account inference through the authenticated Electron transport.
+
+The bridge resolves a fresh account session on each call. The core never
+receives a Supabase refresh token or a supplier credential.
+"""
+from __future__ import annotations
+
+import os
+
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+MODEL = "collie-auto"
+
+
+def managed_transport() -> tuple[str, str]:
+    try:
+        port = int(os.environ.get("COLLIE_KEYCHAIN_PORT", "0"))
+    except ValueError:
+        port = 0
+    token = os.environ.get("COLLIE_KEYCHAIN_TOKEN", "")
+    if not 1 <= port <= 65535 or not token:
+        raise ValueError("Collie AI needs the desktop app. Please restart Collie.")
+    return f"http://127.0.0.1:{port}/inference/v1", token
+
+
+class ManagedProvider(OpenAICompatProvider):
+    """Fixed hosted model; never retry uncertain attempts automatically."""
+
+    def _build_kwargs(self, messages, tools, model, max_tokens, temperature,
+                      reasoning_effort, tool_choice):
+        return super()._build_kwargs(messages, tools, MODEL, min(max_tokens, 1024),
+                                     temperature, None, tool_choice)
+
+    def _should_use_responses_api(self, model, reasoning_effort):
+        return False
+
+    @staticmethod
+    def _handle_error(e, *, spec=None, api_base=None):
+        response = OpenAICompatProvider._handle_error(e, spec=spec, api_base=api_base)
+        response.error_should_retry = False
+        return response
+
+
+def managed_provider() -> ManagedProvider:
+    base, token = managed_transport()
+    return ManagedProvider(api_key=token, api_base=base, default_model=MODEL)

--- a/collie-core/collie_core/providers/managed.py
+++ b/collie-core/collie_core/providers/managed.py
@@ -3,6 +3,7 @@
 The bridge resolves a fresh account session on each call. The core never
 receives a Supabase refresh token or a supplier credential.
 """
+
 from __future__ import annotations
 
 import os
@@ -26,10 +27,12 @@ def managed_transport() -> tuple[str, str]:
 class ManagedProvider(OpenAICompatProvider):
     """Fixed hosted model; never retry uncertain attempts automatically."""
 
-    def _build_kwargs(self, messages, tools, model, max_tokens, temperature,
-                      reasoning_effort, tool_choice):
-        return super()._build_kwargs(messages, tools, MODEL, min(max_tokens, 1024),
-                                     temperature, None, tool_choice)
+    def _build_kwargs(
+        self, messages, tools, model, max_tokens, temperature, reasoning_effort, tool_choice
+    ):
+        return super()._build_kwargs(
+            messages, tools, MODEL, min(max_tokens, 1024), temperature, None, tool_choice
+        )
 
     def _should_use_responses_api(self, model, reasoning_effort):
         return False

--- a/collie-core/collie_core/runtime.py
+++ b/collie-core/collie_core/runtime.py
@@ -473,8 +473,12 @@ class CollieRuntime:
         return True
 
     def _provider_override(self) -> Any | None:
-        """Build an OAuth-backed provider when the user signed in that way."""
+        """Resolve account-backed providers without personal API credentials."""
         auth_type = str(self.db.get_setting("provider.auth", "") or "").lower()
+        if auth_type == "collie-managed":
+            from collie_core.providers.managed import managed_provider
+
+            return managed_provider()
         if auth_type == "claude-oauth":
             from collie_core.providers.claude_oauth import ClaudeOAuthProvider
 
@@ -1533,7 +1537,7 @@ class CollieRuntime:
             # up a provider. OAuth tokens live on disk, so those can configure
             # immediately; API keys arrive from the shell over IPC first.
             auth = str(self.db.get_setting("provider.auth", "") or "")
-            if auth in ("chatgpt-oauth", "claude-oauth"):
+            if auth in ("chatgpt-oauth", "claude-oauth", "collie-managed"):
                 await self._configure()
             else:
                 logger.info("Waiting for the shell to deliver credentials")

--- a/collie-core/collie_core/settings.py
+++ b/collie-core/collie_core/settings.py
@@ -156,6 +156,12 @@ def build_config(db: CollieDB, *, mcp_servers: dict[str, Any] | None = None) -> 
     api_base = settings.get("provider.api_base") or None
 
     provider_section: dict[str, Any] = {"apiKey": _api_key_for(secret_name)}
+    if settings.get("provider.auth") == "collie-managed":
+        # No personal key/base/model may leak into managed inference or tools.
+        from collie_core.providers.managed import MODEL
+
+        provider_name, model, api_base = "custom", MODEL, None
+        provider_section = {"apiKey": None}
     if api_base:
         provider_section["apiBase"] = api_base
 

--- a/collie-core/tests/collie/test_managed_provider.py
+++ b/collie-core/tests/collie/test_managed_provider.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+import pytest
+
+from collie_core.db import CollieDB
+from collie_core.ipc.server import CollieIPCServer
+from collie_core.providers.managed import MODEL, managed_provider, managed_transport
+
+
+def test_transport_requires_desktop_credentials(monkeypatch):
+    monkeypatch.delenv("COLLIE_KEYCHAIN_TOKEN", raising=False)
+    monkeypatch.setenv("COLLIE_KEYCHAIN_PORT", "999999")
+    with pytest.raises(ValueError, match="desktop app"):
+        managed_transport()
+
+
+async def test_fixed_model_output_cap_and_no_retries(monkeypatch):
+    monkeypatch.setenv("COLLIE_KEYCHAIN_PORT", "12345")
+    monkeypatch.setenv("COLLIE_KEYCHAIN_TOKEN", "test-bridge-token")
+    provider = managed_provider()
+    kwargs = provider._build_kwargs(
+        [{"role": "user", "content": "Hello"}], None, "expensive-model",
+        4096, 0.7, "high", None,
+    )
+    assert kwargs["model"] == MODEL
+    assert kwargs.get("max_tokens", kwargs.get("max_completion_tokens")) == 1024
+    assert not provider._should_use_responses_api("gpt-5", "high")
+    assert provider._handle_error(TimeoutError()).error_should_retry is False
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as client:
+        await provider._ensure_client()
+    assert client.call_args.kwargs["max_retries"] == 0
+    assert client.call_args.kwargs["api_key"] == "test-bridge-token"
+    assert client.call_args.kwargs["base_url"] == "http://127.0.0.1:12345/inference/v1"
+
+
+@pytest.mark.parametrize("success", [True, False])
+async def test_activation_preserves_personal_provider_and_rolls_back(tmp_path, monkeypatch, success):
+    monkeypatch.setenv("COLLIE_KEYCHAIN_PORT", "12345")
+    monkeypatch.setenv("COLLIE_KEYCHAIN_TOKEN", "test-bridge-token")
+    db = CollieDB(tmp_path / "collie.db")
+    db.upsert_provider("personal", name="openai", auth_type="api-key",
+                       model="personal-model", is_default=True)
+    async def configure():
+        return {"configured": success}
+    server = CollieIPCServer(db, on_configure=configure)
+    try:
+        result = await server._cmd_activate_managed_provider(None, {})
+        assert result["configured"] is success
+        assert db.get_provider("personal")["model"] == "personal-model"
+        assert db.default_provider()["id"] == ("collie-managed" if success else "personal")
+        if success:
+            assert db.get_setting("provider.auth") == "collie-managed"
+            # Re-activation cannot unset the existing default while upserting.
+            await server._cmd_activate_managed_provider(None, {})
+            assert db.default_provider()["id"] == "collie-managed"
+        else:
+            assert db.get_provider("collie-managed") is None
+    finally:
+        db.close()
+
+
+async def test_failed_first_activation_leaves_no_managed_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("COLLIE_KEYCHAIN_PORT", "12345")
+    monkeypatch.setenv("COLLIE_KEYCHAIN_TOKEN", "test-bridge-token")
+    db = CollieDB(tmp_path / "collie.db")
+    async def configure():
+        return {"configured": False}
+    server = CollieIPCServer(db, on_configure=configure)
+    try:
+        await server._cmd_activate_managed_provider(None, {})
+        assert db.default_provider() is None
+        assert not db.get_setting("provider.auth")
+    finally:
+        db.close()

--- a/collie-core/tests/collie/test_managed_provider.py
+++ b/collie-core/tests/collie/test_managed_provider.py
@@ -19,8 +19,13 @@ async def test_fixed_model_output_cap_and_no_retries(monkeypatch):
     monkeypatch.setenv("COLLIE_KEYCHAIN_TOKEN", "test-bridge-token")
     provider = managed_provider()
     kwargs = provider._build_kwargs(
-        [{"role": "user", "content": "Hello"}], None, "expensive-model",
-        4096, 0.7, "high", None,
+        [{"role": "user", "content": "Hello"}],
+        None,
+        "expensive-model",
+        4096,
+        0.7,
+        "high",
+        None,
     )
     assert kwargs["model"] == MODEL
     assert kwargs.get("max_tokens", kwargs.get("max_completion_tokens")) == 1024
@@ -34,14 +39,19 @@ async def test_fixed_model_output_cap_and_no_retries(monkeypatch):
 
 
 @pytest.mark.parametrize("success", [True, False])
-async def test_activation_preserves_personal_provider_and_rolls_back(tmp_path, monkeypatch, success):
+async def test_activation_preserves_personal_provider_and_rolls_back(
+    tmp_path, monkeypatch, success
+):
     monkeypatch.setenv("COLLIE_KEYCHAIN_PORT", "12345")
     monkeypatch.setenv("COLLIE_KEYCHAIN_TOKEN", "test-bridge-token")
     db = CollieDB(tmp_path / "collie.db")
-    db.upsert_provider("personal", name="openai", auth_type="api-key",
-                       model="personal-model", is_default=True)
+    db.upsert_provider(
+        "personal", name="openai", auth_type="api-key", model="personal-model", is_default=True
+    )
+
     async def configure():
         return {"configured": success}
+
     server = CollieIPCServer(db, on_configure=configure)
     try:
         result = await server._cmd_activate_managed_provider(None, {})
@@ -63,8 +73,10 @@ async def test_failed_first_activation_leaves_no_managed_default(tmp_path, monke
     monkeypatch.setenv("COLLIE_KEYCHAIN_PORT", "12345")
     monkeypatch.setenv("COLLIE_KEYCHAIN_TOKEN", "test-bridge-token")
     db = CollieDB(tmp_path / "collie.db")
+
     async def configure():
         return {"configured": False}
+
     server = CollieIPCServer(db, on_configure=configure)
     try:
         await server._cmd_activate_managed_provider(None, {})

--- a/collie-core/tests/collie/test_settings.py
+++ b/collie-core/tests/collie/test_settings.py
@@ -37,6 +37,17 @@ def test_build_config_defaults(db: CollieDB) -> None:
     assert str(collie_settings.workspace_path()) in config.agents.defaults.workspace
 
 
+def test_managed_config_does_not_inherit_personal_credentials(db: CollieDB) -> None:
+    db.set_setting("provider.auth", "collie-managed")
+    db.set_setting("provider.name", "custom")
+    db.set_setting("provider.api_base", "https://personal.example/v1")
+    collie_settings.set_api_key("custom", "personal-test-key")
+    config = collie_settings.build_config(db)
+    assert config.agents.defaults.model == "collie-auto"
+    assert not config.providers.custom.api_key
+    assert not config.providers.custom.api_base
+
+
 def test_build_config_from_settings(db: CollieDB) -> None:
     db.set_setting("provider.name", "openrouter")
     db.set_setting("provider.model", "anthropic/claude-sonnet-5")

--- a/collie-ui/electron.vite.config.ts
+++ b/collie-ui/electron.vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     // to ship in clients. release.yml sets them on the build step; without
     // them the packaged app reports "sign-in is not configured".
     define: {
+      'process.env.COLLIE_INFERENCE_URL': JSON.stringify(process.env.COLLIE_INFERENCE_URL ?? ''),
       'process.env.COLLIE_SUPABASE_URL': JSON.stringify(
         process.env.COLLIE_SUPABASE_URL ?? ''
       ),

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -33,6 +33,8 @@ import {
 } from './core-client'
 import { startKeychainServer, stopKeychainServer } from './keychain-server'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
+import { managedStatus } from './managed-inference'
+import { commandWithCore as managedCoreCommand } from './core-client'
 import { submitFeedback } from './feedback'
 import {
   enableSync,
@@ -391,6 +393,12 @@ function registerIpc(): void {
   handle('account:start-sign-in', () => startAccountSignIn())
   handle('collie:submit-feedback', (submission: unknown) => submitFeedback(submission))
   handle('account:get-state', () => getAccountState())
+  handle('account:inference-status', () => managedStatus())
+  handle('account:use-inference', async () => {
+    const status = await managedStatus()
+    if (!status.available) return { configured: false, error: status.message }
+    return managedCoreCommand('activate_managed_provider', {})
+  })
   handle('account:sign-out', () => signOut())
   // Account cloud sync (account-cloud-sync.md): per-device snapshots,
   // opt-in. Payloads never include secrets; RLS scopes every REST call.

--- a/collie-ui/src/main/index.ts
+++ b/collie-ui/src/main/index.ts
@@ -34,7 +34,6 @@ import {
 import { startKeychainServer, stopKeychainServer } from './keychain-server'
 import { getAccountState, signOut, startAccountSignIn } from './account-auth'
 import { managedStatus } from './managed-inference'
-import { commandWithCore as managedCoreCommand } from './core-client'
 import { submitFeedback } from './feedback'
 import {
   enableSync,
@@ -397,7 +396,7 @@ function registerIpc(): void {
   handle('account:use-inference', async () => {
     const status = await managedStatus()
     if (!status.available) return { configured: false, error: status.message }
-    return managedCoreCommand('activate_managed_provider', {})
+    return commandWithCore('activate_managed_provider', {})
   })
   handle('account:sign-out', () => signOut())
   // Account cloud sync (account-cloud-sync.md): per-device snapshots,

--- a/collie-ui/src/main/keychain-server.test.ts
+++ b/collie-ui/src/main/keychain-server.test.ts
@@ -86,6 +86,8 @@ describe('main-process keychain bridge', () => {
     const { port, token } = (await startKeychainServer())!
     const noAuth = await call(port, 'wrong-token', '/encrypt', { data: 'AA==' })
     expect(noAuth.status).toBe(401)
+    const noInferenceAuth = await call(port, 'wrong-token', '/inference/v1/chat/completions', { data: 'AA==' })
+    expect(noInferenceAuth.status).toBe(401)
     const badPath = await call(port, token, '/nope', { data: 'AA==' })
     expect(badPath.status).toBe(404)
   })

--- a/collie-ui/src/main/keychain-server.ts
+++ b/collie-ui/src/main/keychain-server.ts
@@ -28,6 +28,7 @@ import { safeStorage } from 'electron'
 import { createServer, IncomingMessage, ServerResponse } from 'http'
 import { randomBytes } from 'crypto'
 import { secureStorageAvailable } from './secrets'
+import { forwardManagedInference } from './managed-inference'
 
 export interface KeychainAddress {
   port: number
@@ -61,12 +62,17 @@ export async function startKeychainServer(): Promise<KeychainAddress | null> {
   }
   token = randomBytes(32).toString('hex')
   const serverInstance = createServer((req: IncomingMessage, res: ServerResponse) => {
-    if (req.method !== 'POST' || (req.url !== '/encrypt' && req.url !== '/decrypt')) {
+    const inference = req.url === '/inference/v1/chat/completions'
+    if (req.method !== 'POST' || (!inference && req.url !== '/encrypt' && req.url !== '/decrypt')) {
       writeJson(res, 404, { error: 'not found' })
       return
     }
     if (req.headers.authorization !== `Bearer ${token}`) {
       writeJson(res, 401, { error: 'unauthorized' })
+      return
+    }
+    if (inference) {
+      void forwardManagedInference(req, res)
       return
     }
     let body = ''

--- a/collie-ui/src/main/managed-inference.test.ts
+++ b/collie-ui/src/main/managed-inference.test.ts
@@ -1,0 +1,68 @@
+import { createServer, type Server } from 'http'
+import { afterEach, expect, it, vi } from 'vitest'
+const state = vi.hoisted(() => {
+  process.env.COLLIE_INFERENCE_URL = 'https://collie.test'
+  return { signedIn: true }
+})
+vi.mock('./account-auth', () => ({
+  getAccountState: async () => ({ signedIn: state.signedIn }),
+  getStoredSession: () => state.signedIn ? { access_token: 'account-test-token' } : null
+}))
+import { forwardManagedInference, managedStatus } from './managed-inference'
+const realFetch = globalThis.fetch
+let server: Server | undefined
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  state.signedIn = true
+  if (server) {
+    server.closeAllConnections()
+    await new Promise<void>(resolve => server!.close(() => resolve()))
+    server = undefined
+  }
+})
+async function bridge(body: string): Promise<Response> {
+  server = createServer((req,res) => { void forwardManagedInference(req,res) })
+  await new Promise<void>(resolve => server!.listen(0,'127.0.0.1',resolve))
+  const address = server.address() as { port: number }
+  return realFetch('http://127.0.0.1:'+address.port,{
+    method:'POST', headers:{Authorization:'Bearer local-test-token'},body
+  })
+}
+it('reads allowance with account token, without making an inference request',async()=>{
+  const fetcher=vi.fn(async()=>new Response(JSON.stringify({available:true,remaining:10,limit:20})))
+  vi.stubGlobal('fetch',fetcher)
+  expect(await managedStatus()).toMatchObject({available:true,signedIn:true,remaining:10})
+  expect(fetcher).toHaveBeenCalledWith('https://collie.test/v1/me/entitlements', expect.any(Object))
+})
+it('signed-out users cannot forward inference',async()=>{
+  state.signedIn=false
+  const fetcher=vi.fn()
+  vi.stubGlobal('fetch',fetcher)
+  expect((await bridge('{}')).status).toBe(401)
+  expect(fetcher).not.toHaveBeenCalled()
+})
+it('streaming replaces loopback auth and creates an idempotency key',async()=>{
+  const fetcher=vi.fn(async()=>new Response('data: [DONE]\n\n'))
+  vi.stubGlobal('fetch',fetcher)
+  expect(await (await bridge('{"model":"collie-auto"}')).text()).toContain('[DONE]')
+  const [url,options]=fetcher.mock.calls[0] as unknown as [string,RequestInit]
+  expect(url).toBe('https://collie.test/v1/chat/completions')
+  expect(options.headers).toMatchObject({Authorization:'Bearer account-test-token'})
+  expect(new Headers(options.headers).get('Idempotency-Key')).toMatch(/^[a-f0-9-]{36}$/)
+  expect(options.redirect).toBe('error')
+  expect(fetcher).toHaveBeenCalledTimes(1)
+})
+it('oversized bodies cannot reach the hosted endpoint',async()=>{
+  const fetcher=vi.fn()
+  vi.stubGlobal('fetch',fetcher)
+  expect((await bridge('x'.repeat(129*1024))).status).toBe(413)
+  expect(fetcher).not.toHaveBeenCalled()
+})
+it('network failure is sanitized and never retried',async()=>{
+  const fetcher=vi.fn(async()=>{throw new Error('private diagnostics')})
+  vi.stubGlobal('fetch',fetcher)
+  const res=await bridge('{}')
+  expect(res.status).toBe(503)
+  expect(await res.text()).not.toContain('private')
+  expect(fetcher).toHaveBeenCalledTimes(1)
+})

--- a/collie-ui/src/main/managed-inference.ts
+++ b/collie-ui/src/main/managed-inference.ts
@@ -1,0 +1,105 @@
+/** Collie-funded inference. Account credentials never cross into the renderer/core. */
+import type { IncomingMessage, ServerResponse } from 'http'
+import { once } from 'events'
+import { randomUUID } from 'crypto'
+import { getAccountState, getStoredSession } from './account-auth'
+
+const endpoint = (process.env.COLLIE_INFERENCE_URL ?? '').trim()
+const MAX_BODY = 128 * 1024
+
+export interface ManagedStatus {
+  configured: boolean
+  available: boolean
+  signedIn: boolean
+  remaining: number
+  limit: number
+  resetsAt: string | null
+  message: string
+}
+
+function baseUrl(): string {
+  if (!endpoint) throw new Error('Collie AI is not available in this build yet.')
+  const url = new URL(endpoint)
+  if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) {
+    throw new Error('Collie AI is not configured correctly.')
+  }
+  return url.toString().replace(/\/$/, '')
+}
+
+async function accessToken(): Promise<string> {
+  const state = await getAccountState()
+  const session = getStoredSession()
+  if (!state.signedIn || !session?.access_token) throw new Error('Sign in to Collie to use Collie AI.')
+  return session.access_token
+}
+
+export async function managedStatus(): Promise<ManagedStatus> {
+  const empty: ManagedStatus = { configured: Boolean(endpoint), available: false, signedIn: false, remaining: 0,
+    limit: 0, resetsAt: null, message: 'Collie AI is not available in this build yet.' }
+  if (!endpoint) return empty
+  try {
+    const token = await accessToken()
+    const response = await fetch(baseUrl() + '/v1/me/entitlements', {
+      headers: { Authorization: 'Bearer ' + token },
+      redirect: 'error', signal: AbortSignal.timeout(10_000)
+    })
+    if (!response.ok) return { ...empty, signedIn: true, message: 'Collie AI is unavailable. Your own providers still work.' }
+    const data = await response.json() as Record<string, unknown>
+    if (typeof data.remaining !== 'number' || typeof data.limit !== 'number' ||
+        !Number.isFinite(data.remaining) || !Number.isFinite(data.limit)) throw new Error('Invalid allowance')
+    return { configured: true, available: data.available === true, signedIn: true,
+      remaining: Math.max(0, data.remaining), limit: Math.max(0, data.limit),
+      resetsAt: typeof data.resetsAt === 'string' ? data.resetsAt : null,
+      message: data.available === true ? 'AI included with your Collie account.' : 'Your included allowance is unavailable.' }
+  } catch {
+    return { ...empty, message: 'Sign in to Collie, then refresh your included allowance.' }
+  }
+}
+
+function error(res: ServerResponse, status: number, code: string, message: string): void {
+  if (res.headersSent) { res.destroy(); return }
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+  res.end(JSON.stringify({ error: { code, message } }))
+}
+
+/** Called only AFTER the keychain bridge authenticates its per-boot bearer token. */
+export async function forwardManagedInference(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 120_000)
+  res.on('close', () => controller.abort())
+  try {
+    const chunks: Buffer[] = []
+    let size = 0
+    for await (const chunk of req) {
+      const bytes = Buffer.from(chunk)
+      size += bytes.length
+      if (size > MAX_BODY) { error(res, 413, 'request_too_large', 'This request is too large.'); return }
+      chunks.push(bytes)
+    }
+    let token: string
+    try { token = await accessToken() } catch {
+      error(res, 401, 'auth_required', 'Sign in to Collie to use Collie AI.'); return
+    }
+    const response = await fetch(baseUrl() + '/v1/chat/completions', {
+      method: 'POST', headers: { Authorization: 'Bearer ' + token,
+        'Content-Type': 'application/json', 'Idempotency-Key': randomUUID() },
+      body: Buffer.concat(chunks).toString('utf8'), redirect: 'error', signal: controller.signal
+    })
+    res.writeHead(response.status, {
+      'Content-Type': response.headers.get('content-type') ?? 'application/json',
+      'Cache-Control': 'no-store'
+    })
+    if (!response.body) { res.end(); return }
+    const reader = response.body.getReader()
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        if (!res.write(Buffer.from(value))) await once(res, 'drain', { signal: controller.signal })
+      }
+      res.end()
+    } finally { await reader.cancel().catch(() => undefined) }
+  } catch {
+    error(res, 503, 'capacity_unavailable', 'Collie AI is unavailable. Please try again later.')
+  } finally { clearTimeout(timeout) }
+}

--- a/collie-ui/src/preload/index.ts
+++ b/collie-ui/src/preload/index.ts
@@ -148,6 +148,10 @@ const api = {
 }
 
 const accountApi = {
+  inferenceStatus: (): Promise<{ configured: boolean; available: boolean; signedIn: boolean; remaining: number; limit: number; resetsAt: string | null; message: string }> =>
+    ipcRenderer.invoke('account:inference-status'),
+  useInference: (): Promise<{ configured: boolean; error?: string }> =>
+    ipcRenderer.invoke('account:use-inference'),
   startSignIn: (): Promise<AccountState> => ipcRenderer.invoke('account:start-sign-in'),
   getState: (): Promise<AccountState> => ipcRenderer.invoke('account:get-state'),
   signOut: (): Promise<AccountState> => ipcRenderer.invoke('account:sign-out'),

--- a/collie-ui/src/renderer/src/components/ManagedInferenceCard.test.tsx
+++ b/collie-ui/src/renderer/src/components/ManagedInferenceCard.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, expect, it, vi } from 'vitest'
+import ManagedInferenceCard from './ManagedInferenceCard'
+let root: Root
+let host: HTMLDivElement
+const status={configured:true,available:true,signedIn:true,remaining:10,limit:20,resetsAt:null,message:'Included AI'}
+async function render(value= status) {
+  Object.assign(globalThis,{IS_REACT_ACT_ENVIRONMENT:true})
+  const api={inferenceStatus:vi.fn(async()=>value),useInference:vi.fn(async()=>({configured:true})),startSignIn:vi.fn()}
+  Object.defineProperty(window,'account',{value:api,configurable:true})
+  host=document.createElement('div')
+  document.body.append(host)
+  root=createRoot(host)
+  const activated=vi.fn()
+  await act(async()=>{root.render(<ManagedInferenceCard onActivated={activated}/>)})
+  return {api,activated}
+}
+afterEach(async()=>{await act(async()=>root.unmount());host.remove()})
+it('disabled builds cannot start sign-in or activate inference',async()=>{
+  const {api}=await render({...status,configured:false,available:false,signedIn:false})
+  const button=host.querySelector('button')!
+  expect(button.disabled).toBe(true)
+  expect(api.startSignIn).not.toHaveBeenCalled()
+  expect(api.useInference).not.toHaveBeenCalled()
+})
+it('shows the allowance and activates the managed route',async()=>{
+  const {api,activated}=await render()
+  expect(host.textContent).toContain('10 / 20 allowance units remaining')
+  await act(async()=>host.querySelector('button')!.click())
+  expect(api.useInference).toHaveBeenCalledOnce()
+  expect(activated).toHaveBeenCalledOnce()
+  expect(api.startSignIn).not.toHaveBeenCalled()
+})
+it('exhausted allowances cannot activate a fallback',async()=>{
+  const {api}=await render({...status,available:false,remaining:0})
+  expect(host.querySelector('button')!.disabled).toBe(true)
+  expect(api.useInference).not.toHaveBeenCalled()
+})

--- a/collie-ui/src/renderer/src/components/ManagedInferenceCard.tsx
+++ b/collie-ui/src/renderer/src/components/ManagedInferenceCard.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+
+type Status = Awaited<ReturnType<NonNullable<Window['account']>['inferenceStatus']>>
+
+export default function ManagedInferenceCard({ onActivated }: {
+  onActivated: () => void | Promise<void>
+}): React.JSX.Element {
+  const [status, setStatus] = useState<Status | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [notice, setNotice] = useState('')
+  const refresh = async (): Promise<void> => {
+    try { setStatus(await window.account.inferenceStatus()) }
+    catch { setNotice('Collie AI is unavailable. Your own providers still work.') }
+  }
+  useEffect(() => { void refresh() }, [])
+  const connect = async (): Promise<void> => {
+    setBusy(true)
+    setNotice('')
+    try {
+      if (!status?.signedIn) await window.account.startSignIn()
+      const next = await window.account.inferenceStatus()
+      setStatus(next)
+      if (!next.available) return
+      const result = await window.account.useInference()
+      if (!result.configured) throw new Error(result.error || 'Collie AI could not connect.')
+      await onActivated()
+    } catch (e) { setNotice(e instanceof Error ? e.message : 'Please try again.') }
+    finally { setBusy(false) }
+  }
+  return (
+    <section className="settings-card" aria-label="Collie AI">
+      <h3>Collie AI</h3>
+      <p>{status?.message ?? 'Checking included AI availability…'}</p>
+      {status?.signedIn && status.limit > 0 && (
+        <p>{status.remaining.toLocaleString()} / {status.limit.toLocaleString()} allowance units remaining
+          {status.resetsAt ? ' · Resets ' + new Date(status.resetsAt).toLocaleDateString() : ''}</p>
+      )}
+      <p className="text-sm">Your own provider connections stay saved. Collie AI never switches to a paid provider automatically.</p>
+      <div className="flex gap-2">
+        <button type="button" className="secondary-button" disabled={busy || !status?.configured ||
+          (status.signedIn && !status.available)} onClick={() => void connect()}>
+          {busy ? 'Connecting…' : status?.signedIn ? 'Use Collie AI' : 'Sign in to Collie'}
+        </button>
+        <button type="button" className="secondary-button" disabled={busy} onClick={() => void refresh()}>Refresh allowance</button>
+      </div>
+      {notice && <p role="status">{notice}</p>}
+    </section>
+  )
+}

--- a/collie-ui/src/renderer/src/components/settings/ProviderManager.tsx
+++ b/collie-ui/src/renderer/src/components/settings/ProviderManager.tsx
@@ -12,6 +12,7 @@ import {
   configureProvider
 } from '../../lib/providerConfiguration'
 import BrandLogo from '../BrandLogo'
+import ManagedInferenceCard from '../ManagedInferenceCard'
 
 interface Props {
   status: RuntimeStatus
@@ -303,6 +304,7 @@ export default function ProviderManager({
 
   return (
     <section className="settings-card provider-manager">
+      <ManagedInferenceCard onActivated={onRefresh} />
       <div className="provider-heading">
         <div>
           <h3>Models & providers</h3>

--- a/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
+++ b/collie-ui/src/renderer/src/screens/WelcomeScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from '../lib/providerConfiguration'
 import BrandLogo from '../components/BrandLogo'
 import CollieFace from '../components/CollieFace'
+import ManagedInferenceCard from '../components/ManagedInferenceCard'
 
 const HELP_URL = 'https://heycollie.com/get-started'
 const CUSTOM_PROVIDER_ID = 'custom'
@@ -425,6 +426,7 @@ export default function WelcomeScreen({ onDone, onCancel }: Props): React.JSX.El
           </p>
         </div>
 
+        <ManagedInferenceCard onActivated={onDone} />
         <button
           onClick={() => void signInOAuth('chatgpt')}
           disabled={busyOAuth !== null || busyKey || busyLocal}

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -129,6 +129,17 @@ ends).
 Full local-file access remains session-only and does not grant connector,
 network, or external-write authority.
 
+### Managed inference pilot
+
+`tools/inference/` owns the disabled-by-default hosted Collie AI worker,
+separate backend allowance schema, and offline verification. Electron's
+`src/main/managed-inference.ts` forwards core requests through the authenticated
+keychain bridge using a Collie account session; supplier credentials remain
+server-only. The core's `providers/managed.py` adds a fixed hosted provider
+alongside saved BYOK records. See
+[managed inference](product/features/managed-inference.md) for the zero-cost
+deployment gate and current context/capacity limits.
+
 ## Documentation ownership
 
 - `docs/VISION.md`: durable product intent.

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -11,11 +11,11 @@
 
 ## Source inventory
 
-- Core Python files: **528**
-- Core Python test files: **243**
-- Desktop TypeScript/TSX files: **190**
-- Desktop test files: **70**
-- Active Markdown docs: **36**
+- Core Python files: **530**
+- Core Python test files: **244**
+- Desktop TypeScript/TSX files: **194**
+- Desktop test files: **72**
+- Active Markdown docs: **37**
 - Archived Markdown docs: **0**
 
 ## Collie-owned core module groups

--- a/docs/product/features/managed-inference.md
+++ b/docs/product/features/managed-inference.md
@@ -1,0 +1,126 @@
+# Collie AI managed inference
+
+Status: implemented, disabled by default; deployment and supplier onboarding are
+not completed. This is a bounded text pilot alongside existing BYOK connections.
+
+## Customer experience
+
+Welcome and Settings offer **Collie AI**. When an endpoint is configured, the
+customer signs in with their Collie account and can select included inference
+without supplying a model-provider API key. Their existing providers remain
+saved and can be selected explicitly. A build without an endpoint disables
+activation. Sign-out, exhausted allowance, capacity errors, and unsupported
+requests stop the hosted request; they never select a personal or paid provider.
+
+The card displays remaining reservation units. These are conservative capacity
+units, not money or exact model tokens. Grants have explicit expiry, no automatic
+renewal, and no checkout. The schema supports free/plus entitlement labels, but
+does not establish a subscription price or implement billing synchronization.
+An operator must grant pilot access. There is no unlimited-use promise.
+
+## Architecture and ownership
+
+```mermaid
+flowchart LR
+  UI[Renderer: account status and selection] --> Main[Electron main]
+  Core[Core managed provider] -->|Per-boot bridge bearer| Main
+  Main -->|Collie account access token| Worker[Collie hosted endpoint]
+  Worker -->|Verify user and reserve allowance| DB[Supabase]
+  Worker -->|Server-only supplier credential| Supplier[Fixed Groq route]
+```
+
+- `collie-ui/src/main/managed-inference.ts` forwards inference via the existing
+  authenticated loopback keychain bridge. It resolves the account session in
+  Electron main on each request; account tokens never enter renderer/core IPC.
+  The HTTPS endpoint is a build-time `COLLIE_INFERENCE_URL`, not renderer input.
+- `collie-core/collie_core/providers/managed.py` pins `collie-auto`, caps output
+  at 1,024 tokens, uses Chat Completions streaming, and disables automatic error
+  retries. Startup restores this provider without requiring a personal API key.
+  The managed configuration does not inherit personal credentials or base URLs.
+- `tools/inference/worker.mjs` validates the account online, accepts only text
+  messages/function tools, reserves capacity, then streams the fixed supplier
+  endpoint. It strips client upstream/model overrides and sanitizes failures.
+  No arbitrary proxy, provider marketplace, or paid fallback is exposed.
+- `tools/inference/schema.sql` contains a separate, manually applied backend
+  schema. Tables are private and RLS-enabled; only service-role RPCs can read
+  allowances or reserve them. The service key exists only in the hosted worker.
+  Existing local SQLite provider records need no migration.
+
+## Hard stops and accounting
+
+Deployment requires `FREE_TIER_CONFIRMED=true` plus three server secrets:
+`GROQ_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`. The committed
+Wrangler configuration disables this flag and has no deployment route.
+The database pool and individual grants are also disabled by default.
+
+Admission locks the shared pool, checks request-ID uniqueness, and atomically
+reserves both account and pool units before contacting the supplier. The same
+request ID is not re-executed. A failed or disconnected attempt remains spent:
+there is no optimistic refund or blind retry when upstream consumption is
+uncertain. Requests store identity, request ID, units and timestamp, not prompts
+or responses. Supplier/account-platform logging and retention require separate
+verification; absence of application prompt logging is not a zero-retention
+claim.
+
+The initial route is `openai/gpt-oss-20b` on Groq. The pilot permits up to
+6,000 reservation units per minute, 100,000 per UTC day across the whole service,
+and 6,000 per request. Units include serialized UTF-8 message/tool bytes, 2,048
+framing headroom, and the maximum output allowance. This is deliberately
+conservative; it is not a provider-tokenizer or exact billing calculation.
+Fixed minute windows also do not guarantee compliance with a supplier's rolling
+window: a supplier 429 is a hard stop.
+
+**Large agent contexts and tool catalogs will be rejected.** No real supplier
+completion, full default agent workflow, tool quality, or production concurrency
+has been validated. Before general release, benchmark real Collie contexts and
+obtain adequate expressly free capacity or a separately authorized funding
+model. Do not trim permission instructions or tool schemas to evade limits.
+
+## Zero-cost onboarding and deployment gate
+
+Creating a company organization and server credential for embedded customer
+requests is distinct from redistributing a personal API key. No account signup,
+terms acceptance, inference request, schema application, or deployment is
+performed by this PR or its tests.
+
+Before enabling:
+
+1. Establish a Collie-owned supplier organization. Review the current
+   [Groq terms](https://groq.com/terms-of-use/) and
+   [rate limits](https://console.groq.com/docs/rate-limits), and verify that the
+   free organization may serve Collie end users. Obtain written confirmation
+   when the intended commercial use is not explicit.
+2. Verify the chosen model has an ongoing free allocation and hard rejection
+   at its limit. Do not add a card, buy credits, upgrade, enable auto-recharge,
+   accept a minimum commitment, or rely on trial credits to satisfy zero cost.
+   Dedicate the organization to this route or account for all other usage.
+3. Independently verify the hosting and account/database projects have free
+   hard stops. A free model does not make Worker or database infrastructure
+   free. A project already on a paid plan is not acceptable under a zero-cost
+   constraint merely because it has an included allowance.
+4. Only after those checks, provision secrets, apply the schema as a separate
+   change, grant a small expiring allowance, and enable the pool/worker.
+   Point an explicitly configured desktop build at the controlled HTTPS route.
+5. Validate streaming, disconnects, account expiry/revocation, quota saturation,
+   realistic context size, and tool use with confirmed free capacity. Keep
+   general customer rollout disabled until these checks pass.
+
+The confirmation flag is an operator attestation, not a technical guarantee
+about a provider's billing configuration. Local quota code cannot prevent a
+supplier from charging an incorrectly configured account. If any zero-cost
+condition cannot be verified, keep the service disabled.
+
+## Local verification
+
+- Core: managed provider, settings credential isolation, provider configuration,
+  and IPC regression tests under `collie-core/tests/`.
+- Desktop: managed card, main forwarding, authenticated keychain bridge,
+  account auth, and Welcome tests; TypeScript check and production build.
+- Worker: `node --test tools/inference/worker.test.mjs` uses mock network calls.
+- Database: install `@electric-sql/pglite@0.3.14` in an ignored local directory,
+  then run `node tools/inference/schema.test.mjs <path-to-pglite-package>`.
+  This executes PostgreSQL functions and permission checks entirely in memory.
+  It checks competing requests in PGlite's serialized executor; it does not
+  replace hosted multi-connection/load testing.
+
+No test requires a provider key, paid service, or external inference call.

--- a/tools/inference/schema.sql
+++ b/tools/inference/schema.sql
@@ -1,0 +1,92 @@
+-- Deployment schema. Apply only to an approved existing free project; never auto-run.
+-- No automatic user grants, purchases, recurring charges, or paid overage.
+create schema if not exists collie_inference;
+revoke all on schema collie_inference from public, anon, authenticated;
+
+create table collie_inference.allowances (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  plan text not null default 'free' check (plan in ('free','plus')),
+  units bigint not null default 0 check (units >= 0),
+  spent bigint not null default 0 check (spent >= 0 and spent <= units),
+  expires_at timestamptz not null,
+  enabled boolean not null default false
+);
+create table collie_inference.pool (
+  id boolean primary key default true check (id),
+  enabled boolean not null default false,
+  daily_limit bigint not null default 100000 check (daily_limit between 0 and 100000),
+  daily_spent bigint not null default 0,
+  day date not null default (now() at time zone 'UTC')::date,
+  minute_start timestamptz not null default date_trunc('minute',now()),
+  minute_spent bigint not null default 0
+);
+insert into collie_inference.pool(id) values(true);
+create table collie_inference.requests (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  request_id text not null,
+  units bigint not null,
+  created_at timestamptz not null default now(),
+  primary key(user_id,request_id)
+);
+alter table collie_inference.allowances enable row level security;
+alter table collie_inference.pool enable row level security;
+alter table collie_inference.requests enable row level security;
+
+-- Only the backend service role can invoke these functions. No user-supplied JWT
+-- can select another identity or allocate funds via the public Data API.
+create or replace function public.collie_inference_allowance(p_user uuid)
+returns jsonb language sql security definer
+set search_path = pg_catalog, collie_inference
+as $$
+ select coalesce((select jsonb_build_object(
+   'available', a.enabled and a.expires_at > now() and a.spent < a.units and p.enabled
+      and (p.day <> (now() at time zone 'UTC')::date or p.daily_spent < p.daily_limit),
+   'remaining', case when a.enabled and a.expires_at > now() then a.units-a.spent else 0 end,
+   'limit', a.units, 'resetsAt', null, 'expiresAt', a.expires_at, 'plan', a.plan)
+ from collie_inference.allowances a cross join collie_inference.pool p
+ where a.user_id=p_user),
+ '{"available":false,"remaining":0,"limit":0,"resetsAt":null}'::jsonb);
+$$;
+revoke all on function public.collie_inference_allowance(uuid) from public,anon,authenticated;
+grant execute on function public.collie_inference_allowance(uuid) to service_role;
+
+create or replace function public.collie_inference_reserve(
+ p_user uuid,p_request text,p_units bigint)
+returns jsonb language plpgsql security definer
+set search_path = pg_catalog, collie_inference
+as $$
+declare
+ p collie_inference.pool%rowtype;
+ a collie_inference.allowances%rowtype;
+begin
+ if p_user is null or p_units is null or p_request is null or
+    p_units < 1 or p_units > 6000 or p_request !~ '^[a-zA-Z0-9-]{16,80}$' then
+   return '{"allowed":false,"reason":"invalid"}'::jsonb;
+ end if;
+ -- One lock order, including duplicate checks; never hold across inference.
+ select * into p from collie_inference.pool where id=true for update;
+ if not found or not p.enabled then
+   return '{"allowed":false,"reason":"pool"}'::jsonb;
+ end if;
+ if exists(select 1 from collie_inference.requests where user_id=p_user and request_id=p_request) then
+   return '{"allowed":false,"reason":"duplicate"}'::jsonb;
+ end if;
+ select * into a from collie_inference.allowances where user_id=p_user for update;
+ if not found or not a.enabled or a.expires_at <= now() or a.units-a.spent < p_units or not p.enabled then
+   return '{"allowed":false,"reason":"allowance"}'::jsonb;
+ end if;
+ if p.day <> (now() at time zone 'UTC')::date then p.daily_spent:=0; end if;
+ if p.minute_start <> date_trunc('minute',now()) then p.minute_spent:=0; end if;
+ if p.daily_spent+p_units > p.daily_limit or p.minute_spent+p_units > 6000 then
+   return '{"allowed":false,"reason":"pool"}'::jsonb;
+ end if;
+ insert into collie_inference.requests(user_id,request_id,units) values(p_user,p_request,p_units);
+ update collie_inference.allowances set spent=spent+p_units where user_id=p_user;
+ update collie_inference.pool set
+   day=(now() at time zone 'UTC')::date, daily_spent=p.daily_spent+p_units,
+   minute_start=date_trunc('minute',now()), minute_spent=p.minute_spent+p_units where id=true;
+ return '{"allowed":true}'::jsonb;
+end;
+$$;
+revoke all on function public.collie_inference_reserve(uuid,text,bigint) from public,anon,authenticated;
+grant execute on function public.collie_inference_reserve(uuid,text,bigint) to service_role;

--- a/tools/inference/schema.test.mjs
+++ b/tools/inference/schema.test.mjs
@@ -1,0 +1,49 @@
+// Run with a local PGlite module directory argument; never connects to a server.
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import assert from 'node:assert/strict'
+const { PGlite } = await import(pathToFileURL(resolve(process.argv[2], 'dist/index.js')).href)
+const db = new PGlite()
+await db.exec(`
+  create role anon; create role authenticated; create role service_role;
+  create schema auth; create table auth.users(id uuid primary key);
+  insert into auth.users values ('00000000-0000-0000-0000-000000000001');
+`)
+await db.exec(await readFile(new URL('./schema.sql',import.meta.url),'utf8'))
+const user='00000000-0000-0000-0000-000000000001'
+const reserve=async(id,units=3000)=>(await db.query(
+  'select public.collie_inference_reserve($1,$2,$3) as result',[user,id,units])).rows[0].result
+assert.equal((await reserve('initial-request-0001')).allowed,false)
+await db.query(`insert into collie_inference.allowances(user_id,units,expires_at,enabled)
+  values($1,10000,now()+interval '1 day',true)`,[user])
+await db.exec('update collie_inference.pool set enabled=true')
+assert.equal((await reserve('first-request-00001')).allowed,true)
+assert.equal((await reserve('first-request-00001')).reason,'duplicate')
+const competing=await Promise.all([
+  reserve('competing-request-01'),reserve('competing-request-02')
+])
+assert.equal(competing.filter(x=>x.allowed).length,1)
+assert.equal((await db.query('select spent from collie_inference.allowances')).rows[0].spent,6000)
+assert.equal((await reserve(null)).reason,'invalid')
+await db.exec("update collie_inference.pool set minute_start=now()-interval '2 minutes'")
+assert.equal((await reserve('next-minute-request1')).allowed,true)
+assert.equal((await reserve('user-budget-request1')).reason,'allowance')
+await db.exec(`update collie_inference.pool set daily_spent=100000;
+  update collie_inference.allowances set units=20000`)
+assert.equal((await reserve('pool-budget-request1')).reason,'pool')
+await db.exec(`update collie_inference.pool set day=current_date-1,
+  minute_start=now()-interval '2 minutes'`)
+assert.equal((await reserve('new-day-request-0001')).allowed,true)
+await db.exec("update collie_inference.allowances set expires_at=now()-interval '1 second'")
+assert.equal((await reserve('expired-request-0001')).reason,'allowance')
+for (const role of ['anon','authenticated']) {
+  await db.exec('set role '+role)
+  await assert.rejects(()=>reserve('unauthorized-request1'),/permission denied/)
+  await assert.rejects(()=>db.exec('select * from collie_inference.allowances'),/permission denied/)
+  await db.exec('reset role')
+}
+await db.exec('set role service_role')
+assert.equal((await reserve('service-expired-0001')).reason,'allowance')
+await db.close()
+console.log('PASS: schema executes; disabled/duplicate/shared/user/expiry limits and role restrictions hold.')

--- a/tools/inference/worker.mjs
+++ b/tools/inference/worker.mjs
@@ -1,0 +1,126 @@
+// Collie managed inference: one explicitly approved free Groq route, no paid fallback.
+// Account grants + shared quota are reserved atomically BEFORE contacting Groq.
+const MODEL = 'openai/gpt-oss-20b'
+const MAX_BODY = 128 * 1024
+const json = (status, body) => new Response(JSON.stringify(body), {
+  status, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+})
+const error = (status, code, message) => json(status, { error: { code, message } })
+
+export async function readLimited(request) {
+  const reader = request.body?.getReader()
+  if (!reader) throw new Error('empty')
+  let size = 0
+  const chunks = []
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size += value.byteLength
+      if (size > MAX_BODY) throw new Error('large')
+      chunks.push(value)
+    }
+  } finally { await reader.cancel().catch(() => {}) }
+  const bytes = new Uint8Array(size)
+  let offset = 0
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength }
+  return new TextDecoder().decode(bytes)
+}
+
+export function payloadFor(body) {
+  if (!body || typeof body !== 'object' || body.model !== 'collie-auto' ||
+      !Array.isArray(body.messages) || body.messages.length < 1 || body.messages.length > 100) {
+    throw new Error('invalid')
+  }
+  if (body.messages.some(m => !m || !['system','developer','user','assistant','tool'].includes(m.role) ||
+      (m.content != null && typeof m.content !== 'string'))) throw new Error('text_only')
+  if (body.tools != null && (!Array.isArray(body.tools) || body.tools.length > 32 ||
+      body.tools.some(t => t?.type !== 'function' || !t.function ||
+        typeof t.function.name !== 'string'))) throw new Error('tools')
+  // Never forward client-supplied upstream, credentials, price, or arbitrary extras.
+  const output = body.max_completion_tokens ?? body.max_tokens ?? 512
+  if (!Number.isInteger(output) || output < 1 || output > 1024) throw new Error('output')
+  const messages = body.messages.map(m => Object.fromEntries(
+    ['role','content','name','tool_call_id','tool_calls'].filter(k => m[k] !== undefined).map(k => [k,m[k]])))
+  const payload = { model: MODEL, messages, max_completion_tokens: output,
+    stream: body.stream === true, ...(body.tools?.length ? { tools: body.tools } : {}) }
+  // UTF-8 bytes bound text tokens, plus conservative template/tool framing headroom.
+  // This is charged reservation units, not a claim of exact vendor token usage.
+  const units = new TextEncoder().encode(JSON.stringify({messages, tools: payload.tools})).length + 2048 + output
+  if (units > 6000) throw new Error('context')
+  return { payload, units }
+}
+
+export function createWorker(fetcher = fetch) {
+  async function rpc(env, name, data) {
+    const res = await fetcher(env.SUPABASE_URL + '/rest/v1/rpc/' + name, {
+      method: 'POST', headers: { apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: 'Bearer ' + env.SUPABASE_SERVICE_ROLE_KEY, 'Content-Type': 'application/json' },
+      body: JSON.stringify(data), redirect: 'error', signal: AbortSignal.timeout(10000)
+    })
+    if (!res.ok) throw new Error('accounting')
+    return res.json()
+  }
+  return {
+    async fetch(request, env, ctx) {
+      if (env.FREE_TIER_CONFIRMED !== 'true' || !env.GROQ_API_KEY ||
+          !env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+        return error(503, 'not_available', 'Collie AI is not available yet.')
+      }
+      const path = new URL(request.url).pathname
+      if (!['/v1/me/entitlements','/v1/chat/completions'].includes(path)) return error(404,'not_found','Not found.')
+      if ((path.endsWith('entitlements') && request.method !== 'GET') ||
+          (path.endsWith('completions') && request.method !== 'POST')) return error(405,'method','Method not allowed.')
+      const auth = request.headers.get('authorization')
+      if (!auth?.startsWith('Bearer ')) return error(401,'auth_required','Sign in to Collie.')
+      try {
+        // Online validation also rejects deleted users; never trust decoded JWT claims.
+        const identity = await fetcher(env.SUPABASE_URL + '/auth/v1/user', {
+          headers: { apikey: env.SUPABASE_SERVICE_ROLE_KEY, Authorization: auth },
+          redirect: 'error', signal: AbortSignal.timeout(10000)
+        })
+        if (!identity.ok) return error(401,'auth_required','Sign in to Collie.')
+        const user = await identity.json()
+        if (typeof user.id !== 'string' || !user.email_confirmed_at) return error(403,'account_required','A verified Collie account is required.')
+        if (path.endsWith('entitlements')) {
+          return json(200, await rpc(env,'collie_inference_allowance',{p_user:user.id}))
+        }
+        let parsed
+        try { parsed = payloadFor(JSON.parse(await readLimited(request))) }
+        catch { return error(400,'unsupported_request','Use a shorter text request with up to 1,024 output tokens.') }
+        const id = request.headers.get('idempotency-key')
+        if (!id || !/^[a-zA-Z0-9-]{16,80}$/.test(id)) return error(400,'request_id_required','Request ID is required.')
+        const admission = await rpc(env,'collie_inference_reserve',{
+          p_user:user.id, p_request:id, p_units:parsed.units
+        })
+        if (!admission.allowed) {
+          return error(admission.reason === 'duplicate' ? 409 : 402,
+            'allowance_exhausted','Included AI is unavailable or its allowance is used up. No paid fallback was used.')
+        }
+        let upstream
+        try {
+          upstream = await fetcher('https://api.groq.com/openai/v1/chat/completions', {
+            method:'POST', headers:{Authorization:'Bearer '+env.GROQ_API_KEY,'Content-Type':'application/json'},
+            body:JSON.stringify(parsed.payload), redirect:'error',
+            signal:AbortSignal.any([request.signal, AbortSignal.timeout(90000)])
+          })
+        } catch {
+          // Reservations remain spent on uncertain attempts; never retry billable work blindly.
+          return error(503,'capacity_unavailable','Collie AI is unavailable. Please try again later.')
+        }
+        if (!upstream.ok) {
+          await upstream.body?.cancel()
+          return error(503,'capacity_unavailable','Collie AI is unavailable. No paid fallback was used.')
+        }
+        // Stream directly. Reservations are durable already, even if client/Worker disconnects.
+        return new Response(upstream.body, {headers:{
+          'Content-Type': parsed.payload.stream ? 'text/event-stream' : 'application/json',
+          'Cache-Control':'no-store'
+        }})
+      } catch {
+        return error(503,'capacity_unavailable','Collie AI is unavailable. Your own providers still work.')
+      }
+    }
+  }
+}
+export default createWorker()

--- a/tools/inference/worker.test.mjs
+++ b/tools/inference/worker.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createWorker, payloadFor } from './worker.mjs'
+
+const env = { FREE_TIER_CONFIRMED:'true', GROQ_API_KEY:'test-supplier',
+  SUPABASE_URL:'https://accounts.test', SUPABASE_SERVICE_ROLE_KEY:'test-service' }
+const body = { model:'collie-auto', messages:[{role:'user',content:'Hello'}], stream:true }
+const request = (value=body) => new Request('https://collie.test/v1/chat/completions',{
+  method:'POST',headers:{Authorization:'Bearer test-user','Idempotency-Key':'12345678-1234-1234'},
+  body:JSON.stringify(value)
+})
+const response = value => new Response(JSON.stringify(value))
+function fixture({allowed=true, upstreamStatus=200, identityStatus=200}={}) {
+  const calls=[]
+  const worker=createWorker(async(url,options) => {
+    calls.push({url,options})
+    if (url.endsWith('/auth/v1/user')) return new Response(JSON.stringify({
+      id:'00000000-0000-0000-0000-000000000001',email_confirmed_at:'2026-01-01'
+    }),{status:identityStatus})
+    if (url.endsWith('collie_inference_reserve')) return response({allowed,reason:'pool'})
+    if (url.endsWith('collie_inference_allowance')) return response({available:true,remaining:100,limit:100})
+    return new Response(upstreamStatus===200 ? 'data: [DONE]\n\n' : 'private upstream diagnostics',
+      {status:upstreamStatus})
+  })
+  return {worker,calls}
+}
+test('disabled deployment makes zero network calls',async()=>{
+  const {worker,calls}=fixture()
+  assert.equal((await worker.fetch(request(),{})).status,503)
+  assert.equal(calls.length,0)
+})
+test('invalid identity and denied allowance never reach supplier',async()=>{
+  for (const options of [{identityStatus:401},{allowed:false}]) {
+    const {worker,calls}=fixture(options)
+    assert.notEqual((await worker.fetch(request(),env)).status,200)
+    assert.ok(calls.every(c=>!c.url.includes('api.groq.com')))
+  }
+})
+test('authenticated reservation precedes streaming; credentials stay on their own hosts',async()=>{
+  const {worker,calls}=fixture()
+  const res=await worker.fetch(request({...body,api_base:'https://evil.test',api_key:'injected'}),env)
+  assert.equal(await res.text(),'data: [DONE]\n\n')
+  assert.equal(calls.length,3)
+  assert.ok(calls[1].url.endsWith('collie_inference_reserve'))
+  assert.equal(calls[0].options.headers.Authorization,'Bearer test-user')
+  assert.equal(calls[2].options.headers.Authorization,'Bearer test-supplier')
+  const sent=JSON.parse(calls[2].options.body)
+  assert.equal(sent.model,'openai/gpt-oss-20b')
+  assert.equal(sent.api_base,undefined)
+  assert.equal(sent.api_key,undefined)
+})
+test('upstream failure is sanitized and never retried',async()=>{
+  const {worker,calls}=fixture({upstreamStatus:429})
+  const res=await worker.fetch(request(),env)
+  assert.equal(res.status,503)
+  assert.ok(!(await res.text()).includes('private'))
+  assert.equal(calls.filter(c=>c.url.includes('api.groq.com')).length,1)
+})
+test('entitlement reads never invoke inference',async()=>{
+  const {worker,calls}=fixture()
+  const res=await worker.fetch(new Request('https://collie.test/v1/me/entitlements',{
+    headers:{Authorization:'Bearer test-user'}
+  }),env)
+  assert.equal(res.status,200)
+  assert.equal(calls.length,2)
+})
+test('unsupported model, output, image and oversized context fail before admission',async()=>{
+  for(const value of [
+    {...body,model:'expensive-model'}, {...body,max_tokens:4096},
+    {...body,messages:[{role:'user',content:[{type:'image_url'}]}]},
+    {...body,messages:[{role:'user',content:'x'.repeat(130000)}]}
+  ]) {
+    const {worker,calls}=fixture()
+    assert.equal((await worker.fetch(request(value),env)).status,400)
+    assert.equal(calls.length,1)
+  }
+  assert.ok(payloadFor(body).units>2048)
+})

--- a/tools/inference/wrangler.jsonc
+++ b/tools/inference/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "collie-inference",
+  "main": "worker.mjs",
+  "compatibility_date": "2026-09-01",
+  "workers_dev": false,
+  "vars": {
+    "FREE_TIER_CONFIRMED": "false"
+  },
+  "observability": { "enabled": false }
+}


### PR DESCRIPTION
Customers can select Collie AI using their Collie account alongside saved BYOK connections. The desktop forwards through an authenticated main-process bridge; supplier credentials remain on the backend.

This PR is a disabled-by-default pilot foundation. It does not create accounts, deploy infrastructure, apply the backend schema, make live inference requests, or enable billing. Keep rollout disabled until a company-owned provider organization and hosting/database setup are verified to have genuinely free hard stops.

- Add account allowance/status UI in Welcome and Settings, managed provider activation and startup restore.
- Pin one Groq candidate route behind a Collie endpoint, cap output/context, disable automatic retries and paid/personal fallback.
- Add atomic service-only account/shared allowance reservation, duplicate protection, explicit grants and expiry. Backend schema is a separate commit.
- Document the architecture, zero-cost onboarding gate, and limitations in docs/product/features/managed-inference.md.

Validation:
- Desktop: 72 test files passed; 503 tests passed, 1 skipped. TypeScript and production build passed.
- Core: 76 focused provider/settings/configuration/IPC tests passed.
- Worker: 6 offline tests passed.
- Database: schema executed in local PGlite; role restrictions, duplicate requests, competing admissions, user/shared budgets, expiry and day rollover passed.
- New Python files pass Ruff; repository snapshot and whitespace checks pass.
- Test output includes React/jsdom warnings and missing pytest-timeout configuration warnings; no test failures.

Remaining rollout checks: no supplier signup or live end-to-end inference was completed. The conservative 6,000-unit request cap rejects large agent contexts/tool catalogs, so this does not yet validate unrestricted default Collie agent workflows. The free-tier flag is operator confirmation, not a guarantee about a provider's billing settings. Production concurrency, actual provider quota/model suitability, account terms, and hosting free-plan limits must be verified before enabling customer access.
