### PR TITLE
chore(release): bump to v0.1.0-alpha.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ terminal. No prompt engineering. No forced subscription.
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow" alt="License: MIT"></a>
   <a href="https://github.com/FoxRick/Collie/releases"><img src="https://img.shields.io/badge/Platform-Windows%20%C2%B7%20macOS%20%C2%B7%20Linux-0078d6" alt="Platform: Windows, macOS, Linux"></a>
-  <a href="https://github.com/FoxRick/Collie/releases"><img src="https://img.shields.io/badge/Release-v0.1.0--alpha.7.3-purple" alt="Current release: v0.1.0-alpha.7.3"></a>
+  <a href="https://github.com/FoxRick/Collie/releases"><img src="https://img.shields.io/badge/Release-v0.1.0--alpha.7.4-purple" alt="Current release: v0.1.0-alpha.7.4"></a>
   <a href="https://github.com/FoxRick/Collie/actions/workflows/ci.yml"><img src="https://github.com/FoxRick/Collie/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="https://heycollie.com"><img src="https://img.shields.io/badge/Website-heycollie.com-2ea44f" alt="heycollie.com"></a>
   <a href="https://github.com/FoxRick/Collie"><img src="https://img.shields.io/github/stars/FoxRick/Collie" alt="GitHub stars"></a>
 </p>
 
-> **Alpha release** — this repo ships a published **alpha** (`v0.1.0-alpha.7.3`)
+> **Alpha release** — this repo ships a published **alpha** (`v0.1.0-alpha.7.4`)
 > with installers for **Windows (x64), macOS (ARM64), and Linux (x64)**, plus
 > the full source. It's a real product you can install and talk to — but it's
 > early, so expect rough edges. The `main` branch is slightly ahead of the
@@ -235,7 +235,7 @@ The alpha installers are built on **Windows (x64)**, **macOS (ARM64)**, and
 development. You need Python 3.12, Node.js, and npm:
 
 > Versioning note: the repo carries two versions that move independently —
-> the desktop app (`collie-ui/package.json`, e.g. `0.1.0-alpha.7.3`) and the
+> the desktop app (`collie-ui/package.json`, e.g. `0.1.0-alpha.7.4`) and the
 > Python core (`collie-core/pyproject.toml`, e.g. `0.2.2`). A release tag
 > tracks the app version.
 

--- a/collie-ui/package-lock.json
+++ b/collie-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.7.3",
+  "version": "0.1.0-alpha.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collie",
-      "version": "0.1.0-alpha.7.3",
+      "version": "0.1.0-alpha.7.4",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/collie-ui/package.json
+++ b/collie-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.1.0-alpha.7.3",
+  "version": "0.1.0-alpha.7.4",
   "description": "Your personal AI. With a dog.",
   "main": "./out/main/index.js",
   "author": "Collie",

--- a/docs/generated/REPOSITORY_SNAPSHOT.md
+++ b/docs/generated/REPOSITORY_SNAPSHOT.md
@@ -7,7 +7,7 @@
 | Component | Path | Version |
 | --- | --- | --- |
 | Python core | `collie-core/` | `0.2.2` |
-| Electron desktop | `collie-ui/` | `0.1.0-alpha.7.3` |
+| Electron desktop | `collie-ui/` | `0.1.0-alpha.7.4` |
 
 ## Source inventory
 


### PR DESCRIPTION
## What
Version bump for the next alpha installer release: `v0.1.0-alpha.7.3` → `v0.1.0-alpha.7.4`.

Bumps the app version in `collie-ui/package.json` + `package-lock.json`, regenerates the repository snapshot, and updates the README release badge.

## Scope
- `collie-ui/package.json` + `package-lock.json`: version `0.1.0-alpha.7.4`
- `docs/generated/REPOSITORY_SNAPSHOT.md`: `tools/update_project_snapshot.py` regen (Electron desktop → 0.1.0-alpha.7.4)
- `README.md`: release badge + versioning note

## Process
- Tag `v0.1.0-alpha.7.4` is pushed **after** this merges, which triggers the tag-triggered `release.yml` pipeline (qualify → 3-OS build → draft release) on GitHub-hosted runners.